### PR TITLE
Use `errors.New()` where appropriate

### DIFF
--- a/lxc/auth.go
+++ b/lxc/auth.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -119,7 +120,7 @@ func (c *cmdGroupCreate) run(cmd *cobra.Command, args []string) error {
 	resource := resources[0]
 
 	if resource.name == "" {
-		return fmt.Errorf(i18n.G("Missing group name"))
+		return errors.New(i18n.G("Missing group name"))
 	}
 
 	// Create the group
@@ -173,7 +174,7 @@ func (c *cmdGroupDelete) run(cmd *cobra.Command, args []string) error {
 	resource := resources[0]
 
 	if resource.name == "" {
-		return fmt.Errorf(i18n.G("Missing group name"))
+		return errors.New(i18n.G("Missing group name"))
 	}
 
 	// Delete the group
@@ -251,7 +252,7 @@ func (c *cmdGroupEdit) run(cmd *cobra.Command, args []string) error {
 	resource := resources[0]
 
 	if resource.name == "" {
-		return fmt.Errorf(i18n.G("Missing group name"))
+		return errors.New(i18n.G("Missing group name"))
 	}
 
 	// If stdin isn't a terminal, read text from it
@@ -413,7 +414,7 @@ func (c *cmdGroupRename) run(cmd *cobra.Command, args []string) error {
 	resource := resources[0]
 
 	if resource.name == "" {
-		return fmt.Errorf(i18n.G("Missing group name"))
+		return errors.New(i18n.G("Missing group name"))
 	}
 
 	// Rename the group
@@ -462,7 +463,7 @@ func (c *cmdGroupShow) run(cmd *cobra.Command, args []string) error {
 	resource := resources[0]
 
 	if resource.name == "" {
-		return fmt.Errorf(i18n.G("Missing group name"))
+		return errors.New(i18n.G("Missing group name"))
 	}
 
 	// Show the group
@@ -537,7 +538,7 @@ func (c *cmdGroupPermissionAdd) run(cmd *cobra.Command, args []string) error {
 	resource := resources[0]
 
 	if resource.name == "" {
-		return fmt.Errorf(i18n.G("Missing group name"))
+		return errors.New(i18n.G("Missing group name"))
 	}
 
 	group, eTag, err := resource.server.GetAuthGroup(resource.name)
@@ -596,7 +597,7 @@ func (c *cmdGroupPermissionRemove) run(cmd *cobra.Command, args []string) error 
 	resource := resources[0]
 
 	if resource.name == "" {
-		return fmt.Errorf(i18n.G("Missing group name"))
+		return errors.New(i18n.G("Missing group name"))
 	}
 
 	group, eTag, err := resource.server.GetAuthGroup(resource.name)
@@ -859,7 +860,7 @@ func (c *cmdIdentityShow) run(cmd *cobra.Command, args []string) error {
 	resource := resources[0]
 
 	if resource.name == "" {
-		return fmt.Errorf(i18n.G("Missing identity argument"))
+		return errors.New(i18n.G("Missing identity argument"))
 	}
 
 	authenticationMethod, nameOrID, ok := strings.Cut(resource.name, "/")
@@ -1000,7 +1001,7 @@ func (c *cmdIdentityEdit) run(cmd *cobra.Command, args []string) error {
 	resource := resources[0]
 
 	if resource.name == "" {
-		return fmt.Errorf(i18n.G("Missing identity argument"))
+		return errors.New(i18n.G("Missing identity argument"))
 	}
 
 	authenticationMethod, nameOrID, ok := strings.Cut(resource.name, "/")
@@ -1128,7 +1129,7 @@ func (c *cmdIdentityGroupAdd) run(cmd *cobra.Command, args []string) error {
 	resource := resources[0]
 
 	if resource.name == "" {
-		return fmt.Errorf(i18n.G("Missing identity argument"))
+		return errors.New(i18n.G("Missing identity argument"))
 	}
 
 	authenticationMethod, nameOrID, ok := strings.Cut(resource.name, "/")
@@ -1186,7 +1187,7 @@ func (c *cmdIdentityGroupRemove) run(cmd *cobra.Command, args []string) error {
 	resource := resources[0]
 
 	if resource.name == "" {
-		return fmt.Errorf(i18n.G("Missing identity argument"))
+		return errors.New(i18n.G("Missing identity argument"))
 	}
 
 	authenticationMethod, nameOrID, ok := strings.Cut(resource.name, "/")
@@ -1492,7 +1493,7 @@ func (c *cmdIdentityProviderGroupCreate) run(cmd *cobra.Command, args []string) 
 	resource := resources[0]
 
 	if resource.name == "" {
-		return fmt.Errorf(i18n.G("Missing identity provider group name"))
+		return errors.New(i18n.G("Missing identity provider group name"))
 	}
 
 	// Create the identity provider group
@@ -1545,7 +1546,7 @@ func (c *cmdIdentityProviderGroupDelete) run(cmd *cobra.Command, args []string) 
 	resource := resources[0]
 
 	if resource.name == "" {
-		return fmt.Errorf(i18n.G("Missing identity provider group name"))
+		return errors.New(i18n.G("Missing identity provider group name"))
 	}
 
 	// Delete the identity provider group
@@ -1611,7 +1612,7 @@ func (c *cmdIdentityProviderGroupEdit) run(cmd *cobra.Command, args []string) er
 	resource := resources[0]
 
 	if resource.name == "" {
-		return fmt.Errorf(i18n.G("Missing identity provider group name"))
+		return errors.New(i18n.G("Missing identity provider group name"))
 	}
 
 	// If stdin isn't a terminal, read text from it
@@ -1773,7 +1774,7 @@ func (c *cmdIdentityProviderGroupRename) run(cmd *cobra.Command, args []string) 
 	resource := resources[0]
 
 	if resource.name == "" {
-		return fmt.Errorf(i18n.G("Missing identity provider group name"))
+		return errors.New(i18n.G("Missing identity provider group name"))
 	}
 
 	// Rename the group
@@ -1822,7 +1823,7 @@ func (c *cmdIdentityProviderGroupShow) run(cmd *cobra.Command, args []string) er
 	resource := resources[0]
 
 	if resource.name == "" {
-		return fmt.Errorf(i18n.G("Missing group name"))
+		return errors.New(i18n.G("Missing group name"))
 	}
 
 	// Show the group
@@ -1896,7 +1897,7 @@ func (c *cmdIdentityProviderGroupGroupAdd) run(cmd *cobra.Command, args []string
 	resource := resources[0]
 
 	if resource.name == "" {
-		return fmt.Errorf(i18n.G("Missing identity provider group name argument"))
+		return errors.New(i18n.G("Missing identity provider group name argument"))
 	}
 
 	idpGroup, eTag, err := resource.server.GetIdentityProviderGroup(resource.name)
@@ -1949,7 +1950,7 @@ func (c *cmdIdentityProviderGroupGroupRemove) run(cmd *cobra.Command, args []str
 	resource := resources[0]
 
 	if resource.name == "" {
-		return fmt.Errorf(i18n.G("Missing identity provider group name argument"))
+		return errors.New(i18n.G("Missing identity provider group name argument"))
 	}
 
 	idpGroup, eTag, err := resource.server.GetIdentityProviderGroup(resource.name)

--- a/lxc/config_trust.go
+++ b/lxc/config_trust.go
@@ -187,7 +187,7 @@ func (c *cmdConfigTrustAdd) run(cmd *cobra.Command, args []string) error {
 		cert.Type = api.CertificateTypeClient
 	} else if c.flagType == "metrics" {
 		if cert.Token {
-			return fmt.Errorf(i18n.G("Cannot use metrics type certificate when using a token"))
+			return errors.New(i18n.G("Cannot use metrics type certificate when using a token"))
 		}
 
 		cert.Type = api.CertificateTypeMetrics
@@ -265,7 +265,7 @@ func (c *cmdConfigTrustEdit) run(cmd *cobra.Command, args []string) error {
 	resource := resources[0]
 
 	if resource.name == "" {
-		return fmt.Errorf(i18n.G("Missing certificate fingerprint"))
+		return errors.New(i18n.G("Missing certificate fingerprint"))
 	}
 
 	// If stdin isn't a terminal, read text from it
@@ -388,7 +388,7 @@ func (c *cmdConfigTrustList) run(cmd *cobra.Command, args []string) error {
 
 		certBlock, _ := pem.Decode([]byte(cert.Certificate))
 		if certBlock == nil {
-			return fmt.Errorf(i18n.G("Invalid certificate"))
+			return errors.New(i18n.G("Invalid certificate"))
 		}
 
 		tlsCert, err := x509.ParseCertificate(certBlock.Bytes)
@@ -673,7 +673,7 @@ func (c *cmdConfigTrustShow) run(cmd *cobra.Command, args []string) error {
 	client := resource.server
 
 	if resource.name == "" {
-		return fmt.Errorf(i18n.G("Missing certificate fingerprint"))
+		return errors.New(i18n.G("Missing certificate fingerprint"))
 	}
 
 	// Show the certificate configuration

--- a/lxc/file.go
+++ b/lxc/file.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"math/rand"
@@ -68,7 +69,7 @@ func fileGetWrapper(server lxd.InstanceServer, inst string, path string) (io.Rea
 			count++
 
 			if count == 3 {
-				return nil, nil, fmt.Errorf(i18n.G("User signaled us three times, exiting. The remote operation will keep running"))
+				return nil, nil, errors.New(i18n.G("User signaled us three times, exiting. The remote operation will keep running"))
 			}
 
 			fmt.Println(i18n.G("Early server side processing of file transfer requests cannot be canceled (interrupt two more times to force)"))
@@ -282,7 +283,7 @@ func (c *cmdFilePull) run(cmd *cobra.Command, args []string) error {
 	if err == nil {
 		targetIsDir = sb.IsDir()
 		if !targetIsDir && len(args)-1 > 1 {
-			return fmt.Errorf(i18n.G("More than one file to download, but target is not a directory"))
+			return errors.New(i18n.G("More than one file to download, but target is not a directory"))
 		}
 	} else if strings.HasSuffix(args[len(args)-1], string(os.PathSeparator)) || len(args)-1 > 1 {
 		err := os.MkdirAll(target, DirMode)
@@ -337,7 +338,7 @@ func (c *cmdFilePull) run(cmd *cobra.Command, args []string) error {
 
 				continue
 			} else {
-				return fmt.Errorf(i18n.G("Can't pull a directory without --recursive"))
+				return errors.New(i18n.G("Can't pull a directory without --recursive"))
 			}
 		}
 
@@ -543,7 +544,7 @@ func (c *cmdFilePush) run(cmd *cobra.Command, args []string) error {
 	if c.file.flagRecursive {
 		// Quick checks.
 		if c.file.flagUID != -1 || c.file.flagGID != -1 || c.file.flagMode != "" {
-			return fmt.Errorf(i18n.G("Can't supply uid/gid/mode in recursive mode"))
+			return errors.New(i18n.G("Can't supply uid/gid/mode in recursive mode"))
 		}
 
 		// Create needed paths if requested
@@ -595,7 +596,7 @@ func (c *cmdFilePush) run(cmd *cobra.Command, args []string) error {
 	}
 
 	if (len(sourcefilenames) > 1) && !targetIsDir {
-		return fmt.Errorf(i18n.G("Missing target directory"))
+		return errors.New(i18n.G("Missing target directory"))
 	}
 
 	reverter := revert.New()
@@ -1023,13 +1024,13 @@ func (c *cmdFileMount) run(cmd *cobra.Command, args []string) error {
 		}
 
 		if !sb.IsDir() {
-			return fmt.Errorf(i18n.G("Target path must be a directory"))
+			return errors.New(i18n.G("Target path must be a directory"))
 		}
 	}
 
 	// Check which mode we should operate in. If target path is provided we use sshfs mode.
 	if targetPath != "" && c.flagListen != "" {
-		return fmt.Errorf(i18n.G("Target path and --listen flag cannot be used together"))
+		return errors.New(i18n.G("Target path and --listen flag cannot be used together"))
 	}
 
 	instSpec := strings.SplitN(resource.name, "/", 2)
@@ -1041,7 +1042,7 @@ func (c *cmdFileMount) run(cmd *cobra.Command, args []string) error {
 
 	// Check instance path isn't provided in listener mode.
 	if len(instSpec) > 1 && targetPath == "" {
-		return fmt.Errorf(i18n.G("Instance path cannot be used in SSH SFTP listener mode"))
+		return errors.New(i18n.G("Instance path cannot be used in SSH SFTP listener mode"))
 	}
 
 	instName := instSpec[0]
@@ -1051,7 +1052,7 @@ func (c *cmdFileMount) run(cmd *cobra.Command, args []string) error {
 		sshfsPath, err := exec.LookPath("sshfs")
 		if err != nil {
 			// If sshfs command not found, then advise user of the --listen flag.
-			return fmt.Errorf(i18n.G("sshfs not found. Try SSH SFTP mode using the --listen flag"))
+			return errors.New(i18n.G("sshfs not found. Try SSH SFTP mode using the --listen flag"))
 		}
 
 		// Setup sourcePath with leading / to ensure we reference the instance path from / location.

--- a/lxc/image_alias.go
+++ b/lxc/image_alias.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"fmt"
+	"errors"
 	"sort"
 	"strings"
 
@@ -81,7 +81,7 @@ func (c *cmdImageAliasCreate) run(cmd *cobra.Command, args []string) error {
 	resource := resources[0]
 
 	if resource.name == "" {
-		return fmt.Errorf(i18n.G("Alias name missing"))
+		return errors.New(i18n.G("Alias name missing"))
 	}
 
 	// Create the alias
@@ -128,7 +128,7 @@ func (c *cmdImageAliasDelete) run(cmd *cobra.Command, args []string) error {
 	resource := resources[0]
 
 	if resource.name == "" {
-		return fmt.Errorf(i18n.G("Alias name missing"))
+		return errors.New(i18n.G("Alias name missing"))
 	}
 
 	// Delete the alias
@@ -276,7 +276,7 @@ func (c *cmdImageAliasRename) run(cmd *cobra.Command, args []string) error {
 	resource := resources[0]
 
 	if resource.name == "" {
-		return fmt.Errorf(i18n.G("Alias name missing"))
+		return errors.New(i18n.G("Alias name missing"))
 	}
 
 	// Rename the alias

--- a/lxc/monitor.go
+++ b/lxc/monitor.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 
@@ -76,7 +77,7 @@ func (c *cmdMonitor) run(cmd *cobra.Command, args []string) error {
 	}
 
 	if c.flagFormat != "pretty" && c.flagLogLevel != "" {
-		return fmt.Errorf(i18n.G("Log level filtering can only be used with pretty formatting"))
+		return errors.New(i18n.G("Log level filtering can only be used with pretty formatting"))
 	}
 
 	// Connect to the event source.

--- a/lxc/operation.go
+++ b/lxc/operation.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -133,7 +134,7 @@ func (c *cmdOperationList) run(cmd *cobra.Command, args []string) error {
 
 	resource := resources[0]
 	if resource.name != "" {
-		return fmt.Errorf(i18n.G("Filtering isn't supported yet"))
+		return errors.New(i18n.G("Filtering isn't supported yet"))
 	}
 
 	// Get operations

--- a/lxc/query.go
+++ b/lxc/query.go
@@ -69,7 +69,7 @@ func (c *cmdQuery) run(cmd *cobra.Command, args []string) error {
 	}
 
 	if c.global.flagProject != "" {
-		return fmt.Errorf(i18n.G("--project cannot be used with the query command"))
+		return errors.New(i18n.G("--project cannot be used with the query command"))
 	}
 
 	if !shared.ValueInSlice(c.flagAction, []string{"GET", "PUT", "POST", "PATCH", "DELETE"}) {
@@ -84,7 +84,7 @@ func (c *cmdQuery) run(cmd *cobra.Command, args []string) error {
 
 	// Validate path
 	if !strings.HasPrefix(path, "/") {
-		return fmt.Errorf(i18n.G("Query path must start with /"))
+		return errors.New(i18n.G("Query path must start with /"))
 	}
 
 	// Attempt to connect
@@ -168,7 +168,7 @@ func (c *cmdQuery) run(cmd *cobra.Command, args []string) error {
 		op := api.Operation{}
 		err = json.Unmarshal(resp.Metadata, &op)
 		if err == nil && op.Err != "" {
-			return fmt.Errorf(op.Err)
+			return errors.New(op.Err)
 		}
 	}
 

--- a/lxc/rebuild.go
+++ b/lxc/rebuild.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -57,11 +58,11 @@ func (c *cmdRebuild) rebuild(conf *config.Config, args []string) error {
 		}
 
 	default:
-		return fmt.Errorf(i18n.G("Missing instance name"))
+		return errors.New(i18n.G("Missing instance name"))
 	}
 
 	if c.flagEmpty && len(args) > 1 {
-		return fmt.Errorf(i18n.G("--empty cannot be combined with an image name"))
+		return errors.New(i18n.G("--empty cannot be combined with an image name"))
 	}
 
 	d, err := conf.GetInstanceServer(remote)
@@ -116,7 +117,7 @@ func (c *cmdRebuild) rebuild(conf *config.Config, args []string) error {
 
 	if !c.flagEmpty {
 		if image == "" && iremote == "" {
-			return fmt.Errorf(i18n.G("You need to specify an image name or use --empty"))
+			return errors.New(i18n.G("You need to specify an image name or use --empty"))
 		}
 
 		iremote, image := guessImage(conf, d, remote, iremote, image)
@@ -127,7 +128,7 @@ func (c *cmdRebuild) rebuild(conf *config.Config, args []string) error {
 
 		if conf.Remotes[iremote].Protocol != "simplestreams" {
 			if imgInfo.Type != "virtual-machine" && current.Type == "virtual-machine" {
-				return fmt.Errorf(i18n.G("Asked for a VM but image is of type container"))
+				return errors.New(i18n.G("Asked for a VM but image is of type container"))
 			}
 		}
 
@@ -157,7 +158,7 @@ func (c *cmdRebuild) rebuild(conf *config.Config, args []string) error {
 	} else {
 		// This is a rebuild as an empty instance
 		if image != "" || iremote != "" {
-			return fmt.Errorf(i18n.G("Can't use an image with --empty"))
+			return errors.New(i18n.G("Can't use an image with --empty"))
 		}
 
 		req.Source.Type = "none"

--- a/lxc/warning.go
+++ b/lxc/warning.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -221,7 +222,7 @@ func (c *cmdWarningList) parseColumns(clustered bool) ([]warningColumn, error) {
 	} else {
 		if c.flagColumns != defaultWarningColumns {
 			if strings.ContainsAny(c.flagColumns, "L") {
-				return nil, fmt.Errorf(i18n.G("Can't specify column L when not clustered"))
+				return nil, errors.New(i18n.G("Can't specify column L when not clustered"))
 			}
 		}
 		c.flagColumns = strings.Replace(c.flagColumns, "L", "", -1)

--- a/po/ar.po
+++ b/po/ar.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-04 08:52-0600\n"
+"POT-Creation-Date: 2024-09-05 08:44-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: lxc/storage_bucket.go:260 lxc/storage_bucket.go:1033
+#: lxc/storage_bucket.go:261 lxc/storage_bucket.go:1034
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -130,7 +130,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:213
+#: lxc/auth.go:214
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -157,7 +157,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:968
+#: lxc/auth.go:969
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -178,7 +178,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1585
+#: lxc/auth.go:1586
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -388,7 +388,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:280
+#: lxc/project.go:281
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -430,12 +430,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:935
+#: lxc/file.go:936
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:825
+#: lxc/file.go:826
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -471,7 +471,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:142 lxc/rebuild.go:64
+#: lxc/init.go:142 lxc/rebuild.go:65
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -524,7 +524,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:465
+#: lxc/file.go:466
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -557,7 +557,7 @@ msgstr ""
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:813
+#: lxc/auth.go:814
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -565,11 +565,11 @@ msgstr ""
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/storage_bucket.go:863
+#: lxc/storage_bucket.go:864
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:941
+#: lxc/storage_bucket.go:942
 #, c-format
 msgid "Access key: %s"
 msgstr ""
@@ -578,7 +578,7 @@ msgstr ""
 msgid "Access the expanded configuration"
 msgstr ""
 
-#: lxc/warning.go:261 lxc/warning.go:262
+#: lxc/warning.go:262 lxc/warning.go:263
 msgid "Acknowledge warning"
 msgstr ""
 
@@ -595,11 +595,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1106 lxc/auth.go:1107
+#: lxc/auth.go:1107 lxc/auth.go:1108
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1874 lxc/auth.go:1875
+#: lxc/auth.go:1875 lxc/auth.go:1876
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -668,7 +668,7 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:515 lxc/auth.go:516
+#: lxc/auth.go:516 lxc/auth.go:517
 msgid "Add permissions to groups"
 msgstr ""
 
@@ -697,7 +697,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:169
+#: lxc/storage_bucket.go:170
 #, c-format
 msgid "Admin access key: %s"
 msgstr ""
@@ -707,7 +707,7 @@ msgstr ""
 msgid "Admin password (or token) for %s:"
 msgstr ""
 
-#: lxc/storage_bucket.go:170
+#: lxc/storage_bucket.go:171
 #, c-format
 msgid "Admin secret key: %s"
 msgstr ""
@@ -766,7 +766,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:342 lxc/rebuild.go:130
+#: lxc/init.go:342 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -866,12 +866,12 @@ msgstr ""
 
 #: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:318
 #: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
-#: lxc/network_zone.go:366 lxc/network_zone.go:1053 lxc/storage_bucket.go:141
+#: lxc/network_zone.go:366 lxc/network_zone.go:1053 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:159
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:160
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Bytes sent"
 msgstr ""
 
-#: lxc/operation.go:174
+#: lxc/operation.go:175
 msgid "CANCELABLE"
 msgstr ""
 
@@ -923,7 +923,7 @@ msgstr ""
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: lxc/warning.go:209
+#: lxc/warning.go:210
 msgid "COUNT"
 msgstr ""
 
@@ -949,7 +949,7 @@ msgstr ""
 msgid "CPUs (%s):"
 msgstr ""
 
-#: lxc/operation.go:175
+#: lxc/operation.go:176
 msgid "CREATED"
 msgstr ""
 
@@ -979,7 +979,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:340
+#: lxc/file.go:341
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1004,11 +1004,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:224
+#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:546
+#: lxc/file.go:547
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1017,7 +1017,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:160
+#: lxc/rebuild.go:161
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1140,13 +1140,13 @@ msgstr ""
 #: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
 #: lxc/network_load_balancer.go:1051 lxc/network_load_balancer.go:1125
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
-#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:90
-#: lxc/storage_bucket.go:190 lxc/storage_bucket.go:253
-#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:541
-#: lxc/storage_bucket.go:634 lxc/storage_bucket.go:700
-#: lxc/storage_bucket.go:775 lxc/storage_bucket.go:861
-#: lxc/storage_bucket.go:961 lxc/storage_bucket.go:1026
-#: lxc/storage_bucket.go:1162 lxc/storage_volume.go:394
+#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
+#: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
+#: lxc/storage_bucket.go:385 lxc/storage_bucket.go:542
+#: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
+#: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
+#: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
 #: lxc/storage_volume.go:612 lxc/storage_volume.go:717
 #: lxc/storage_volume.go:1005 lxc/storage_volume.go:1231
 #: lxc/storage_volume.go:1360 lxc/storage_volume.go:1848
@@ -1170,7 +1170,7 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1113 lxc/list.go:132 lxc/storage_volume.go:1589
-#: lxc/warning.go:92
+#: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
@@ -1198,7 +1198,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:100
+#: lxc/project.go:101
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1212,8 +1212,8 @@ msgstr ""
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
-#: lxc/project.go:362 lxc/storage.go:359 lxc/storage_bucket.go:348
-#: lxc/storage_bucket.go:1125 lxc/storage_volume.go:1150
+#: lxc/project.go:363 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1150
 #: lxc/storage_volume.go:1182
 #, c-format
 msgid "Config parsing error: %s"
@@ -1340,12 +1340,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:300 lxc/auth.go:1660
+#: lxc/auth.go:301 lxc/auth.go:1661
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1054
+#: lxc/auth.go:1055
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1394,15 +1394,15 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:248 lxc/file.go:474
+#: lxc/file.go:249 lxc/file.go:475
 msgid "Create any directories necessary"
 msgstr ""
 
-#: lxc/auth.go:97 lxc/auth.go:98
+#: lxc/auth.go:98 lxc/auth.go:99
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1471 lxc/auth.go:1472
+#: lxc/auth.go:1472 lxc/auth.go:1473
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1422,11 +1422,11 @@ msgstr ""
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_bucket.go:851 lxc/storage_bucket.go:852
+#: lxc/storage_bucket.go:852 lxc/storage_bucket.go:853
 msgid "Create key for a storage bucket"
 msgstr ""
 
-#: lxc/storage_bucket.go:82 lxc/storage_bucket.go:83
+#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
 msgid "Create new custom storage buckets"
 msgstr ""
 
@@ -1470,7 +1470,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:92 lxc/project.go:93
+#: lxc/project.go:93 lxc/project.go:94
 msgid "Create projects"
 msgstr ""
 
@@ -1505,13 +1505,13 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:376 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1135 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
-#: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:172
-#: lxc/profile.go:756 lxc/project.go:572 lxc/storage.go:723
-#: lxc/storage_bucket.go:512 lxc/storage_bucket.go:832
+#: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
+#: lxc/profile.go:756 lxc/project.go:573 lxc/storage.go:723
+#: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1732
 msgid "DESCRIPTION"
 msgstr ""
@@ -1536,7 +1536,7 @@ msgstr ""
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
-#: lxc/operation.go:55 lxc/operation.go:56
+#: lxc/operation.go:56 lxc/operation.go:57
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
@@ -1544,19 +1544,19 @@ msgstr ""
 msgid "Delete a cluster group"
 msgstr ""
 
-#: lxc/warning.go:360
+#: lxc/warning.go:361
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:122 lxc/file.go:123
+#: lxc/file.go:123 lxc/file.go:124
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/auth.go:151 lxc/auth.go:152
+#: lxc/auth.go:152 lxc/auth.go:153
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1523 lxc/auth.go:1524
+#: lxc/auth.go:1524 lxc/auth.go:1525
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1576,7 +1576,7 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/storage_bucket.go:957 lxc/storage_bucket.go:958
+#: lxc/storage_bucket.go:958 lxc/storage_bucket.go:959
 msgid "Delete key from a storage bucket"
 msgstr ""
 
@@ -1612,11 +1612,11 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:188 lxc/project.go:189
+#: lxc/project.go:189 lxc/project.go:190
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:187 lxc/storage_bucket.go:188
+#: lxc/storage_bucket.go:188 lxc/storage_bucket.go:189
 msgid "Delete storage buckets"
 msgstr ""
 
@@ -1628,20 +1628,20 @@ msgstr ""
 msgid "Delete storage volumes"
 msgstr ""
 
-#: lxc/warning.go:356 lxc/warning.go:357
+#: lxc/warning.go:357 lxc/warning.go:358
 msgid "Delete warning"
 msgstr ""
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:30 lxc/auth.go:59 lxc/auth.go:98
-#: lxc/auth.go:152 lxc/auth.go:201 lxc/auth.go:332 lxc/auth.go:392
-#: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
-#: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
-#: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
-#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1434 lxc/auth.go:1472
-#: lxc/auth.go:1524 lxc/auth.go:1573 lxc/auth.go:1692 lxc/auth.go:1752
-#: lxc/auth.go:1801 lxc/auth.go:1852 lxc/auth.go:1875 lxc/auth.go:1928
+#: lxc/alias.go:214 lxc/auth.go:31 lxc/auth.go:60 lxc/auth.go:99
+#: lxc/auth.go:153 lxc/auth.go:202 lxc/auth.go:333 lxc/auth.go:393
+#: lxc/auth.go:442 lxc/auth.go:494 lxc/auth.go:517 lxc/auth.go:576
+#: lxc/auth.go:732 lxc/auth.go:766 lxc/auth.go:833 lxc/auth.go:896
+#: lxc/auth.go:957 lxc/auth.go:1085 lxc/auth.go:1108 lxc/auth.go:1166
+#: lxc/auth.go:1235 lxc/auth.go:1257 lxc/auth.go:1435 lxc/auth.go:1473
+#: lxc/auth.go:1525 lxc/auth.go:1574 lxc/auth.go:1693 lxc/auth.go:1753
+#: lxc/auth.go:1802 lxc/auth.go:1853 lxc/auth.go:1876 lxc/auth.go:1929
 #: lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215 lxc/cluster.go:272
 #: lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:484 lxc/cluster.go:528
 #: lxc/cluster.go:586 lxc/cluster.go:677 lxc/cluster.go:770 lxc/cluster.go:893
@@ -1665,15 +1665,15 @@ msgstr ""
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:83 lxc/file.go:123 lxc/file.go:172
-#: lxc/file.go:242 lxc/file.go:467 lxc/file.go:986 lxc/image.go:38
+#: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
+#: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
 #: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
 #: lxc/image.go:697 lxc/image.go:946 lxc/image.go:1088 lxc/image.go:1415
 #: lxc/image.go:1506 lxc/image.go:1572 lxc/image.go:1636 lxc/image.go:1699
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:38 lxc/network.go:33
+#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33
 #: lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405
 #: lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793
 #: lxc/network.go:874 lxc/network.go:1005 lxc/network.go:1106
@@ -1707,27 +1707,27 @@ msgstr ""
 #: lxc/network_zone.go:909 lxc/network_zone.go:985 lxc/network_zone.go:1083
 #: lxc/network_zone.go:1172 lxc/network_zone.go:1219 lxc/network_zone.go:1349
 #: lxc/network_zone.go:1410 lxc/network_zone.go:1425 lxc/network_zone.go:1483
-#: lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:106
-#: lxc/operation.go:193 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
+#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
+#: lxc/operation.go:194 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
 #: lxc/profile.go:271 lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493
 #: lxc/profile.go:629 lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860
-#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:29
-#: lxc/project.go:93 lxc/project.go:189 lxc/project.go:260 lxc/project.go:396
-#: lxc/project.go:470 lxc/project.go:590 lxc/project.go:655 lxc/project.go:743
-#: lxc/project.go:787 lxc/project.go:848 lxc/project.go:915 lxc/publish.go:34
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:35 lxc/remote.go:91
+#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:30
+#: lxc/project.go:94 lxc/project.go:190 lxc/project.go:261 lxc/project.go:397
+#: lxc/project.go:471 lxc/project.go:591 lxc/project.go:656 lxc/project.go:744
+#: lxc/project.go:788 lxc/project.go:849 lxc/project.go:916 lxc/publish.go:34
+#: lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91
 #: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853
 #: lxc/remote.go:917 lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24
 #: lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203
 #: lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655
 #: lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940
-#: lxc/storage_bucket.go:29 lxc/storage_bucket.go:83 lxc/storage_bucket.go:188
-#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:382
-#: lxc/storage_bucket.go:458 lxc/storage_bucket.go:535
-#: lxc/storage_bucket.go:629 lxc/storage_bucket.go:698
-#: lxc/storage_bucket.go:732 lxc/storage_bucket.go:773
-#: lxc/storage_bucket.go:852 lxc/storage_bucket.go:958
-#: lxc/storage_bucket.go:1022 lxc/storage_bucket.go:1157
+#: lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189
+#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:383
+#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:536
+#: lxc/storage_bucket.go:630 lxc/storage_bucket.go:699
+#: lxc/storage_bucket.go:733 lxc/storage_bucket.go:774
+#: lxc/storage_bucket.go:853 lxc/storage_bucket.go:959
+#: lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158
 #: lxc/storage_volume.go:58 lxc/storage_volume.go:169 lxc/storage_volume.go:283
 #: lxc/storage_volume.go:390 lxc/storage_volume.go:605
 #: lxc/storage_volume.go:714 lxc/storage_volume.go:801
@@ -1738,8 +1738,8 @@ msgstr ""
 #: lxc/storage_volume.go:2064 lxc/storage_volume.go:2222
 #: lxc/storage_volume.go:2343 lxc/storage_volume.go:2405
 #: lxc/storage_volume.go:2541 lxc/storage_volume.go:2624
-#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:29
-#: lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
+#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:30
+#: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
@@ -1826,7 +1826,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:994
+#: lxc/file.go:995
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1892,7 +1892,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:74
+#: lxc/file.go:75
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1902,7 +1902,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:955 lxc/auth.go:956
+#: lxc/auth.go:956 lxc/auth.go:957
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1910,15 +1910,15 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:171 lxc/file.go:172
+#: lxc/file.go:172 lxc/file.go:173
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/auth.go:200 lxc/auth.go:201
+#: lxc/auth.go:201 lxc/auth.go:202
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1572 lxc/auth.go:1573
+#: lxc/auth.go:1573 lxc/auth.go:1574
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -1974,15 +1974,15 @@ msgstr ""
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:259 lxc/project.go:260
+#: lxc/project.go:260 lxc/project.go:261
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:248 lxc/storage_bucket.go:249
+#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:250
 msgid "Edit storage bucket configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:1021 lxc/storage_bucket.go:1022
+#: lxc/storage_bucket.go:1022 lxc/storage_bucket.go:1023
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
@@ -1999,7 +1999,7 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1147 lxc/list.go:622 lxc/storage_volume.go:1766
-#: lxc/warning.go:235
+#: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2054,7 +2054,7 @@ msgstr ""
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
-#: lxc/project.go:718 lxc/storage.go:812 lxc/storage_bucket.go:602
+#: lxc/project.go:719 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2155 lxc/storage_volume.go:2193
 #, c-format
 msgid "Error setting properties: %v"
@@ -2068,8 +2068,8 @@ msgstr ""
 #: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
-#: lxc/profile.go:981 lxc/project.go:712 lxc/storage.go:806
-#: lxc/storage_bucket.go:596 lxc/storage_volume.go:2149
+#: lxc/profile.go:981 lxc/project.go:713 lxc/storage.go:806
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2149
 #: lxc/storage_volume.go:2187
 #, c-format
 msgid "Error unsetting property: %v"
@@ -2089,7 +2089,7 @@ msgstr ""
 msgid "Evacuating cluster member: %s"
 msgstr ""
 
-#: lxc/monitor.go:50
+#: lxc/monitor.go:51
 msgid "Event type to listen for"
 msgstr ""
 
@@ -2176,16 +2176,16 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/warning.go:210
+#: lxc/warning.go:211
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1237
+#: lxc/file.go:1238
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1260
+#: lxc/file.go:1261
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2200,12 +2200,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1287
+#: lxc/file.go:1288
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1072
+#: lxc/file.go:1073
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2235,7 +2235,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1193
+#: lxc/file.go:1194
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2250,7 +2250,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1198
+#: lxc/file.go:1199
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2260,12 +2260,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1098
+#: lxc/file.go:1099
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1225
+#: lxc/file.go:1226
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2304,7 +2304,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1210
+#: lxc/file.go:1211
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2319,7 +2319,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:820
+#: lxc/file.go:821
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2334,7 +2334,7 @@ msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
 #: lxc/network.go:1044 lxc/network_acl.go:133 lxc/network_zone.go:124
-#: lxc/operation.go:136
+#: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
 
@@ -2399,21 +2399,21 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
+#: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:770 lxc/auth.go:1697
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1114 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:57
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
-#: lxc/operation.go:108 lxc/profile.go:707 lxc/project.go:472
-#: lxc/project.go:917 lxc/remote.go:690 lxc/storage.go:657
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:774
-#: lxc/storage_volume.go:1608 lxc/warning.go:93
+#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:473
+#: lxc/project.go:918 lxc/remote.go:690 lxc/storage.go:657
+#: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
+#: lxc/storage_volume.go:1608 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
-#: lxc/monitor.go:52
+#: lxc/monitor.go:53
 msgid "Format (json|pretty|yaml)"
 msgstr ""
 
@@ -2457,7 +2457,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:817 lxc/auth.go:1736
+#: lxc/auth.go:818 lxc/auth.go:1737
 msgid "GROUPS"
 msgstr ""
 
@@ -2473,7 +2473,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:914 lxc/project.go:915
+#: lxc/project.go:915 lxc/project.go:916
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2521,11 +2521,11 @@ msgstr ""
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:400
+#: lxc/project.go:401
 msgid "Get the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:385
+#: lxc/storage_bucket.go:386
 msgid "Get the key as a storage bucket property"
 msgstr ""
 
@@ -2585,11 +2585,11 @@ msgstr ""
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:395 lxc/project.go:396
+#: lxc/project.go:396 lxc/project.go:397
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:382
+#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:383
 msgid "Get values for storage bucket configuration keys"
 msgstr ""
 
@@ -2606,17 +2606,17 @@ msgstr ""
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: lxc/auth.go:136
+#: lxc/auth.go:137
 #, c-format
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:186
+#: lxc/auth.go:187
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:426 lxc/auth.go:1786
+#: lxc/auth.go:427 lxc/auth.go:1787
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2641,27 +2641,27 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1310
+#: lxc/file.go:1311
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1299
+#: lxc/file.go:1300
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1122
+#: lxc/file.go:1123
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1132
+#: lxc/file.go:1133
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:966 lxc/operation.go:170
+#: lxc/network.go:966 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2675,11 +2675,11 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:816
+#: lxc/auth.go:817
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:566
+#: lxc/project.go:567
 msgid "IMAGES"
 msgstr ""
 
@@ -2707,17 +2707,17 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1508
+#: lxc/auth.go:1509
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1558
+#: lxc/auth.go:1559
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
 
-#: lxc/rebuild.go:32
+#: lxc/rebuild.go:33
 msgid "If an instance is running, stop it and then rebuild it"
 msgstr ""
 
@@ -2838,7 +2838,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1233 lxc/auth.go:1234
+#: lxc/auth.go:1234 lxc/auth.go:1235
 msgid "Inspect permissions"
 msgstr ""
 
@@ -2846,11 +2846,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1124
+#: lxc/file.go:1125
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1301
+#: lxc/file.go:1302
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2868,7 +2868,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1044
+#: lxc/file.go:1045
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2877,7 +2877,7 @@ msgstr ""
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/rebuild.go:74
+#: lxc/rebuild.go:75
 #, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
@@ -2910,7 +2910,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/monitor.go:70
+#: lxc/monitor.go:71
 #, c-format
 msgid "Invalid format: %s"
 msgstr ""
@@ -2920,7 +2920,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1039
+#: lxc/file.go:1040
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2962,7 +2962,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:147
+#: lxc/file.go:148
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2978,12 +2978,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:313
+#: lxc/file.go:314
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:495
+#: lxc/file.go:496
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2997,7 +2997,7 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/warning.go:212
 msgid "LAST SEEN"
 msgstr ""
 
@@ -3005,7 +3005,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:984
+#: lxc/project.go:985
 msgid "LIMIT"
 msgstr ""
 
@@ -3014,8 +3014,8 @@ msgid "LISTEN ADDRESS"
 msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
-#: lxc/network_load_balancer.go:165 lxc/operation.go:177
-#: lxc/storage_bucket.go:516 lxc/storage_volume.go:1739 lxc/warning.go:220
+#: lxc/network_load_balancer.go:165 lxc/operation.go:178
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1739 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3089,7 +3089,7 @@ msgstr ""
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/warning.go:94
+#: lxc/warning.go:95
 msgid "List all warnings"
 msgstr ""
 
@@ -3133,19 +3133,19 @@ msgstr ""
 msgid "List available storage pools"
 msgstr ""
 
-#: lxc/operation.go:105 lxc/operation.go:106
+#: lxc/operation.go:106 lxc/operation.go:107
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:331 lxc/auth.go:332
+#: lxc/auth.go:332 lxc/auth.go:333
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:764 lxc/auth.go:765
+#: lxc/auth.go:765 lxc/auth.go:766
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1691 lxc/auth.go:1692
+#: lxc/auth.go:1692 lxc/auth.go:1693
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3294,11 +3294,11 @@ msgstr ""
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/operation.go:109
+#: lxc/operation.go:110
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1255 lxc/auth.go:1256
+#: lxc/auth.go:1256 lxc/auth.go:1257
 msgid "List permissions"
 msgstr ""
 
@@ -3306,15 +3306,15 @@ msgstr ""
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:469 lxc/project.go:470
+#: lxc/project.go:470 lxc/project.go:471
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:771 lxc/storage_bucket.go:773
+#: lxc/storage_bucket.go:772 lxc/storage_bucket.go:774
 msgid "List storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:456 lxc/storage_bucket.go:458
+#: lxc/storage_bucket.go:457 lxc/storage_bucket.go:459
 msgid "List storage buckets"
 msgstr ""
 
@@ -3350,11 +3350,11 @@ msgstr ""
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/warning.go:70
+#: lxc/warning.go:71
 msgid "List warnings"
 msgstr ""
 
-#: lxc/warning.go:71
+#: lxc/warning.go:72
 msgid ""
 "List warnings\n"
 "\n"
@@ -3377,7 +3377,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/operation.go:23 lxc/operation.go:24
+#: lxc/operation.go:24 lxc/operation.go:25
 msgid "List, show and delete background operations"
 msgstr ""
 
@@ -3386,7 +3386,7 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/monitor.go:79
+#: lxc/monitor.go:80
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
@@ -3490,23 +3490,23 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:82 lxc/file.go:83
+#: lxc/file.go:83 lxc/file.go:84
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1433 lxc/auth.go:1434
+#: lxc/auth.go:59 lxc/auth.go:60 lxc/auth.go:1434 lxc/auth.go:1435
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1083 lxc/auth.go:1084
+#: lxc/auth.go:1084 lxc/auth.go:1085
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:730 lxc/auth.go:731
+#: lxc/auth.go:731 lxc/auth.go:732
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1851 lxc/auth.go:1852
+#: lxc/auth.go:1852 lxc/auth.go:1853
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3597,7 +3597,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:492 lxc/auth.go:493
+#: lxc/auth.go:493 lxc/auth.go:494
 msgid "Manage permissions"
 msgstr ""
 
@@ -3605,23 +3605,23 @@ msgstr ""
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:28 lxc/project.go:29
+#: lxc/project.go:29 lxc/project.go:30
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:731
+#: lxc/storage_bucket.go:732
 msgid "Manage storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:732
+#: lxc/storage_bucket.go:733
 msgid "Manage storage bucket keys."
 msgstr ""
 
-#: lxc/storage_bucket.go:28
+#: lxc/storage_bucket.go:29
 msgid "Manage storage buckets"
 msgstr ""
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:30
 msgid "Manage storage buckets."
 msgstr ""
 
@@ -3649,11 +3649,11 @@ msgstr ""
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/auth.go:29 lxc/auth.go:30
+#: lxc/auth.go:30 lxc/auth.go:31
 msgid "Manage user authorization"
 msgstr ""
 
-#: lxc/warning.go:28 lxc/warning.go:29
+#: lxc/warning.go:29 lxc/warning.go:30
 msgid "Manage warnings"
 msgstr ""
 
@@ -3717,17 +3717,17 @@ msgstr ""
 msgid "Migration operation failure: %w"
 msgstr ""
 
-#: lxc/monitor.go:51
+#: lxc/monitor.go:52
 msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: lxc/storage_bucket.go:116 lxc/storage_bucket.go:216
-#: lxc/storage_bucket.go:292 lxc/storage_bucket.go:411
-#: lxc/storage_bucket.go:568 lxc/storage_bucket.go:660
-#: lxc/storage_bucket.go:802 lxc/storage_bucket.go:889
-#: lxc/storage_bucket.go:986 lxc/storage_bucket.go:1065
-#: lxc/storage_bucket.go:1188
+#: lxc/storage_bucket.go:117 lxc/storage_bucket.go:217
+#: lxc/storage_bucket.go:293 lxc/storage_bucket.go:412
+#: lxc/storage_bucket.go:569 lxc/storage_bucket.go:661
+#: lxc/storage_bucket.go:803 lxc/storage_bucket.go:890
+#: lxc/storage_bucket.go:987 lxc/storage_bucket.go:1066
+#: lxc/storage_bucket.go:1189
 msgid "Missing bucket name"
 msgstr ""
 
@@ -3746,20 +3746,20 @@ msgstr ""
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1825
+#: lxc/auth.go:123 lxc/auth.go:177 lxc/auth.go:255 lxc/auth.go:417
+#: lxc/auth.go:466 lxc/auth.go:541 lxc/auth.go:600 lxc/auth.go:1826
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:862 lxc/auth.go:1003 lxc/auth.go:1131 lxc/auth.go:1189
+#: lxc/auth.go:863 lxc/auth.go:1004 lxc/auth.go:1132 lxc/auth.go:1190
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1495 lxc/auth.go:1548 lxc/auth.go:1614 lxc/auth.go:1776
+#: lxc/auth.go:1496 lxc/auth.go:1549 lxc/auth.go:1615 lxc/auth.go:1777
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1899 lxc/auth.go:1952
+#: lxc/auth.go:1900 lxc/auth.go:1953
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -3767,12 +3767,12 @@ msgstr ""
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
 #: lxc/config_template.go:377 lxc/profile.go:141 lxc/profile.go:222
-#: lxc/profile.go:808 lxc/rebuild.go:60
+#: lxc/profile.go:808 lxc/rebuild.go:61
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/storage_bucket.go:893 lxc/storage_bucket.go:990
-#: lxc/storage_bucket.go:1069 lxc/storage_bucket.go:1192
+#: lxc/storage_bucket.go:894 lxc/storage_bucket.go:991
+#: lxc/storage_bucket.go:1070 lxc/storage_bucket.go:1193
 msgid "Missing key name"
 msgstr ""
 
@@ -3837,13 +3837,13 @@ msgid "Missing peer name"
 msgstr ""
 
 #: lxc/storage.go:235 lxc/storage.go:313 lxc/storage.go:431 lxc/storage.go:509
-#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:112
-#: lxc/storage_bucket.go:212 lxc/storage_bucket.go:288
-#: lxc/storage_bucket.go:407 lxc/storage_bucket.go:482
-#: lxc/storage_bucket.go:564 lxc/storage_bucket.go:656
-#: lxc/storage_bucket.go:798 lxc/storage_bucket.go:885
-#: lxc/storage_bucket.go:982 lxc/storage_bucket.go:1061
-#: lxc/storage_bucket.go:1184 lxc/storage_volume.go:209
+#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:113
+#: lxc/storage_bucket.go:213 lxc/storage_bucket.go:289
+#: lxc/storage_bucket.go:408 lxc/storage_bucket.go:483
+#: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
+#: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
+#: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
 #: lxc/storage_volume.go:323 lxc/storage_volume.go:643
 #: lxc/storage_volume.go:750 lxc/storage_volume.go:841
 #: lxc/storage_volume.go:939 lxc/storage_volume.go:1053
@@ -3858,9 +3858,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:404 lxc/project.go:146 lxc/project.go:226 lxc/project.go:316
-#: lxc/project.go:433 lxc/project.go:622 lxc/project.go:691 lxc/project.go:819
-#: lxc/project.go:948
+#: lxc/profile.go:404 lxc/project.go:147 lxc/project.go:227 lxc/project.go:317
+#: lxc/project.go:434 lxc/project.go:623 lxc/project.go:692 lxc/project.go:820
+#: lxc/project.go:949
 msgid "Missing project name"
 msgstr ""
 
@@ -3876,7 +3876,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:598
+#: lxc/file.go:599
 msgid "Missing target directory"
 msgstr ""
 
@@ -3898,11 +3898,11 @@ msgstr ""
 msgid "Model: %v"
 msgstr ""
 
-#: lxc/monitor.go:32
+#: lxc/monitor.go:33
 msgid "Monitor a local or remote LXD server"
 msgstr ""
 
-#: lxc/monitor.go:33
+#: lxc/monitor.go:34
 msgid ""
 "Monitor a local or remote LXD server\n"
 "\n"
@@ -3914,11 +3914,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:285
+#: lxc/file.go:286
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:985 lxc/file.go:986
+#: lxc/file.go:986 lxc/file.go:987
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3980,13 +3980,13 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:192
+#: lxc/auth.go:376 lxc/auth.go:816 lxc/auth.go:1736 lxc/cluster.go:192
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
-#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:565
-#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:511
-#: lxc/storage_bucket.go:831 lxc/storage_volume.go:1731
+#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:566
+#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1731
 msgid "NAME"
 msgstr ""
 
@@ -3994,11 +3994,11 @@ msgstr ""
 msgid "NAT"
 msgstr ""
 
-#: lxc/project.go:571
+#: lxc/project.go:572
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:570
+#: lxc/project.go:571
 msgid "NETWORKS"
 msgstr ""
 
@@ -4010,9 +4010,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/operation.go:154 lxc/project.go:523
-#: lxc/project.go:528 lxc/project.go:533 lxc/project.go:538 lxc/project.go:543
-#: lxc/project.go:548 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
+#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:524
+#: lxc/project.go:529 lxc/project.go:534 lxc/project.go:539 lxc/project.go:544
+#: lxc/project.go:549 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
 msgid "NO"
 msgstr ""
 
@@ -4257,7 +4257,7 @@ msgstr ""
 msgid "Only managed networks can be modified"
 msgstr ""
 
-#: lxc/operation.go:86
+#: lxc/operation.go:87
 #, c-format
 msgid "Operation %s deleted"
 msgstr ""
@@ -4304,11 +4304,11 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:567
+#: lxc/list.go:576 lxc/project.go:568
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:212
+#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4370,24 +4370,24 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1102
+#: lxc/file.go:1103
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:860
+#: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
-#: lxc/project.go:363 lxc/storage.go:360 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1151
+#: lxc/project.go:364 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1151
 #: lxc/storage_volume.go:1183
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
-#: lxc/monitor.go:48
+#: lxc/monitor.go:49
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
@@ -4473,17 +4473,17 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:172
+#: lxc/project.go:173
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:236
+#: lxc/project.go:237
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:637
+#: lxc/project.go:638
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -4604,20 +4604,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:241 lxc/file.go:242
+#: lxc/file.go:242 lxc/file.go:243
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:416 lxc/file.go:767
+#: lxc/file.go:417 lxc/file.go:768
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:466 lxc/file.go:467
+#: lxc/file.go:467 lxc/file.go:468
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:701 lxc/file.go:867
+#: lxc/file.go:702 lxc/file.go:868
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4630,11 +4630,11 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:983
+#: lxc/project.go:984
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/storage_bucket.go:833
+#: lxc/storage_bucket.go:834
 msgid "ROLE"
 msgstr ""
 
@@ -4647,15 +4647,15 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/rebuild.go:31
+#: lxc/rebuild.go:32
 msgid "Rebuild as an empty instance"
 msgstr ""
 
-#: lxc/rebuild.go:26
+#: lxc/rebuild.go:27
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:249 lxc/file.go:473
+#: lxc/file.go:250 lxc/file.go:474
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4682,7 +4682,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:882 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
+#: lxc/project.go:883 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
 #: lxc/remote.go:994
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4733,7 +4733,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1164 lxc/auth.go:1165
+#: lxc/auth.go:1165 lxc/auth.go:1166
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4769,7 +4769,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1927 lxc/auth.go:1928
+#: lxc/auth.go:1928 lxc/auth.go:1929
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4781,7 +4781,7 @@ msgstr ""
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:574 lxc/auth.go:575
+#: lxc/auth.go:575 lxc/auth.go:576
 msgid "Remove permissions from groups"
 msgstr ""
 
@@ -4826,11 +4826,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:391 lxc/auth.go:392
+#: lxc/auth.go:392 lxc/auth.go:393
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1751 lxc/auth.go:1752
+#: lxc/auth.go:1752 lxc/auth.go:1753
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -4850,7 +4850,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:589 lxc/project.go:590
+#: lxc/project.go:590 lxc/project.go:591
 msgid "Rename projects"
 msgstr ""
 
@@ -4948,7 +4948,7 @@ msgstr ""
 msgid "Revoke cluster member join token"
 msgstr ""
 
-#: lxc/storage_bucket.go:862
+#: lxc/storage_bucket.go:863
 msgid "Role (admin or read-only)"
 msgstr ""
 
@@ -4964,7 +4964,7 @@ msgstr ""
 msgid "Run against all projects"
 msgstr ""
 
-#: lxc/warning.go:213
+#: lxc/warning.go:214
 msgid "SEVERITY"
 msgstr ""
 
@@ -4984,12 +4984,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1231
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1231
+#: lxc/file.go:1232
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5003,11 +5003,11 @@ msgstr ""
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:173 lxc/warning.go:214
+#: lxc/operation.go:174 lxc/warning.go:215
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:569
+#: lxc/project.go:570
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5015,7 +5015,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:569
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -5023,11 +5023,11 @@ msgstr ""
 msgid "STP"
 msgstr ""
 
-#: lxc/storage_bucket.go:864
+#: lxc/storage_bucket.go:865
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:942
+#: lxc/storage_bucket.go:943
 #, c-format
 msgid "Secret key: %s"
 msgstr ""
@@ -5065,7 +5065,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:995
+#: lxc/file.go:996
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5203,11 +5203,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:654
+#: lxc/project.go:655
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:655
+#: lxc/project.go:656
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5216,11 +5216,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage_bucket.go:534
+#: lxc/storage_bucket.go:535
 msgid "Set storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:535
+#: lxc/storage_bucket.go:536
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -5259,15 +5259,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:476
+#: lxc/file.go:477
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:477
+#: lxc/file.go:478
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:475
+#: lxc/file.go:476
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5307,11 +5307,11 @@ msgstr ""
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 msgid "Set the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:542
+#: lxc/storage_bucket.go:543
 msgid "Set the key as a storage bucket property"
 msgstr ""
 
@@ -5327,7 +5327,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:993
+#: lxc/file.go:994
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5339,7 +5339,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1800 lxc/auth.go:1801
+#: lxc/auth.go:1801 lxc/auth.go:1802
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5355,11 +5355,11 @@ msgstr ""
 msgid "Show details of a cluster member"
 msgstr ""
 
-#: lxc/operation.go:192 lxc/operation.go:193
+#: lxc/operation.go:193 lxc/operation.go:194
 msgid "Show details on a background operation"
 msgstr ""
 
-#: lxc/monitor.go:49
+#: lxc/monitor.go:50
 msgid "Show events from all projects"
 msgstr ""
 
@@ -5367,11 +5367,11 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:440 lxc/auth.go:441
+#: lxc/auth.go:441 lxc/auth.go:442
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:832
+#: lxc/auth.go:833
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5452,15 +5452,15 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:786 lxc/project.go:787
+#: lxc/project.go:787 lxc/project.go:788
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage_bucket.go:628 lxc/storage_bucket.go:629
+#: lxc/storage_bucket.go:629 lxc/storage_bucket.go:630
 msgid "Show storage bucket configurations"
 msgstr ""
 
-#: lxc/storage_bucket.go:1156 lxc/storage_bucket.go:1157
+#: lxc/storage_bucket.go:1157 lxc/storage_bucket.go:1158
 msgid "Show storage bucket key configurations"
 msgstr ""
 
@@ -5476,7 +5476,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:895
+#: lxc/auth.go:896
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5526,7 +5526,7 @@ msgstr ""
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: lxc/warning.go:302 lxc/warning.go:303
+#: lxc/warning.go:303 lxc/warning.go:304
 msgid "Show warning"
 msgstr ""
 
@@ -5610,22 +5610,22 @@ msgstr ""
 msgid "Stopping the instance failed: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:166
+#: lxc/storage_bucket.go:167
 #, c-format
 msgid "Storage bucket %s created"
 msgstr ""
 
-#: lxc/storage_bucket.go:233
+#: lxc/storage_bucket.go:234
 #, c-format
 msgid "Storage bucket %s deleted"
 msgstr ""
 
-#: lxc/storage_bucket.go:940
+#: lxc/storage_bucket.go:941
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr ""
 
-#: lxc/storage_bucket.go:1006
+#: lxc/storage_bucket.go:1007
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr ""
@@ -5694,7 +5694,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:847 lxc/project.go:848
+#: lxc/project.go:848 lxc/project.go:849
 msgid "Switch the current project"
 msgstr ""
 
@@ -5710,10 +5710,10 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1139
+#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1139
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
-#: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:171
-#: lxc/storage_volume.go:1730 lxc/warning.go:215
+#: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
+#: lxc/storage_volume.go:1730 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
@@ -5721,11 +5721,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1032
+#: lxc/file.go:1033
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1026
+#: lxc/file.go:1027
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5853,12 +5853,12 @@ msgstr ""
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:446
+#: lxc/project.go:447
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
 
-#: lxc/storage_bucket.go:431
+#: lxc/storage_bucket.go:432
 #, c-format
 msgid "The property %q does not exist on the storage bucket %q: %v"
 msgstr ""
@@ -6043,7 +6043,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:961
+#: lxc/project.go:962
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6055,17 +6055,17 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:985 lxc/storage_volume.go:1735
+#: lxc/project.go:986 lxc/storage_volume.go:1735
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:573
+#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:574
 #: lxc/storage.go:724 lxc/storage_volume.go:1734
 msgid "USED BY"
 msgstr ""
 
-#: lxc/warning.go:216
+#: lxc/warning.go:217
 msgid "UUID"
 msgstr ""
 
@@ -6074,7 +6074,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:197
+#: lxc/file.go:198
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6088,13 +6088,13 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1253
+#: lxc/file.go:1254
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1153 lxc/list.go:631 lxc/storage_volume.go:1772
-#: lxc/warning.go:241
+#: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6104,7 +6104,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:807
+#: lxc/file.go:808
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6187,11 +6187,11 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:742 lxc/project.go:743
+#: lxc/project.go:743 lxc/project.go:744
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:697 lxc/storage_bucket.go:698
+#: lxc/storage_bucket.go:698 lxc/storage_bucket.go:699
 msgid "Unset storage bucket configuration keys"
 msgstr ""
 
@@ -6239,11 +6239,11 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:747
+#: lxc/project.go:748
 msgid "Unset the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:701
+#: lxc/storage_bucket.go:702
 msgid "Unset the key as a storage bucket property"
 msgstr ""
 
@@ -6322,7 +6322,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:71
+#: lxc/file.go:72
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6359,11 +6359,11 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:831
+#: lxc/auth.go:832
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:894
+#: lxc/auth.go:895
 msgid "View the current identity"
 msgstr ""
 
@@ -6394,15 +6394,15 @@ msgstr ""
 msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
-#: lxc/rebuild.go:27
+#: lxc/rebuild.go:28
 msgid ""
 "Wipe the instance root disk and re-initialize. The original image is used to "
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:156 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
+#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:526
+#: lxc/project.go:531 lxc/project.go:536 lxc/project.go:541 lxc/project.go:546
+#: lxc/project.go:551 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
 msgid "YES"
 msgstr ""
 
@@ -6422,7 +6422,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/rebuild.go:119
+#: lxc/rebuild.go:120
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
@@ -6434,12 +6434,12 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1689
+#: lxc/auth.go:330 lxc/auth.go:763 lxc/auth.go:894 lxc/auth.go:1690
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
-#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
+#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
-#: lxc/operation.go:103 lxc/profile.go:700 lxc/project.go:467
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:68
+#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:468
+#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6467,7 +6467,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1254
+#: lxc/auth.go:1255
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6528,11 +6528,11 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:830
+#: lxc/auth.go:831
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1926
+#: lxc/auth.go:1106 lxc/auth.go:1164 lxc/auth.go:1927
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6540,13 +6540,13 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:954 lxc/auth.go:1470 lxc/cluster_group.go:168
+#: lxc/auth.go:97 lxc/auth.go:150 lxc/auth.go:200 lxc/auth.go:440
+#: lxc/auth.go:955 lxc/auth.go:1471 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:514 lxc/auth.go:572
+#: lxc/auth.go:515 lxc/auth.go:573
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
@@ -6556,19 +6556,19 @@ msgstr ""
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:389
+#: lxc/auth.go:390
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1521 lxc/auth.go:1571 lxc/auth.go:1799
+#: lxc/auth.go:1522 lxc/auth.go:1572 lxc/auth.go:1800
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1873
+#: lxc/auth.go:1874
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1749
+#: lxc/auth.go:1750
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -6588,7 +6588,7 @@ msgstr ""
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
-#: lxc/rebuild.go:25
+#: lxc/rebuild.go:26
 msgid "[<remote>:]<image> [<remote>:]<instance>"
 msgstr ""
 
@@ -6671,20 +6671,20 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:170
+#: lxc/file.go:171
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:120
+#: lxc/file.go:121
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:240
+#: lxc/file.go:241
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:984
+#: lxc/file.go:985
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6835,12 +6835,12 @@ msgstr ""
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
-#: lxc/operation.go:53 lxc/operation.go:191
+#: lxc/operation.go:54 lxc/operation.go:192
 msgid "[<remote>:]<operation>"
 msgstr ""
 
 #: lxc/storage.go:200 lxc/storage.go:259 lxc/storage.go:473 lxc/storage.go:844
-#: lxc/storage_bucket.go:454
+#: lxc/storage_bucket.go:455
 msgid "[<remote>:]<pool>"
 msgstr ""
 
@@ -6848,22 +6848,22 @@ msgstr ""
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
-#: lxc/storage_bucket.go:185 lxc/storage_bucket.go:247
-#: lxc/storage_bucket.go:627 lxc/storage_bucket.go:769
+#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:248
+#: lxc/storage_bucket.go:628 lxc/storage_bucket.go:770
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
 
-#: lxc/storage_bucket.go:380 lxc/storage_bucket.go:696
-#: lxc/storage_bucket.go:850 lxc/storage_bucket.go:956
-#: lxc/storage_bucket.go:1020 lxc/storage_bucket.go:1155
+#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:697
+#: lxc/storage_bucket.go:851 lxc/storage_bucket.go:957
+#: lxc/storage_bucket.go:1021 lxc/storage_bucket.go:1156
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
 
-#: lxc/storage_bucket.go:533
+#: lxc/storage_bucket.go:534
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_bucket.go:81
+#: lxc/storage_bucket.go:82
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
 
@@ -6978,20 +6978,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:91 lxc/project.go:186 lxc/project.go:258 lxc/project.go:785
-#: lxc/project.go:846 lxc/project.go:913
+#: lxc/project.go:92 lxc/project.go:187 lxc/project.go:259 lxc/project.go:786
+#: lxc/project.go:847 lxc/project.go:914
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:394 lxc/project.go:741
+#: lxc/project.go:395 lxc/project.go:742
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:653
+#: lxc/project.go:654
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:587
+#: lxc/project.go:588
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -6999,7 +6999,7 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:259 lxc/warning.go:301 lxc/warning.go:354
+#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
@@ -7055,7 +7055,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:555 lxc/remote.go:739
+#: lxc/project.go:556 lxc/remote.go:739
 msgid "current"
 msgstr ""
 
@@ -7102,20 +7102,20 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/auth.go:203
+#: lxc/auth.go:204
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:958
+#: lxc/auth.go:959
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1575
+#: lxc/auth.go:1576
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7193,20 +7193,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:988
+#: lxc/file.go:989
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:244
+#: lxc/file.go:245
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:470
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7288,7 +7288,7 @@ msgid ""
 "  List instances with their running state and user comment."
 msgstr ""
 
-#: lxc/monitor.go:37
+#: lxc/monitor.go:38
 msgid ""
 "lxc monitor --type=logging\n"
 "    Only show log messages.\n"
@@ -7364,7 +7364,7 @@ msgid ""
 "    Create record r1 for zone z1 with configuration from config.yaml"
 msgstr ""
 
-#: lxc/operation.go:195
+#: lxc/operation.go:196
 msgid ""
 "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Show details on that operation UUID"
@@ -7407,7 +7407,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:95
+#: lxc/project.go:96
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7415,7 +7415,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:262
+#: lxc/project.go:263
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7446,7 +7446,7 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:85
 msgid ""
 "lxc storage bucket create p1 b01\n"
 "\tCreate a new storage bucket name b01 in storage pool p1\n"
@@ -7456,19 +7456,19 @@ msgid ""
 "of config.yaml"
 msgstr ""
 
-#: lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:251
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1023
+#: lxc/storage_bucket.go:1024
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:854
 msgid ""
 "lxc storage bucket key create p1 b01 k1\n"
 "\tCreate a key called k1 for the bucket b01 in the pool p1.\n"
@@ -7478,14 +7478,14 @@ msgid ""
 "of config.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1158
+#: lxc/storage_bucket.go:1159
 msgid ""
 "lxc storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_bucket.go:630
+#: lxc/storage_bucket.go:631
 msgid ""
 "lxc storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
@@ -7555,16 +7555,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1142
+#: lxc/file.go:1143
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1101
+#: lxc/file.go:1102
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1054
+#: lxc/file.go:1055
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/ber.po
+++ b/po/ber.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-04 08:52-0600\n"
+"POT-Creation-Date: 2024-09-05 08:44-0400\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Berber <https://hosted.weblate.org/projects/linux-containers/"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: lxc/storage_bucket.go:260 lxc/storage_bucket.go:1033
+#: lxc/storage_bucket.go:261 lxc/storage_bucket.go:1034
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -133,7 +133,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:213
+#: lxc/auth.go:214
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -160,7 +160,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:968
+#: lxc/auth.go:969
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -181,7 +181,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1585
+#: lxc/auth.go:1586
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -391,7 +391,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:280
+#: lxc/project.go:281
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -433,12 +433,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:935
+#: lxc/file.go:936
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:825
+#: lxc/file.go:826
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -474,7 +474,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:142 lxc/rebuild.go:64
+#: lxc/init.go:142 lxc/rebuild.go:65
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -527,7 +527,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:465
+#: lxc/file.go:466
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -560,7 +560,7 @@ msgstr ""
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:813
+#: lxc/auth.go:814
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -568,11 +568,11 @@ msgstr ""
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/storage_bucket.go:863
+#: lxc/storage_bucket.go:864
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:941
+#: lxc/storage_bucket.go:942
 #, c-format
 msgid "Access key: %s"
 msgstr ""
@@ -581,7 +581,7 @@ msgstr ""
 msgid "Access the expanded configuration"
 msgstr ""
 
-#: lxc/warning.go:261 lxc/warning.go:262
+#: lxc/warning.go:262 lxc/warning.go:263
 msgid "Acknowledge warning"
 msgstr ""
 
@@ -598,11 +598,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1106 lxc/auth.go:1107
+#: lxc/auth.go:1107 lxc/auth.go:1108
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1874 lxc/auth.go:1875
+#: lxc/auth.go:1875 lxc/auth.go:1876
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -671,7 +671,7 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:515 lxc/auth.go:516
+#: lxc/auth.go:516 lxc/auth.go:517
 msgid "Add permissions to groups"
 msgstr ""
 
@@ -700,7 +700,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:169
+#: lxc/storage_bucket.go:170
 #, c-format
 msgid "Admin access key: %s"
 msgstr ""
@@ -710,7 +710,7 @@ msgstr ""
 msgid "Admin password (or token) for %s:"
 msgstr ""
 
-#: lxc/storage_bucket.go:170
+#: lxc/storage_bucket.go:171
 #, c-format
 msgid "Admin secret key: %s"
 msgstr ""
@@ -769,7 +769,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:342 lxc/rebuild.go:130
+#: lxc/init.go:342 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -869,12 +869,12 @@ msgstr ""
 
 #: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:318
 #: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
-#: lxc/network_zone.go:366 lxc/network_zone.go:1053 lxc/storage_bucket.go:141
+#: lxc/network_zone.go:366 lxc/network_zone.go:1053 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:159
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:160
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -914,7 +914,7 @@ msgstr ""
 msgid "Bytes sent"
 msgstr ""
 
-#: lxc/operation.go:174
+#: lxc/operation.go:175
 msgid "CANCELABLE"
 msgstr ""
 
@@ -926,7 +926,7 @@ msgstr ""
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: lxc/warning.go:209
+#: lxc/warning.go:210
 msgid "COUNT"
 msgstr ""
 
@@ -952,7 +952,7 @@ msgstr ""
 msgid "CPUs (%s):"
 msgstr ""
 
-#: lxc/operation.go:175
+#: lxc/operation.go:176
 msgid "CREATED"
 msgstr ""
 
@@ -982,7 +982,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:340
+#: lxc/file.go:341
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1007,11 +1007,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:224
+#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:546
+#: lxc/file.go:547
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1020,7 +1020,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:160
+#: lxc/rebuild.go:161
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1143,13 +1143,13 @@ msgstr ""
 #: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
 #: lxc/network_load_balancer.go:1051 lxc/network_load_balancer.go:1125
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
-#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:90
-#: lxc/storage_bucket.go:190 lxc/storage_bucket.go:253
-#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:541
-#: lxc/storage_bucket.go:634 lxc/storage_bucket.go:700
-#: lxc/storage_bucket.go:775 lxc/storage_bucket.go:861
-#: lxc/storage_bucket.go:961 lxc/storage_bucket.go:1026
-#: lxc/storage_bucket.go:1162 lxc/storage_volume.go:394
+#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
+#: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
+#: lxc/storage_bucket.go:385 lxc/storage_bucket.go:542
+#: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
+#: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
+#: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
 #: lxc/storage_volume.go:612 lxc/storage_volume.go:717
 #: lxc/storage_volume.go:1005 lxc/storage_volume.go:1231
 #: lxc/storage_volume.go:1360 lxc/storage_volume.go:1848
@@ -1173,7 +1173,7 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1113 lxc/list.go:132 lxc/storage_volume.go:1589
-#: lxc/warning.go:92
+#: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
@@ -1201,7 +1201,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:100
+#: lxc/project.go:101
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1215,8 +1215,8 @@ msgstr ""
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
-#: lxc/project.go:362 lxc/storage.go:359 lxc/storage_bucket.go:348
-#: lxc/storage_bucket.go:1125 lxc/storage_volume.go:1150
+#: lxc/project.go:363 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1150
 #: lxc/storage_volume.go:1182
 #, c-format
 msgid "Config parsing error: %s"
@@ -1343,12 +1343,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:300 lxc/auth.go:1660
+#: lxc/auth.go:301 lxc/auth.go:1661
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1054
+#: lxc/auth.go:1055
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1397,15 +1397,15 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:248 lxc/file.go:474
+#: lxc/file.go:249 lxc/file.go:475
 msgid "Create any directories necessary"
 msgstr ""
 
-#: lxc/auth.go:97 lxc/auth.go:98
+#: lxc/auth.go:98 lxc/auth.go:99
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1471 lxc/auth.go:1472
+#: lxc/auth.go:1472 lxc/auth.go:1473
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1425,11 +1425,11 @@ msgstr ""
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_bucket.go:851 lxc/storage_bucket.go:852
+#: lxc/storage_bucket.go:852 lxc/storage_bucket.go:853
 msgid "Create key for a storage bucket"
 msgstr ""
 
-#: lxc/storage_bucket.go:82 lxc/storage_bucket.go:83
+#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
 msgid "Create new custom storage buckets"
 msgstr ""
 
@@ -1473,7 +1473,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:92 lxc/project.go:93
+#: lxc/project.go:93 lxc/project.go:94
 msgid "Create projects"
 msgstr ""
 
@@ -1508,13 +1508,13 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:376 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1135 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
-#: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:172
-#: lxc/profile.go:756 lxc/project.go:572 lxc/storage.go:723
-#: lxc/storage_bucket.go:512 lxc/storage_bucket.go:832
+#: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
+#: lxc/profile.go:756 lxc/project.go:573 lxc/storage.go:723
+#: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1732
 msgid "DESCRIPTION"
 msgstr ""
@@ -1539,7 +1539,7 @@ msgstr ""
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
-#: lxc/operation.go:55 lxc/operation.go:56
+#: lxc/operation.go:56 lxc/operation.go:57
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
@@ -1547,19 +1547,19 @@ msgstr ""
 msgid "Delete a cluster group"
 msgstr ""
 
-#: lxc/warning.go:360
+#: lxc/warning.go:361
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:122 lxc/file.go:123
+#: lxc/file.go:123 lxc/file.go:124
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/auth.go:151 lxc/auth.go:152
+#: lxc/auth.go:152 lxc/auth.go:153
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1523 lxc/auth.go:1524
+#: lxc/auth.go:1524 lxc/auth.go:1525
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1579,7 +1579,7 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/storage_bucket.go:957 lxc/storage_bucket.go:958
+#: lxc/storage_bucket.go:958 lxc/storage_bucket.go:959
 msgid "Delete key from a storage bucket"
 msgstr ""
 
@@ -1615,11 +1615,11 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:188 lxc/project.go:189
+#: lxc/project.go:189 lxc/project.go:190
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:187 lxc/storage_bucket.go:188
+#: lxc/storage_bucket.go:188 lxc/storage_bucket.go:189
 msgid "Delete storage buckets"
 msgstr ""
 
@@ -1631,20 +1631,20 @@ msgstr ""
 msgid "Delete storage volumes"
 msgstr ""
 
-#: lxc/warning.go:356 lxc/warning.go:357
+#: lxc/warning.go:357 lxc/warning.go:358
 msgid "Delete warning"
 msgstr ""
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:30 lxc/auth.go:59 lxc/auth.go:98
-#: lxc/auth.go:152 lxc/auth.go:201 lxc/auth.go:332 lxc/auth.go:392
-#: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
-#: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
-#: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
-#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1434 lxc/auth.go:1472
-#: lxc/auth.go:1524 lxc/auth.go:1573 lxc/auth.go:1692 lxc/auth.go:1752
-#: lxc/auth.go:1801 lxc/auth.go:1852 lxc/auth.go:1875 lxc/auth.go:1928
+#: lxc/alias.go:214 lxc/auth.go:31 lxc/auth.go:60 lxc/auth.go:99
+#: lxc/auth.go:153 lxc/auth.go:202 lxc/auth.go:333 lxc/auth.go:393
+#: lxc/auth.go:442 lxc/auth.go:494 lxc/auth.go:517 lxc/auth.go:576
+#: lxc/auth.go:732 lxc/auth.go:766 lxc/auth.go:833 lxc/auth.go:896
+#: lxc/auth.go:957 lxc/auth.go:1085 lxc/auth.go:1108 lxc/auth.go:1166
+#: lxc/auth.go:1235 lxc/auth.go:1257 lxc/auth.go:1435 lxc/auth.go:1473
+#: lxc/auth.go:1525 lxc/auth.go:1574 lxc/auth.go:1693 lxc/auth.go:1753
+#: lxc/auth.go:1802 lxc/auth.go:1853 lxc/auth.go:1876 lxc/auth.go:1929
 #: lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215 lxc/cluster.go:272
 #: lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:484 lxc/cluster.go:528
 #: lxc/cluster.go:586 lxc/cluster.go:677 lxc/cluster.go:770 lxc/cluster.go:893
@@ -1668,15 +1668,15 @@ msgstr ""
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:83 lxc/file.go:123 lxc/file.go:172
-#: lxc/file.go:242 lxc/file.go:467 lxc/file.go:986 lxc/image.go:38
+#: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
+#: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
 #: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
 #: lxc/image.go:697 lxc/image.go:946 lxc/image.go:1088 lxc/image.go:1415
 #: lxc/image.go:1506 lxc/image.go:1572 lxc/image.go:1636 lxc/image.go:1699
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:38 lxc/network.go:33
+#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33
 #: lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405
 #: lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793
 #: lxc/network.go:874 lxc/network.go:1005 lxc/network.go:1106
@@ -1710,27 +1710,27 @@ msgstr ""
 #: lxc/network_zone.go:909 lxc/network_zone.go:985 lxc/network_zone.go:1083
 #: lxc/network_zone.go:1172 lxc/network_zone.go:1219 lxc/network_zone.go:1349
 #: lxc/network_zone.go:1410 lxc/network_zone.go:1425 lxc/network_zone.go:1483
-#: lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:106
-#: lxc/operation.go:193 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
+#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
+#: lxc/operation.go:194 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
 #: lxc/profile.go:271 lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493
 #: lxc/profile.go:629 lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860
-#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:29
-#: lxc/project.go:93 lxc/project.go:189 lxc/project.go:260 lxc/project.go:396
-#: lxc/project.go:470 lxc/project.go:590 lxc/project.go:655 lxc/project.go:743
-#: lxc/project.go:787 lxc/project.go:848 lxc/project.go:915 lxc/publish.go:34
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:35 lxc/remote.go:91
+#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:30
+#: lxc/project.go:94 lxc/project.go:190 lxc/project.go:261 lxc/project.go:397
+#: lxc/project.go:471 lxc/project.go:591 lxc/project.go:656 lxc/project.go:744
+#: lxc/project.go:788 lxc/project.go:849 lxc/project.go:916 lxc/publish.go:34
+#: lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91
 #: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853
 #: lxc/remote.go:917 lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24
 #: lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203
 #: lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655
 #: lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940
-#: lxc/storage_bucket.go:29 lxc/storage_bucket.go:83 lxc/storage_bucket.go:188
-#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:382
-#: lxc/storage_bucket.go:458 lxc/storage_bucket.go:535
-#: lxc/storage_bucket.go:629 lxc/storage_bucket.go:698
-#: lxc/storage_bucket.go:732 lxc/storage_bucket.go:773
-#: lxc/storage_bucket.go:852 lxc/storage_bucket.go:958
-#: lxc/storage_bucket.go:1022 lxc/storage_bucket.go:1157
+#: lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189
+#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:383
+#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:536
+#: lxc/storage_bucket.go:630 lxc/storage_bucket.go:699
+#: lxc/storage_bucket.go:733 lxc/storage_bucket.go:774
+#: lxc/storage_bucket.go:853 lxc/storage_bucket.go:959
+#: lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158
 #: lxc/storage_volume.go:58 lxc/storage_volume.go:169 lxc/storage_volume.go:283
 #: lxc/storage_volume.go:390 lxc/storage_volume.go:605
 #: lxc/storage_volume.go:714 lxc/storage_volume.go:801
@@ -1741,8 +1741,8 @@ msgstr ""
 #: lxc/storage_volume.go:2064 lxc/storage_volume.go:2222
 #: lxc/storage_volume.go:2343 lxc/storage_volume.go:2405
 #: lxc/storage_volume.go:2541 lxc/storage_volume.go:2624
-#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:29
-#: lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
+#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:30
+#: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
@@ -1829,7 +1829,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:994
+#: lxc/file.go:995
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1895,7 +1895,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:74
+#: lxc/file.go:75
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1905,7 +1905,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:955 lxc/auth.go:956
+#: lxc/auth.go:956 lxc/auth.go:957
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1913,15 +1913,15 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:171 lxc/file.go:172
+#: lxc/file.go:172 lxc/file.go:173
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/auth.go:200 lxc/auth.go:201
+#: lxc/auth.go:201 lxc/auth.go:202
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1572 lxc/auth.go:1573
+#: lxc/auth.go:1573 lxc/auth.go:1574
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -1977,15 +1977,15 @@ msgstr ""
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:259 lxc/project.go:260
+#: lxc/project.go:260 lxc/project.go:261
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:248 lxc/storage_bucket.go:249
+#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:250
 msgid "Edit storage bucket configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:1021 lxc/storage_bucket.go:1022
+#: lxc/storage_bucket.go:1022 lxc/storage_bucket.go:1023
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
@@ -2002,7 +2002,7 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1147 lxc/list.go:622 lxc/storage_volume.go:1766
-#: lxc/warning.go:235
+#: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2057,7 +2057,7 @@ msgstr ""
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
-#: lxc/project.go:718 lxc/storage.go:812 lxc/storage_bucket.go:602
+#: lxc/project.go:719 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2155 lxc/storage_volume.go:2193
 #, c-format
 msgid "Error setting properties: %v"
@@ -2071,8 +2071,8 @@ msgstr ""
 #: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
-#: lxc/profile.go:981 lxc/project.go:712 lxc/storage.go:806
-#: lxc/storage_bucket.go:596 lxc/storage_volume.go:2149
+#: lxc/profile.go:981 lxc/project.go:713 lxc/storage.go:806
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2149
 #: lxc/storage_volume.go:2187
 #, c-format
 msgid "Error unsetting property: %v"
@@ -2092,7 +2092,7 @@ msgstr ""
 msgid "Evacuating cluster member: %s"
 msgstr ""
 
-#: lxc/monitor.go:50
+#: lxc/monitor.go:51
 msgid "Event type to listen for"
 msgstr ""
 
@@ -2179,16 +2179,16 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/warning.go:210
+#: lxc/warning.go:211
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1237
+#: lxc/file.go:1238
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1260
+#: lxc/file.go:1261
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2203,12 +2203,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1287
+#: lxc/file.go:1288
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1072
+#: lxc/file.go:1073
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2238,7 +2238,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1193
+#: lxc/file.go:1194
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2253,7 +2253,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1198
+#: lxc/file.go:1199
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2263,12 +2263,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1098
+#: lxc/file.go:1099
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1225
+#: lxc/file.go:1226
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2307,7 +2307,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1210
+#: lxc/file.go:1211
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2322,7 +2322,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:820
+#: lxc/file.go:821
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2337,7 +2337,7 @@ msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
 #: lxc/network.go:1044 lxc/network_acl.go:133 lxc/network_zone.go:124
-#: lxc/operation.go:136
+#: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
 
@@ -2402,21 +2402,21 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
+#: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:770 lxc/auth.go:1697
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1114 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:57
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
-#: lxc/operation.go:108 lxc/profile.go:707 lxc/project.go:472
-#: lxc/project.go:917 lxc/remote.go:690 lxc/storage.go:657
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:774
-#: lxc/storage_volume.go:1608 lxc/warning.go:93
+#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:473
+#: lxc/project.go:918 lxc/remote.go:690 lxc/storage.go:657
+#: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
+#: lxc/storage_volume.go:1608 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
-#: lxc/monitor.go:52
+#: lxc/monitor.go:53
 msgid "Format (json|pretty|yaml)"
 msgstr ""
 
@@ -2460,7 +2460,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:817 lxc/auth.go:1736
+#: lxc/auth.go:818 lxc/auth.go:1737
 msgid "GROUPS"
 msgstr ""
 
@@ -2476,7 +2476,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:914 lxc/project.go:915
+#: lxc/project.go:915 lxc/project.go:916
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2524,11 +2524,11 @@ msgstr ""
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:400
+#: lxc/project.go:401
 msgid "Get the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:385
+#: lxc/storage_bucket.go:386
 msgid "Get the key as a storage bucket property"
 msgstr ""
 
@@ -2588,11 +2588,11 @@ msgstr ""
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:395 lxc/project.go:396
+#: lxc/project.go:396 lxc/project.go:397
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:382
+#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:383
 msgid "Get values for storage bucket configuration keys"
 msgstr ""
 
@@ -2609,17 +2609,17 @@ msgstr ""
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: lxc/auth.go:136
+#: lxc/auth.go:137
 #, c-format
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:186
+#: lxc/auth.go:187
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:426 lxc/auth.go:1786
+#: lxc/auth.go:427 lxc/auth.go:1787
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2644,27 +2644,27 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1310
+#: lxc/file.go:1311
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1299
+#: lxc/file.go:1300
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1122
+#: lxc/file.go:1123
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1132
+#: lxc/file.go:1133
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:966 lxc/operation.go:170
+#: lxc/network.go:966 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2678,11 +2678,11 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:816
+#: lxc/auth.go:817
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:566
+#: lxc/project.go:567
 msgid "IMAGES"
 msgstr ""
 
@@ -2710,17 +2710,17 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1508
+#: lxc/auth.go:1509
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1558
+#: lxc/auth.go:1559
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
 
-#: lxc/rebuild.go:32
+#: lxc/rebuild.go:33
 msgid "If an instance is running, stop it and then rebuild it"
 msgstr ""
 
@@ -2841,7 +2841,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1233 lxc/auth.go:1234
+#: lxc/auth.go:1234 lxc/auth.go:1235
 msgid "Inspect permissions"
 msgstr ""
 
@@ -2849,11 +2849,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1124
+#: lxc/file.go:1125
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1301
+#: lxc/file.go:1302
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2871,7 +2871,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1044
+#: lxc/file.go:1045
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2880,7 +2880,7 @@ msgstr ""
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/rebuild.go:74
+#: lxc/rebuild.go:75
 #, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
@@ -2913,7 +2913,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/monitor.go:70
+#: lxc/monitor.go:71
 #, c-format
 msgid "Invalid format: %s"
 msgstr ""
@@ -2923,7 +2923,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1039
+#: lxc/file.go:1040
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2965,7 +2965,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:147
+#: lxc/file.go:148
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2981,12 +2981,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:313
+#: lxc/file.go:314
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:495
+#: lxc/file.go:496
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3000,7 +3000,7 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/warning.go:212
 msgid "LAST SEEN"
 msgstr ""
 
@@ -3008,7 +3008,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:984
+#: lxc/project.go:985
 msgid "LIMIT"
 msgstr ""
 
@@ -3017,8 +3017,8 @@ msgid "LISTEN ADDRESS"
 msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
-#: lxc/network_load_balancer.go:165 lxc/operation.go:177
-#: lxc/storage_bucket.go:516 lxc/storage_volume.go:1739 lxc/warning.go:220
+#: lxc/network_load_balancer.go:165 lxc/operation.go:178
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1739 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3092,7 +3092,7 @@ msgstr ""
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/warning.go:94
+#: lxc/warning.go:95
 msgid "List all warnings"
 msgstr ""
 
@@ -3136,19 +3136,19 @@ msgstr ""
 msgid "List available storage pools"
 msgstr ""
 
-#: lxc/operation.go:105 lxc/operation.go:106
+#: lxc/operation.go:106 lxc/operation.go:107
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:331 lxc/auth.go:332
+#: lxc/auth.go:332 lxc/auth.go:333
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:764 lxc/auth.go:765
+#: lxc/auth.go:765 lxc/auth.go:766
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1691 lxc/auth.go:1692
+#: lxc/auth.go:1692 lxc/auth.go:1693
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3297,11 +3297,11 @@ msgstr ""
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/operation.go:109
+#: lxc/operation.go:110
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1255 lxc/auth.go:1256
+#: lxc/auth.go:1256 lxc/auth.go:1257
 msgid "List permissions"
 msgstr ""
 
@@ -3309,15 +3309,15 @@ msgstr ""
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:469 lxc/project.go:470
+#: lxc/project.go:470 lxc/project.go:471
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:771 lxc/storage_bucket.go:773
+#: lxc/storage_bucket.go:772 lxc/storage_bucket.go:774
 msgid "List storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:456 lxc/storage_bucket.go:458
+#: lxc/storage_bucket.go:457 lxc/storage_bucket.go:459
 msgid "List storage buckets"
 msgstr ""
 
@@ -3353,11 +3353,11 @@ msgstr ""
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/warning.go:70
+#: lxc/warning.go:71
 msgid "List warnings"
 msgstr ""
 
-#: lxc/warning.go:71
+#: lxc/warning.go:72
 msgid ""
 "List warnings\n"
 "\n"
@@ -3380,7 +3380,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/operation.go:23 lxc/operation.go:24
+#: lxc/operation.go:24 lxc/operation.go:25
 msgid "List, show and delete background operations"
 msgstr ""
 
@@ -3389,7 +3389,7 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/monitor.go:79
+#: lxc/monitor.go:80
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
@@ -3493,23 +3493,23 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:82 lxc/file.go:83
+#: lxc/file.go:83 lxc/file.go:84
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1433 lxc/auth.go:1434
+#: lxc/auth.go:59 lxc/auth.go:60 lxc/auth.go:1434 lxc/auth.go:1435
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1083 lxc/auth.go:1084
+#: lxc/auth.go:1084 lxc/auth.go:1085
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:730 lxc/auth.go:731
+#: lxc/auth.go:731 lxc/auth.go:732
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1851 lxc/auth.go:1852
+#: lxc/auth.go:1852 lxc/auth.go:1853
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3600,7 +3600,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:492 lxc/auth.go:493
+#: lxc/auth.go:493 lxc/auth.go:494
 msgid "Manage permissions"
 msgstr ""
 
@@ -3608,23 +3608,23 @@ msgstr ""
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:28 lxc/project.go:29
+#: lxc/project.go:29 lxc/project.go:30
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:731
+#: lxc/storage_bucket.go:732
 msgid "Manage storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:732
+#: lxc/storage_bucket.go:733
 msgid "Manage storage bucket keys."
 msgstr ""
 
-#: lxc/storage_bucket.go:28
+#: lxc/storage_bucket.go:29
 msgid "Manage storage buckets"
 msgstr ""
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:30
 msgid "Manage storage buckets."
 msgstr ""
 
@@ -3652,11 +3652,11 @@ msgstr ""
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/auth.go:29 lxc/auth.go:30
+#: lxc/auth.go:30 lxc/auth.go:31
 msgid "Manage user authorization"
 msgstr ""
 
-#: lxc/warning.go:28 lxc/warning.go:29
+#: lxc/warning.go:29 lxc/warning.go:30
 msgid "Manage warnings"
 msgstr ""
 
@@ -3720,17 +3720,17 @@ msgstr ""
 msgid "Migration operation failure: %w"
 msgstr ""
 
-#: lxc/monitor.go:51
+#: lxc/monitor.go:52
 msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: lxc/storage_bucket.go:116 lxc/storage_bucket.go:216
-#: lxc/storage_bucket.go:292 lxc/storage_bucket.go:411
-#: lxc/storage_bucket.go:568 lxc/storage_bucket.go:660
-#: lxc/storage_bucket.go:802 lxc/storage_bucket.go:889
-#: lxc/storage_bucket.go:986 lxc/storage_bucket.go:1065
-#: lxc/storage_bucket.go:1188
+#: lxc/storage_bucket.go:117 lxc/storage_bucket.go:217
+#: lxc/storage_bucket.go:293 lxc/storage_bucket.go:412
+#: lxc/storage_bucket.go:569 lxc/storage_bucket.go:661
+#: lxc/storage_bucket.go:803 lxc/storage_bucket.go:890
+#: lxc/storage_bucket.go:987 lxc/storage_bucket.go:1066
+#: lxc/storage_bucket.go:1189
 msgid "Missing bucket name"
 msgstr ""
 
@@ -3749,20 +3749,20 @@ msgstr ""
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1825
+#: lxc/auth.go:123 lxc/auth.go:177 lxc/auth.go:255 lxc/auth.go:417
+#: lxc/auth.go:466 lxc/auth.go:541 lxc/auth.go:600 lxc/auth.go:1826
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:862 lxc/auth.go:1003 lxc/auth.go:1131 lxc/auth.go:1189
+#: lxc/auth.go:863 lxc/auth.go:1004 lxc/auth.go:1132 lxc/auth.go:1190
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1495 lxc/auth.go:1548 lxc/auth.go:1614 lxc/auth.go:1776
+#: lxc/auth.go:1496 lxc/auth.go:1549 lxc/auth.go:1615 lxc/auth.go:1777
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1899 lxc/auth.go:1952
+#: lxc/auth.go:1900 lxc/auth.go:1953
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -3770,12 +3770,12 @@ msgstr ""
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
 #: lxc/config_template.go:377 lxc/profile.go:141 lxc/profile.go:222
-#: lxc/profile.go:808 lxc/rebuild.go:60
+#: lxc/profile.go:808 lxc/rebuild.go:61
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/storage_bucket.go:893 lxc/storage_bucket.go:990
-#: lxc/storage_bucket.go:1069 lxc/storage_bucket.go:1192
+#: lxc/storage_bucket.go:894 lxc/storage_bucket.go:991
+#: lxc/storage_bucket.go:1070 lxc/storage_bucket.go:1193
 msgid "Missing key name"
 msgstr ""
 
@@ -3840,13 +3840,13 @@ msgid "Missing peer name"
 msgstr ""
 
 #: lxc/storage.go:235 lxc/storage.go:313 lxc/storage.go:431 lxc/storage.go:509
-#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:112
-#: lxc/storage_bucket.go:212 lxc/storage_bucket.go:288
-#: lxc/storage_bucket.go:407 lxc/storage_bucket.go:482
-#: lxc/storage_bucket.go:564 lxc/storage_bucket.go:656
-#: lxc/storage_bucket.go:798 lxc/storage_bucket.go:885
-#: lxc/storage_bucket.go:982 lxc/storage_bucket.go:1061
-#: lxc/storage_bucket.go:1184 lxc/storage_volume.go:209
+#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:113
+#: lxc/storage_bucket.go:213 lxc/storage_bucket.go:289
+#: lxc/storage_bucket.go:408 lxc/storage_bucket.go:483
+#: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
+#: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
+#: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
 #: lxc/storage_volume.go:323 lxc/storage_volume.go:643
 #: lxc/storage_volume.go:750 lxc/storage_volume.go:841
 #: lxc/storage_volume.go:939 lxc/storage_volume.go:1053
@@ -3861,9 +3861,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:404 lxc/project.go:146 lxc/project.go:226 lxc/project.go:316
-#: lxc/project.go:433 lxc/project.go:622 lxc/project.go:691 lxc/project.go:819
-#: lxc/project.go:948
+#: lxc/profile.go:404 lxc/project.go:147 lxc/project.go:227 lxc/project.go:317
+#: lxc/project.go:434 lxc/project.go:623 lxc/project.go:692 lxc/project.go:820
+#: lxc/project.go:949
 msgid "Missing project name"
 msgstr ""
 
@@ -3879,7 +3879,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:598
+#: lxc/file.go:599
 msgid "Missing target directory"
 msgstr ""
 
@@ -3901,11 +3901,11 @@ msgstr ""
 msgid "Model: %v"
 msgstr ""
 
-#: lxc/monitor.go:32
+#: lxc/monitor.go:33
 msgid "Monitor a local or remote LXD server"
 msgstr ""
 
-#: lxc/monitor.go:33
+#: lxc/monitor.go:34
 msgid ""
 "Monitor a local or remote LXD server\n"
 "\n"
@@ -3917,11 +3917,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:285
+#: lxc/file.go:286
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:985 lxc/file.go:986
+#: lxc/file.go:986 lxc/file.go:987
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3983,13 +3983,13 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:192
+#: lxc/auth.go:376 lxc/auth.go:816 lxc/auth.go:1736 lxc/cluster.go:192
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
-#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:565
-#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:511
-#: lxc/storage_bucket.go:831 lxc/storage_volume.go:1731
+#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:566
+#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1731
 msgid "NAME"
 msgstr ""
 
@@ -3997,11 +3997,11 @@ msgstr ""
 msgid "NAT"
 msgstr ""
 
-#: lxc/project.go:571
+#: lxc/project.go:572
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:570
+#: lxc/project.go:571
 msgid "NETWORKS"
 msgstr ""
 
@@ -4013,9 +4013,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/operation.go:154 lxc/project.go:523
-#: lxc/project.go:528 lxc/project.go:533 lxc/project.go:538 lxc/project.go:543
-#: lxc/project.go:548 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
+#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:524
+#: lxc/project.go:529 lxc/project.go:534 lxc/project.go:539 lxc/project.go:544
+#: lxc/project.go:549 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
 msgid "NO"
 msgstr ""
 
@@ -4260,7 +4260,7 @@ msgstr ""
 msgid "Only managed networks can be modified"
 msgstr ""
 
-#: lxc/operation.go:86
+#: lxc/operation.go:87
 #, c-format
 msgid "Operation %s deleted"
 msgstr ""
@@ -4307,11 +4307,11 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:567
+#: lxc/list.go:576 lxc/project.go:568
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:212
+#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4373,24 +4373,24 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1102
+#: lxc/file.go:1103
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:860
+#: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
-#: lxc/project.go:363 lxc/storage.go:360 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1151
+#: lxc/project.go:364 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1151
 #: lxc/storage_volume.go:1183
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
-#: lxc/monitor.go:48
+#: lxc/monitor.go:49
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
@@ -4476,17 +4476,17 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:172
+#: lxc/project.go:173
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:236
+#: lxc/project.go:237
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:637
+#: lxc/project.go:638
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -4607,20 +4607,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:241 lxc/file.go:242
+#: lxc/file.go:242 lxc/file.go:243
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:416 lxc/file.go:767
+#: lxc/file.go:417 lxc/file.go:768
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:466 lxc/file.go:467
+#: lxc/file.go:467 lxc/file.go:468
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:701 lxc/file.go:867
+#: lxc/file.go:702 lxc/file.go:868
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4633,11 +4633,11 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:983
+#: lxc/project.go:984
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/storage_bucket.go:833
+#: lxc/storage_bucket.go:834
 msgid "ROLE"
 msgstr ""
 
@@ -4650,15 +4650,15 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/rebuild.go:31
+#: lxc/rebuild.go:32
 msgid "Rebuild as an empty instance"
 msgstr ""
 
-#: lxc/rebuild.go:26
+#: lxc/rebuild.go:27
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:249 lxc/file.go:473
+#: lxc/file.go:250 lxc/file.go:474
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4685,7 +4685,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:882 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
+#: lxc/project.go:883 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
 #: lxc/remote.go:994
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4736,7 +4736,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1164 lxc/auth.go:1165
+#: lxc/auth.go:1165 lxc/auth.go:1166
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4772,7 +4772,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1927 lxc/auth.go:1928
+#: lxc/auth.go:1928 lxc/auth.go:1929
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4784,7 +4784,7 @@ msgstr ""
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:574 lxc/auth.go:575
+#: lxc/auth.go:575 lxc/auth.go:576
 msgid "Remove permissions from groups"
 msgstr ""
 
@@ -4829,11 +4829,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:391 lxc/auth.go:392
+#: lxc/auth.go:392 lxc/auth.go:393
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1751 lxc/auth.go:1752
+#: lxc/auth.go:1752 lxc/auth.go:1753
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -4853,7 +4853,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:589 lxc/project.go:590
+#: lxc/project.go:590 lxc/project.go:591
 msgid "Rename projects"
 msgstr ""
 
@@ -4951,7 +4951,7 @@ msgstr ""
 msgid "Revoke cluster member join token"
 msgstr ""
 
-#: lxc/storage_bucket.go:862
+#: lxc/storage_bucket.go:863
 msgid "Role (admin or read-only)"
 msgstr ""
 
@@ -4967,7 +4967,7 @@ msgstr ""
 msgid "Run against all projects"
 msgstr ""
 
-#: lxc/warning.go:213
+#: lxc/warning.go:214
 msgid "SEVERITY"
 msgstr ""
 
@@ -4987,12 +4987,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1231
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1231
+#: lxc/file.go:1232
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5006,11 +5006,11 @@ msgstr ""
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:173 lxc/warning.go:214
+#: lxc/operation.go:174 lxc/warning.go:215
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:569
+#: lxc/project.go:570
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5018,7 +5018,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:569
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -5026,11 +5026,11 @@ msgstr ""
 msgid "STP"
 msgstr ""
 
-#: lxc/storage_bucket.go:864
+#: lxc/storage_bucket.go:865
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:942
+#: lxc/storage_bucket.go:943
 #, c-format
 msgid "Secret key: %s"
 msgstr ""
@@ -5068,7 +5068,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:995
+#: lxc/file.go:996
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5206,11 +5206,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:654
+#: lxc/project.go:655
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:655
+#: lxc/project.go:656
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5219,11 +5219,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage_bucket.go:534
+#: lxc/storage_bucket.go:535
 msgid "Set storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:535
+#: lxc/storage_bucket.go:536
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -5262,15 +5262,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:476
+#: lxc/file.go:477
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:477
+#: lxc/file.go:478
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:475
+#: lxc/file.go:476
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5310,11 +5310,11 @@ msgstr ""
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 msgid "Set the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:542
+#: lxc/storage_bucket.go:543
 msgid "Set the key as a storage bucket property"
 msgstr ""
 
@@ -5330,7 +5330,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:993
+#: lxc/file.go:994
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5342,7 +5342,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1800 lxc/auth.go:1801
+#: lxc/auth.go:1801 lxc/auth.go:1802
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5358,11 +5358,11 @@ msgstr ""
 msgid "Show details of a cluster member"
 msgstr ""
 
-#: lxc/operation.go:192 lxc/operation.go:193
+#: lxc/operation.go:193 lxc/operation.go:194
 msgid "Show details on a background operation"
 msgstr ""
 
-#: lxc/monitor.go:49
+#: lxc/monitor.go:50
 msgid "Show events from all projects"
 msgstr ""
 
@@ -5370,11 +5370,11 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:440 lxc/auth.go:441
+#: lxc/auth.go:441 lxc/auth.go:442
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:832
+#: lxc/auth.go:833
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5455,15 +5455,15 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:786 lxc/project.go:787
+#: lxc/project.go:787 lxc/project.go:788
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage_bucket.go:628 lxc/storage_bucket.go:629
+#: lxc/storage_bucket.go:629 lxc/storage_bucket.go:630
 msgid "Show storage bucket configurations"
 msgstr ""
 
-#: lxc/storage_bucket.go:1156 lxc/storage_bucket.go:1157
+#: lxc/storage_bucket.go:1157 lxc/storage_bucket.go:1158
 msgid "Show storage bucket key configurations"
 msgstr ""
 
@@ -5479,7 +5479,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:895
+#: lxc/auth.go:896
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5529,7 +5529,7 @@ msgstr ""
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: lxc/warning.go:302 lxc/warning.go:303
+#: lxc/warning.go:303 lxc/warning.go:304
 msgid "Show warning"
 msgstr ""
 
@@ -5613,22 +5613,22 @@ msgstr ""
 msgid "Stopping the instance failed: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:166
+#: lxc/storage_bucket.go:167
 #, c-format
 msgid "Storage bucket %s created"
 msgstr ""
 
-#: lxc/storage_bucket.go:233
+#: lxc/storage_bucket.go:234
 #, c-format
 msgid "Storage bucket %s deleted"
 msgstr ""
 
-#: lxc/storage_bucket.go:940
+#: lxc/storage_bucket.go:941
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr ""
 
-#: lxc/storage_bucket.go:1006
+#: lxc/storage_bucket.go:1007
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr ""
@@ -5697,7 +5697,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:847 lxc/project.go:848
+#: lxc/project.go:848 lxc/project.go:849
 msgid "Switch the current project"
 msgstr ""
 
@@ -5713,10 +5713,10 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1139
+#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1139
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
-#: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:171
-#: lxc/storage_volume.go:1730 lxc/warning.go:215
+#: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
+#: lxc/storage_volume.go:1730 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
@@ -5724,11 +5724,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1032
+#: lxc/file.go:1033
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1026
+#: lxc/file.go:1027
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5856,12 +5856,12 @@ msgstr ""
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:446
+#: lxc/project.go:447
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
 
-#: lxc/storage_bucket.go:431
+#: lxc/storage_bucket.go:432
 #, c-format
 msgid "The property %q does not exist on the storage bucket %q: %v"
 msgstr ""
@@ -6046,7 +6046,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:961
+#: lxc/project.go:962
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6058,17 +6058,17 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:985 lxc/storage_volume.go:1735
+#: lxc/project.go:986 lxc/storage_volume.go:1735
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:573
+#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:574
 #: lxc/storage.go:724 lxc/storage_volume.go:1734
 msgid "USED BY"
 msgstr ""
 
-#: lxc/warning.go:216
+#: lxc/warning.go:217
 msgid "UUID"
 msgstr ""
 
@@ -6077,7 +6077,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:197
+#: lxc/file.go:198
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6091,13 +6091,13 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1253
+#: lxc/file.go:1254
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1153 lxc/list.go:631 lxc/storage_volume.go:1772
-#: lxc/warning.go:241
+#: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6107,7 +6107,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:807
+#: lxc/file.go:808
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6190,11 +6190,11 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:742 lxc/project.go:743
+#: lxc/project.go:743 lxc/project.go:744
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:697 lxc/storage_bucket.go:698
+#: lxc/storage_bucket.go:698 lxc/storage_bucket.go:699
 msgid "Unset storage bucket configuration keys"
 msgstr ""
 
@@ -6242,11 +6242,11 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:747
+#: lxc/project.go:748
 msgid "Unset the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:701
+#: lxc/storage_bucket.go:702
 msgid "Unset the key as a storage bucket property"
 msgstr ""
 
@@ -6325,7 +6325,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:71
+#: lxc/file.go:72
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6362,11 +6362,11 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:831
+#: lxc/auth.go:832
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:894
+#: lxc/auth.go:895
 msgid "View the current identity"
 msgstr ""
 
@@ -6397,15 +6397,15 @@ msgstr ""
 msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
-#: lxc/rebuild.go:27
+#: lxc/rebuild.go:28
 msgid ""
 "Wipe the instance root disk and re-initialize. The original image is used to "
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:156 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
+#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:526
+#: lxc/project.go:531 lxc/project.go:536 lxc/project.go:541 lxc/project.go:546
+#: lxc/project.go:551 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
 msgid "YES"
 msgstr ""
 
@@ -6425,7 +6425,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/rebuild.go:119
+#: lxc/rebuild.go:120
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
@@ -6437,12 +6437,12 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1689
+#: lxc/auth.go:330 lxc/auth.go:763 lxc/auth.go:894 lxc/auth.go:1690
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
-#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
+#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
-#: lxc/operation.go:103 lxc/profile.go:700 lxc/project.go:467
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:68
+#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:468
+#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6470,7 +6470,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1254
+#: lxc/auth.go:1255
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6531,11 +6531,11 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:830
+#: lxc/auth.go:831
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1926
+#: lxc/auth.go:1106 lxc/auth.go:1164 lxc/auth.go:1927
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6543,13 +6543,13 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:954 lxc/auth.go:1470 lxc/cluster_group.go:168
+#: lxc/auth.go:97 lxc/auth.go:150 lxc/auth.go:200 lxc/auth.go:440
+#: lxc/auth.go:955 lxc/auth.go:1471 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:514 lxc/auth.go:572
+#: lxc/auth.go:515 lxc/auth.go:573
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
@@ -6559,19 +6559,19 @@ msgstr ""
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:389
+#: lxc/auth.go:390
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1521 lxc/auth.go:1571 lxc/auth.go:1799
+#: lxc/auth.go:1522 lxc/auth.go:1572 lxc/auth.go:1800
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1873
+#: lxc/auth.go:1874
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1749
+#: lxc/auth.go:1750
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -6591,7 +6591,7 @@ msgstr ""
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
-#: lxc/rebuild.go:25
+#: lxc/rebuild.go:26
 msgid "[<remote>:]<image> [<remote>:]<instance>"
 msgstr ""
 
@@ -6674,20 +6674,20 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:170
+#: lxc/file.go:171
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:120
+#: lxc/file.go:121
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:240
+#: lxc/file.go:241
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:984
+#: lxc/file.go:985
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6838,12 +6838,12 @@ msgstr ""
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
-#: lxc/operation.go:53 lxc/operation.go:191
+#: lxc/operation.go:54 lxc/operation.go:192
 msgid "[<remote>:]<operation>"
 msgstr ""
 
 #: lxc/storage.go:200 lxc/storage.go:259 lxc/storage.go:473 lxc/storage.go:844
-#: lxc/storage_bucket.go:454
+#: lxc/storage_bucket.go:455
 msgid "[<remote>:]<pool>"
 msgstr ""
 
@@ -6851,22 +6851,22 @@ msgstr ""
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
-#: lxc/storage_bucket.go:185 lxc/storage_bucket.go:247
-#: lxc/storage_bucket.go:627 lxc/storage_bucket.go:769
+#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:248
+#: lxc/storage_bucket.go:628 lxc/storage_bucket.go:770
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
 
-#: lxc/storage_bucket.go:380 lxc/storage_bucket.go:696
-#: lxc/storage_bucket.go:850 lxc/storage_bucket.go:956
-#: lxc/storage_bucket.go:1020 lxc/storage_bucket.go:1155
+#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:697
+#: lxc/storage_bucket.go:851 lxc/storage_bucket.go:957
+#: lxc/storage_bucket.go:1021 lxc/storage_bucket.go:1156
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
 
-#: lxc/storage_bucket.go:533
+#: lxc/storage_bucket.go:534
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_bucket.go:81
+#: lxc/storage_bucket.go:82
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
 
@@ -6981,20 +6981,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:91 lxc/project.go:186 lxc/project.go:258 lxc/project.go:785
-#: lxc/project.go:846 lxc/project.go:913
+#: lxc/project.go:92 lxc/project.go:187 lxc/project.go:259 lxc/project.go:786
+#: lxc/project.go:847 lxc/project.go:914
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:394 lxc/project.go:741
+#: lxc/project.go:395 lxc/project.go:742
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:653
+#: lxc/project.go:654
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:587
+#: lxc/project.go:588
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7002,7 +7002,7 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:259 lxc/warning.go:301 lxc/warning.go:354
+#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
@@ -7058,7 +7058,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:555 lxc/remote.go:739
+#: lxc/project.go:556 lxc/remote.go:739
 msgid "current"
 msgstr ""
 
@@ -7105,20 +7105,20 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/auth.go:203
+#: lxc/auth.go:204
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:958
+#: lxc/auth.go:959
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1575
+#: lxc/auth.go:1576
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7196,20 +7196,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:988
+#: lxc/file.go:989
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:244
+#: lxc/file.go:245
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:470
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7291,7 +7291,7 @@ msgid ""
 "  List instances with their running state and user comment."
 msgstr ""
 
-#: lxc/monitor.go:37
+#: lxc/monitor.go:38
 msgid ""
 "lxc monitor --type=logging\n"
 "    Only show log messages.\n"
@@ -7367,7 +7367,7 @@ msgid ""
 "    Create record r1 for zone z1 with configuration from config.yaml"
 msgstr ""
 
-#: lxc/operation.go:195
+#: lxc/operation.go:196
 msgid ""
 "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Show details on that operation UUID"
@@ -7410,7 +7410,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:95
+#: lxc/project.go:96
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7418,7 +7418,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:262
+#: lxc/project.go:263
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7449,7 +7449,7 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:85
 msgid ""
 "lxc storage bucket create p1 b01\n"
 "\tCreate a new storage bucket name b01 in storage pool p1\n"
@@ -7459,19 +7459,19 @@ msgid ""
 "of config.yaml"
 msgstr ""
 
-#: lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:251
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1023
+#: lxc/storage_bucket.go:1024
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:854
 msgid ""
 "lxc storage bucket key create p1 b01 k1\n"
 "\tCreate a key called k1 for the bucket b01 in the pool p1.\n"
@@ -7481,14 +7481,14 @@ msgid ""
 "of config.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1158
+#: lxc/storage_bucket.go:1159
 msgid ""
 "lxc storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_bucket.go:630
+#: lxc/storage_bucket.go:631
 msgid ""
 "lxc storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
@@ -7558,16 +7558,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1142
+#: lxc/file.go:1143
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1101
+#: lxc/file.go:1102
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1054
+#: lxc/file.go:1055
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/bg.po
+++ b/po/bg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-04 08:52-0600\n"
+"POT-Creation-Date: 2024-09-05 08:44-0400\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Bulgarian <https://hosted.weblate.org/projects/linux-"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: lxc/storage_bucket.go:260 lxc/storage_bucket.go:1033
+#: lxc/storage_bucket.go:261 lxc/storage_bucket.go:1034
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -133,7 +133,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:213
+#: lxc/auth.go:214
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -160,7 +160,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:968
+#: lxc/auth.go:969
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -181,7 +181,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1585
+#: lxc/auth.go:1586
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -391,7 +391,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:280
+#: lxc/project.go:281
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -433,12 +433,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:935
+#: lxc/file.go:936
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:825
+#: lxc/file.go:826
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -474,7 +474,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:142 lxc/rebuild.go:64
+#: lxc/init.go:142 lxc/rebuild.go:65
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -527,7 +527,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:465
+#: lxc/file.go:466
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -560,7 +560,7 @@ msgstr ""
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:813
+#: lxc/auth.go:814
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -568,11 +568,11 @@ msgstr ""
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/storage_bucket.go:863
+#: lxc/storage_bucket.go:864
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:941
+#: lxc/storage_bucket.go:942
 #, c-format
 msgid "Access key: %s"
 msgstr ""
@@ -581,7 +581,7 @@ msgstr ""
 msgid "Access the expanded configuration"
 msgstr ""
 
-#: lxc/warning.go:261 lxc/warning.go:262
+#: lxc/warning.go:262 lxc/warning.go:263
 msgid "Acknowledge warning"
 msgstr ""
 
@@ -598,11 +598,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1106 lxc/auth.go:1107
+#: lxc/auth.go:1107 lxc/auth.go:1108
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1874 lxc/auth.go:1875
+#: lxc/auth.go:1875 lxc/auth.go:1876
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -671,7 +671,7 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:515 lxc/auth.go:516
+#: lxc/auth.go:516 lxc/auth.go:517
 msgid "Add permissions to groups"
 msgstr ""
 
@@ -700,7 +700,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:169
+#: lxc/storage_bucket.go:170
 #, c-format
 msgid "Admin access key: %s"
 msgstr ""
@@ -710,7 +710,7 @@ msgstr ""
 msgid "Admin password (or token) for %s:"
 msgstr ""
 
-#: lxc/storage_bucket.go:170
+#: lxc/storage_bucket.go:171
 #, c-format
 msgid "Admin secret key: %s"
 msgstr ""
@@ -769,7 +769,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:342 lxc/rebuild.go:130
+#: lxc/init.go:342 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -869,12 +869,12 @@ msgstr ""
 
 #: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:318
 #: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
-#: lxc/network_zone.go:366 lxc/network_zone.go:1053 lxc/storage_bucket.go:141
+#: lxc/network_zone.go:366 lxc/network_zone.go:1053 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:159
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:160
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -914,7 +914,7 @@ msgstr ""
 msgid "Bytes sent"
 msgstr ""
 
-#: lxc/operation.go:174
+#: lxc/operation.go:175
 msgid "CANCELABLE"
 msgstr ""
 
@@ -926,7 +926,7 @@ msgstr ""
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: lxc/warning.go:209
+#: lxc/warning.go:210
 msgid "COUNT"
 msgstr ""
 
@@ -952,7 +952,7 @@ msgstr ""
 msgid "CPUs (%s):"
 msgstr ""
 
-#: lxc/operation.go:175
+#: lxc/operation.go:176
 msgid "CREATED"
 msgstr ""
 
@@ -982,7 +982,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:340
+#: lxc/file.go:341
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1007,11 +1007,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:224
+#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:546
+#: lxc/file.go:547
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1020,7 +1020,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:160
+#: lxc/rebuild.go:161
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1143,13 +1143,13 @@ msgstr ""
 #: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
 #: lxc/network_load_balancer.go:1051 lxc/network_load_balancer.go:1125
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
-#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:90
-#: lxc/storage_bucket.go:190 lxc/storage_bucket.go:253
-#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:541
-#: lxc/storage_bucket.go:634 lxc/storage_bucket.go:700
-#: lxc/storage_bucket.go:775 lxc/storage_bucket.go:861
-#: lxc/storage_bucket.go:961 lxc/storage_bucket.go:1026
-#: lxc/storage_bucket.go:1162 lxc/storage_volume.go:394
+#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
+#: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
+#: lxc/storage_bucket.go:385 lxc/storage_bucket.go:542
+#: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
+#: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
+#: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
 #: lxc/storage_volume.go:612 lxc/storage_volume.go:717
 #: lxc/storage_volume.go:1005 lxc/storage_volume.go:1231
 #: lxc/storage_volume.go:1360 lxc/storage_volume.go:1848
@@ -1173,7 +1173,7 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1113 lxc/list.go:132 lxc/storage_volume.go:1589
-#: lxc/warning.go:92
+#: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
@@ -1201,7 +1201,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:100
+#: lxc/project.go:101
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1215,8 +1215,8 @@ msgstr ""
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
-#: lxc/project.go:362 lxc/storage.go:359 lxc/storage_bucket.go:348
-#: lxc/storage_bucket.go:1125 lxc/storage_volume.go:1150
+#: lxc/project.go:363 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1150
 #: lxc/storage_volume.go:1182
 #, c-format
 msgid "Config parsing error: %s"
@@ -1343,12 +1343,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:300 lxc/auth.go:1660
+#: lxc/auth.go:301 lxc/auth.go:1661
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1054
+#: lxc/auth.go:1055
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1397,15 +1397,15 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:248 lxc/file.go:474
+#: lxc/file.go:249 lxc/file.go:475
 msgid "Create any directories necessary"
 msgstr ""
 
-#: lxc/auth.go:97 lxc/auth.go:98
+#: lxc/auth.go:98 lxc/auth.go:99
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1471 lxc/auth.go:1472
+#: lxc/auth.go:1472 lxc/auth.go:1473
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1425,11 +1425,11 @@ msgstr ""
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_bucket.go:851 lxc/storage_bucket.go:852
+#: lxc/storage_bucket.go:852 lxc/storage_bucket.go:853
 msgid "Create key for a storage bucket"
 msgstr ""
 
-#: lxc/storage_bucket.go:82 lxc/storage_bucket.go:83
+#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
 msgid "Create new custom storage buckets"
 msgstr ""
 
@@ -1473,7 +1473,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:92 lxc/project.go:93
+#: lxc/project.go:93 lxc/project.go:94
 msgid "Create projects"
 msgstr ""
 
@@ -1508,13 +1508,13 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:376 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1135 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
-#: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:172
-#: lxc/profile.go:756 lxc/project.go:572 lxc/storage.go:723
-#: lxc/storage_bucket.go:512 lxc/storage_bucket.go:832
+#: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
+#: lxc/profile.go:756 lxc/project.go:573 lxc/storage.go:723
+#: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1732
 msgid "DESCRIPTION"
 msgstr ""
@@ -1539,7 +1539,7 @@ msgstr ""
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
-#: lxc/operation.go:55 lxc/operation.go:56
+#: lxc/operation.go:56 lxc/operation.go:57
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
@@ -1547,19 +1547,19 @@ msgstr ""
 msgid "Delete a cluster group"
 msgstr ""
 
-#: lxc/warning.go:360
+#: lxc/warning.go:361
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:122 lxc/file.go:123
+#: lxc/file.go:123 lxc/file.go:124
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/auth.go:151 lxc/auth.go:152
+#: lxc/auth.go:152 lxc/auth.go:153
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1523 lxc/auth.go:1524
+#: lxc/auth.go:1524 lxc/auth.go:1525
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1579,7 +1579,7 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/storage_bucket.go:957 lxc/storage_bucket.go:958
+#: lxc/storage_bucket.go:958 lxc/storage_bucket.go:959
 msgid "Delete key from a storage bucket"
 msgstr ""
 
@@ -1615,11 +1615,11 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:188 lxc/project.go:189
+#: lxc/project.go:189 lxc/project.go:190
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:187 lxc/storage_bucket.go:188
+#: lxc/storage_bucket.go:188 lxc/storage_bucket.go:189
 msgid "Delete storage buckets"
 msgstr ""
 
@@ -1631,20 +1631,20 @@ msgstr ""
 msgid "Delete storage volumes"
 msgstr ""
 
-#: lxc/warning.go:356 lxc/warning.go:357
+#: lxc/warning.go:357 lxc/warning.go:358
 msgid "Delete warning"
 msgstr ""
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:30 lxc/auth.go:59 lxc/auth.go:98
-#: lxc/auth.go:152 lxc/auth.go:201 lxc/auth.go:332 lxc/auth.go:392
-#: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
-#: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
-#: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
-#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1434 lxc/auth.go:1472
-#: lxc/auth.go:1524 lxc/auth.go:1573 lxc/auth.go:1692 lxc/auth.go:1752
-#: lxc/auth.go:1801 lxc/auth.go:1852 lxc/auth.go:1875 lxc/auth.go:1928
+#: lxc/alias.go:214 lxc/auth.go:31 lxc/auth.go:60 lxc/auth.go:99
+#: lxc/auth.go:153 lxc/auth.go:202 lxc/auth.go:333 lxc/auth.go:393
+#: lxc/auth.go:442 lxc/auth.go:494 lxc/auth.go:517 lxc/auth.go:576
+#: lxc/auth.go:732 lxc/auth.go:766 lxc/auth.go:833 lxc/auth.go:896
+#: lxc/auth.go:957 lxc/auth.go:1085 lxc/auth.go:1108 lxc/auth.go:1166
+#: lxc/auth.go:1235 lxc/auth.go:1257 lxc/auth.go:1435 lxc/auth.go:1473
+#: lxc/auth.go:1525 lxc/auth.go:1574 lxc/auth.go:1693 lxc/auth.go:1753
+#: lxc/auth.go:1802 lxc/auth.go:1853 lxc/auth.go:1876 lxc/auth.go:1929
 #: lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215 lxc/cluster.go:272
 #: lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:484 lxc/cluster.go:528
 #: lxc/cluster.go:586 lxc/cluster.go:677 lxc/cluster.go:770 lxc/cluster.go:893
@@ -1668,15 +1668,15 @@ msgstr ""
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:83 lxc/file.go:123 lxc/file.go:172
-#: lxc/file.go:242 lxc/file.go:467 lxc/file.go:986 lxc/image.go:38
+#: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
+#: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
 #: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
 #: lxc/image.go:697 lxc/image.go:946 lxc/image.go:1088 lxc/image.go:1415
 #: lxc/image.go:1506 lxc/image.go:1572 lxc/image.go:1636 lxc/image.go:1699
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:38 lxc/network.go:33
+#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33
 #: lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405
 #: lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793
 #: lxc/network.go:874 lxc/network.go:1005 lxc/network.go:1106
@@ -1710,27 +1710,27 @@ msgstr ""
 #: lxc/network_zone.go:909 lxc/network_zone.go:985 lxc/network_zone.go:1083
 #: lxc/network_zone.go:1172 lxc/network_zone.go:1219 lxc/network_zone.go:1349
 #: lxc/network_zone.go:1410 lxc/network_zone.go:1425 lxc/network_zone.go:1483
-#: lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:106
-#: lxc/operation.go:193 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
+#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
+#: lxc/operation.go:194 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
 #: lxc/profile.go:271 lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493
 #: lxc/profile.go:629 lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860
-#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:29
-#: lxc/project.go:93 lxc/project.go:189 lxc/project.go:260 lxc/project.go:396
-#: lxc/project.go:470 lxc/project.go:590 lxc/project.go:655 lxc/project.go:743
-#: lxc/project.go:787 lxc/project.go:848 lxc/project.go:915 lxc/publish.go:34
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:35 lxc/remote.go:91
+#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:30
+#: lxc/project.go:94 lxc/project.go:190 lxc/project.go:261 lxc/project.go:397
+#: lxc/project.go:471 lxc/project.go:591 lxc/project.go:656 lxc/project.go:744
+#: lxc/project.go:788 lxc/project.go:849 lxc/project.go:916 lxc/publish.go:34
+#: lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91
 #: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853
 #: lxc/remote.go:917 lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24
 #: lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203
 #: lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655
 #: lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940
-#: lxc/storage_bucket.go:29 lxc/storage_bucket.go:83 lxc/storage_bucket.go:188
-#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:382
-#: lxc/storage_bucket.go:458 lxc/storage_bucket.go:535
-#: lxc/storage_bucket.go:629 lxc/storage_bucket.go:698
-#: lxc/storage_bucket.go:732 lxc/storage_bucket.go:773
-#: lxc/storage_bucket.go:852 lxc/storage_bucket.go:958
-#: lxc/storage_bucket.go:1022 lxc/storage_bucket.go:1157
+#: lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189
+#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:383
+#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:536
+#: lxc/storage_bucket.go:630 lxc/storage_bucket.go:699
+#: lxc/storage_bucket.go:733 lxc/storage_bucket.go:774
+#: lxc/storage_bucket.go:853 lxc/storage_bucket.go:959
+#: lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158
 #: lxc/storage_volume.go:58 lxc/storage_volume.go:169 lxc/storage_volume.go:283
 #: lxc/storage_volume.go:390 lxc/storage_volume.go:605
 #: lxc/storage_volume.go:714 lxc/storage_volume.go:801
@@ -1741,8 +1741,8 @@ msgstr ""
 #: lxc/storage_volume.go:2064 lxc/storage_volume.go:2222
 #: lxc/storage_volume.go:2343 lxc/storage_volume.go:2405
 #: lxc/storage_volume.go:2541 lxc/storage_volume.go:2624
-#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:29
-#: lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
+#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:30
+#: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
@@ -1829,7 +1829,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:994
+#: lxc/file.go:995
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1895,7 +1895,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:74
+#: lxc/file.go:75
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1905,7 +1905,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:955 lxc/auth.go:956
+#: lxc/auth.go:956 lxc/auth.go:957
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1913,15 +1913,15 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:171 lxc/file.go:172
+#: lxc/file.go:172 lxc/file.go:173
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/auth.go:200 lxc/auth.go:201
+#: lxc/auth.go:201 lxc/auth.go:202
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1572 lxc/auth.go:1573
+#: lxc/auth.go:1573 lxc/auth.go:1574
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -1977,15 +1977,15 @@ msgstr ""
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:259 lxc/project.go:260
+#: lxc/project.go:260 lxc/project.go:261
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:248 lxc/storage_bucket.go:249
+#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:250
 msgid "Edit storage bucket configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:1021 lxc/storage_bucket.go:1022
+#: lxc/storage_bucket.go:1022 lxc/storage_bucket.go:1023
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
@@ -2002,7 +2002,7 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1147 lxc/list.go:622 lxc/storage_volume.go:1766
-#: lxc/warning.go:235
+#: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2057,7 +2057,7 @@ msgstr ""
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
-#: lxc/project.go:718 lxc/storage.go:812 lxc/storage_bucket.go:602
+#: lxc/project.go:719 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2155 lxc/storage_volume.go:2193
 #, c-format
 msgid "Error setting properties: %v"
@@ -2071,8 +2071,8 @@ msgstr ""
 #: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
-#: lxc/profile.go:981 lxc/project.go:712 lxc/storage.go:806
-#: lxc/storage_bucket.go:596 lxc/storage_volume.go:2149
+#: lxc/profile.go:981 lxc/project.go:713 lxc/storage.go:806
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2149
 #: lxc/storage_volume.go:2187
 #, c-format
 msgid "Error unsetting property: %v"
@@ -2092,7 +2092,7 @@ msgstr ""
 msgid "Evacuating cluster member: %s"
 msgstr ""
 
-#: lxc/monitor.go:50
+#: lxc/monitor.go:51
 msgid "Event type to listen for"
 msgstr ""
 
@@ -2179,16 +2179,16 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/warning.go:210
+#: lxc/warning.go:211
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1237
+#: lxc/file.go:1238
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1260
+#: lxc/file.go:1261
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2203,12 +2203,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1287
+#: lxc/file.go:1288
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1072
+#: lxc/file.go:1073
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2238,7 +2238,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1193
+#: lxc/file.go:1194
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2253,7 +2253,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1198
+#: lxc/file.go:1199
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2263,12 +2263,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1098
+#: lxc/file.go:1099
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1225
+#: lxc/file.go:1226
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2307,7 +2307,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1210
+#: lxc/file.go:1211
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2322,7 +2322,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:820
+#: lxc/file.go:821
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2337,7 +2337,7 @@ msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
 #: lxc/network.go:1044 lxc/network_acl.go:133 lxc/network_zone.go:124
-#: lxc/operation.go:136
+#: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
 
@@ -2402,21 +2402,21 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
+#: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:770 lxc/auth.go:1697
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1114 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:57
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
-#: lxc/operation.go:108 lxc/profile.go:707 lxc/project.go:472
-#: lxc/project.go:917 lxc/remote.go:690 lxc/storage.go:657
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:774
-#: lxc/storage_volume.go:1608 lxc/warning.go:93
+#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:473
+#: lxc/project.go:918 lxc/remote.go:690 lxc/storage.go:657
+#: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
+#: lxc/storage_volume.go:1608 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
-#: lxc/monitor.go:52
+#: lxc/monitor.go:53
 msgid "Format (json|pretty|yaml)"
 msgstr ""
 
@@ -2460,7 +2460,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:817 lxc/auth.go:1736
+#: lxc/auth.go:818 lxc/auth.go:1737
 msgid "GROUPS"
 msgstr ""
 
@@ -2476,7 +2476,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:914 lxc/project.go:915
+#: lxc/project.go:915 lxc/project.go:916
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2524,11 +2524,11 @@ msgstr ""
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:400
+#: lxc/project.go:401
 msgid "Get the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:385
+#: lxc/storage_bucket.go:386
 msgid "Get the key as a storage bucket property"
 msgstr ""
 
@@ -2588,11 +2588,11 @@ msgstr ""
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:395 lxc/project.go:396
+#: lxc/project.go:396 lxc/project.go:397
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:382
+#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:383
 msgid "Get values for storage bucket configuration keys"
 msgstr ""
 
@@ -2609,17 +2609,17 @@ msgstr ""
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: lxc/auth.go:136
+#: lxc/auth.go:137
 #, c-format
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:186
+#: lxc/auth.go:187
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:426 lxc/auth.go:1786
+#: lxc/auth.go:427 lxc/auth.go:1787
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2644,27 +2644,27 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1310
+#: lxc/file.go:1311
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1299
+#: lxc/file.go:1300
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1122
+#: lxc/file.go:1123
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1132
+#: lxc/file.go:1133
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:966 lxc/operation.go:170
+#: lxc/network.go:966 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2678,11 +2678,11 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:816
+#: lxc/auth.go:817
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:566
+#: lxc/project.go:567
 msgid "IMAGES"
 msgstr ""
 
@@ -2710,17 +2710,17 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1508
+#: lxc/auth.go:1509
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1558
+#: lxc/auth.go:1559
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
 
-#: lxc/rebuild.go:32
+#: lxc/rebuild.go:33
 msgid "If an instance is running, stop it and then rebuild it"
 msgstr ""
 
@@ -2841,7 +2841,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1233 lxc/auth.go:1234
+#: lxc/auth.go:1234 lxc/auth.go:1235
 msgid "Inspect permissions"
 msgstr ""
 
@@ -2849,11 +2849,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1124
+#: lxc/file.go:1125
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1301
+#: lxc/file.go:1302
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2871,7 +2871,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1044
+#: lxc/file.go:1045
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2880,7 +2880,7 @@ msgstr ""
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/rebuild.go:74
+#: lxc/rebuild.go:75
 #, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
@@ -2913,7 +2913,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/monitor.go:70
+#: lxc/monitor.go:71
 #, c-format
 msgid "Invalid format: %s"
 msgstr ""
@@ -2923,7 +2923,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1039
+#: lxc/file.go:1040
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2965,7 +2965,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:147
+#: lxc/file.go:148
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2981,12 +2981,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:313
+#: lxc/file.go:314
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:495
+#: lxc/file.go:496
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3000,7 +3000,7 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/warning.go:212
 msgid "LAST SEEN"
 msgstr ""
 
@@ -3008,7 +3008,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:984
+#: lxc/project.go:985
 msgid "LIMIT"
 msgstr ""
 
@@ -3017,8 +3017,8 @@ msgid "LISTEN ADDRESS"
 msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
-#: lxc/network_load_balancer.go:165 lxc/operation.go:177
-#: lxc/storage_bucket.go:516 lxc/storage_volume.go:1739 lxc/warning.go:220
+#: lxc/network_load_balancer.go:165 lxc/operation.go:178
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1739 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3092,7 +3092,7 @@ msgstr ""
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/warning.go:94
+#: lxc/warning.go:95
 msgid "List all warnings"
 msgstr ""
 
@@ -3136,19 +3136,19 @@ msgstr ""
 msgid "List available storage pools"
 msgstr ""
 
-#: lxc/operation.go:105 lxc/operation.go:106
+#: lxc/operation.go:106 lxc/operation.go:107
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:331 lxc/auth.go:332
+#: lxc/auth.go:332 lxc/auth.go:333
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:764 lxc/auth.go:765
+#: lxc/auth.go:765 lxc/auth.go:766
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1691 lxc/auth.go:1692
+#: lxc/auth.go:1692 lxc/auth.go:1693
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3297,11 +3297,11 @@ msgstr ""
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/operation.go:109
+#: lxc/operation.go:110
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1255 lxc/auth.go:1256
+#: lxc/auth.go:1256 lxc/auth.go:1257
 msgid "List permissions"
 msgstr ""
 
@@ -3309,15 +3309,15 @@ msgstr ""
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:469 lxc/project.go:470
+#: lxc/project.go:470 lxc/project.go:471
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:771 lxc/storage_bucket.go:773
+#: lxc/storage_bucket.go:772 lxc/storage_bucket.go:774
 msgid "List storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:456 lxc/storage_bucket.go:458
+#: lxc/storage_bucket.go:457 lxc/storage_bucket.go:459
 msgid "List storage buckets"
 msgstr ""
 
@@ -3353,11 +3353,11 @@ msgstr ""
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/warning.go:70
+#: lxc/warning.go:71
 msgid "List warnings"
 msgstr ""
 
-#: lxc/warning.go:71
+#: lxc/warning.go:72
 msgid ""
 "List warnings\n"
 "\n"
@@ -3380,7 +3380,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/operation.go:23 lxc/operation.go:24
+#: lxc/operation.go:24 lxc/operation.go:25
 msgid "List, show and delete background operations"
 msgstr ""
 
@@ -3389,7 +3389,7 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/monitor.go:79
+#: lxc/monitor.go:80
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
@@ -3493,23 +3493,23 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:82 lxc/file.go:83
+#: lxc/file.go:83 lxc/file.go:84
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1433 lxc/auth.go:1434
+#: lxc/auth.go:59 lxc/auth.go:60 lxc/auth.go:1434 lxc/auth.go:1435
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1083 lxc/auth.go:1084
+#: lxc/auth.go:1084 lxc/auth.go:1085
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:730 lxc/auth.go:731
+#: lxc/auth.go:731 lxc/auth.go:732
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1851 lxc/auth.go:1852
+#: lxc/auth.go:1852 lxc/auth.go:1853
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3600,7 +3600,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:492 lxc/auth.go:493
+#: lxc/auth.go:493 lxc/auth.go:494
 msgid "Manage permissions"
 msgstr ""
 
@@ -3608,23 +3608,23 @@ msgstr ""
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:28 lxc/project.go:29
+#: lxc/project.go:29 lxc/project.go:30
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:731
+#: lxc/storage_bucket.go:732
 msgid "Manage storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:732
+#: lxc/storage_bucket.go:733
 msgid "Manage storage bucket keys."
 msgstr ""
 
-#: lxc/storage_bucket.go:28
+#: lxc/storage_bucket.go:29
 msgid "Manage storage buckets"
 msgstr ""
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:30
 msgid "Manage storage buckets."
 msgstr ""
 
@@ -3652,11 +3652,11 @@ msgstr ""
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/auth.go:29 lxc/auth.go:30
+#: lxc/auth.go:30 lxc/auth.go:31
 msgid "Manage user authorization"
 msgstr ""
 
-#: lxc/warning.go:28 lxc/warning.go:29
+#: lxc/warning.go:29 lxc/warning.go:30
 msgid "Manage warnings"
 msgstr ""
 
@@ -3720,17 +3720,17 @@ msgstr ""
 msgid "Migration operation failure: %w"
 msgstr ""
 
-#: lxc/monitor.go:51
+#: lxc/monitor.go:52
 msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: lxc/storage_bucket.go:116 lxc/storage_bucket.go:216
-#: lxc/storage_bucket.go:292 lxc/storage_bucket.go:411
-#: lxc/storage_bucket.go:568 lxc/storage_bucket.go:660
-#: lxc/storage_bucket.go:802 lxc/storage_bucket.go:889
-#: lxc/storage_bucket.go:986 lxc/storage_bucket.go:1065
-#: lxc/storage_bucket.go:1188
+#: lxc/storage_bucket.go:117 lxc/storage_bucket.go:217
+#: lxc/storage_bucket.go:293 lxc/storage_bucket.go:412
+#: lxc/storage_bucket.go:569 lxc/storage_bucket.go:661
+#: lxc/storage_bucket.go:803 lxc/storage_bucket.go:890
+#: lxc/storage_bucket.go:987 lxc/storage_bucket.go:1066
+#: lxc/storage_bucket.go:1189
 msgid "Missing bucket name"
 msgstr ""
 
@@ -3749,20 +3749,20 @@ msgstr ""
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1825
+#: lxc/auth.go:123 lxc/auth.go:177 lxc/auth.go:255 lxc/auth.go:417
+#: lxc/auth.go:466 lxc/auth.go:541 lxc/auth.go:600 lxc/auth.go:1826
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:862 lxc/auth.go:1003 lxc/auth.go:1131 lxc/auth.go:1189
+#: lxc/auth.go:863 lxc/auth.go:1004 lxc/auth.go:1132 lxc/auth.go:1190
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1495 lxc/auth.go:1548 lxc/auth.go:1614 lxc/auth.go:1776
+#: lxc/auth.go:1496 lxc/auth.go:1549 lxc/auth.go:1615 lxc/auth.go:1777
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1899 lxc/auth.go:1952
+#: lxc/auth.go:1900 lxc/auth.go:1953
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -3770,12 +3770,12 @@ msgstr ""
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
 #: lxc/config_template.go:377 lxc/profile.go:141 lxc/profile.go:222
-#: lxc/profile.go:808 lxc/rebuild.go:60
+#: lxc/profile.go:808 lxc/rebuild.go:61
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/storage_bucket.go:893 lxc/storage_bucket.go:990
-#: lxc/storage_bucket.go:1069 lxc/storage_bucket.go:1192
+#: lxc/storage_bucket.go:894 lxc/storage_bucket.go:991
+#: lxc/storage_bucket.go:1070 lxc/storage_bucket.go:1193
 msgid "Missing key name"
 msgstr ""
 
@@ -3840,13 +3840,13 @@ msgid "Missing peer name"
 msgstr ""
 
 #: lxc/storage.go:235 lxc/storage.go:313 lxc/storage.go:431 lxc/storage.go:509
-#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:112
-#: lxc/storage_bucket.go:212 lxc/storage_bucket.go:288
-#: lxc/storage_bucket.go:407 lxc/storage_bucket.go:482
-#: lxc/storage_bucket.go:564 lxc/storage_bucket.go:656
-#: lxc/storage_bucket.go:798 lxc/storage_bucket.go:885
-#: lxc/storage_bucket.go:982 lxc/storage_bucket.go:1061
-#: lxc/storage_bucket.go:1184 lxc/storage_volume.go:209
+#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:113
+#: lxc/storage_bucket.go:213 lxc/storage_bucket.go:289
+#: lxc/storage_bucket.go:408 lxc/storage_bucket.go:483
+#: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
+#: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
+#: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
 #: lxc/storage_volume.go:323 lxc/storage_volume.go:643
 #: lxc/storage_volume.go:750 lxc/storage_volume.go:841
 #: lxc/storage_volume.go:939 lxc/storage_volume.go:1053
@@ -3861,9 +3861,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:404 lxc/project.go:146 lxc/project.go:226 lxc/project.go:316
-#: lxc/project.go:433 lxc/project.go:622 lxc/project.go:691 lxc/project.go:819
-#: lxc/project.go:948
+#: lxc/profile.go:404 lxc/project.go:147 lxc/project.go:227 lxc/project.go:317
+#: lxc/project.go:434 lxc/project.go:623 lxc/project.go:692 lxc/project.go:820
+#: lxc/project.go:949
 msgid "Missing project name"
 msgstr ""
 
@@ -3879,7 +3879,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:598
+#: lxc/file.go:599
 msgid "Missing target directory"
 msgstr ""
 
@@ -3901,11 +3901,11 @@ msgstr ""
 msgid "Model: %v"
 msgstr ""
 
-#: lxc/monitor.go:32
+#: lxc/monitor.go:33
 msgid "Monitor a local or remote LXD server"
 msgstr ""
 
-#: lxc/monitor.go:33
+#: lxc/monitor.go:34
 msgid ""
 "Monitor a local or remote LXD server\n"
 "\n"
@@ -3917,11 +3917,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:285
+#: lxc/file.go:286
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:985 lxc/file.go:986
+#: lxc/file.go:986 lxc/file.go:987
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3983,13 +3983,13 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:192
+#: lxc/auth.go:376 lxc/auth.go:816 lxc/auth.go:1736 lxc/cluster.go:192
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
-#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:565
-#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:511
-#: lxc/storage_bucket.go:831 lxc/storage_volume.go:1731
+#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:566
+#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1731
 msgid "NAME"
 msgstr ""
 
@@ -3997,11 +3997,11 @@ msgstr ""
 msgid "NAT"
 msgstr ""
 
-#: lxc/project.go:571
+#: lxc/project.go:572
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:570
+#: lxc/project.go:571
 msgid "NETWORKS"
 msgstr ""
 
@@ -4013,9 +4013,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/operation.go:154 lxc/project.go:523
-#: lxc/project.go:528 lxc/project.go:533 lxc/project.go:538 lxc/project.go:543
-#: lxc/project.go:548 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
+#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:524
+#: lxc/project.go:529 lxc/project.go:534 lxc/project.go:539 lxc/project.go:544
+#: lxc/project.go:549 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
 msgid "NO"
 msgstr ""
 
@@ -4260,7 +4260,7 @@ msgstr ""
 msgid "Only managed networks can be modified"
 msgstr ""
 
-#: lxc/operation.go:86
+#: lxc/operation.go:87
 #, c-format
 msgid "Operation %s deleted"
 msgstr ""
@@ -4307,11 +4307,11 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:567
+#: lxc/list.go:576 lxc/project.go:568
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:212
+#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4373,24 +4373,24 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1102
+#: lxc/file.go:1103
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:860
+#: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
-#: lxc/project.go:363 lxc/storage.go:360 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1151
+#: lxc/project.go:364 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1151
 #: lxc/storage_volume.go:1183
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
-#: lxc/monitor.go:48
+#: lxc/monitor.go:49
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
@@ -4476,17 +4476,17 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:172
+#: lxc/project.go:173
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:236
+#: lxc/project.go:237
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:637
+#: lxc/project.go:638
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -4607,20 +4607,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:241 lxc/file.go:242
+#: lxc/file.go:242 lxc/file.go:243
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:416 lxc/file.go:767
+#: lxc/file.go:417 lxc/file.go:768
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:466 lxc/file.go:467
+#: lxc/file.go:467 lxc/file.go:468
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:701 lxc/file.go:867
+#: lxc/file.go:702 lxc/file.go:868
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4633,11 +4633,11 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:983
+#: lxc/project.go:984
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/storage_bucket.go:833
+#: lxc/storage_bucket.go:834
 msgid "ROLE"
 msgstr ""
 
@@ -4650,15 +4650,15 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/rebuild.go:31
+#: lxc/rebuild.go:32
 msgid "Rebuild as an empty instance"
 msgstr ""
 
-#: lxc/rebuild.go:26
+#: lxc/rebuild.go:27
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:249 lxc/file.go:473
+#: lxc/file.go:250 lxc/file.go:474
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4685,7 +4685,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:882 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
+#: lxc/project.go:883 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
 #: lxc/remote.go:994
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4736,7 +4736,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1164 lxc/auth.go:1165
+#: lxc/auth.go:1165 lxc/auth.go:1166
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4772,7 +4772,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1927 lxc/auth.go:1928
+#: lxc/auth.go:1928 lxc/auth.go:1929
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4784,7 +4784,7 @@ msgstr ""
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:574 lxc/auth.go:575
+#: lxc/auth.go:575 lxc/auth.go:576
 msgid "Remove permissions from groups"
 msgstr ""
 
@@ -4829,11 +4829,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:391 lxc/auth.go:392
+#: lxc/auth.go:392 lxc/auth.go:393
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1751 lxc/auth.go:1752
+#: lxc/auth.go:1752 lxc/auth.go:1753
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -4853,7 +4853,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:589 lxc/project.go:590
+#: lxc/project.go:590 lxc/project.go:591
 msgid "Rename projects"
 msgstr ""
 
@@ -4951,7 +4951,7 @@ msgstr ""
 msgid "Revoke cluster member join token"
 msgstr ""
 
-#: lxc/storage_bucket.go:862
+#: lxc/storage_bucket.go:863
 msgid "Role (admin or read-only)"
 msgstr ""
 
@@ -4967,7 +4967,7 @@ msgstr ""
 msgid "Run against all projects"
 msgstr ""
 
-#: lxc/warning.go:213
+#: lxc/warning.go:214
 msgid "SEVERITY"
 msgstr ""
 
@@ -4987,12 +4987,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1231
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1231
+#: lxc/file.go:1232
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5006,11 +5006,11 @@ msgstr ""
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:173 lxc/warning.go:214
+#: lxc/operation.go:174 lxc/warning.go:215
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:569
+#: lxc/project.go:570
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5018,7 +5018,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:569
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -5026,11 +5026,11 @@ msgstr ""
 msgid "STP"
 msgstr ""
 
-#: lxc/storage_bucket.go:864
+#: lxc/storage_bucket.go:865
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:942
+#: lxc/storage_bucket.go:943
 #, c-format
 msgid "Secret key: %s"
 msgstr ""
@@ -5068,7 +5068,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:995
+#: lxc/file.go:996
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5206,11 +5206,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:654
+#: lxc/project.go:655
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:655
+#: lxc/project.go:656
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5219,11 +5219,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage_bucket.go:534
+#: lxc/storage_bucket.go:535
 msgid "Set storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:535
+#: lxc/storage_bucket.go:536
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -5262,15 +5262,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:476
+#: lxc/file.go:477
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:477
+#: lxc/file.go:478
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:475
+#: lxc/file.go:476
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5310,11 +5310,11 @@ msgstr ""
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 msgid "Set the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:542
+#: lxc/storage_bucket.go:543
 msgid "Set the key as a storage bucket property"
 msgstr ""
 
@@ -5330,7 +5330,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:993
+#: lxc/file.go:994
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5342,7 +5342,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1800 lxc/auth.go:1801
+#: lxc/auth.go:1801 lxc/auth.go:1802
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5358,11 +5358,11 @@ msgstr ""
 msgid "Show details of a cluster member"
 msgstr ""
 
-#: lxc/operation.go:192 lxc/operation.go:193
+#: lxc/operation.go:193 lxc/operation.go:194
 msgid "Show details on a background operation"
 msgstr ""
 
-#: lxc/monitor.go:49
+#: lxc/monitor.go:50
 msgid "Show events from all projects"
 msgstr ""
 
@@ -5370,11 +5370,11 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:440 lxc/auth.go:441
+#: lxc/auth.go:441 lxc/auth.go:442
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:832
+#: lxc/auth.go:833
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5455,15 +5455,15 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:786 lxc/project.go:787
+#: lxc/project.go:787 lxc/project.go:788
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage_bucket.go:628 lxc/storage_bucket.go:629
+#: lxc/storage_bucket.go:629 lxc/storage_bucket.go:630
 msgid "Show storage bucket configurations"
 msgstr ""
 
-#: lxc/storage_bucket.go:1156 lxc/storage_bucket.go:1157
+#: lxc/storage_bucket.go:1157 lxc/storage_bucket.go:1158
 msgid "Show storage bucket key configurations"
 msgstr ""
 
@@ -5479,7 +5479,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:895
+#: lxc/auth.go:896
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5529,7 +5529,7 @@ msgstr ""
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: lxc/warning.go:302 lxc/warning.go:303
+#: lxc/warning.go:303 lxc/warning.go:304
 msgid "Show warning"
 msgstr ""
 
@@ -5613,22 +5613,22 @@ msgstr ""
 msgid "Stopping the instance failed: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:166
+#: lxc/storage_bucket.go:167
 #, c-format
 msgid "Storage bucket %s created"
 msgstr ""
 
-#: lxc/storage_bucket.go:233
+#: lxc/storage_bucket.go:234
 #, c-format
 msgid "Storage bucket %s deleted"
 msgstr ""
 
-#: lxc/storage_bucket.go:940
+#: lxc/storage_bucket.go:941
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr ""
 
-#: lxc/storage_bucket.go:1006
+#: lxc/storage_bucket.go:1007
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr ""
@@ -5697,7 +5697,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:847 lxc/project.go:848
+#: lxc/project.go:848 lxc/project.go:849
 msgid "Switch the current project"
 msgstr ""
 
@@ -5713,10 +5713,10 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1139
+#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1139
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
-#: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:171
-#: lxc/storage_volume.go:1730 lxc/warning.go:215
+#: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
+#: lxc/storage_volume.go:1730 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
@@ -5724,11 +5724,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1032
+#: lxc/file.go:1033
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1026
+#: lxc/file.go:1027
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5856,12 +5856,12 @@ msgstr ""
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:446
+#: lxc/project.go:447
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
 
-#: lxc/storage_bucket.go:431
+#: lxc/storage_bucket.go:432
 #, c-format
 msgid "The property %q does not exist on the storage bucket %q: %v"
 msgstr ""
@@ -6046,7 +6046,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:961
+#: lxc/project.go:962
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6058,17 +6058,17 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:985 lxc/storage_volume.go:1735
+#: lxc/project.go:986 lxc/storage_volume.go:1735
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:573
+#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:574
 #: lxc/storage.go:724 lxc/storage_volume.go:1734
 msgid "USED BY"
 msgstr ""
 
-#: lxc/warning.go:216
+#: lxc/warning.go:217
 msgid "UUID"
 msgstr ""
 
@@ -6077,7 +6077,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:197
+#: lxc/file.go:198
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6091,13 +6091,13 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1253
+#: lxc/file.go:1254
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1153 lxc/list.go:631 lxc/storage_volume.go:1772
-#: lxc/warning.go:241
+#: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6107,7 +6107,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:807
+#: lxc/file.go:808
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6190,11 +6190,11 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:742 lxc/project.go:743
+#: lxc/project.go:743 lxc/project.go:744
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:697 lxc/storage_bucket.go:698
+#: lxc/storage_bucket.go:698 lxc/storage_bucket.go:699
 msgid "Unset storage bucket configuration keys"
 msgstr ""
 
@@ -6242,11 +6242,11 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:747
+#: lxc/project.go:748
 msgid "Unset the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:701
+#: lxc/storage_bucket.go:702
 msgid "Unset the key as a storage bucket property"
 msgstr ""
 
@@ -6325,7 +6325,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:71
+#: lxc/file.go:72
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6362,11 +6362,11 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:831
+#: lxc/auth.go:832
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:894
+#: lxc/auth.go:895
 msgid "View the current identity"
 msgstr ""
 
@@ -6397,15 +6397,15 @@ msgstr ""
 msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
-#: lxc/rebuild.go:27
+#: lxc/rebuild.go:28
 msgid ""
 "Wipe the instance root disk and re-initialize. The original image is used to "
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:156 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
+#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:526
+#: lxc/project.go:531 lxc/project.go:536 lxc/project.go:541 lxc/project.go:546
+#: lxc/project.go:551 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
 msgid "YES"
 msgstr ""
 
@@ -6425,7 +6425,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/rebuild.go:119
+#: lxc/rebuild.go:120
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
@@ -6437,12 +6437,12 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1689
+#: lxc/auth.go:330 lxc/auth.go:763 lxc/auth.go:894 lxc/auth.go:1690
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
-#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
+#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
-#: lxc/operation.go:103 lxc/profile.go:700 lxc/project.go:467
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:68
+#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:468
+#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6470,7 +6470,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1254
+#: lxc/auth.go:1255
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6531,11 +6531,11 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:830
+#: lxc/auth.go:831
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1926
+#: lxc/auth.go:1106 lxc/auth.go:1164 lxc/auth.go:1927
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6543,13 +6543,13 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:954 lxc/auth.go:1470 lxc/cluster_group.go:168
+#: lxc/auth.go:97 lxc/auth.go:150 lxc/auth.go:200 lxc/auth.go:440
+#: lxc/auth.go:955 lxc/auth.go:1471 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:514 lxc/auth.go:572
+#: lxc/auth.go:515 lxc/auth.go:573
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
@@ -6559,19 +6559,19 @@ msgstr ""
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:389
+#: lxc/auth.go:390
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1521 lxc/auth.go:1571 lxc/auth.go:1799
+#: lxc/auth.go:1522 lxc/auth.go:1572 lxc/auth.go:1800
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1873
+#: lxc/auth.go:1874
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1749
+#: lxc/auth.go:1750
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -6591,7 +6591,7 @@ msgstr ""
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
-#: lxc/rebuild.go:25
+#: lxc/rebuild.go:26
 msgid "[<remote>:]<image> [<remote>:]<instance>"
 msgstr ""
 
@@ -6674,20 +6674,20 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:170
+#: lxc/file.go:171
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:120
+#: lxc/file.go:121
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:240
+#: lxc/file.go:241
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:984
+#: lxc/file.go:985
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6838,12 +6838,12 @@ msgstr ""
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
-#: lxc/operation.go:53 lxc/operation.go:191
+#: lxc/operation.go:54 lxc/operation.go:192
 msgid "[<remote>:]<operation>"
 msgstr ""
 
 #: lxc/storage.go:200 lxc/storage.go:259 lxc/storage.go:473 lxc/storage.go:844
-#: lxc/storage_bucket.go:454
+#: lxc/storage_bucket.go:455
 msgid "[<remote>:]<pool>"
 msgstr ""
 
@@ -6851,22 +6851,22 @@ msgstr ""
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
-#: lxc/storage_bucket.go:185 lxc/storage_bucket.go:247
-#: lxc/storage_bucket.go:627 lxc/storage_bucket.go:769
+#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:248
+#: lxc/storage_bucket.go:628 lxc/storage_bucket.go:770
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
 
-#: lxc/storage_bucket.go:380 lxc/storage_bucket.go:696
-#: lxc/storage_bucket.go:850 lxc/storage_bucket.go:956
-#: lxc/storage_bucket.go:1020 lxc/storage_bucket.go:1155
+#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:697
+#: lxc/storage_bucket.go:851 lxc/storage_bucket.go:957
+#: lxc/storage_bucket.go:1021 lxc/storage_bucket.go:1156
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
 
-#: lxc/storage_bucket.go:533
+#: lxc/storage_bucket.go:534
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_bucket.go:81
+#: lxc/storage_bucket.go:82
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
 
@@ -6981,20 +6981,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:91 lxc/project.go:186 lxc/project.go:258 lxc/project.go:785
-#: lxc/project.go:846 lxc/project.go:913
+#: lxc/project.go:92 lxc/project.go:187 lxc/project.go:259 lxc/project.go:786
+#: lxc/project.go:847 lxc/project.go:914
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:394 lxc/project.go:741
+#: lxc/project.go:395 lxc/project.go:742
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:653
+#: lxc/project.go:654
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:587
+#: lxc/project.go:588
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7002,7 +7002,7 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:259 lxc/warning.go:301 lxc/warning.go:354
+#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
@@ -7058,7 +7058,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:555 lxc/remote.go:739
+#: lxc/project.go:556 lxc/remote.go:739
 msgid "current"
 msgstr ""
 
@@ -7105,20 +7105,20 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/auth.go:203
+#: lxc/auth.go:204
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:958
+#: lxc/auth.go:959
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1575
+#: lxc/auth.go:1576
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7196,20 +7196,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:988
+#: lxc/file.go:989
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:244
+#: lxc/file.go:245
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:470
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7291,7 +7291,7 @@ msgid ""
 "  List instances with their running state and user comment."
 msgstr ""
 
-#: lxc/monitor.go:37
+#: lxc/monitor.go:38
 msgid ""
 "lxc monitor --type=logging\n"
 "    Only show log messages.\n"
@@ -7367,7 +7367,7 @@ msgid ""
 "    Create record r1 for zone z1 with configuration from config.yaml"
 msgstr ""
 
-#: lxc/operation.go:195
+#: lxc/operation.go:196
 msgid ""
 "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Show details on that operation UUID"
@@ -7410,7 +7410,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:95
+#: lxc/project.go:96
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7418,7 +7418,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:262
+#: lxc/project.go:263
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7449,7 +7449,7 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:85
 msgid ""
 "lxc storage bucket create p1 b01\n"
 "\tCreate a new storage bucket name b01 in storage pool p1\n"
@@ -7459,19 +7459,19 @@ msgid ""
 "of config.yaml"
 msgstr ""
 
-#: lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:251
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1023
+#: lxc/storage_bucket.go:1024
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:854
 msgid ""
 "lxc storage bucket key create p1 b01 k1\n"
 "\tCreate a key called k1 for the bucket b01 in the pool p1.\n"
@@ -7481,14 +7481,14 @@ msgid ""
 "of config.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1158
+#: lxc/storage_bucket.go:1159
 msgid ""
 "lxc storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_bucket.go:630
+#: lxc/storage_bucket.go:631
 msgid ""
 "lxc storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
@@ -7558,16 +7558,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1142
+#: lxc/file.go:1143
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1101
+#: lxc/file.go:1102
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1054
+#: lxc/file.go:1055
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/ca.po
+++ b/po/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-04 08:52-0600\n"
+"POT-Creation-Date: 2024-09-05 08:44-0400\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Catalan <https://hosted.weblate.org/projects/linux-containers/"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: lxc/storage_bucket.go:260 lxc/storage_bucket.go:1033
+#: lxc/storage_bucket.go:261 lxc/storage_bucket.go:1034
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -133,7 +133,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:213
+#: lxc/auth.go:214
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -160,7 +160,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:968
+#: lxc/auth.go:969
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -181,7 +181,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1585
+#: lxc/auth.go:1586
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -391,7 +391,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:280
+#: lxc/project.go:281
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -433,12 +433,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:935
+#: lxc/file.go:936
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:825
+#: lxc/file.go:826
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -474,7 +474,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:142 lxc/rebuild.go:64
+#: lxc/init.go:142 lxc/rebuild.go:65
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -527,7 +527,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:465
+#: lxc/file.go:466
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -560,7 +560,7 @@ msgstr ""
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:813
+#: lxc/auth.go:814
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -568,11 +568,11 @@ msgstr ""
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/storage_bucket.go:863
+#: lxc/storage_bucket.go:864
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:941
+#: lxc/storage_bucket.go:942
 #, c-format
 msgid "Access key: %s"
 msgstr ""
@@ -581,7 +581,7 @@ msgstr ""
 msgid "Access the expanded configuration"
 msgstr ""
 
-#: lxc/warning.go:261 lxc/warning.go:262
+#: lxc/warning.go:262 lxc/warning.go:263
 msgid "Acknowledge warning"
 msgstr ""
 
@@ -598,11 +598,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1106 lxc/auth.go:1107
+#: lxc/auth.go:1107 lxc/auth.go:1108
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1874 lxc/auth.go:1875
+#: lxc/auth.go:1875 lxc/auth.go:1876
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -671,7 +671,7 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:515 lxc/auth.go:516
+#: lxc/auth.go:516 lxc/auth.go:517
 msgid "Add permissions to groups"
 msgstr ""
 
@@ -700,7 +700,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:169
+#: lxc/storage_bucket.go:170
 #, c-format
 msgid "Admin access key: %s"
 msgstr ""
@@ -710,7 +710,7 @@ msgstr ""
 msgid "Admin password (or token) for %s:"
 msgstr ""
 
-#: lxc/storage_bucket.go:170
+#: lxc/storage_bucket.go:171
 #, c-format
 msgid "Admin secret key: %s"
 msgstr ""
@@ -769,7 +769,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:342 lxc/rebuild.go:130
+#: lxc/init.go:342 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -869,12 +869,12 @@ msgstr ""
 
 #: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:318
 #: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
-#: lxc/network_zone.go:366 lxc/network_zone.go:1053 lxc/storage_bucket.go:141
+#: lxc/network_zone.go:366 lxc/network_zone.go:1053 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:159
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:160
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -914,7 +914,7 @@ msgstr ""
 msgid "Bytes sent"
 msgstr ""
 
-#: lxc/operation.go:174
+#: lxc/operation.go:175
 msgid "CANCELABLE"
 msgstr ""
 
@@ -926,7 +926,7 @@ msgstr ""
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: lxc/warning.go:209
+#: lxc/warning.go:210
 msgid "COUNT"
 msgstr ""
 
@@ -952,7 +952,7 @@ msgstr ""
 msgid "CPUs (%s):"
 msgstr ""
 
-#: lxc/operation.go:175
+#: lxc/operation.go:176
 msgid "CREATED"
 msgstr ""
 
@@ -982,7 +982,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:340
+#: lxc/file.go:341
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1007,11 +1007,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:224
+#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:546
+#: lxc/file.go:547
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1020,7 +1020,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:160
+#: lxc/rebuild.go:161
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1143,13 +1143,13 @@ msgstr ""
 #: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
 #: lxc/network_load_balancer.go:1051 lxc/network_load_balancer.go:1125
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
-#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:90
-#: lxc/storage_bucket.go:190 lxc/storage_bucket.go:253
-#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:541
-#: lxc/storage_bucket.go:634 lxc/storage_bucket.go:700
-#: lxc/storage_bucket.go:775 lxc/storage_bucket.go:861
-#: lxc/storage_bucket.go:961 lxc/storage_bucket.go:1026
-#: lxc/storage_bucket.go:1162 lxc/storage_volume.go:394
+#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
+#: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
+#: lxc/storage_bucket.go:385 lxc/storage_bucket.go:542
+#: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
+#: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
+#: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
 #: lxc/storage_volume.go:612 lxc/storage_volume.go:717
 #: lxc/storage_volume.go:1005 lxc/storage_volume.go:1231
 #: lxc/storage_volume.go:1360 lxc/storage_volume.go:1848
@@ -1173,7 +1173,7 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1113 lxc/list.go:132 lxc/storage_volume.go:1589
-#: lxc/warning.go:92
+#: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
@@ -1201,7 +1201,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:100
+#: lxc/project.go:101
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1215,8 +1215,8 @@ msgstr ""
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
-#: lxc/project.go:362 lxc/storage.go:359 lxc/storage_bucket.go:348
-#: lxc/storage_bucket.go:1125 lxc/storage_volume.go:1150
+#: lxc/project.go:363 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1150
 #: lxc/storage_volume.go:1182
 #, c-format
 msgid "Config parsing error: %s"
@@ -1343,12 +1343,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:300 lxc/auth.go:1660
+#: lxc/auth.go:301 lxc/auth.go:1661
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1054
+#: lxc/auth.go:1055
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1397,15 +1397,15 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:248 lxc/file.go:474
+#: lxc/file.go:249 lxc/file.go:475
 msgid "Create any directories necessary"
 msgstr ""
 
-#: lxc/auth.go:97 lxc/auth.go:98
+#: lxc/auth.go:98 lxc/auth.go:99
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1471 lxc/auth.go:1472
+#: lxc/auth.go:1472 lxc/auth.go:1473
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1425,11 +1425,11 @@ msgstr ""
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_bucket.go:851 lxc/storage_bucket.go:852
+#: lxc/storage_bucket.go:852 lxc/storage_bucket.go:853
 msgid "Create key for a storage bucket"
 msgstr ""
 
-#: lxc/storage_bucket.go:82 lxc/storage_bucket.go:83
+#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
 msgid "Create new custom storage buckets"
 msgstr ""
 
@@ -1473,7 +1473,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:92 lxc/project.go:93
+#: lxc/project.go:93 lxc/project.go:94
 msgid "Create projects"
 msgstr ""
 
@@ -1508,13 +1508,13 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:376 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1135 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
-#: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:172
-#: lxc/profile.go:756 lxc/project.go:572 lxc/storage.go:723
-#: lxc/storage_bucket.go:512 lxc/storage_bucket.go:832
+#: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
+#: lxc/profile.go:756 lxc/project.go:573 lxc/storage.go:723
+#: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1732
 msgid "DESCRIPTION"
 msgstr ""
@@ -1539,7 +1539,7 @@ msgstr ""
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
-#: lxc/operation.go:55 lxc/operation.go:56
+#: lxc/operation.go:56 lxc/operation.go:57
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
@@ -1547,19 +1547,19 @@ msgstr ""
 msgid "Delete a cluster group"
 msgstr ""
 
-#: lxc/warning.go:360
+#: lxc/warning.go:361
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:122 lxc/file.go:123
+#: lxc/file.go:123 lxc/file.go:124
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/auth.go:151 lxc/auth.go:152
+#: lxc/auth.go:152 lxc/auth.go:153
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1523 lxc/auth.go:1524
+#: lxc/auth.go:1524 lxc/auth.go:1525
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1579,7 +1579,7 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/storage_bucket.go:957 lxc/storage_bucket.go:958
+#: lxc/storage_bucket.go:958 lxc/storage_bucket.go:959
 msgid "Delete key from a storage bucket"
 msgstr ""
 
@@ -1615,11 +1615,11 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:188 lxc/project.go:189
+#: lxc/project.go:189 lxc/project.go:190
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:187 lxc/storage_bucket.go:188
+#: lxc/storage_bucket.go:188 lxc/storage_bucket.go:189
 msgid "Delete storage buckets"
 msgstr ""
 
@@ -1631,20 +1631,20 @@ msgstr ""
 msgid "Delete storage volumes"
 msgstr ""
 
-#: lxc/warning.go:356 lxc/warning.go:357
+#: lxc/warning.go:357 lxc/warning.go:358
 msgid "Delete warning"
 msgstr ""
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:30 lxc/auth.go:59 lxc/auth.go:98
-#: lxc/auth.go:152 lxc/auth.go:201 lxc/auth.go:332 lxc/auth.go:392
-#: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
-#: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
-#: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
-#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1434 lxc/auth.go:1472
-#: lxc/auth.go:1524 lxc/auth.go:1573 lxc/auth.go:1692 lxc/auth.go:1752
-#: lxc/auth.go:1801 lxc/auth.go:1852 lxc/auth.go:1875 lxc/auth.go:1928
+#: lxc/alias.go:214 lxc/auth.go:31 lxc/auth.go:60 lxc/auth.go:99
+#: lxc/auth.go:153 lxc/auth.go:202 lxc/auth.go:333 lxc/auth.go:393
+#: lxc/auth.go:442 lxc/auth.go:494 lxc/auth.go:517 lxc/auth.go:576
+#: lxc/auth.go:732 lxc/auth.go:766 lxc/auth.go:833 lxc/auth.go:896
+#: lxc/auth.go:957 lxc/auth.go:1085 lxc/auth.go:1108 lxc/auth.go:1166
+#: lxc/auth.go:1235 lxc/auth.go:1257 lxc/auth.go:1435 lxc/auth.go:1473
+#: lxc/auth.go:1525 lxc/auth.go:1574 lxc/auth.go:1693 lxc/auth.go:1753
+#: lxc/auth.go:1802 lxc/auth.go:1853 lxc/auth.go:1876 lxc/auth.go:1929
 #: lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215 lxc/cluster.go:272
 #: lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:484 lxc/cluster.go:528
 #: lxc/cluster.go:586 lxc/cluster.go:677 lxc/cluster.go:770 lxc/cluster.go:893
@@ -1668,15 +1668,15 @@ msgstr ""
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:83 lxc/file.go:123 lxc/file.go:172
-#: lxc/file.go:242 lxc/file.go:467 lxc/file.go:986 lxc/image.go:38
+#: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
+#: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
 #: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
 #: lxc/image.go:697 lxc/image.go:946 lxc/image.go:1088 lxc/image.go:1415
 #: lxc/image.go:1506 lxc/image.go:1572 lxc/image.go:1636 lxc/image.go:1699
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:38 lxc/network.go:33
+#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33
 #: lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405
 #: lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793
 #: lxc/network.go:874 lxc/network.go:1005 lxc/network.go:1106
@@ -1710,27 +1710,27 @@ msgstr ""
 #: lxc/network_zone.go:909 lxc/network_zone.go:985 lxc/network_zone.go:1083
 #: lxc/network_zone.go:1172 lxc/network_zone.go:1219 lxc/network_zone.go:1349
 #: lxc/network_zone.go:1410 lxc/network_zone.go:1425 lxc/network_zone.go:1483
-#: lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:106
-#: lxc/operation.go:193 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
+#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
+#: lxc/operation.go:194 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
 #: lxc/profile.go:271 lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493
 #: lxc/profile.go:629 lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860
-#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:29
-#: lxc/project.go:93 lxc/project.go:189 lxc/project.go:260 lxc/project.go:396
-#: lxc/project.go:470 lxc/project.go:590 lxc/project.go:655 lxc/project.go:743
-#: lxc/project.go:787 lxc/project.go:848 lxc/project.go:915 lxc/publish.go:34
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:35 lxc/remote.go:91
+#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:30
+#: lxc/project.go:94 lxc/project.go:190 lxc/project.go:261 lxc/project.go:397
+#: lxc/project.go:471 lxc/project.go:591 lxc/project.go:656 lxc/project.go:744
+#: lxc/project.go:788 lxc/project.go:849 lxc/project.go:916 lxc/publish.go:34
+#: lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91
 #: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853
 #: lxc/remote.go:917 lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24
 #: lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203
 #: lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655
 #: lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940
-#: lxc/storage_bucket.go:29 lxc/storage_bucket.go:83 lxc/storage_bucket.go:188
-#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:382
-#: lxc/storage_bucket.go:458 lxc/storage_bucket.go:535
-#: lxc/storage_bucket.go:629 lxc/storage_bucket.go:698
-#: lxc/storage_bucket.go:732 lxc/storage_bucket.go:773
-#: lxc/storage_bucket.go:852 lxc/storage_bucket.go:958
-#: lxc/storage_bucket.go:1022 lxc/storage_bucket.go:1157
+#: lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189
+#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:383
+#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:536
+#: lxc/storage_bucket.go:630 lxc/storage_bucket.go:699
+#: lxc/storage_bucket.go:733 lxc/storage_bucket.go:774
+#: lxc/storage_bucket.go:853 lxc/storage_bucket.go:959
+#: lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158
 #: lxc/storage_volume.go:58 lxc/storage_volume.go:169 lxc/storage_volume.go:283
 #: lxc/storage_volume.go:390 lxc/storage_volume.go:605
 #: lxc/storage_volume.go:714 lxc/storage_volume.go:801
@@ -1741,8 +1741,8 @@ msgstr ""
 #: lxc/storage_volume.go:2064 lxc/storage_volume.go:2222
 #: lxc/storage_volume.go:2343 lxc/storage_volume.go:2405
 #: lxc/storage_volume.go:2541 lxc/storage_volume.go:2624
-#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:29
-#: lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
+#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:30
+#: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
@@ -1829,7 +1829,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:994
+#: lxc/file.go:995
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1895,7 +1895,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:74
+#: lxc/file.go:75
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1905,7 +1905,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:955 lxc/auth.go:956
+#: lxc/auth.go:956 lxc/auth.go:957
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1913,15 +1913,15 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:171 lxc/file.go:172
+#: lxc/file.go:172 lxc/file.go:173
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/auth.go:200 lxc/auth.go:201
+#: lxc/auth.go:201 lxc/auth.go:202
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1572 lxc/auth.go:1573
+#: lxc/auth.go:1573 lxc/auth.go:1574
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -1977,15 +1977,15 @@ msgstr ""
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:259 lxc/project.go:260
+#: lxc/project.go:260 lxc/project.go:261
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:248 lxc/storage_bucket.go:249
+#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:250
 msgid "Edit storage bucket configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:1021 lxc/storage_bucket.go:1022
+#: lxc/storage_bucket.go:1022 lxc/storage_bucket.go:1023
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
@@ -2002,7 +2002,7 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1147 lxc/list.go:622 lxc/storage_volume.go:1766
-#: lxc/warning.go:235
+#: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2057,7 +2057,7 @@ msgstr ""
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
-#: lxc/project.go:718 lxc/storage.go:812 lxc/storage_bucket.go:602
+#: lxc/project.go:719 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2155 lxc/storage_volume.go:2193
 #, c-format
 msgid "Error setting properties: %v"
@@ -2071,8 +2071,8 @@ msgstr ""
 #: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
-#: lxc/profile.go:981 lxc/project.go:712 lxc/storage.go:806
-#: lxc/storage_bucket.go:596 lxc/storage_volume.go:2149
+#: lxc/profile.go:981 lxc/project.go:713 lxc/storage.go:806
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2149
 #: lxc/storage_volume.go:2187
 #, c-format
 msgid "Error unsetting property: %v"
@@ -2092,7 +2092,7 @@ msgstr ""
 msgid "Evacuating cluster member: %s"
 msgstr ""
 
-#: lxc/monitor.go:50
+#: lxc/monitor.go:51
 msgid "Event type to listen for"
 msgstr ""
 
@@ -2179,16 +2179,16 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/warning.go:210
+#: lxc/warning.go:211
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1237
+#: lxc/file.go:1238
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1260
+#: lxc/file.go:1261
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2203,12 +2203,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1287
+#: lxc/file.go:1288
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1072
+#: lxc/file.go:1073
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2238,7 +2238,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1193
+#: lxc/file.go:1194
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2253,7 +2253,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1198
+#: lxc/file.go:1199
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2263,12 +2263,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1098
+#: lxc/file.go:1099
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1225
+#: lxc/file.go:1226
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2307,7 +2307,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1210
+#: lxc/file.go:1211
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2322,7 +2322,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:820
+#: lxc/file.go:821
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2337,7 +2337,7 @@ msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
 #: lxc/network.go:1044 lxc/network_acl.go:133 lxc/network_zone.go:124
-#: lxc/operation.go:136
+#: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
 
@@ -2402,21 +2402,21 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
+#: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:770 lxc/auth.go:1697
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1114 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:57
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
-#: lxc/operation.go:108 lxc/profile.go:707 lxc/project.go:472
-#: lxc/project.go:917 lxc/remote.go:690 lxc/storage.go:657
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:774
-#: lxc/storage_volume.go:1608 lxc/warning.go:93
+#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:473
+#: lxc/project.go:918 lxc/remote.go:690 lxc/storage.go:657
+#: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
+#: lxc/storage_volume.go:1608 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
-#: lxc/monitor.go:52
+#: lxc/monitor.go:53
 msgid "Format (json|pretty|yaml)"
 msgstr ""
 
@@ -2460,7 +2460,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:817 lxc/auth.go:1736
+#: lxc/auth.go:818 lxc/auth.go:1737
 msgid "GROUPS"
 msgstr ""
 
@@ -2476,7 +2476,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:914 lxc/project.go:915
+#: lxc/project.go:915 lxc/project.go:916
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2524,11 +2524,11 @@ msgstr ""
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:400
+#: lxc/project.go:401
 msgid "Get the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:385
+#: lxc/storage_bucket.go:386
 msgid "Get the key as a storage bucket property"
 msgstr ""
 
@@ -2588,11 +2588,11 @@ msgstr ""
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:395 lxc/project.go:396
+#: lxc/project.go:396 lxc/project.go:397
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:382
+#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:383
 msgid "Get values for storage bucket configuration keys"
 msgstr ""
 
@@ -2609,17 +2609,17 @@ msgstr ""
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: lxc/auth.go:136
+#: lxc/auth.go:137
 #, c-format
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:186
+#: lxc/auth.go:187
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:426 lxc/auth.go:1786
+#: lxc/auth.go:427 lxc/auth.go:1787
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2644,27 +2644,27 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1310
+#: lxc/file.go:1311
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1299
+#: lxc/file.go:1300
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1122
+#: lxc/file.go:1123
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1132
+#: lxc/file.go:1133
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:966 lxc/operation.go:170
+#: lxc/network.go:966 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2678,11 +2678,11 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:816
+#: lxc/auth.go:817
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:566
+#: lxc/project.go:567
 msgid "IMAGES"
 msgstr ""
 
@@ -2710,17 +2710,17 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1508
+#: lxc/auth.go:1509
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1558
+#: lxc/auth.go:1559
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
 
-#: lxc/rebuild.go:32
+#: lxc/rebuild.go:33
 msgid "If an instance is running, stop it and then rebuild it"
 msgstr ""
 
@@ -2841,7 +2841,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1233 lxc/auth.go:1234
+#: lxc/auth.go:1234 lxc/auth.go:1235
 msgid "Inspect permissions"
 msgstr ""
 
@@ -2849,11 +2849,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1124
+#: lxc/file.go:1125
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1301
+#: lxc/file.go:1302
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2871,7 +2871,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1044
+#: lxc/file.go:1045
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2880,7 +2880,7 @@ msgstr ""
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/rebuild.go:74
+#: lxc/rebuild.go:75
 #, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
@@ -2913,7 +2913,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/monitor.go:70
+#: lxc/monitor.go:71
 #, c-format
 msgid "Invalid format: %s"
 msgstr ""
@@ -2923,7 +2923,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1039
+#: lxc/file.go:1040
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2965,7 +2965,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:147
+#: lxc/file.go:148
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2981,12 +2981,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:313
+#: lxc/file.go:314
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:495
+#: lxc/file.go:496
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3000,7 +3000,7 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/warning.go:212
 msgid "LAST SEEN"
 msgstr ""
 
@@ -3008,7 +3008,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:984
+#: lxc/project.go:985
 msgid "LIMIT"
 msgstr ""
 
@@ -3017,8 +3017,8 @@ msgid "LISTEN ADDRESS"
 msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
-#: lxc/network_load_balancer.go:165 lxc/operation.go:177
-#: lxc/storage_bucket.go:516 lxc/storage_volume.go:1739 lxc/warning.go:220
+#: lxc/network_load_balancer.go:165 lxc/operation.go:178
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1739 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3092,7 +3092,7 @@ msgstr ""
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/warning.go:94
+#: lxc/warning.go:95
 msgid "List all warnings"
 msgstr ""
 
@@ -3136,19 +3136,19 @@ msgstr ""
 msgid "List available storage pools"
 msgstr ""
 
-#: lxc/operation.go:105 lxc/operation.go:106
+#: lxc/operation.go:106 lxc/operation.go:107
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:331 lxc/auth.go:332
+#: lxc/auth.go:332 lxc/auth.go:333
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:764 lxc/auth.go:765
+#: lxc/auth.go:765 lxc/auth.go:766
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1691 lxc/auth.go:1692
+#: lxc/auth.go:1692 lxc/auth.go:1693
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3297,11 +3297,11 @@ msgstr ""
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/operation.go:109
+#: lxc/operation.go:110
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1255 lxc/auth.go:1256
+#: lxc/auth.go:1256 lxc/auth.go:1257
 msgid "List permissions"
 msgstr ""
 
@@ -3309,15 +3309,15 @@ msgstr ""
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:469 lxc/project.go:470
+#: lxc/project.go:470 lxc/project.go:471
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:771 lxc/storage_bucket.go:773
+#: lxc/storage_bucket.go:772 lxc/storage_bucket.go:774
 msgid "List storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:456 lxc/storage_bucket.go:458
+#: lxc/storage_bucket.go:457 lxc/storage_bucket.go:459
 msgid "List storage buckets"
 msgstr ""
 
@@ -3353,11 +3353,11 @@ msgstr ""
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/warning.go:70
+#: lxc/warning.go:71
 msgid "List warnings"
 msgstr ""
 
-#: lxc/warning.go:71
+#: lxc/warning.go:72
 msgid ""
 "List warnings\n"
 "\n"
@@ -3380,7 +3380,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/operation.go:23 lxc/operation.go:24
+#: lxc/operation.go:24 lxc/operation.go:25
 msgid "List, show and delete background operations"
 msgstr ""
 
@@ -3389,7 +3389,7 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/monitor.go:79
+#: lxc/monitor.go:80
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
@@ -3493,23 +3493,23 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:82 lxc/file.go:83
+#: lxc/file.go:83 lxc/file.go:84
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1433 lxc/auth.go:1434
+#: lxc/auth.go:59 lxc/auth.go:60 lxc/auth.go:1434 lxc/auth.go:1435
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1083 lxc/auth.go:1084
+#: lxc/auth.go:1084 lxc/auth.go:1085
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:730 lxc/auth.go:731
+#: lxc/auth.go:731 lxc/auth.go:732
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1851 lxc/auth.go:1852
+#: lxc/auth.go:1852 lxc/auth.go:1853
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3600,7 +3600,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:492 lxc/auth.go:493
+#: lxc/auth.go:493 lxc/auth.go:494
 msgid "Manage permissions"
 msgstr ""
 
@@ -3608,23 +3608,23 @@ msgstr ""
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:28 lxc/project.go:29
+#: lxc/project.go:29 lxc/project.go:30
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:731
+#: lxc/storage_bucket.go:732
 msgid "Manage storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:732
+#: lxc/storage_bucket.go:733
 msgid "Manage storage bucket keys."
 msgstr ""
 
-#: lxc/storage_bucket.go:28
+#: lxc/storage_bucket.go:29
 msgid "Manage storage buckets"
 msgstr ""
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:30
 msgid "Manage storage buckets."
 msgstr ""
 
@@ -3652,11 +3652,11 @@ msgstr ""
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/auth.go:29 lxc/auth.go:30
+#: lxc/auth.go:30 lxc/auth.go:31
 msgid "Manage user authorization"
 msgstr ""
 
-#: lxc/warning.go:28 lxc/warning.go:29
+#: lxc/warning.go:29 lxc/warning.go:30
 msgid "Manage warnings"
 msgstr ""
 
@@ -3720,17 +3720,17 @@ msgstr ""
 msgid "Migration operation failure: %w"
 msgstr ""
 
-#: lxc/monitor.go:51
+#: lxc/monitor.go:52
 msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: lxc/storage_bucket.go:116 lxc/storage_bucket.go:216
-#: lxc/storage_bucket.go:292 lxc/storage_bucket.go:411
-#: lxc/storage_bucket.go:568 lxc/storage_bucket.go:660
-#: lxc/storage_bucket.go:802 lxc/storage_bucket.go:889
-#: lxc/storage_bucket.go:986 lxc/storage_bucket.go:1065
-#: lxc/storage_bucket.go:1188
+#: lxc/storage_bucket.go:117 lxc/storage_bucket.go:217
+#: lxc/storage_bucket.go:293 lxc/storage_bucket.go:412
+#: lxc/storage_bucket.go:569 lxc/storage_bucket.go:661
+#: lxc/storage_bucket.go:803 lxc/storage_bucket.go:890
+#: lxc/storage_bucket.go:987 lxc/storage_bucket.go:1066
+#: lxc/storage_bucket.go:1189
 msgid "Missing bucket name"
 msgstr ""
 
@@ -3749,20 +3749,20 @@ msgstr ""
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1825
+#: lxc/auth.go:123 lxc/auth.go:177 lxc/auth.go:255 lxc/auth.go:417
+#: lxc/auth.go:466 lxc/auth.go:541 lxc/auth.go:600 lxc/auth.go:1826
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:862 lxc/auth.go:1003 lxc/auth.go:1131 lxc/auth.go:1189
+#: lxc/auth.go:863 lxc/auth.go:1004 lxc/auth.go:1132 lxc/auth.go:1190
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1495 lxc/auth.go:1548 lxc/auth.go:1614 lxc/auth.go:1776
+#: lxc/auth.go:1496 lxc/auth.go:1549 lxc/auth.go:1615 lxc/auth.go:1777
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1899 lxc/auth.go:1952
+#: lxc/auth.go:1900 lxc/auth.go:1953
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -3770,12 +3770,12 @@ msgstr ""
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
 #: lxc/config_template.go:377 lxc/profile.go:141 lxc/profile.go:222
-#: lxc/profile.go:808 lxc/rebuild.go:60
+#: lxc/profile.go:808 lxc/rebuild.go:61
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/storage_bucket.go:893 lxc/storage_bucket.go:990
-#: lxc/storage_bucket.go:1069 lxc/storage_bucket.go:1192
+#: lxc/storage_bucket.go:894 lxc/storage_bucket.go:991
+#: lxc/storage_bucket.go:1070 lxc/storage_bucket.go:1193
 msgid "Missing key name"
 msgstr ""
 
@@ -3840,13 +3840,13 @@ msgid "Missing peer name"
 msgstr ""
 
 #: lxc/storage.go:235 lxc/storage.go:313 lxc/storage.go:431 lxc/storage.go:509
-#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:112
-#: lxc/storage_bucket.go:212 lxc/storage_bucket.go:288
-#: lxc/storage_bucket.go:407 lxc/storage_bucket.go:482
-#: lxc/storage_bucket.go:564 lxc/storage_bucket.go:656
-#: lxc/storage_bucket.go:798 lxc/storage_bucket.go:885
-#: lxc/storage_bucket.go:982 lxc/storage_bucket.go:1061
-#: lxc/storage_bucket.go:1184 lxc/storage_volume.go:209
+#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:113
+#: lxc/storage_bucket.go:213 lxc/storage_bucket.go:289
+#: lxc/storage_bucket.go:408 lxc/storage_bucket.go:483
+#: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
+#: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
+#: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
 #: lxc/storage_volume.go:323 lxc/storage_volume.go:643
 #: lxc/storage_volume.go:750 lxc/storage_volume.go:841
 #: lxc/storage_volume.go:939 lxc/storage_volume.go:1053
@@ -3861,9 +3861,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:404 lxc/project.go:146 lxc/project.go:226 lxc/project.go:316
-#: lxc/project.go:433 lxc/project.go:622 lxc/project.go:691 lxc/project.go:819
-#: lxc/project.go:948
+#: lxc/profile.go:404 lxc/project.go:147 lxc/project.go:227 lxc/project.go:317
+#: lxc/project.go:434 lxc/project.go:623 lxc/project.go:692 lxc/project.go:820
+#: lxc/project.go:949
 msgid "Missing project name"
 msgstr ""
 
@@ -3879,7 +3879,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:598
+#: lxc/file.go:599
 msgid "Missing target directory"
 msgstr ""
 
@@ -3901,11 +3901,11 @@ msgstr ""
 msgid "Model: %v"
 msgstr ""
 
-#: lxc/monitor.go:32
+#: lxc/monitor.go:33
 msgid "Monitor a local or remote LXD server"
 msgstr ""
 
-#: lxc/monitor.go:33
+#: lxc/monitor.go:34
 msgid ""
 "Monitor a local or remote LXD server\n"
 "\n"
@@ -3917,11 +3917,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:285
+#: lxc/file.go:286
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:985 lxc/file.go:986
+#: lxc/file.go:986 lxc/file.go:987
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3983,13 +3983,13 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:192
+#: lxc/auth.go:376 lxc/auth.go:816 lxc/auth.go:1736 lxc/cluster.go:192
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
-#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:565
-#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:511
-#: lxc/storage_bucket.go:831 lxc/storage_volume.go:1731
+#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:566
+#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1731
 msgid "NAME"
 msgstr ""
 
@@ -3997,11 +3997,11 @@ msgstr ""
 msgid "NAT"
 msgstr ""
 
-#: lxc/project.go:571
+#: lxc/project.go:572
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:570
+#: lxc/project.go:571
 msgid "NETWORKS"
 msgstr ""
 
@@ -4013,9 +4013,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/operation.go:154 lxc/project.go:523
-#: lxc/project.go:528 lxc/project.go:533 lxc/project.go:538 lxc/project.go:543
-#: lxc/project.go:548 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
+#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:524
+#: lxc/project.go:529 lxc/project.go:534 lxc/project.go:539 lxc/project.go:544
+#: lxc/project.go:549 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
 msgid "NO"
 msgstr ""
 
@@ -4260,7 +4260,7 @@ msgstr ""
 msgid "Only managed networks can be modified"
 msgstr ""
 
-#: lxc/operation.go:86
+#: lxc/operation.go:87
 #, c-format
 msgid "Operation %s deleted"
 msgstr ""
@@ -4307,11 +4307,11 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:567
+#: lxc/list.go:576 lxc/project.go:568
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:212
+#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4373,24 +4373,24 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1102
+#: lxc/file.go:1103
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:860
+#: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
-#: lxc/project.go:363 lxc/storage.go:360 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1151
+#: lxc/project.go:364 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1151
 #: lxc/storage_volume.go:1183
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
-#: lxc/monitor.go:48
+#: lxc/monitor.go:49
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
@@ -4476,17 +4476,17 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:172
+#: lxc/project.go:173
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:236
+#: lxc/project.go:237
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:637
+#: lxc/project.go:638
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -4607,20 +4607,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:241 lxc/file.go:242
+#: lxc/file.go:242 lxc/file.go:243
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:416 lxc/file.go:767
+#: lxc/file.go:417 lxc/file.go:768
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:466 lxc/file.go:467
+#: lxc/file.go:467 lxc/file.go:468
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:701 lxc/file.go:867
+#: lxc/file.go:702 lxc/file.go:868
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4633,11 +4633,11 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:983
+#: lxc/project.go:984
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/storage_bucket.go:833
+#: lxc/storage_bucket.go:834
 msgid "ROLE"
 msgstr ""
 
@@ -4650,15 +4650,15 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/rebuild.go:31
+#: lxc/rebuild.go:32
 msgid "Rebuild as an empty instance"
 msgstr ""
 
-#: lxc/rebuild.go:26
+#: lxc/rebuild.go:27
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:249 lxc/file.go:473
+#: lxc/file.go:250 lxc/file.go:474
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4685,7 +4685,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:882 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
+#: lxc/project.go:883 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
 #: lxc/remote.go:994
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4736,7 +4736,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1164 lxc/auth.go:1165
+#: lxc/auth.go:1165 lxc/auth.go:1166
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4772,7 +4772,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1927 lxc/auth.go:1928
+#: lxc/auth.go:1928 lxc/auth.go:1929
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4784,7 +4784,7 @@ msgstr ""
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:574 lxc/auth.go:575
+#: lxc/auth.go:575 lxc/auth.go:576
 msgid "Remove permissions from groups"
 msgstr ""
 
@@ -4829,11 +4829,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:391 lxc/auth.go:392
+#: lxc/auth.go:392 lxc/auth.go:393
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1751 lxc/auth.go:1752
+#: lxc/auth.go:1752 lxc/auth.go:1753
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -4853,7 +4853,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:589 lxc/project.go:590
+#: lxc/project.go:590 lxc/project.go:591
 msgid "Rename projects"
 msgstr ""
 
@@ -4951,7 +4951,7 @@ msgstr ""
 msgid "Revoke cluster member join token"
 msgstr ""
 
-#: lxc/storage_bucket.go:862
+#: lxc/storage_bucket.go:863
 msgid "Role (admin or read-only)"
 msgstr ""
 
@@ -4967,7 +4967,7 @@ msgstr ""
 msgid "Run against all projects"
 msgstr ""
 
-#: lxc/warning.go:213
+#: lxc/warning.go:214
 msgid "SEVERITY"
 msgstr ""
 
@@ -4987,12 +4987,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1231
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1231
+#: lxc/file.go:1232
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5006,11 +5006,11 @@ msgstr ""
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:173 lxc/warning.go:214
+#: lxc/operation.go:174 lxc/warning.go:215
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:569
+#: lxc/project.go:570
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5018,7 +5018,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:569
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -5026,11 +5026,11 @@ msgstr ""
 msgid "STP"
 msgstr ""
 
-#: lxc/storage_bucket.go:864
+#: lxc/storage_bucket.go:865
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:942
+#: lxc/storage_bucket.go:943
 #, c-format
 msgid "Secret key: %s"
 msgstr ""
@@ -5068,7 +5068,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:995
+#: lxc/file.go:996
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5206,11 +5206,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:654
+#: lxc/project.go:655
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:655
+#: lxc/project.go:656
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5219,11 +5219,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage_bucket.go:534
+#: lxc/storage_bucket.go:535
 msgid "Set storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:535
+#: lxc/storage_bucket.go:536
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -5262,15 +5262,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:476
+#: lxc/file.go:477
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:477
+#: lxc/file.go:478
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:475
+#: lxc/file.go:476
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5310,11 +5310,11 @@ msgstr ""
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 msgid "Set the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:542
+#: lxc/storage_bucket.go:543
 msgid "Set the key as a storage bucket property"
 msgstr ""
 
@@ -5330,7 +5330,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:993
+#: lxc/file.go:994
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5342,7 +5342,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1800 lxc/auth.go:1801
+#: lxc/auth.go:1801 lxc/auth.go:1802
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5358,11 +5358,11 @@ msgstr ""
 msgid "Show details of a cluster member"
 msgstr ""
 
-#: lxc/operation.go:192 lxc/operation.go:193
+#: lxc/operation.go:193 lxc/operation.go:194
 msgid "Show details on a background operation"
 msgstr ""
 
-#: lxc/monitor.go:49
+#: lxc/monitor.go:50
 msgid "Show events from all projects"
 msgstr ""
 
@@ -5370,11 +5370,11 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:440 lxc/auth.go:441
+#: lxc/auth.go:441 lxc/auth.go:442
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:832
+#: lxc/auth.go:833
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5455,15 +5455,15 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:786 lxc/project.go:787
+#: lxc/project.go:787 lxc/project.go:788
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage_bucket.go:628 lxc/storage_bucket.go:629
+#: lxc/storage_bucket.go:629 lxc/storage_bucket.go:630
 msgid "Show storage bucket configurations"
 msgstr ""
 
-#: lxc/storage_bucket.go:1156 lxc/storage_bucket.go:1157
+#: lxc/storage_bucket.go:1157 lxc/storage_bucket.go:1158
 msgid "Show storage bucket key configurations"
 msgstr ""
 
@@ -5479,7 +5479,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:895
+#: lxc/auth.go:896
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5529,7 +5529,7 @@ msgstr ""
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: lxc/warning.go:302 lxc/warning.go:303
+#: lxc/warning.go:303 lxc/warning.go:304
 msgid "Show warning"
 msgstr ""
 
@@ -5613,22 +5613,22 @@ msgstr ""
 msgid "Stopping the instance failed: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:166
+#: lxc/storage_bucket.go:167
 #, c-format
 msgid "Storage bucket %s created"
 msgstr ""
 
-#: lxc/storage_bucket.go:233
+#: lxc/storage_bucket.go:234
 #, c-format
 msgid "Storage bucket %s deleted"
 msgstr ""
 
-#: lxc/storage_bucket.go:940
+#: lxc/storage_bucket.go:941
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr ""
 
-#: lxc/storage_bucket.go:1006
+#: lxc/storage_bucket.go:1007
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr ""
@@ -5697,7 +5697,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:847 lxc/project.go:848
+#: lxc/project.go:848 lxc/project.go:849
 msgid "Switch the current project"
 msgstr ""
 
@@ -5713,10 +5713,10 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1139
+#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1139
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
-#: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:171
-#: lxc/storage_volume.go:1730 lxc/warning.go:215
+#: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
+#: lxc/storage_volume.go:1730 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
@@ -5724,11 +5724,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1032
+#: lxc/file.go:1033
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1026
+#: lxc/file.go:1027
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5856,12 +5856,12 @@ msgstr ""
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:446
+#: lxc/project.go:447
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
 
-#: lxc/storage_bucket.go:431
+#: lxc/storage_bucket.go:432
 #, c-format
 msgid "The property %q does not exist on the storage bucket %q: %v"
 msgstr ""
@@ -6046,7 +6046,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:961
+#: lxc/project.go:962
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6058,17 +6058,17 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:985 lxc/storage_volume.go:1735
+#: lxc/project.go:986 lxc/storage_volume.go:1735
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:573
+#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:574
 #: lxc/storage.go:724 lxc/storage_volume.go:1734
 msgid "USED BY"
 msgstr ""
 
-#: lxc/warning.go:216
+#: lxc/warning.go:217
 msgid "UUID"
 msgstr ""
 
@@ -6077,7 +6077,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:197
+#: lxc/file.go:198
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6091,13 +6091,13 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1253
+#: lxc/file.go:1254
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1153 lxc/list.go:631 lxc/storage_volume.go:1772
-#: lxc/warning.go:241
+#: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6107,7 +6107,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:807
+#: lxc/file.go:808
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6190,11 +6190,11 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:742 lxc/project.go:743
+#: lxc/project.go:743 lxc/project.go:744
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:697 lxc/storage_bucket.go:698
+#: lxc/storage_bucket.go:698 lxc/storage_bucket.go:699
 msgid "Unset storage bucket configuration keys"
 msgstr ""
 
@@ -6242,11 +6242,11 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:747
+#: lxc/project.go:748
 msgid "Unset the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:701
+#: lxc/storage_bucket.go:702
 msgid "Unset the key as a storage bucket property"
 msgstr ""
 
@@ -6325,7 +6325,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:71
+#: lxc/file.go:72
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6362,11 +6362,11 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:831
+#: lxc/auth.go:832
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:894
+#: lxc/auth.go:895
 msgid "View the current identity"
 msgstr ""
 
@@ -6397,15 +6397,15 @@ msgstr ""
 msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
-#: lxc/rebuild.go:27
+#: lxc/rebuild.go:28
 msgid ""
 "Wipe the instance root disk and re-initialize. The original image is used to "
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:156 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
+#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:526
+#: lxc/project.go:531 lxc/project.go:536 lxc/project.go:541 lxc/project.go:546
+#: lxc/project.go:551 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
 msgid "YES"
 msgstr ""
 
@@ -6425,7 +6425,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/rebuild.go:119
+#: lxc/rebuild.go:120
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
@@ -6437,12 +6437,12 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1689
+#: lxc/auth.go:330 lxc/auth.go:763 lxc/auth.go:894 lxc/auth.go:1690
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
-#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
+#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
-#: lxc/operation.go:103 lxc/profile.go:700 lxc/project.go:467
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:68
+#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:468
+#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6470,7 +6470,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1254
+#: lxc/auth.go:1255
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6531,11 +6531,11 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:830
+#: lxc/auth.go:831
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1926
+#: lxc/auth.go:1106 lxc/auth.go:1164 lxc/auth.go:1927
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6543,13 +6543,13 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:954 lxc/auth.go:1470 lxc/cluster_group.go:168
+#: lxc/auth.go:97 lxc/auth.go:150 lxc/auth.go:200 lxc/auth.go:440
+#: lxc/auth.go:955 lxc/auth.go:1471 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:514 lxc/auth.go:572
+#: lxc/auth.go:515 lxc/auth.go:573
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
@@ -6559,19 +6559,19 @@ msgstr ""
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:389
+#: lxc/auth.go:390
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1521 lxc/auth.go:1571 lxc/auth.go:1799
+#: lxc/auth.go:1522 lxc/auth.go:1572 lxc/auth.go:1800
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1873
+#: lxc/auth.go:1874
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1749
+#: lxc/auth.go:1750
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -6591,7 +6591,7 @@ msgstr ""
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
-#: lxc/rebuild.go:25
+#: lxc/rebuild.go:26
 msgid "[<remote>:]<image> [<remote>:]<instance>"
 msgstr ""
 
@@ -6674,20 +6674,20 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:170
+#: lxc/file.go:171
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:120
+#: lxc/file.go:121
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:240
+#: lxc/file.go:241
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:984
+#: lxc/file.go:985
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6838,12 +6838,12 @@ msgstr ""
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
-#: lxc/operation.go:53 lxc/operation.go:191
+#: lxc/operation.go:54 lxc/operation.go:192
 msgid "[<remote>:]<operation>"
 msgstr ""
 
 #: lxc/storage.go:200 lxc/storage.go:259 lxc/storage.go:473 lxc/storage.go:844
-#: lxc/storage_bucket.go:454
+#: lxc/storage_bucket.go:455
 msgid "[<remote>:]<pool>"
 msgstr ""
 
@@ -6851,22 +6851,22 @@ msgstr ""
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
-#: lxc/storage_bucket.go:185 lxc/storage_bucket.go:247
-#: lxc/storage_bucket.go:627 lxc/storage_bucket.go:769
+#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:248
+#: lxc/storage_bucket.go:628 lxc/storage_bucket.go:770
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
 
-#: lxc/storage_bucket.go:380 lxc/storage_bucket.go:696
-#: lxc/storage_bucket.go:850 lxc/storage_bucket.go:956
-#: lxc/storage_bucket.go:1020 lxc/storage_bucket.go:1155
+#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:697
+#: lxc/storage_bucket.go:851 lxc/storage_bucket.go:957
+#: lxc/storage_bucket.go:1021 lxc/storage_bucket.go:1156
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
 
-#: lxc/storage_bucket.go:533
+#: lxc/storage_bucket.go:534
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_bucket.go:81
+#: lxc/storage_bucket.go:82
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
 
@@ -6981,20 +6981,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:91 lxc/project.go:186 lxc/project.go:258 lxc/project.go:785
-#: lxc/project.go:846 lxc/project.go:913
+#: lxc/project.go:92 lxc/project.go:187 lxc/project.go:259 lxc/project.go:786
+#: lxc/project.go:847 lxc/project.go:914
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:394 lxc/project.go:741
+#: lxc/project.go:395 lxc/project.go:742
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:653
+#: lxc/project.go:654
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:587
+#: lxc/project.go:588
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7002,7 +7002,7 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:259 lxc/warning.go:301 lxc/warning.go:354
+#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
@@ -7058,7 +7058,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:555 lxc/remote.go:739
+#: lxc/project.go:556 lxc/remote.go:739
 msgid "current"
 msgstr ""
 
@@ -7105,20 +7105,20 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/auth.go:203
+#: lxc/auth.go:204
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:958
+#: lxc/auth.go:959
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1575
+#: lxc/auth.go:1576
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7196,20 +7196,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:988
+#: lxc/file.go:989
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:244
+#: lxc/file.go:245
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:470
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7291,7 +7291,7 @@ msgid ""
 "  List instances with their running state and user comment."
 msgstr ""
 
-#: lxc/monitor.go:37
+#: lxc/monitor.go:38
 msgid ""
 "lxc monitor --type=logging\n"
 "    Only show log messages.\n"
@@ -7367,7 +7367,7 @@ msgid ""
 "    Create record r1 for zone z1 with configuration from config.yaml"
 msgstr ""
 
-#: lxc/operation.go:195
+#: lxc/operation.go:196
 msgid ""
 "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Show details on that operation UUID"
@@ -7410,7 +7410,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:95
+#: lxc/project.go:96
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7418,7 +7418,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:262
+#: lxc/project.go:263
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7449,7 +7449,7 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:85
 msgid ""
 "lxc storage bucket create p1 b01\n"
 "\tCreate a new storage bucket name b01 in storage pool p1\n"
@@ -7459,19 +7459,19 @@ msgid ""
 "of config.yaml"
 msgstr ""
 
-#: lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:251
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1023
+#: lxc/storage_bucket.go:1024
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:854
 msgid ""
 "lxc storage bucket key create p1 b01 k1\n"
 "\tCreate a key called k1 for the bucket b01 in the pool p1.\n"
@@ -7481,14 +7481,14 @@ msgid ""
 "of config.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1158
+#: lxc/storage_bucket.go:1159
 msgid ""
 "lxc storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_bucket.go:630
+#: lxc/storage_bucket.go:631
 msgid ""
 "lxc storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
@@ -7558,16 +7558,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1142
+#: lxc/file.go:1143
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1101
+#: lxc/file.go:1102
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1054
+#: lxc/file.go:1055
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/cs.po
+++ b/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-04 08:52-0600\n"
+"POT-Creation-Date: 2024-09-05 08:44-0400\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Czech <https://hosted.weblate.org/projects/linux-containers/"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: lxc/storage_bucket.go:260 lxc/storage_bucket.go:1033
+#: lxc/storage_bucket.go:261 lxc/storage_bucket.go:1034
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -133,7 +133,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:213
+#: lxc/auth.go:214
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -160,7 +160,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:968
+#: lxc/auth.go:969
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -181,7 +181,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1585
+#: lxc/auth.go:1586
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -391,7 +391,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:280
+#: lxc/project.go:281
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -433,12 +433,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:935
+#: lxc/file.go:936
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:825
+#: lxc/file.go:826
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -474,7 +474,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:142 lxc/rebuild.go:64
+#: lxc/init.go:142 lxc/rebuild.go:65
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -527,7 +527,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:465
+#: lxc/file.go:466
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -560,7 +560,7 @@ msgstr ""
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:813
+#: lxc/auth.go:814
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -568,11 +568,11 @@ msgstr ""
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/storage_bucket.go:863
+#: lxc/storage_bucket.go:864
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:941
+#: lxc/storage_bucket.go:942
 #, c-format
 msgid "Access key: %s"
 msgstr ""
@@ -581,7 +581,7 @@ msgstr ""
 msgid "Access the expanded configuration"
 msgstr ""
 
-#: lxc/warning.go:261 lxc/warning.go:262
+#: lxc/warning.go:262 lxc/warning.go:263
 msgid "Acknowledge warning"
 msgstr ""
 
@@ -598,11 +598,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1106 lxc/auth.go:1107
+#: lxc/auth.go:1107 lxc/auth.go:1108
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1874 lxc/auth.go:1875
+#: lxc/auth.go:1875 lxc/auth.go:1876
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -671,7 +671,7 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:515 lxc/auth.go:516
+#: lxc/auth.go:516 lxc/auth.go:517
 msgid "Add permissions to groups"
 msgstr ""
 
@@ -700,7 +700,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:169
+#: lxc/storage_bucket.go:170
 #, c-format
 msgid "Admin access key: %s"
 msgstr ""
@@ -710,7 +710,7 @@ msgstr ""
 msgid "Admin password (or token) for %s:"
 msgstr ""
 
-#: lxc/storage_bucket.go:170
+#: lxc/storage_bucket.go:171
 #, c-format
 msgid "Admin secret key: %s"
 msgstr ""
@@ -769,7 +769,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:342 lxc/rebuild.go:130
+#: lxc/init.go:342 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -869,12 +869,12 @@ msgstr ""
 
 #: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:318
 #: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
-#: lxc/network_zone.go:366 lxc/network_zone.go:1053 lxc/storage_bucket.go:141
+#: lxc/network_zone.go:366 lxc/network_zone.go:1053 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:159
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:160
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -914,7 +914,7 @@ msgstr ""
 msgid "Bytes sent"
 msgstr ""
 
-#: lxc/operation.go:174
+#: lxc/operation.go:175
 msgid "CANCELABLE"
 msgstr ""
 
@@ -926,7 +926,7 @@ msgstr ""
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: lxc/warning.go:209
+#: lxc/warning.go:210
 msgid "COUNT"
 msgstr ""
 
@@ -952,7 +952,7 @@ msgstr ""
 msgid "CPUs (%s):"
 msgstr ""
 
-#: lxc/operation.go:175
+#: lxc/operation.go:176
 msgid "CREATED"
 msgstr ""
 
@@ -982,7 +982,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:340
+#: lxc/file.go:341
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1007,11 +1007,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:224
+#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:546
+#: lxc/file.go:547
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1020,7 +1020,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:160
+#: lxc/rebuild.go:161
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1143,13 +1143,13 @@ msgstr ""
 #: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
 #: lxc/network_load_balancer.go:1051 lxc/network_load_balancer.go:1125
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
-#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:90
-#: lxc/storage_bucket.go:190 lxc/storage_bucket.go:253
-#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:541
-#: lxc/storage_bucket.go:634 lxc/storage_bucket.go:700
-#: lxc/storage_bucket.go:775 lxc/storage_bucket.go:861
-#: lxc/storage_bucket.go:961 lxc/storage_bucket.go:1026
-#: lxc/storage_bucket.go:1162 lxc/storage_volume.go:394
+#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
+#: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
+#: lxc/storage_bucket.go:385 lxc/storage_bucket.go:542
+#: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
+#: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
+#: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
 #: lxc/storage_volume.go:612 lxc/storage_volume.go:717
 #: lxc/storage_volume.go:1005 lxc/storage_volume.go:1231
 #: lxc/storage_volume.go:1360 lxc/storage_volume.go:1848
@@ -1173,7 +1173,7 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1113 lxc/list.go:132 lxc/storage_volume.go:1589
-#: lxc/warning.go:92
+#: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
@@ -1201,7 +1201,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:100
+#: lxc/project.go:101
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1215,8 +1215,8 @@ msgstr ""
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
-#: lxc/project.go:362 lxc/storage.go:359 lxc/storage_bucket.go:348
-#: lxc/storage_bucket.go:1125 lxc/storage_volume.go:1150
+#: lxc/project.go:363 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1150
 #: lxc/storage_volume.go:1182
 #, c-format
 msgid "Config parsing error: %s"
@@ -1343,12 +1343,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:300 lxc/auth.go:1660
+#: lxc/auth.go:301 lxc/auth.go:1661
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1054
+#: lxc/auth.go:1055
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1397,15 +1397,15 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:248 lxc/file.go:474
+#: lxc/file.go:249 lxc/file.go:475
 msgid "Create any directories necessary"
 msgstr ""
 
-#: lxc/auth.go:97 lxc/auth.go:98
+#: lxc/auth.go:98 lxc/auth.go:99
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1471 lxc/auth.go:1472
+#: lxc/auth.go:1472 lxc/auth.go:1473
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1425,11 +1425,11 @@ msgstr ""
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_bucket.go:851 lxc/storage_bucket.go:852
+#: lxc/storage_bucket.go:852 lxc/storage_bucket.go:853
 msgid "Create key for a storage bucket"
 msgstr ""
 
-#: lxc/storage_bucket.go:82 lxc/storage_bucket.go:83
+#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
 msgid "Create new custom storage buckets"
 msgstr ""
 
@@ -1473,7 +1473,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:92 lxc/project.go:93
+#: lxc/project.go:93 lxc/project.go:94
 msgid "Create projects"
 msgstr ""
 
@@ -1508,13 +1508,13 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:376 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1135 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
-#: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:172
-#: lxc/profile.go:756 lxc/project.go:572 lxc/storage.go:723
-#: lxc/storage_bucket.go:512 lxc/storage_bucket.go:832
+#: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
+#: lxc/profile.go:756 lxc/project.go:573 lxc/storage.go:723
+#: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1732
 msgid "DESCRIPTION"
 msgstr ""
@@ -1539,7 +1539,7 @@ msgstr ""
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
-#: lxc/operation.go:55 lxc/operation.go:56
+#: lxc/operation.go:56 lxc/operation.go:57
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
@@ -1547,19 +1547,19 @@ msgstr ""
 msgid "Delete a cluster group"
 msgstr ""
 
-#: lxc/warning.go:360
+#: lxc/warning.go:361
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:122 lxc/file.go:123
+#: lxc/file.go:123 lxc/file.go:124
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/auth.go:151 lxc/auth.go:152
+#: lxc/auth.go:152 lxc/auth.go:153
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1523 lxc/auth.go:1524
+#: lxc/auth.go:1524 lxc/auth.go:1525
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1579,7 +1579,7 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/storage_bucket.go:957 lxc/storage_bucket.go:958
+#: lxc/storage_bucket.go:958 lxc/storage_bucket.go:959
 msgid "Delete key from a storage bucket"
 msgstr ""
 
@@ -1615,11 +1615,11 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:188 lxc/project.go:189
+#: lxc/project.go:189 lxc/project.go:190
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:187 lxc/storage_bucket.go:188
+#: lxc/storage_bucket.go:188 lxc/storage_bucket.go:189
 msgid "Delete storage buckets"
 msgstr ""
 
@@ -1631,20 +1631,20 @@ msgstr ""
 msgid "Delete storage volumes"
 msgstr ""
 
-#: lxc/warning.go:356 lxc/warning.go:357
+#: lxc/warning.go:357 lxc/warning.go:358
 msgid "Delete warning"
 msgstr ""
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:30 lxc/auth.go:59 lxc/auth.go:98
-#: lxc/auth.go:152 lxc/auth.go:201 lxc/auth.go:332 lxc/auth.go:392
-#: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
-#: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
-#: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
-#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1434 lxc/auth.go:1472
-#: lxc/auth.go:1524 lxc/auth.go:1573 lxc/auth.go:1692 lxc/auth.go:1752
-#: lxc/auth.go:1801 lxc/auth.go:1852 lxc/auth.go:1875 lxc/auth.go:1928
+#: lxc/alias.go:214 lxc/auth.go:31 lxc/auth.go:60 lxc/auth.go:99
+#: lxc/auth.go:153 lxc/auth.go:202 lxc/auth.go:333 lxc/auth.go:393
+#: lxc/auth.go:442 lxc/auth.go:494 lxc/auth.go:517 lxc/auth.go:576
+#: lxc/auth.go:732 lxc/auth.go:766 lxc/auth.go:833 lxc/auth.go:896
+#: lxc/auth.go:957 lxc/auth.go:1085 lxc/auth.go:1108 lxc/auth.go:1166
+#: lxc/auth.go:1235 lxc/auth.go:1257 lxc/auth.go:1435 lxc/auth.go:1473
+#: lxc/auth.go:1525 lxc/auth.go:1574 lxc/auth.go:1693 lxc/auth.go:1753
+#: lxc/auth.go:1802 lxc/auth.go:1853 lxc/auth.go:1876 lxc/auth.go:1929
 #: lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215 lxc/cluster.go:272
 #: lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:484 lxc/cluster.go:528
 #: lxc/cluster.go:586 lxc/cluster.go:677 lxc/cluster.go:770 lxc/cluster.go:893
@@ -1668,15 +1668,15 @@ msgstr ""
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:83 lxc/file.go:123 lxc/file.go:172
-#: lxc/file.go:242 lxc/file.go:467 lxc/file.go:986 lxc/image.go:38
+#: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
+#: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
 #: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
 #: lxc/image.go:697 lxc/image.go:946 lxc/image.go:1088 lxc/image.go:1415
 #: lxc/image.go:1506 lxc/image.go:1572 lxc/image.go:1636 lxc/image.go:1699
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:38 lxc/network.go:33
+#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33
 #: lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405
 #: lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793
 #: lxc/network.go:874 lxc/network.go:1005 lxc/network.go:1106
@@ -1710,27 +1710,27 @@ msgstr ""
 #: lxc/network_zone.go:909 lxc/network_zone.go:985 lxc/network_zone.go:1083
 #: lxc/network_zone.go:1172 lxc/network_zone.go:1219 lxc/network_zone.go:1349
 #: lxc/network_zone.go:1410 lxc/network_zone.go:1425 lxc/network_zone.go:1483
-#: lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:106
-#: lxc/operation.go:193 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
+#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
+#: lxc/operation.go:194 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
 #: lxc/profile.go:271 lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493
 #: lxc/profile.go:629 lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860
-#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:29
-#: lxc/project.go:93 lxc/project.go:189 lxc/project.go:260 lxc/project.go:396
-#: lxc/project.go:470 lxc/project.go:590 lxc/project.go:655 lxc/project.go:743
-#: lxc/project.go:787 lxc/project.go:848 lxc/project.go:915 lxc/publish.go:34
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:35 lxc/remote.go:91
+#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:30
+#: lxc/project.go:94 lxc/project.go:190 lxc/project.go:261 lxc/project.go:397
+#: lxc/project.go:471 lxc/project.go:591 lxc/project.go:656 lxc/project.go:744
+#: lxc/project.go:788 lxc/project.go:849 lxc/project.go:916 lxc/publish.go:34
+#: lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91
 #: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853
 #: lxc/remote.go:917 lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24
 #: lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203
 #: lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655
 #: lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940
-#: lxc/storage_bucket.go:29 lxc/storage_bucket.go:83 lxc/storage_bucket.go:188
-#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:382
-#: lxc/storage_bucket.go:458 lxc/storage_bucket.go:535
-#: lxc/storage_bucket.go:629 lxc/storage_bucket.go:698
-#: lxc/storage_bucket.go:732 lxc/storage_bucket.go:773
-#: lxc/storage_bucket.go:852 lxc/storage_bucket.go:958
-#: lxc/storage_bucket.go:1022 lxc/storage_bucket.go:1157
+#: lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189
+#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:383
+#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:536
+#: lxc/storage_bucket.go:630 lxc/storage_bucket.go:699
+#: lxc/storage_bucket.go:733 lxc/storage_bucket.go:774
+#: lxc/storage_bucket.go:853 lxc/storage_bucket.go:959
+#: lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158
 #: lxc/storage_volume.go:58 lxc/storage_volume.go:169 lxc/storage_volume.go:283
 #: lxc/storage_volume.go:390 lxc/storage_volume.go:605
 #: lxc/storage_volume.go:714 lxc/storage_volume.go:801
@@ -1741,8 +1741,8 @@ msgstr ""
 #: lxc/storage_volume.go:2064 lxc/storage_volume.go:2222
 #: lxc/storage_volume.go:2343 lxc/storage_volume.go:2405
 #: lxc/storage_volume.go:2541 lxc/storage_volume.go:2624
-#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:29
-#: lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
+#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:30
+#: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
@@ -1829,7 +1829,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:994
+#: lxc/file.go:995
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1895,7 +1895,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:74
+#: lxc/file.go:75
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1905,7 +1905,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:955 lxc/auth.go:956
+#: lxc/auth.go:956 lxc/auth.go:957
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1913,15 +1913,15 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:171 lxc/file.go:172
+#: lxc/file.go:172 lxc/file.go:173
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/auth.go:200 lxc/auth.go:201
+#: lxc/auth.go:201 lxc/auth.go:202
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1572 lxc/auth.go:1573
+#: lxc/auth.go:1573 lxc/auth.go:1574
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -1977,15 +1977,15 @@ msgstr ""
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:259 lxc/project.go:260
+#: lxc/project.go:260 lxc/project.go:261
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:248 lxc/storage_bucket.go:249
+#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:250
 msgid "Edit storage bucket configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:1021 lxc/storage_bucket.go:1022
+#: lxc/storage_bucket.go:1022 lxc/storage_bucket.go:1023
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
@@ -2002,7 +2002,7 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1147 lxc/list.go:622 lxc/storage_volume.go:1766
-#: lxc/warning.go:235
+#: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2057,7 +2057,7 @@ msgstr ""
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
-#: lxc/project.go:718 lxc/storage.go:812 lxc/storage_bucket.go:602
+#: lxc/project.go:719 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2155 lxc/storage_volume.go:2193
 #, c-format
 msgid "Error setting properties: %v"
@@ -2071,8 +2071,8 @@ msgstr ""
 #: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
-#: lxc/profile.go:981 lxc/project.go:712 lxc/storage.go:806
-#: lxc/storage_bucket.go:596 lxc/storage_volume.go:2149
+#: lxc/profile.go:981 lxc/project.go:713 lxc/storage.go:806
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2149
 #: lxc/storage_volume.go:2187
 #, c-format
 msgid "Error unsetting property: %v"
@@ -2092,7 +2092,7 @@ msgstr ""
 msgid "Evacuating cluster member: %s"
 msgstr ""
 
-#: lxc/monitor.go:50
+#: lxc/monitor.go:51
 msgid "Event type to listen for"
 msgstr ""
 
@@ -2179,16 +2179,16 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/warning.go:210
+#: lxc/warning.go:211
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1237
+#: lxc/file.go:1238
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1260
+#: lxc/file.go:1261
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2203,12 +2203,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1287
+#: lxc/file.go:1288
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1072
+#: lxc/file.go:1073
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2238,7 +2238,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1193
+#: lxc/file.go:1194
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2253,7 +2253,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1198
+#: lxc/file.go:1199
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2263,12 +2263,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1098
+#: lxc/file.go:1099
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1225
+#: lxc/file.go:1226
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2307,7 +2307,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1210
+#: lxc/file.go:1211
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2322,7 +2322,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:820
+#: lxc/file.go:821
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2337,7 +2337,7 @@ msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
 #: lxc/network.go:1044 lxc/network_acl.go:133 lxc/network_zone.go:124
-#: lxc/operation.go:136
+#: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
 
@@ -2402,21 +2402,21 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
+#: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:770 lxc/auth.go:1697
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1114 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:57
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
-#: lxc/operation.go:108 lxc/profile.go:707 lxc/project.go:472
-#: lxc/project.go:917 lxc/remote.go:690 lxc/storage.go:657
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:774
-#: lxc/storage_volume.go:1608 lxc/warning.go:93
+#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:473
+#: lxc/project.go:918 lxc/remote.go:690 lxc/storage.go:657
+#: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
+#: lxc/storage_volume.go:1608 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
-#: lxc/monitor.go:52
+#: lxc/monitor.go:53
 msgid "Format (json|pretty|yaml)"
 msgstr ""
 
@@ -2460,7 +2460,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:817 lxc/auth.go:1736
+#: lxc/auth.go:818 lxc/auth.go:1737
 msgid "GROUPS"
 msgstr ""
 
@@ -2476,7 +2476,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:914 lxc/project.go:915
+#: lxc/project.go:915 lxc/project.go:916
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2524,11 +2524,11 @@ msgstr ""
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:400
+#: lxc/project.go:401
 msgid "Get the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:385
+#: lxc/storage_bucket.go:386
 msgid "Get the key as a storage bucket property"
 msgstr ""
 
@@ -2588,11 +2588,11 @@ msgstr ""
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:395 lxc/project.go:396
+#: lxc/project.go:396 lxc/project.go:397
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:382
+#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:383
 msgid "Get values for storage bucket configuration keys"
 msgstr ""
 
@@ -2609,17 +2609,17 @@ msgstr ""
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: lxc/auth.go:136
+#: lxc/auth.go:137
 #, c-format
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:186
+#: lxc/auth.go:187
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:426 lxc/auth.go:1786
+#: lxc/auth.go:427 lxc/auth.go:1787
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2644,27 +2644,27 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1310
+#: lxc/file.go:1311
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1299
+#: lxc/file.go:1300
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1122
+#: lxc/file.go:1123
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1132
+#: lxc/file.go:1133
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:966 lxc/operation.go:170
+#: lxc/network.go:966 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2678,11 +2678,11 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:816
+#: lxc/auth.go:817
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:566
+#: lxc/project.go:567
 msgid "IMAGES"
 msgstr ""
 
@@ -2710,17 +2710,17 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1508
+#: lxc/auth.go:1509
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1558
+#: lxc/auth.go:1559
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
 
-#: lxc/rebuild.go:32
+#: lxc/rebuild.go:33
 msgid "If an instance is running, stop it and then rebuild it"
 msgstr ""
 
@@ -2841,7 +2841,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1233 lxc/auth.go:1234
+#: lxc/auth.go:1234 lxc/auth.go:1235
 msgid "Inspect permissions"
 msgstr ""
 
@@ -2849,11 +2849,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1124
+#: lxc/file.go:1125
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1301
+#: lxc/file.go:1302
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2871,7 +2871,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1044
+#: lxc/file.go:1045
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2880,7 +2880,7 @@ msgstr ""
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/rebuild.go:74
+#: lxc/rebuild.go:75
 #, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
@@ -2913,7 +2913,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/monitor.go:70
+#: lxc/monitor.go:71
 #, c-format
 msgid "Invalid format: %s"
 msgstr ""
@@ -2923,7 +2923,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1039
+#: lxc/file.go:1040
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2965,7 +2965,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:147
+#: lxc/file.go:148
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2981,12 +2981,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:313
+#: lxc/file.go:314
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:495
+#: lxc/file.go:496
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3000,7 +3000,7 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/warning.go:212
 msgid "LAST SEEN"
 msgstr ""
 
@@ -3008,7 +3008,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:984
+#: lxc/project.go:985
 msgid "LIMIT"
 msgstr ""
 
@@ -3017,8 +3017,8 @@ msgid "LISTEN ADDRESS"
 msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
-#: lxc/network_load_balancer.go:165 lxc/operation.go:177
-#: lxc/storage_bucket.go:516 lxc/storage_volume.go:1739 lxc/warning.go:220
+#: lxc/network_load_balancer.go:165 lxc/operation.go:178
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1739 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3092,7 +3092,7 @@ msgstr ""
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/warning.go:94
+#: lxc/warning.go:95
 msgid "List all warnings"
 msgstr ""
 
@@ -3136,19 +3136,19 @@ msgstr ""
 msgid "List available storage pools"
 msgstr ""
 
-#: lxc/operation.go:105 lxc/operation.go:106
+#: lxc/operation.go:106 lxc/operation.go:107
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:331 lxc/auth.go:332
+#: lxc/auth.go:332 lxc/auth.go:333
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:764 lxc/auth.go:765
+#: lxc/auth.go:765 lxc/auth.go:766
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1691 lxc/auth.go:1692
+#: lxc/auth.go:1692 lxc/auth.go:1693
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3297,11 +3297,11 @@ msgstr ""
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/operation.go:109
+#: lxc/operation.go:110
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1255 lxc/auth.go:1256
+#: lxc/auth.go:1256 lxc/auth.go:1257
 msgid "List permissions"
 msgstr ""
 
@@ -3309,15 +3309,15 @@ msgstr ""
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:469 lxc/project.go:470
+#: lxc/project.go:470 lxc/project.go:471
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:771 lxc/storage_bucket.go:773
+#: lxc/storage_bucket.go:772 lxc/storage_bucket.go:774
 msgid "List storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:456 lxc/storage_bucket.go:458
+#: lxc/storage_bucket.go:457 lxc/storage_bucket.go:459
 msgid "List storage buckets"
 msgstr ""
 
@@ -3353,11 +3353,11 @@ msgstr ""
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/warning.go:70
+#: lxc/warning.go:71
 msgid "List warnings"
 msgstr ""
 
-#: lxc/warning.go:71
+#: lxc/warning.go:72
 msgid ""
 "List warnings\n"
 "\n"
@@ -3380,7 +3380,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/operation.go:23 lxc/operation.go:24
+#: lxc/operation.go:24 lxc/operation.go:25
 msgid "List, show and delete background operations"
 msgstr ""
 
@@ -3389,7 +3389,7 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/monitor.go:79
+#: lxc/monitor.go:80
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
@@ -3493,23 +3493,23 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:82 lxc/file.go:83
+#: lxc/file.go:83 lxc/file.go:84
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1433 lxc/auth.go:1434
+#: lxc/auth.go:59 lxc/auth.go:60 lxc/auth.go:1434 lxc/auth.go:1435
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1083 lxc/auth.go:1084
+#: lxc/auth.go:1084 lxc/auth.go:1085
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:730 lxc/auth.go:731
+#: lxc/auth.go:731 lxc/auth.go:732
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1851 lxc/auth.go:1852
+#: lxc/auth.go:1852 lxc/auth.go:1853
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3600,7 +3600,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:492 lxc/auth.go:493
+#: lxc/auth.go:493 lxc/auth.go:494
 msgid "Manage permissions"
 msgstr ""
 
@@ -3608,23 +3608,23 @@ msgstr ""
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:28 lxc/project.go:29
+#: lxc/project.go:29 lxc/project.go:30
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:731
+#: lxc/storage_bucket.go:732
 msgid "Manage storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:732
+#: lxc/storage_bucket.go:733
 msgid "Manage storage bucket keys."
 msgstr ""
 
-#: lxc/storage_bucket.go:28
+#: lxc/storage_bucket.go:29
 msgid "Manage storage buckets"
 msgstr ""
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:30
 msgid "Manage storage buckets."
 msgstr ""
 
@@ -3652,11 +3652,11 @@ msgstr ""
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/auth.go:29 lxc/auth.go:30
+#: lxc/auth.go:30 lxc/auth.go:31
 msgid "Manage user authorization"
 msgstr ""
 
-#: lxc/warning.go:28 lxc/warning.go:29
+#: lxc/warning.go:29 lxc/warning.go:30
 msgid "Manage warnings"
 msgstr ""
 
@@ -3720,17 +3720,17 @@ msgstr ""
 msgid "Migration operation failure: %w"
 msgstr ""
 
-#: lxc/monitor.go:51
+#: lxc/monitor.go:52
 msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: lxc/storage_bucket.go:116 lxc/storage_bucket.go:216
-#: lxc/storage_bucket.go:292 lxc/storage_bucket.go:411
-#: lxc/storage_bucket.go:568 lxc/storage_bucket.go:660
-#: lxc/storage_bucket.go:802 lxc/storage_bucket.go:889
-#: lxc/storage_bucket.go:986 lxc/storage_bucket.go:1065
-#: lxc/storage_bucket.go:1188
+#: lxc/storage_bucket.go:117 lxc/storage_bucket.go:217
+#: lxc/storage_bucket.go:293 lxc/storage_bucket.go:412
+#: lxc/storage_bucket.go:569 lxc/storage_bucket.go:661
+#: lxc/storage_bucket.go:803 lxc/storage_bucket.go:890
+#: lxc/storage_bucket.go:987 lxc/storage_bucket.go:1066
+#: lxc/storage_bucket.go:1189
 msgid "Missing bucket name"
 msgstr ""
 
@@ -3749,20 +3749,20 @@ msgstr ""
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1825
+#: lxc/auth.go:123 lxc/auth.go:177 lxc/auth.go:255 lxc/auth.go:417
+#: lxc/auth.go:466 lxc/auth.go:541 lxc/auth.go:600 lxc/auth.go:1826
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:862 lxc/auth.go:1003 lxc/auth.go:1131 lxc/auth.go:1189
+#: lxc/auth.go:863 lxc/auth.go:1004 lxc/auth.go:1132 lxc/auth.go:1190
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1495 lxc/auth.go:1548 lxc/auth.go:1614 lxc/auth.go:1776
+#: lxc/auth.go:1496 lxc/auth.go:1549 lxc/auth.go:1615 lxc/auth.go:1777
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1899 lxc/auth.go:1952
+#: lxc/auth.go:1900 lxc/auth.go:1953
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -3770,12 +3770,12 @@ msgstr ""
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
 #: lxc/config_template.go:377 lxc/profile.go:141 lxc/profile.go:222
-#: lxc/profile.go:808 lxc/rebuild.go:60
+#: lxc/profile.go:808 lxc/rebuild.go:61
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/storage_bucket.go:893 lxc/storage_bucket.go:990
-#: lxc/storage_bucket.go:1069 lxc/storage_bucket.go:1192
+#: lxc/storage_bucket.go:894 lxc/storage_bucket.go:991
+#: lxc/storage_bucket.go:1070 lxc/storage_bucket.go:1193
 msgid "Missing key name"
 msgstr ""
 
@@ -3840,13 +3840,13 @@ msgid "Missing peer name"
 msgstr ""
 
 #: lxc/storage.go:235 lxc/storage.go:313 lxc/storage.go:431 lxc/storage.go:509
-#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:112
-#: lxc/storage_bucket.go:212 lxc/storage_bucket.go:288
-#: lxc/storage_bucket.go:407 lxc/storage_bucket.go:482
-#: lxc/storage_bucket.go:564 lxc/storage_bucket.go:656
-#: lxc/storage_bucket.go:798 lxc/storage_bucket.go:885
-#: lxc/storage_bucket.go:982 lxc/storage_bucket.go:1061
-#: lxc/storage_bucket.go:1184 lxc/storage_volume.go:209
+#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:113
+#: lxc/storage_bucket.go:213 lxc/storage_bucket.go:289
+#: lxc/storage_bucket.go:408 lxc/storage_bucket.go:483
+#: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
+#: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
+#: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
 #: lxc/storage_volume.go:323 lxc/storage_volume.go:643
 #: lxc/storage_volume.go:750 lxc/storage_volume.go:841
 #: lxc/storage_volume.go:939 lxc/storage_volume.go:1053
@@ -3861,9 +3861,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:404 lxc/project.go:146 lxc/project.go:226 lxc/project.go:316
-#: lxc/project.go:433 lxc/project.go:622 lxc/project.go:691 lxc/project.go:819
-#: lxc/project.go:948
+#: lxc/profile.go:404 lxc/project.go:147 lxc/project.go:227 lxc/project.go:317
+#: lxc/project.go:434 lxc/project.go:623 lxc/project.go:692 lxc/project.go:820
+#: lxc/project.go:949
 msgid "Missing project name"
 msgstr ""
 
@@ -3879,7 +3879,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:598
+#: lxc/file.go:599
 msgid "Missing target directory"
 msgstr ""
 
@@ -3901,11 +3901,11 @@ msgstr ""
 msgid "Model: %v"
 msgstr ""
 
-#: lxc/monitor.go:32
+#: lxc/monitor.go:33
 msgid "Monitor a local or remote LXD server"
 msgstr ""
 
-#: lxc/monitor.go:33
+#: lxc/monitor.go:34
 msgid ""
 "Monitor a local or remote LXD server\n"
 "\n"
@@ -3917,11 +3917,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:285
+#: lxc/file.go:286
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:985 lxc/file.go:986
+#: lxc/file.go:986 lxc/file.go:987
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3983,13 +3983,13 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:192
+#: lxc/auth.go:376 lxc/auth.go:816 lxc/auth.go:1736 lxc/cluster.go:192
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
-#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:565
-#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:511
-#: lxc/storage_bucket.go:831 lxc/storage_volume.go:1731
+#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:566
+#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1731
 msgid "NAME"
 msgstr ""
 
@@ -3997,11 +3997,11 @@ msgstr ""
 msgid "NAT"
 msgstr ""
 
-#: lxc/project.go:571
+#: lxc/project.go:572
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:570
+#: lxc/project.go:571
 msgid "NETWORKS"
 msgstr ""
 
@@ -4013,9 +4013,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/operation.go:154 lxc/project.go:523
-#: lxc/project.go:528 lxc/project.go:533 lxc/project.go:538 lxc/project.go:543
-#: lxc/project.go:548 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
+#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:524
+#: lxc/project.go:529 lxc/project.go:534 lxc/project.go:539 lxc/project.go:544
+#: lxc/project.go:549 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
 msgid "NO"
 msgstr ""
 
@@ -4260,7 +4260,7 @@ msgstr ""
 msgid "Only managed networks can be modified"
 msgstr ""
 
-#: lxc/operation.go:86
+#: lxc/operation.go:87
 #, c-format
 msgid "Operation %s deleted"
 msgstr ""
@@ -4307,11 +4307,11 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:567
+#: lxc/list.go:576 lxc/project.go:568
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:212
+#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4373,24 +4373,24 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1102
+#: lxc/file.go:1103
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:860
+#: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
-#: lxc/project.go:363 lxc/storage.go:360 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1151
+#: lxc/project.go:364 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1151
 #: lxc/storage_volume.go:1183
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
-#: lxc/monitor.go:48
+#: lxc/monitor.go:49
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
@@ -4476,17 +4476,17 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:172
+#: lxc/project.go:173
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:236
+#: lxc/project.go:237
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:637
+#: lxc/project.go:638
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -4607,20 +4607,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:241 lxc/file.go:242
+#: lxc/file.go:242 lxc/file.go:243
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:416 lxc/file.go:767
+#: lxc/file.go:417 lxc/file.go:768
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:466 lxc/file.go:467
+#: lxc/file.go:467 lxc/file.go:468
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:701 lxc/file.go:867
+#: lxc/file.go:702 lxc/file.go:868
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4633,11 +4633,11 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:983
+#: lxc/project.go:984
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/storage_bucket.go:833
+#: lxc/storage_bucket.go:834
 msgid "ROLE"
 msgstr ""
 
@@ -4650,15 +4650,15 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/rebuild.go:31
+#: lxc/rebuild.go:32
 msgid "Rebuild as an empty instance"
 msgstr ""
 
-#: lxc/rebuild.go:26
+#: lxc/rebuild.go:27
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:249 lxc/file.go:473
+#: lxc/file.go:250 lxc/file.go:474
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4685,7 +4685,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:882 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
+#: lxc/project.go:883 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
 #: lxc/remote.go:994
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4736,7 +4736,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1164 lxc/auth.go:1165
+#: lxc/auth.go:1165 lxc/auth.go:1166
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4772,7 +4772,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1927 lxc/auth.go:1928
+#: lxc/auth.go:1928 lxc/auth.go:1929
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4784,7 +4784,7 @@ msgstr ""
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:574 lxc/auth.go:575
+#: lxc/auth.go:575 lxc/auth.go:576
 msgid "Remove permissions from groups"
 msgstr ""
 
@@ -4829,11 +4829,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:391 lxc/auth.go:392
+#: lxc/auth.go:392 lxc/auth.go:393
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1751 lxc/auth.go:1752
+#: lxc/auth.go:1752 lxc/auth.go:1753
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -4853,7 +4853,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:589 lxc/project.go:590
+#: lxc/project.go:590 lxc/project.go:591
 msgid "Rename projects"
 msgstr ""
 
@@ -4951,7 +4951,7 @@ msgstr ""
 msgid "Revoke cluster member join token"
 msgstr ""
 
-#: lxc/storage_bucket.go:862
+#: lxc/storage_bucket.go:863
 msgid "Role (admin or read-only)"
 msgstr ""
 
@@ -4967,7 +4967,7 @@ msgstr ""
 msgid "Run against all projects"
 msgstr ""
 
-#: lxc/warning.go:213
+#: lxc/warning.go:214
 msgid "SEVERITY"
 msgstr ""
 
@@ -4987,12 +4987,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1231
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1231
+#: lxc/file.go:1232
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5006,11 +5006,11 @@ msgstr ""
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:173 lxc/warning.go:214
+#: lxc/operation.go:174 lxc/warning.go:215
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:569
+#: lxc/project.go:570
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5018,7 +5018,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:569
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -5026,11 +5026,11 @@ msgstr ""
 msgid "STP"
 msgstr ""
 
-#: lxc/storage_bucket.go:864
+#: lxc/storage_bucket.go:865
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:942
+#: lxc/storage_bucket.go:943
 #, c-format
 msgid "Secret key: %s"
 msgstr ""
@@ -5068,7 +5068,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:995
+#: lxc/file.go:996
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5206,11 +5206,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:654
+#: lxc/project.go:655
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:655
+#: lxc/project.go:656
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5219,11 +5219,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage_bucket.go:534
+#: lxc/storage_bucket.go:535
 msgid "Set storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:535
+#: lxc/storage_bucket.go:536
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -5262,15 +5262,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:476
+#: lxc/file.go:477
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:477
+#: lxc/file.go:478
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:475
+#: lxc/file.go:476
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5310,11 +5310,11 @@ msgstr ""
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 msgid "Set the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:542
+#: lxc/storage_bucket.go:543
 msgid "Set the key as a storage bucket property"
 msgstr ""
 
@@ -5330,7 +5330,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:993
+#: lxc/file.go:994
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5342,7 +5342,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1800 lxc/auth.go:1801
+#: lxc/auth.go:1801 lxc/auth.go:1802
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5358,11 +5358,11 @@ msgstr ""
 msgid "Show details of a cluster member"
 msgstr ""
 
-#: lxc/operation.go:192 lxc/operation.go:193
+#: lxc/operation.go:193 lxc/operation.go:194
 msgid "Show details on a background operation"
 msgstr ""
 
-#: lxc/monitor.go:49
+#: lxc/monitor.go:50
 msgid "Show events from all projects"
 msgstr ""
 
@@ -5370,11 +5370,11 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:440 lxc/auth.go:441
+#: lxc/auth.go:441 lxc/auth.go:442
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:832
+#: lxc/auth.go:833
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5455,15 +5455,15 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:786 lxc/project.go:787
+#: lxc/project.go:787 lxc/project.go:788
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage_bucket.go:628 lxc/storage_bucket.go:629
+#: lxc/storage_bucket.go:629 lxc/storage_bucket.go:630
 msgid "Show storage bucket configurations"
 msgstr ""
 
-#: lxc/storage_bucket.go:1156 lxc/storage_bucket.go:1157
+#: lxc/storage_bucket.go:1157 lxc/storage_bucket.go:1158
 msgid "Show storage bucket key configurations"
 msgstr ""
 
@@ -5479,7 +5479,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:895
+#: lxc/auth.go:896
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5529,7 +5529,7 @@ msgstr ""
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: lxc/warning.go:302 lxc/warning.go:303
+#: lxc/warning.go:303 lxc/warning.go:304
 msgid "Show warning"
 msgstr ""
 
@@ -5613,22 +5613,22 @@ msgstr ""
 msgid "Stopping the instance failed: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:166
+#: lxc/storage_bucket.go:167
 #, c-format
 msgid "Storage bucket %s created"
 msgstr ""
 
-#: lxc/storage_bucket.go:233
+#: lxc/storage_bucket.go:234
 #, c-format
 msgid "Storage bucket %s deleted"
 msgstr ""
 
-#: lxc/storage_bucket.go:940
+#: lxc/storage_bucket.go:941
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr ""
 
-#: lxc/storage_bucket.go:1006
+#: lxc/storage_bucket.go:1007
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr ""
@@ -5697,7 +5697,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:847 lxc/project.go:848
+#: lxc/project.go:848 lxc/project.go:849
 msgid "Switch the current project"
 msgstr ""
 
@@ -5713,10 +5713,10 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1139
+#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1139
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
-#: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:171
-#: lxc/storage_volume.go:1730 lxc/warning.go:215
+#: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
+#: lxc/storage_volume.go:1730 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
@@ -5724,11 +5724,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1032
+#: lxc/file.go:1033
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1026
+#: lxc/file.go:1027
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5856,12 +5856,12 @@ msgstr ""
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:446
+#: lxc/project.go:447
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
 
-#: lxc/storage_bucket.go:431
+#: lxc/storage_bucket.go:432
 #, c-format
 msgid "The property %q does not exist on the storage bucket %q: %v"
 msgstr ""
@@ -6046,7 +6046,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:961
+#: lxc/project.go:962
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6058,17 +6058,17 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:985 lxc/storage_volume.go:1735
+#: lxc/project.go:986 lxc/storage_volume.go:1735
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:573
+#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:574
 #: lxc/storage.go:724 lxc/storage_volume.go:1734
 msgid "USED BY"
 msgstr ""
 
-#: lxc/warning.go:216
+#: lxc/warning.go:217
 msgid "UUID"
 msgstr ""
 
@@ -6077,7 +6077,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:197
+#: lxc/file.go:198
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6091,13 +6091,13 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1253
+#: lxc/file.go:1254
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1153 lxc/list.go:631 lxc/storage_volume.go:1772
-#: lxc/warning.go:241
+#: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6107,7 +6107,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:807
+#: lxc/file.go:808
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6190,11 +6190,11 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:742 lxc/project.go:743
+#: lxc/project.go:743 lxc/project.go:744
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:697 lxc/storage_bucket.go:698
+#: lxc/storage_bucket.go:698 lxc/storage_bucket.go:699
 msgid "Unset storage bucket configuration keys"
 msgstr ""
 
@@ -6242,11 +6242,11 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:747
+#: lxc/project.go:748
 msgid "Unset the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:701
+#: lxc/storage_bucket.go:702
 msgid "Unset the key as a storage bucket property"
 msgstr ""
 
@@ -6325,7 +6325,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:71
+#: lxc/file.go:72
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6362,11 +6362,11 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:831
+#: lxc/auth.go:832
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:894
+#: lxc/auth.go:895
 msgid "View the current identity"
 msgstr ""
 
@@ -6397,15 +6397,15 @@ msgstr ""
 msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
-#: lxc/rebuild.go:27
+#: lxc/rebuild.go:28
 msgid ""
 "Wipe the instance root disk and re-initialize. The original image is used to "
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:156 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
+#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:526
+#: lxc/project.go:531 lxc/project.go:536 lxc/project.go:541 lxc/project.go:546
+#: lxc/project.go:551 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
 msgid "YES"
 msgstr ""
 
@@ -6425,7 +6425,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/rebuild.go:119
+#: lxc/rebuild.go:120
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
@@ -6437,12 +6437,12 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1689
+#: lxc/auth.go:330 lxc/auth.go:763 lxc/auth.go:894 lxc/auth.go:1690
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
-#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
+#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
-#: lxc/operation.go:103 lxc/profile.go:700 lxc/project.go:467
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:68
+#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:468
+#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6470,7 +6470,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1254
+#: lxc/auth.go:1255
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6531,11 +6531,11 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:830
+#: lxc/auth.go:831
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1926
+#: lxc/auth.go:1106 lxc/auth.go:1164 lxc/auth.go:1927
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6543,13 +6543,13 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:954 lxc/auth.go:1470 lxc/cluster_group.go:168
+#: lxc/auth.go:97 lxc/auth.go:150 lxc/auth.go:200 lxc/auth.go:440
+#: lxc/auth.go:955 lxc/auth.go:1471 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:514 lxc/auth.go:572
+#: lxc/auth.go:515 lxc/auth.go:573
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
@@ -6559,19 +6559,19 @@ msgstr ""
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:389
+#: lxc/auth.go:390
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1521 lxc/auth.go:1571 lxc/auth.go:1799
+#: lxc/auth.go:1522 lxc/auth.go:1572 lxc/auth.go:1800
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1873
+#: lxc/auth.go:1874
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1749
+#: lxc/auth.go:1750
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -6591,7 +6591,7 @@ msgstr ""
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
-#: lxc/rebuild.go:25
+#: lxc/rebuild.go:26
 msgid "[<remote>:]<image> [<remote>:]<instance>"
 msgstr ""
 
@@ -6674,20 +6674,20 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:170
+#: lxc/file.go:171
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:120
+#: lxc/file.go:121
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:240
+#: lxc/file.go:241
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:984
+#: lxc/file.go:985
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6838,12 +6838,12 @@ msgstr ""
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
-#: lxc/operation.go:53 lxc/operation.go:191
+#: lxc/operation.go:54 lxc/operation.go:192
 msgid "[<remote>:]<operation>"
 msgstr ""
 
 #: lxc/storage.go:200 lxc/storage.go:259 lxc/storage.go:473 lxc/storage.go:844
-#: lxc/storage_bucket.go:454
+#: lxc/storage_bucket.go:455
 msgid "[<remote>:]<pool>"
 msgstr ""
 
@@ -6851,22 +6851,22 @@ msgstr ""
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
-#: lxc/storage_bucket.go:185 lxc/storage_bucket.go:247
-#: lxc/storage_bucket.go:627 lxc/storage_bucket.go:769
+#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:248
+#: lxc/storage_bucket.go:628 lxc/storage_bucket.go:770
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
 
-#: lxc/storage_bucket.go:380 lxc/storage_bucket.go:696
-#: lxc/storage_bucket.go:850 lxc/storage_bucket.go:956
-#: lxc/storage_bucket.go:1020 lxc/storage_bucket.go:1155
+#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:697
+#: lxc/storage_bucket.go:851 lxc/storage_bucket.go:957
+#: lxc/storage_bucket.go:1021 lxc/storage_bucket.go:1156
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
 
-#: lxc/storage_bucket.go:533
+#: lxc/storage_bucket.go:534
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_bucket.go:81
+#: lxc/storage_bucket.go:82
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
 
@@ -6981,20 +6981,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:91 lxc/project.go:186 lxc/project.go:258 lxc/project.go:785
-#: lxc/project.go:846 lxc/project.go:913
+#: lxc/project.go:92 lxc/project.go:187 lxc/project.go:259 lxc/project.go:786
+#: lxc/project.go:847 lxc/project.go:914
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:394 lxc/project.go:741
+#: lxc/project.go:395 lxc/project.go:742
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:653
+#: lxc/project.go:654
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:587
+#: lxc/project.go:588
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7002,7 +7002,7 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:259 lxc/warning.go:301 lxc/warning.go:354
+#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
@@ -7058,7 +7058,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:555 lxc/remote.go:739
+#: lxc/project.go:556 lxc/remote.go:739
 msgid "current"
 msgstr ""
 
@@ -7105,20 +7105,20 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/auth.go:203
+#: lxc/auth.go:204
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:958
+#: lxc/auth.go:959
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1575
+#: lxc/auth.go:1576
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7196,20 +7196,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:988
+#: lxc/file.go:989
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:244
+#: lxc/file.go:245
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:470
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7291,7 +7291,7 @@ msgid ""
 "  List instances with their running state and user comment."
 msgstr ""
 
-#: lxc/monitor.go:37
+#: lxc/monitor.go:38
 msgid ""
 "lxc monitor --type=logging\n"
 "    Only show log messages.\n"
@@ -7367,7 +7367,7 @@ msgid ""
 "    Create record r1 for zone z1 with configuration from config.yaml"
 msgstr ""
 
-#: lxc/operation.go:195
+#: lxc/operation.go:196
 msgid ""
 "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Show details on that operation UUID"
@@ -7410,7 +7410,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:95
+#: lxc/project.go:96
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7418,7 +7418,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:262
+#: lxc/project.go:263
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7449,7 +7449,7 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:85
 msgid ""
 "lxc storage bucket create p1 b01\n"
 "\tCreate a new storage bucket name b01 in storage pool p1\n"
@@ -7459,19 +7459,19 @@ msgid ""
 "of config.yaml"
 msgstr ""
 
-#: lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:251
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1023
+#: lxc/storage_bucket.go:1024
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:854
 msgid ""
 "lxc storage bucket key create p1 b01 k1\n"
 "\tCreate a key called k1 for the bucket b01 in the pool p1.\n"
@@ -7481,14 +7481,14 @@ msgid ""
 "of config.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1158
+#: lxc/storage_bucket.go:1159
 msgid ""
 "lxc storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_bucket.go:630
+#: lxc/storage_bucket.go:631
 msgid ""
 "lxc storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
@@ -7558,16 +7558,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1142
+#: lxc/file.go:1143
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1101
+#: lxc/file.go:1102
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1054
+#: lxc/file.go:1055
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-04 08:52-0600\n"
+"POT-Creation-Date: 2024-09-05 08:44-0400\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Krombel <krombel@krombel.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/linux-containers/"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: lxc/storage_bucket.go:260 lxc/storage_bucket.go:1033
+#: lxc/storage_bucket.go:261 lxc/storage_bucket.go:1034
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
@@ -198,7 +198,7 @@ msgstr ""
 "###\n"
 "### Der Name wird zwar angezeigt, lässt sich jedoch nicht ändern.\n"
 
-#: lxc/auth.go:213
+#: lxc/auth.go:214
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -225,7 +225,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:968
+#: lxc/auth.go:969
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -246,7 +246,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1585
+#: lxc/auth.go:1586
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
@@ -620,7 +620,7 @@ msgstr ""
 "###\n"
 "### Der Name wird zwar angezeigt, lässt sich jedoch nicht ändern.\n"
 
-#: lxc/project.go:280
+#: lxc/project.go:281
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the project.\n"
@@ -682,12 +682,12 @@ msgstr "%s (%d mehr)"
 msgid "%s (%s) (%d available)"
 msgstr "%s (%d mehr)"
 
-#: lxc/file.go:935
+#: lxc/file.go:936
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s ist kein Verzeichnis"
 
-#: lxc/file.go:825
+#: lxc/file.go:826
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' ist kein unterstützter Dateityp"
@@ -726,7 +726,7 @@ msgstr "--refresh kann nur mit Containern verwendet werden"
 msgid "--console only works with a single instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/init.go:142 lxc/rebuild.go:64
+#: lxc/init.go:142 lxc/rebuild.go:65
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -786,7 +786,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:465
+#: lxc/file.go:466
 #, fuzzy
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
@@ -824,7 +824,7 @@ msgstr "ARCHITEKTUR"
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:813
+#: lxc/auth.go:814
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -832,11 +832,11 @@ msgstr ""
 msgid "Accept certificate"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/storage_bucket.go:863
+#: lxc/storage_bucket.go:864
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:941
+#: lxc/storage_bucket.go:942
 #, fuzzy, c-format
 msgid "Access key: %s"
 msgstr "Profil %s erstellt\n"
@@ -846,7 +846,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Access the expanded configuration"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/warning.go:261 lxc/warning.go:262
+#: lxc/warning.go:262 lxc/warning.go:263
 msgid "Acknowledge warning"
 msgstr ""
 
@@ -866,11 +866,11 @@ msgstr "Aktion (Standard: GET)"
 msgid "Add a cluster member to a cluster group"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/auth.go:1106 lxc/auth.go:1107
+#: lxc/auth.go:1107 lxc/auth.go:1108
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1874 lxc/auth.go:1875
+#: lxc/auth.go:1875 lxc/auth.go:1876
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -942,7 +942,7 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:515 lxc/auth.go:516
+#: lxc/auth.go:516 lxc/auth.go:517
 msgid "Add permissions to groups"
 msgstr ""
 
@@ -974,7 +974,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Address: %s"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/storage_bucket.go:169
+#: lxc/storage_bucket.go:170
 #, fuzzy, c-format
 msgid "Admin access key: %s"
 msgstr "Profil %s erstellt\n"
@@ -984,7 +984,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Admin password (or token) for %s:"
 msgstr "Administrator Passwort für %s: "
 
-#: lxc/storage_bucket.go:170
+#: lxc/storage_bucket.go:171
 #, fuzzy, c-format
 msgid "Admin secret key: %s"
 msgstr "Erstellt: %s"
@@ -1046,7 +1046,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:342 lxc/rebuild.go:130
+#: lxc/init.go:342 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -1154,12 +1154,12 @@ msgstr ""
 
 #: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:318
 #: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
-#: lxc/network_zone.go:366 lxc/network_zone.go:1053 lxc/storage_bucket.go:141
+#: lxc/network_zone.go:366 lxc/network_zone.go:1053 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:159
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:160
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "Alternatives config Verzeichnis."
@@ -1199,7 +1199,7 @@ msgstr "Bytes empfangen"
 msgid "Bytes sent"
 msgstr "Bytes gesendet"
 
-#: lxc/operation.go:174
+#: lxc/operation.go:175
 msgid "CANCELABLE"
 msgstr ""
 
@@ -1211,7 +1211,7 @@ msgstr ""
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: lxc/warning.go:209
+#: lxc/warning.go:210
 msgid "COUNT"
 msgstr ""
 
@@ -1238,7 +1238,7 @@ msgstr " Prozessorauslastung:"
 msgid "CPUs (%s):"
 msgstr ""
 
-#: lxc/operation.go:175
+#: lxc/operation.go:176
 #, fuzzy
 msgid "CREATED"
 msgstr "ERSTELLT AM"
@@ -1278,7 +1278,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:340
+#: lxc/file.go:341
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1303,11 +1303,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:224
+#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:546
+#: lxc/file.go:547
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1316,7 +1316,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:160
+#: lxc/rebuild.go:161
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1445,13 +1445,13 @@ msgstr "Gerät %s wurde von %s entfernt\n"
 #: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
 #: lxc/network_load_balancer.go:1051 lxc/network_load_balancer.go:1125
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
-#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:90
-#: lxc/storage_bucket.go:190 lxc/storage_bucket.go:253
-#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:541
-#: lxc/storage_bucket.go:634 lxc/storage_bucket.go:700
-#: lxc/storage_bucket.go:775 lxc/storage_bucket.go:861
-#: lxc/storage_bucket.go:961 lxc/storage_bucket.go:1026
-#: lxc/storage_bucket.go:1162 lxc/storage_volume.go:394
+#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
+#: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
+#: lxc/storage_bucket.go:385 lxc/storage_bucket.go:542
+#: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
+#: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
+#: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
 #: lxc/storage_volume.go:612 lxc/storage_volume.go:717
 #: lxc/storage_volume.go:1005 lxc/storage_volume.go:1231
 #: lxc/storage_volume.go:1360 lxc/storage_volume.go:1848
@@ -1475,7 +1475,7 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1113 lxc/list.go:132 lxc/storage_volume.go:1589
-#: lxc/warning.go:92
+#: lxc/warning.go:93
 msgid "Columns"
 msgstr "Spalten"
 
@@ -1504,7 +1504,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/project.go:100
+#: lxc/project.go:101
 #, fuzzy
 msgid "Config key/value to apply to the new project"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -1520,8 +1520,8 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
-#: lxc/project.go:362 lxc/storage.go:359 lxc/storage_bucket.go:348
-#: lxc/storage_bucket.go:1125 lxc/storage_volume.go:1150
+#: lxc/project.go:363 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1150
 #: lxc/storage_volume.go:1182
 #, fuzzy, c-format
 msgid "Config parsing error: %s"
@@ -1653,12 +1653,12 @@ msgstr "Fingerabdruck des Zertifikats: % x\n"
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:300 lxc/auth.go:1660
+#: lxc/auth.go:301 lxc/auth.go:1661
 #, fuzzy, c-format
 msgid "Could not parse group: %s"
 msgstr "YAML Analyse Fehler %v\n"
 
-#: lxc/auth.go:1054
+#: lxc/auth.go:1055
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1710,16 +1710,16 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Create and start instances from images"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/file.go:248 lxc/file.go:474
+#: lxc/file.go:249 lxc/file.go:475
 msgid "Create any directories necessary"
 msgstr ""
 
-#: lxc/auth.go:97 lxc/auth.go:98
+#: lxc/auth.go:98 lxc/auth.go:99
 #, fuzzy
 msgid "Create groups"
 msgstr "Fehlerhafte Profil URL %s"
 
-#: lxc/auth.go:1471 lxc/auth.go:1472
+#: lxc/auth.go:1472 lxc/auth.go:1473
 #, fuzzy
 msgid "Create identity provider groups"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -1742,12 +1742,12 @@ msgstr ""
 msgid "Create instances from images"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/storage_bucket.go:851 lxc/storage_bucket.go:852
+#: lxc/storage_bucket.go:852 lxc/storage_bucket.go:853
 #, fuzzy
 msgid "Create key for a storage bucket"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/storage_bucket.go:82 lxc/storage_bucket.go:83
+#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
 #, fuzzy
 msgid "Create new custom storage buckets"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -1800,7 +1800,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr "Fehlerhafte Profil URL %s"
 
-#: lxc/project.go:92 lxc/project.go:93
+#: lxc/project.go:93 lxc/project.go:94
 #, fuzzy
 msgid "Create projects"
 msgstr "Fehlerhafte Profil URL %s"
@@ -1839,13 +1839,13 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:376 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1135 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
-#: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:172
-#: lxc/profile.go:756 lxc/project.go:572 lxc/storage.go:723
-#: lxc/storage_bucket.go:512 lxc/storage_bucket.go:832
+#: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
+#: lxc/profile.go:756 lxc/project.go:573 lxc/storage.go:723
+#: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1732
 msgid "DESCRIPTION"
 msgstr "BESCHREIBUNG"
@@ -1870,7 +1870,7 @@ msgstr ""
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
-#: lxc/operation.go:55 lxc/operation.go:56
+#: lxc/operation.go:56 lxc/operation.go:57
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
@@ -1878,21 +1878,21 @@ msgstr ""
 msgid "Delete a cluster group"
 msgstr ""
 
-#: lxc/warning.go:360
+#: lxc/warning.go:361
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:122 lxc/file.go:123
+#: lxc/file.go:123 lxc/file.go:124
 #, fuzzy
 msgid "Delete files in instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/auth.go:151 lxc/auth.go:152
+#: lxc/auth.go:152 lxc/auth.go:153
 #, fuzzy
 msgid "Delete groups"
 msgstr "Fehlerhafte Profil URL %s"
 
-#: lxc/auth.go:1523 lxc/auth.go:1524
+#: lxc/auth.go:1524 lxc/auth.go:1525
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1914,7 +1914,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Delete instances and snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/storage_bucket.go:957 lxc/storage_bucket.go:958
+#: lxc/storage_bucket.go:958 lxc/storage_bucket.go:959
 #, fuzzy
 msgid "Delete key from a storage bucket"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -1954,12 +1954,12 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:188 lxc/project.go:189
+#: lxc/project.go:189 lxc/project.go:190
 #, fuzzy
 msgid "Delete projects"
 msgstr "Fehlerhafte Profil URL %s"
 
-#: lxc/storage_bucket.go:187 lxc/storage_bucket.go:188
+#: lxc/storage_bucket.go:188 lxc/storage_bucket.go:189
 #, fuzzy
 msgid "Delete storage buckets"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -1973,20 +1973,20 @@ msgstr ""
 msgid "Delete storage volumes"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/warning.go:356 lxc/warning.go:357
+#: lxc/warning.go:357 lxc/warning.go:358
 msgid "Delete warning"
 msgstr ""
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:30 lxc/auth.go:59 lxc/auth.go:98
-#: lxc/auth.go:152 lxc/auth.go:201 lxc/auth.go:332 lxc/auth.go:392
-#: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
-#: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
-#: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
-#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1434 lxc/auth.go:1472
-#: lxc/auth.go:1524 lxc/auth.go:1573 lxc/auth.go:1692 lxc/auth.go:1752
-#: lxc/auth.go:1801 lxc/auth.go:1852 lxc/auth.go:1875 lxc/auth.go:1928
+#: lxc/alias.go:214 lxc/auth.go:31 lxc/auth.go:60 lxc/auth.go:99
+#: lxc/auth.go:153 lxc/auth.go:202 lxc/auth.go:333 lxc/auth.go:393
+#: lxc/auth.go:442 lxc/auth.go:494 lxc/auth.go:517 lxc/auth.go:576
+#: lxc/auth.go:732 lxc/auth.go:766 lxc/auth.go:833 lxc/auth.go:896
+#: lxc/auth.go:957 lxc/auth.go:1085 lxc/auth.go:1108 lxc/auth.go:1166
+#: lxc/auth.go:1235 lxc/auth.go:1257 lxc/auth.go:1435 lxc/auth.go:1473
+#: lxc/auth.go:1525 lxc/auth.go:1574 lxc/auth.go:1693 lxc/auth.go:1753
+#: lxc/auth.go:1802 lxc/auth.go:1853 lxc/auth.go:1876 lxc/auth.go:1929
 #: lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215 lxc/cluster.go:272
 #: lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:484 lxc/cluster.go:528
 #: lxc/cluster.go:586 lxc/cluster.go:677 lxc/cluster.go:770 lxc/cluster.go:893
@@ -2010,15 +2010,15 @@ msgstr ""
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:83 lxc/file.go:123 lxc/file.go:172
-#: lxc/file.go:242 lxc/file.go:467 lxc/file.go:986 lxc/image.go:38
+#: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
+#: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
 #: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
 #: lxc/image.go:697 lxc/image.go:946 lxc/image.go:1088 lxc/image.go:1415
 #: lxc/image.go:1506 lxc/image.go:1572 lxc/image.go:1636 lxc/image.go:1699
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:38 lxc/network.go:33
+#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33
 #: lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405
 #: lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793
 #: lxc/network.go:874 lxc/network.go:1005 lxc/network.go:1106
@@ -2052,27 +2052,27 @@ msgstr ""
 #: lxc/network_zone.go:909 lxc/network_zone.go:985 lxc/network_zone.go:1083
 #: lxc/network_zone.go:1172 lxc/network_zone.go:1219 lxc/network_zone.go:1349
 #: lxc/network_zone.go:1410 lxc/network_zone.go:1425 lxc/network_zone.go:1483
-#: lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:106
-#: lxc/operation.go:193 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
+#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
+#: lxc/operation.go:194 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
 #: lxc/profile.go:271 lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493
 #: lxc/profile.go:629 lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860
-#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:29
-#: lxc/project.go:93 lxc/project.go:189 lxc/project.go:260 lxc/project.go:396
-#: lxc/project.go:470 lxc/project.go:590 lxc/project.go:655 lxc/project.go:743
-#: lxc/project.go:787 lxc/project.go:848 lxc/project.go:915 lxc/publish.go:34
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:35 lxc/remote.go:91
+#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:30
+#: lxc/project.go:94 lxc/project.go:190 lxc/project.go:261 lxc/project.go:397
+#: lxc/project.go:471 lxc/project.go:591 lxc/project.go:656 lxc/project.go:744
+#: lxc/project.go:788 lxc/project.go:849 lxc/project.go:916 lxc/publish.go:34
+#: lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91
 #: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853
 #: lxc/remote.go:917 lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24
 #: lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203
 #: lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655
 #: lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940
-#: lxc/storage_bucket.go:29 lxc/storage_bucket.go:83 lxc/storage_bucket.go:188
-#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:382
-#: lxc/storage_bucket.go:458 lxc/storage_bucket.go:535
-#: lxc/storage_bucket.go:629 lxc/storage_bucket.go:698
-#: lxc/storage_bucket.go:732 lxc/storage_bucket.go:773
-#: lxc/storage_bucket.go:852 lxc/storage_bucket.go:958
-#: lxc/storage_bucket.go:1022 lxc/storage_bucket.go:1157
+#: lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189
+#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:383
+#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:536
+#: lxc/storage_bucket.go:630 lxc/storage_bucket.go:699
+#: lxc/storage_bucket.go:733 lxc/storage_bucket.go:774
+#: lxc/storage_bucket.go:853 lxc/storage_bucket.go:959
+#: lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158
 #: lxc/storage_volume.go:58 lxc/storage_volume.go:169 lxc/storage_volume.go:283
 #: lxc/storage_volume.go:390 lxc/storage_volume.go:605
 #: lxc/storage_volume.go:714 lxc/storage_volume.go:801
@@ -2083,8 +2083,8 @@ msgstr ""
 #: lxc/storage_volume.go:2064 lxc/storage_volume.go:2222
 #: lxc/storage_volume.go:2343 lxc/storage_volume.go:2405
 #: lxc/storage_volume.go:2541 lxc/storage_volume.go:2624
-#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:29
-#: lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
+#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:30
+#: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
@@ -2181,7 +2181,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:994
+#: lxc/file.go:995
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2252,7 +2252,7 @@ msgstr "ABLAUFDATUM"
 msgid "EXPIRY DATE"
 msgstr "ABLAUFDATUM"
 
-#: lxc/file.go:74
+#: lxc/file.go:75
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -2262,7 +2262,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:955 lxc/auth.go:956
+#: lxc/auth.go:956 lxc/auth.go:957
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -2271,17 +2271,17 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/file.go:171 lxc/file.go:172
+#: lxc/file.go:172 lxc/file.go:173
 #, fuzzy
 msgid "Edit files in instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/auth.go:200 lxc/auth.go:201
+#: lxc/auth.go:201 lxc/auth.go:202
 #, fuzzy
 msgid "Edit groups as YAML"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/auth.go:1572 lxc/auth.go:1573
+#: lxc/auth.go:1573 lxc/auth.go:1574
 #, fuzzy
 msgid "Edit identity provider groups as YAML"
 msgstr "Alternatives config Verzeichnis."
@@ -2348,16 +2348,16 @@ msgstr "Alternatives config Verzeichnis."
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:259 lxc/project.go:260
+#: lxc/project.go:260 lxc/project.go:261
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:248 lxc/storage_bucket.go:249
+#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:250
 #, fuzzy
 msgid "Edit storage bucket configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/storage_bucket.go:1021 lxc/storage_bucket.go:1022
+#: lxc/storage_bucket.go:1022 lxc/storage_bucket.go:1023
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
@@ -2375,7 +2375,7 @@ msgid "Edit trust configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
 
 #: lxc/image.go:1147 lxc/list.go:622 lxc/storage_volume.go:1766
-#: lxc/warning.go:235
+#: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2431,7 +2431,7 @@ msgstr ""
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
-#: lxc/project.go:718 lxc/storage.go:812 lxc/storage_bucket.go:602
+#: lxc/project.go:719 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2155 lxc/storage_volume.go:2193
 #, fuzzy, c-format
 msgid "Error setting properties: %v"
@@ -2445,8 +2445,8 @@ msgstr "Fehler beim hinzufügen des Alias %s\n"
 #: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
-#: lxc/profile.go:981 lxc/project.go:712 lxc/storage.go:806
-#: lxc/storage_bucket.go:596 lxc/storage_volume.go:2149
+#: lxc/profile.go:981 lxc/project.go:713 lxc/storage.go:806
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2149
 #: lxc/storage_volume.go:2187
 #, c-format
 msgid "Error unsetting property: %v"
@@ -2471,7 +2471,7 @@ msgstr ""
 msgid "Evacuating cluster member: %s"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/monitor.go:50
+#: lxc/monitor.go:51
 msgid "Event type to listen for"
 msgstr ""
 
@@ -2566,16 +2566,16 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr "FINGERABDRUCK"
 
-#: lxc/warning.go:210
+#: lxc/warning.go:211
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1237
+#: lxc/file.go:1238
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1260
+#: lxc/file.go:1261
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2590,12 +2590,12 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/file.go:1287
+#: lxc/file.go:1288
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1072
+#: lxc/file.go:1073
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -2625,7 +2625,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Failed fetching fingerprint %q: %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/file.go:1193
+#: lxc/file.go:1194
 #, fuzzy, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "Akzeptiere Zertifikat"
@@ -2640,7 +2640,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/file.go:1198
+#: lxc/file.go:1199
 #, fuzzy, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "Akzeptiere Zertifikat"
@@ -2650,12 +2650,12 @@ msgstr "Akzeptiere Zertifikat"
 msgid "Failed starting command: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/file.go:1098
+#: lxc/file.go:1099
 #, fuzzy, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/file.go:1225
+#: lxc/file.go:1226
 #, fuzzy, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "Akzeptiere Zertifikat"
@@ -2694,7 +2694,7 @@ msgstr "Akzeptiere Zertifikat"
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1210
+#: lxc/file.go:1211
 #, fuzzy, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "Akzeptiere Zertifikat"
@@ -2709,7 +2709,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Failed to remove alias %s: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/file.go:820
+#: lxc/file.go:821
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2724,7 +2724,7 @@ msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
 #: lxc/network.go:1044 lxc/network_acl.go:133 lxc/network_zone.go:124
-#: lxc/operation.go:136
+#: lxc/operation.go:137
 #, fuzzy
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2793,21 +2793,21 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
+#: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:770 lxc/auth.go:1697
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1114 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:57
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
-#: lxc/operation.go:108 lxc/profile.go:707 lxc/project.go:472
-#: lxc/project.go:917 lxc/remote.go:690 lxc/storage.go:657
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:774
-#: lxc/storage_volume.go:1608 lxc/warning.go:93
+#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:473
+#: lxc/project.go:918 lxc/remote.go:690 lxc/storage.go:657
+#: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
+#: lxc/storage_volume.go:1608 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
-#: lxc/monitor.go:52
+#: lxc/monitor.go:53
 msgid "Format (json|pretty|yaml)"
 msgstr ""
 
@@ -2851,7 +2851,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:817 lxc/auth.go:1736
+#: lxc/auth.go:818 lxc/auth.go:1737
 msgid "GROUPS"
 msgstr ""
 
@@ -2869,7 +2869,7 @@ msgstr "Generiere Nutzerzertifikat. Dies kann wenige Minuten dauern...\n"
 msgid "Get UEFI variables for instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/project.go:914 lxc/project.go:915
+#: lxc/project.go:915 lxc/project.go:916
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2922,11 +2922,11 @@ msgstr "Profil %s erstellt\n"
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:400
+#: lxc/project.go:401
 msgid "Get the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:385
+#: lxc/storage_bucket.go:386
 #, fuzzy
 msgid "Get the key as a storage bucket property"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -2998,12 +2998,12 @@ msgstr "Profil %s erstellt\n"
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:395 lxc/project.go:396
+#: lxc/project.go:396 lxc/project.go:397
 #, fuzzy
 msgid "Get values for project configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:382
+#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:383
 #, fuzzy
 msgid "Get values for storage bucket configuration keys"
 msgstr "Profil %s erstellt\n"
@@ -3021,17 +3021,17 @@ msgstr ""
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: lxc/auth.go:136
+#: lxc/auth.go:137
 #, fuzzy, c-format
 msgid "Group %s created"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/auth.go:186
+#: lxc/auth.go:187
 #, fuzzy, c-format
 msgid "Group %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: lxc/auth.go:426 lxc/auth.go:1786
+#: lxc/auth.go:427 lxc/auth.go:1787
 #, fuzzy, c-format
 msgid "Group %s renamed to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
@@ -3057,27 +3057,27 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1310
+#: lxc/file.go:1311
 #, fuzzy, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/file.go:1299
+#: lxc/file.go:1300
 #, fuzzy, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/file.go:1122
+#: lxc/file.go:1123
 #, fuzzy, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/file.go:1132
+#: lxc/file.go:1133
 #, fuzzy, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/network.go:966 lxc/operation.go:170
+#: lxc/network.go:966 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -3091,11 +3091,11 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:816
+#: lxc/auth.go:817
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:566
+#: lxc/project.go:567
 msgid "IMAGES"
 msgstr ""
 
@@ -3125,17 +3125,17 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1508
+#: lxc/auth.go:1509
 #, fuzzy, c-format
 msgid "Identity provider group %s created"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/auth.go:1558
+#: lxc/auth.go:1559
 #, fuzzy, c-format
 msgid "Identity provider group %s deleted"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/rebuild.go:32
+#: lxc/rebuild.go:33
 msgid "If an instance is running, stop it and then rebuild it"
 msgstr ""
 
@@ -3260,7 +3260,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1233 lxc/auth.go:1234
+#: lxc/auth.go:1234 lxc/auth.go:1235
 msgid "Inspect permissions"
 msgstr ""
 
@@ -3268,12 +3268,12 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1124
+#: lxc/file.go:1125
 #, fuzzy
 msgid "Instance disconnected"
 msgstr "Entferntes Administrator Passwort"
 
-#: lxc/file.go:1301
+#: lxc/file.go:1302
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3291,7 +3291,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1044
+#: lxc/file.go:1045
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3300,7 +3300,7 @@ msgstr ""
 msgid "Instance published with fingerprint: %s"
 msgstr "Abbild mit Fingerabdruck %s importiert\n"
 
-#: lxc/rebuild.go:74
+#: lxc/rebuild.go:75
 #, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
@@ -3334,7 +3334,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/monitor.go:70
+#: lxc/monitor.go:71
 #, fuzzy, c-format
 msgid "Invalid format: %s"
 msgstr "Ungültiges Ziel %s"
@@ -3344,7 +3344,7 @@ msgstr "Ungültiges Ziel %s"
 msgid "Invalid instance name: %s"
 msgstr "Ungültige Quelle %s"
 
-#: lxc/file.go:1039
+#: lxc/file.go:1040
 #, fuzzy, c-format
 msgid "Invalid instance path: %q"
 msgstr "Ungültige Quelle %s"
@@ -3388,7 +3388,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr "ungültiges Argument %s"
 
-#: lxc/file.go:147
+#: lxc/file.go:148
 #, fuzzy, c-format
 msgid "Invalid path %s"
 msgstr "Ungültiges Ziel %s"
@@ -3405,12 +3405,12 @@ msgstr "Ungültiges Ziel %s"
 msgid "Invalid snapshot name"
 msgstr "Ungültige Quelle %s"
 
-#: lxc/file.go:313
+#: lxc/file.go:314
 #, c-format
 msgid "Invalid source %s"
 msgstr "Ungültige Quelle %s"
 
-#: lxc/file.go:495
+#: lxc/file.go:496
 #, c-format
 msgid "Invalid target %s"
 msgstr "Ungültiges Ziel %s"
@@ -3428,7 +3428,7 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/warning.go:212
 msgid "LAST SEEN"
 msgstr ""
 
@@ -3436,7 +3436,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:984
+#: lxc/project.go:985
 msgid "LIMIT"
 msgstr ""
 
@@ -3445,8 +3445,8 @@ msgid "LISTEN ADDRESS"
 msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
-#: lxc/network_load_balancer.go:165 lxc/operation.go:177
-#: lxc/storage_bucket.go:516 lxc/storage_volume.go:1739 lxc/warning.go:220
+#: lxc/network_load_balancer.go:165 lxc/operation.go:178
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1739 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3525,7 +3525,7 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/warning.go:94
+#: lxc/warning.go:95
 #, fuzzy
 msgid "List all warnings"
 msgstr "Aliasse:\n"
@@ -3572,20 +3572,20 @@ msgstr ""
 msgid "List available storage pools"
 msgstr ""
 
-#: lxc/operation.go:105 lxc/operation.go:106
+#: lxc/operation.go:106 lxc/operation.go:107
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:331 lxc/auth.go:332
+#: lxc/auth.go:332 lxc/auth.go:333
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:764 lxc/auth.go:765
+#: lxc/auth.go:765 lxc/auth.go:766
 #, fuzzy
 msgid "List identities"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/auth.go:1691 lxc/auth.go:1692
+#: lxc/auth.go:1692 lxc/auth.go:1693
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3751,12 +3751,12 @@ msgstr ""
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/operation.go:109
+#: lxc/operation.go:110
 #, fuzzy
 msgid "List operations from all projects"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/auth.go:1255 lxc/auth.go:1256
+#: lxc/auth.go:1256 lxc/auth.go:1257
 #, fuzzy
 msgid "List permissions"
 msgstr "Aliasse:\n"
@@ -3765,16 +3765,16 @@ msgstr "Aliasse:\n"
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:469 lxc/project.go:470
+#: lxc/project.go:470 lxc/project.go:471
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:771 lxc/storage_bucket.go:773
+#: lxc/storage_bucket.go:772 lxc/storage_bucket.go:774
 #, fuzzy
 msgid "List storage bucket keys"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/storage_bucket.go:456 lxc/storage_bucket.go:458
+#: lxc/storage_bucket.go:457 lxc/storage_bucket.go:459
 #, fuzzy
 msgid "List storage buckets"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -3812,12 +3812,12 @@ msgstr ""
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/warning.go:70
+#: lxc/warning.go:71
 #, fuzzy
 msgid "List warnings"
 msgstr "Aliasse:\n"
 
-#: lxc/warning.go:71
+#: lxc/warning.go:72
 msgid ""
 "List warnings\n"
 "\n"
@@ -3840,7 +3840,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/operation.go:23 lxc/operation.go:24
+#: lxc/operation.go:24 lxc/operation.go:25
 msgid "List, show and delete background operations"
 msgstr ""
 
@@ -3849,7 +3849,7 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/monitor.go:79
+#: lxc/monitor.go:80
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
@@ -3965,26 +3965,26 @@ msgstr "Unbekannter Befehl %s für Abbild"
 msgid "Manage devices"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/file.go:82 lxc/file.go:83
+#: lxc/file.go:83 lxc/file.go:84
 #, fuzzy
 msgid "Manage files in instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1433 lxc/auth.go:1434
+#: lxc/auth.go:59 lxc/auth.go:60 lxc/auth.go:1434 lxc/auth.go:1435
 #, fuzzy
 msgid "Manage groups"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/auth.go:1083 lxc/auth.go:1084
+#: lxc/auth.go:1084 lxc/auth.go:1085
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:730 lxc/auth.go:731
+#: lxc/auth.go:731 lxc/auth.go:732
 #, fuzzy
 msgid "Manage identities"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/auth.go:1851 lxc/auth.go:1852
+#: lxc/auth.go:1852 lxc/auth.go:1853
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -4091,7 +4091,7 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Manage network zones"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/auth.go:492 lxc/auth.go:493
+#: lxc/auth.go:493 lxc/auth.go:494
 #, fuzzy
 msgid "Manage permissions"
 msgstr "Fehlerhafte Profil URL %s"
@@ -4101,27 +4101,27 @@ msgstr "Fehlerhafte Profil URL %s"
 msgid "Manage profiles"
 msgstr "Fehlerhafte Profil URL %s"
 
-#: lxc/project.go:28 lxc/project.go:29
+#: lxc/project.go:29 lxc/project.go:30
 #, fuzzy
 msgid "Manage projects"
 msgstr "Fehlerhafte Profil URL %s"
 
-#: lxc/storage_bucket.go:731
+#: lxc/storage_bucket.go:732
 #, fuzzy
 msgid "Manage storage bucket keys"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/storage_bucket.go:732
+#: lxc/storage_bucket.go:733
 #, fuzzy
 msgid "Manage storage bucket keys."
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/storage_bucket.go:28
+#: lxc/storage_bucket.go:29
 #, fuzzy
 msgid "Manage storage buckets"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:30
 #, fuzzy
 msgid "Manage storage buckets."
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -4152,12 +4152,12 @@ msgstr ""
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/auth.go:29 lxc/auth.go:30
+#: lxc/auth.go:30 lxc/auth.go:31
 #, fuzzy
 msgid "Manage user authorization"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/warning.go:28 lxc/warning.go:29
+#: lxc/warning.go:29 lxc/warning.go:30
 #, fuzzy
 msgid "Manage warnings"
 msgstr "Veröffentliche Abbild"
@@ -4223,17 +4223,17 @@ msgstr ""
 msgid "Migration operation failure: %w"
 msgstr ""
 
-#: lxc/monitor.go:51
+#: lxc/monitor.go:52
 msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: lxc/storage_bucket.go:116 lxc/storage_bucket.go:216
-#: lxc/storage_bucket.go:292 lxc/storage_bucket.go:411
-#: lxc/storage_bucket.go:568 lxc/storage_bucket.go:660
-#: lxc/storage_bucket.go:802 lxc/storage_bucket.go:889
-#: lxc/storage_bucket.go:986 lxc/storage_bucket.go:1065
-#: lxc/storage_bucket.go:1188
+#: lxc/storage_bucket.go:117 lxc/storage_bucket.go:217
+#: lxc/storage_bucket.go:293 lxc/storage_bucket.go:412
+#: lxc/storage_bucket.go:569 lxc/storage_bucket.go:661
+#: lxc/storage_bucket.go:803 lxc/storage_bucket.go:890
+#: lxc/storage_bucket.go:987 lxc/storage_bucket.go:1066
+#: lxc/storage_bucket.go:1189
 #, fuzzy
 msgid "Missing bucket name"
 msgstr "Fehlende Zusammenfassung."
@@ -4256,23 +4256,23 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 msgid "Missing cluster member name"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1825
+#: lxc/auth.go:123 lxc/auth.go:177 lxc/auth.go:255 lxc/auth.go:417
+#: lxc/auth.go:466 lxc/auth.go:541 lxc/auth.go:600 lxc/auth.go:1826
 #, fuzzy
 msgid "Missing group name"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/auth.go:862 lxc/auth.go:1003 lxc/auth.go:1131 lxc/auth.go:1189
+#: lxc/auth.go:863 lxc/auth.go:1004 lxc/auth.go:1132 lxc/auth.go:1190
 #, fuzzy
 msgid "Missing identity argument"
 msgstr "Fehlende Zusammenfassung."
 
-#: lxc/auth.go:1495 lxc/auth.go:1548 lxc/auth.go:1614 lxc/auth.go:1776
+#: lxc/auth.go:1496 lxc/auth.go:1549 lxc/auth.go:1615 lxc/auth.go:1777
 #, fuzzy
 msgid "Missing identity provider group name"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/auth.go:1899 lxc/auth.go:1952
+#: lxc/auth.go:1900 lxc/auth.go:1953
 #, fuzzy
 msgid "Missing identity provider group name argument"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -4281,13 +4281,13 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
 #: lxc/config_template.go:377 lxc/profile.go:141 lxc/profile.go:222
-#: lxc/profile.go:808 lxc/rebuild.go:60
+#: lxc/profile.go:808 lxc/rebuild.go:61
 #, fuzzy
 msgid "Missing instance name"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/storage_bucket.go:893 lxc/storage_bucket.go:990
-#: lxc/storage_bucket.go:1069 lxc/storage_bucket.go:1192
+#: lxc/storage_bucket.go:894 lxc/storage_bucket.go:991
+#: lxc/storage_bucket.go:1070 lxc/storage_bucket.go:1193
 #, fuzzy
 msgid "Missing key name"
 msgstr "Fehlende Zusammenfassung."
@@ -4359,13 +4359,13 @@ msgid "Missing peer name"
 msgstr "Fehlende Zusammenfassung."
 
 #: lxc/storage.go:235 lxc/storage.go:313 lxc/storage.go:431 lxc/storage.go:509
-#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:112
-#: lxc/storage_bucket.go:212 lxc/storage_bucket.go:288
-#: lxc/storage_bucket.go:407 lxc/storage_bucket.go:482
-#: lxc/storage_bucket.go:564 lxc/storage_bucket.go:656
-#: lxc/storage_bucket.go:798 lxc/storage_bucket.go:885
-#: lxc/storage_bucket.go:982 lxc/storage_bucket.go:1061
-#: lxc/storage_bucket.go:1184 lxc/storage_volume.go:209
+#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:113
+#: lxc/storage_bucket.go:213 lxc/storage_bucket.go:289
+#: lxc/storage_bucket.go:408 lxc/storage_bucket.go:483
+#: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
+#: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
+#: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
 #: lxc/storage_volume.go:323 lxc/storage_volume.go:643
 #: lxc/storage_volume.go:750 lxc/storage_volume.go:841
 #: lxc/storage_volume.go:939 lxc/storage_volume.go:1053
@@ -4381,9 +4381,9 @@ msgstr "Profilname kann nicht geändert werden"
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:404 lxc/project.go:146 lxc/project.go:226 lxc/project.go:316
-#: lxc/project.go:433 lxc/project.go:622 lxc/project.go:691 lxc/project.go:819
-#: lxc/project.go:948
+#: lxc/profile.go:404 lxc/project.go:147 lxc/project.go:227 lxc/project.go:317
+#: lxc/project.go:434 lxc/project.go:623 lxc/project.go:692 lxc/project.go:820
+#: lxc/project.go:949
 #, fuzzy
 msgid "Missing project name"
 msgstr "Profilname kann nicht geändert werden"
@@ -4402,7 +4402,7 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Missing storage pool name"
 msgstr "Profilname kann nicht geändert werden"
 
-#: lxc/file.go:598
+#: lxc/file.go:599
 msgid "Missing target directory"
 msgstr ""
 
@@ -4425,11 +4425,11 @@ msgstr ""
 msgid "Model: %v"
 msgstr ""
 
-#: lxc/monitor.go:32
+#: lxc/monitor.go:33
 msgid "Monitor a local or remote LXD server"
 msgstr ""
 
-#: lxc/monitor.go:33
+#: lxc/monitor.go:34
 msgid ""
 "Monitor a local or remote LXD server\n"
 "\n"
@@ -4441,12 +4441,12 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:285
+#: lxc/file.go:286
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 "Mehr als eine Datei herunterzuladen, aber das Ziel ist kein Verzeichnis"
 
-#: lxc/file.go:985 lxc/file.go:986
+#: lxc/file.go:986 lxc/file.go:987
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -4513,13 +4513,13 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:192
+#: lxc/auth.go:376 lxc/auth.go:816 lxc/auth.go:1736 lxc/cluster.go:192
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
-#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:565
-#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:511
-#: lxc/storage_bucket.go:831 lxc/storage_volume.go:1731
+#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:566
+#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1731
 msgid "NAME"
 msgstr ""
 
@@ -4527,11 +4527,11 @@ msgstr ""
 msgid "NAT"
 msgstr ""
 
-#: lxc/project.go:571
+#: lxc/project.go:572
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:570
+#: lxc/project.go:571
 msgid "NETWORKS"
 msgstr ""
 
@@ -4543,9 +4543,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/operation.go:154 lxc/project.go:523
-#: lxc/project.go:528 lxc/project.go:533 lxc/project.go:538 lxc/project.go:543
-#: lxc/project.go:548 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
+#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:524
+#: lxc/project.go:529 lxc/project.go:534 lxc/project.go:539 lxc/project.go:544
+#: lxc/project.go:549 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
 msgid "NO"
 msgstr ""
 
@@ -4796,7 +4796,7 @@ msgstr ""
 msgid "Only managed networks can be modified"
 msgstr ""
 
-#: lxc/operation.go:86
+#: lxc/operation.go:87
 #, fuzzy, c-format
 msgid "Operation %s deleted"
 msgstr "Profil %s gelöscht\n"
@@ -4843,11 +4843,11 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:567
+#: lxc/list.go:576 lxc/project.go:568
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:212
+#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4912,24 +4912,24 @@ msgstr "Erstellt: %s"
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1102
+#: lxc/file.go:1103
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:860
+#: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
-#: lxc/project.go:363 lxc/storage.go:360 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1151
+#: lxc/project.go:364 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1151
 #: lxc/storage_volume.go:1183
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
-#: lxc/monitor.go:48
+#: lxc/monitor.go:49
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
@@ -5020,17 +5020,17 @@ msgstr "Profil %s erstellt\n"
 msgid "Profiles: "
 msgstr "Profil %s erstellt\n"
 
-#: lxc/project.go:172
+#: lxc/project.go:173
 #, fuzzy, c-format
 msgid "Project %s created"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/project.go:236
+#: lxc/project.go:237
 #, fuzzy, c-format
 msgid "Project %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: lxc/project.go:637
+#: lxc/project.go:638
 #, fuzzy, c-format
 msgid "Project %s renamed to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
@@ -5153,22 +5153,22 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Publishing instance: %s"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/file.go:241 lxc/file.go:242
+#: lxc/file.go:242 lxc/file.go:243
 #, fuzzy
 msgid "Pull files from instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/file.go:416 lxc/file.go:767
+#: lxc/file.go:417 lxc/file.go:768
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:466 lxc/file.go:467
+#: lxc/file.go:467 lxc/file.go:468
 #, fuzzy
 msgid "Push files into instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/file.go:701 lxc/file.go:867
+#: lxc/file.go:702 lxc/file.go:868
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -5181,11 +5181,11 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:983
+#: lxc/project.go:984
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/storage_bucket.go:833
+#: lxc/storage_bucket.go:834
 msgid "ROLE"
 msgstr ""
 
@@ -5198,17 +5198,17 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/rebuild.go:31
+#: lxc/rebuild.go:32
 #, fuzzy
 msgid "Rebuild as an empty instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/rebuild.go:26
+#: lxc/rebuild.go:27
 #, fuzzy
 msgid "Rebuild instances"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/file.go:249 lxc/file.go:473
+#: lxc/file.go:250 lxc/file.go:474
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -5236,7 +5236,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr "entfernte Instanz %s existiert bereits"
 
-#: lxc/project.go:882 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
+#: lxc/project.go:883 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
 #: lxc/remote.go:994
 #, fuzzy, c-format
 msgid "Remote %s doesn't exist"
@@ -5288,7 +5288,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/auth.go:1164 lxc/auth.go:1165
+#: lxc/auth.go:1165 lxc/auth.go:1166
 #, fuzzy
 msgid "Remove a group from an identity"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -5330,7 +5330,7 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 msgid "Remove entries from a network zone record"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/auth.go:1927 lxc/auth.go:1928
+#: lxc/auth.go:1928 lxc/auth.go:1929
 #, fuzzy
 msgid "Remove identities from groups"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -5344,7 +5344,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:574 lxc/auth.go:575
+#: lxc/auth.go:575 lxc/auth.go:576
 #, fuzzy
 msgid "Remove permissions from groups"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -5395,12 +5395,12 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:391 lxc/auth.go:392
+#: lxc/auth.go:392 lxc/auth.go:393
 #, fuzzy
 msgid "Rename groups"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/auth.go:1751 lxc/auth.go:1752
+#: lxc/auth.go:1752 lxc/auth.go:1753
 #, fuzzy
 msgid "Rename identity provider groups"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -5423,7 +5423,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr "Fehlerhafte Profil URL %s"
 
-#: lxc/project.go:589 lxc/project.go:590
+#: lxc/project.go:590 lxc/project.go:591
 #, fuzzy
 msgid "Rename projects"
 msgstr "Fehlerhafte Profil URL %s"
@@ -5531,7 +5531,7 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 msgid "Revoke cluster member join token"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/storage_bucket.go:862
+#: lxc/storage_bucket.go:863
 msgid "Role (admin or read-only)"
 msgstr ""
 
@@ -5548,7 +5548,7 @@ msgstr ""
 msgid "Run against all projects"
 msgstr "Fehlerhafte Profil URL %s"
 
-#: lxc/warning.go:213
+#: lxc/warning.go:214
 msgid "SEVERITY"
 msgstr ""
 
@@ -5568,12 +5568,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1231
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1231
+#: lxc/file.go:1232
 #, fuzzy, c-format
 msgid "SSH client disconnected %q"
 msgstr "Entferntes Administrator Passwort"
@@ -5587,11 +5587,11 @@ msgstr ""
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:173 lxc/warning.go:214
+#: lxc/operation.go:174 lxc/warning.go:215
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:569
+#: lxc/project.go:570
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5599,7 +5599,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:569
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -5607,11 +5607,11 @@ msgstr ""
 msgid "STP"
 msgstr ""
 
-#: lxc/storage_bucket.go:864
+#: lxc/storage_bucket.go:865
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:942
+#: lxc/storage_bucket.go:943
 #, fuzzy, c-format
 msgid "Secret key: %s"
 msgstr "Erstellt: %s"
@@ -5653,7 +5653,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Set a cluster member's configuration keys"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/file.go:995
+#: lxc/file.go:996
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5799,12 +5799,12 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:654
+#: lxc/project.go:655
 #, fuzzy
 msgid "Set project configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/project.go:655
+#: lxc/project.go:656
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5813,12 +5813,12 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage_bucket.go:534
+#: lxc/storage_bucket.go:535
 #, fuzzy
 msgid "Set storage bucket configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/storage_bucket.go:535
+#: lxc/storage_bucket.go:536
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -5859,15 +5859,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:476
+#: lxc/file.go:477
 msgid "Set the file's gid on push"
 msgstr "Setzt die gid der Datei beim Übertragen"
 
-#: lxc/file.go:477
+#: lxc/file.go:478
 msgid "Set the file's perms on push"
 msgstr "Setzt die Dateiberechtigungen beim Übertragen"
 
-#: lxc/file.go:475
+#: lxc/file.go:476
 msgid "Set the file's uid on push"
 msgstr "Setzt die uid der Datei beim Übertragen"
 
@@ -5912,11 +5912,11 @@ msgstr "Profil %s erstellt\n"
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 msgid "Set the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:542
+#: lxc/storage_bucket.go:543
 #, fuzzy
 msgid "Set the key as a storage bucket property"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -5935,7 +5935,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:993
+#: lxc/file.go:994
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5947,7 +5947,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1800 lxc/auth.go:1801
+#: lxc/auth.go:1801 lxc/auth.go:1802
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5965,11 +5965,11 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Show details of a cluster member"
 msgstr ""
 
-#: lxc/operation.go:192 lxc/operation.go:193
+#: lxc/operation.go:193 lxc/operation.go:194
 msgid "Show details on a background operation"
 msgstr ""
 
-#: lxc/monitor.go:49
+#: lxc/monitor.go:50
 msgid "Show events from all projects"
 msgstr ""
 
@@ -5978,12 +5978,12 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr "Geräte zu Containern oder Profilen hinzufügen"
 
-#: lxc/auth.go:440 lxc/auth.go:441
+#: lxc/auth.go:441 lxc/auth.go:442
 #, fuzzy
 msgid "Show group configurations"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/auth.go:832
+#: lxc/auth.go:833
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -6076,16 +6076,16 @@ msgstr "Profil %s erstellt\n"
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:786 lxc/project.go:787
+#: lxc/project.go:787 lxc/project.go:788
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage_bucket.go:628 lxc/storage_bucket.go:629
+#: lxc/storage_bucket.go:629 lxc/storage_bucket.go:630
 #, fuzzy
 msgid "Show storage bucket configurations"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/storage_bucket.go:1156 lxc/storage_bucket.go:1157
+#: lxc/storage_bucket.go:1157 lxc/storage_bucket.go:1158
 #, fuzzy
 msgid "Show storage bucket key configurations"
 msgstr "Profil %s erstellt\n"
@@ -6104,7 +6104,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Show storage volume state information"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/auth.go:895
+#: lxc/auth.go:896
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -6157,7 +6157,7 @@ msgstr ""
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: lxc/warning.go:302 lxc/warning.go:303
+#: lxc/warning.go:303 lxc/warning.go:304
 msgid "Show warning"
 msgstr ""
 
@@ -6246,22 +6246,22 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Stopping the instance failed: %s"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/storage_bucket.go:166
+#: lxc/storage_bucket.go:167
 #, fuzzy, c-format
 msgid "Storage bucket %s created"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/storage_bucket.go:233
+#: lxc/storage_bucket.go:234
 #, fuzzy, c-format
 msgid "Storage bucket %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: lxc/storage_bucket.go:940
+#: lxc/storage_bucket.go:941
 #, fuzzy, c-format
 msgid "Storage bucket key %s added"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/storage_bucket.go:1006
+#: lxc/storage_bucket.go:1007
 #, fuzzy, c-format
 msgid "Storage bucket key %s removed"
 msgstr "Profil %s erstellt\n"
@@ -6334,7 +6334,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:847 lxc/project.go:848
+#: lxc/project.go:848 lxc/project.go:849
 msgid "Switch the current project"
 msgstr ""
 
@@ -6350,10 +6350,10 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1139
+#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1139
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
-#: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:171
-#: lxc/storage_volume.go:1730 lxc/warning.go:215
+#: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
+#: lxc/storage_volume.go:1730 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
@@ -6361,12 +6361,12 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1032
+#: lxc/file.go:1033
 #, fuzzy
 msgid "Target path and --listen flag cannot be used together"
 msgstr "--refresh kann nur mit Containern verwendet werden"
 
-#: lxc/file.go:1026
+#: lxc/file.go:1027
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -6499,12 +6499,12 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/project.go:446
+#: lxc/project.go:447
 #, fuzzy, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/storage_bucket.go:431
+#: lxc/storage_bucket.go:432
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage bucket %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -6695,7 +6695,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:961
+#: lxc/project.go:962
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6707,17 +6707,17 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:985 lxc/storage_volume.go:1735
+#: lxc/project.go:986 lxc/storage_volume.go:1735
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:573
+#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:574
 #: lxc/storage.go:724 lxc/storage_volume.go:1734
 msgid "USED BY"
 msgstr ""
 
-#: lxc/warning.go:216
+#: lxc/warning.go:217
 msgid "UUID"
 msgstr ""
 
@@ -6726,7 +6726,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:197
+#: lxc/file.go:198
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6741,13 +6741,13 @@ msgstr "Neue entfernte Server hinzufügen"
 msgid "Unknown certificate type %q"
 msgstr "Unbekannter Befehl %s für Abbild"
 
-#: lxc/file.go:1253
+#: lxc/file.go:1254
 #, fuzzy, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr "Unbekannter Befehl %s für Abbild"
 
 #: lxc/image.go:1153 lxc/list.go:631 lxc/storage_volume.go:1772
-#: lxc/warning.go:241
+#: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6757,7 +6757,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr "Unbekannter Befehl %s für Abbild"
 
-#: lxc/file.go:807
+#: lxc/file.go:808
 #, fuzzy, c-format
 msgid "Unknown file type '%s'"
 msgstr "Unbekannter Befehl %s für Abbild"
@@ -6854,12 +6854,12 @@ msgstr "Profil %s erstellt\n"
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:742 lxc/project.go:743
+#: lxc/project.go:743 lxc/project.go:744
 #, fuzzy
 msgid "Unset project configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/storage_bucket.go:697 lxc/storage_bucket.go:698
+#: lxc/storage_bucket.go:698 lxc/storage_bucket.go:699
 #, fuzzy
 msgid "Unset storage bucket configuration keys"
 msgstr "Alternatives config Verzeichnis."
@@ -6915,11 +6915,11 @@ msgstr "Profil %s erstellt\n"
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:747
+#: lxc/project.go:748
 msgid "Unset the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:701
+#: lxc/storage_bucket.go:702
 #, fuzzy
 msgid "Unset the key as a storage bucket property"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -7003,7 +7003,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:71
+#: lxc/file.go:72
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -7044,11 +7044,11 @@ msgstr ""
 "Optionen:\n"
 "\n"
 
-#: lxc/auth.go:831
+#: lxc/auth.go:832
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:894
+#: lxc/auth.go:895
 msgid "View the current identity"
 msgstr ""
 
@@ -7084,15 +7084,15 @@ msgstr ""
 msgid "Whether or not to snapshot the instance's running state"
 msgstr "Zustand des laufenden Containers sichern oder nicht"
 
-#: lxc/rebuild.go:27
+#: lxc/rebuild.go:28
 msgid ""
 "Wipe the instance root disk and re-initialize. The original image is used to "
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:156 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
+#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:526
+#: lxc/project.go:531 lxc/project.go:536 lxc/project.go:541 lxc/project.go:546
+#: lxc/project.go:551 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
 msgid "YES"
 msgstr ""
 
@@ -7115,7 +7115,7 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 msgid "You must specify a source instance name"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/rebuild.go:119
+#: lxc/rebuild.go:120
 #, fuzzy
 msgid "You need to specify an image name or use --empty"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -7136,12 +7136,12 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1689
+#: lxc/auth.go:330 lxc/auth.go:763 lxc/auth.go:894 lxc/auth.go:1690
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
-#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
+#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
-#: lxc/operation.go:103 lxc/profile.go:700 lxc/project.go:467
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:68
+#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:468
+#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 #, fuzzy
 msgid "[<remote>:]"
 msgstr ""
@@ -7200,7 +7200,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/auth.go:1254
+#: lxc/auth.go:1255
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -7320,11 +7320,11 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/auth.go:830
+#: lxc/auth.go:831
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1926
+#: lxc/auth.go:1106 lxc/auth.go:1164 lxc/auth.go:1927
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -7337,8 +7337,8 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:954 lxc/auth.go:1470 lxc/cluster_group.go:168
+#: lxc/auth.go:97 lxc/auth.go:150 lxc/auth.go:200 lxc/auth.go:440
+#: lxc/auth.go:955 lxc/auth.go:1471 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 #, fuzzy
 msgid "[<remote>:]<group>"
@@ -7347,7 +7347,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/auth.go:514 lxc/auth.go:572
+#: lxc/auth.go:515 lxc/auth.go:573
 #, fuzzy
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
@@ -7365,7 +7365,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/auth.go:389
+#: lxc/auth.go:390
 #, fuzzy
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
@@ -7373,7 +7373,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/auth.go:1521 lxc/auth.go:1571 lxc/auth.go:1799
+#: lxc/auth.go:1522 lxc/auth.go:1572 lxc/auth.go:1800
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
@@ -7381,7 +7381,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/auth.go:1873
+#: lxc/auth.go:1874
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
@@ -7390,7 +7390,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/auth.go:1749
+#: lxc/auth.go:1750
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
@@ -7432,7 +7432,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/rebuild.go:25
+#: lxc/rebuild.go:26
 #, fuzzy
 msgid "[<remote>:]<image> [<remote>:]<instance>"
 msgstr ""
@@ -7602,7 +7602,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/file.go:170
+#: lxc/file.go:171
 #, fuzzy
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
@@ -7611,7 +7611,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/file.go:120
+#: lxc/file.go:121
 #, fuzzy
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
@@ -7619,7 +7619,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/file.go:240
+#: lxc/file.go:241
 #, fuzzy
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
@@ -7629,7 +7629,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/file.go:984
+#: lxc/file.go:985
 #, fuzzy
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
@@ -7921,7 +7921,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/operation.go:53 lxc/operation.go:191
+#: lxc/operation.go:54 lxc/operation.go:192
 #, fuzzy
 msgid "[<remote>:]<operation>"
 msgstr ""
@@ -7930,7 +7930,7 @@ msgstr ""
 "lxd %s <Name>\n"
 
 #: lxc/storage.go:200 lxc/storage.go:259 lxc/storage.go:473 lxc/storage.go:844
-#: lxc/storage_bucket.go:454
+#: lxc/storage_bucket.go:455
 #, fuzzy
 msgid "[<remote>:]<pool>"
 msgstr ""
@@ -7946,8 +7946,8 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_bucket.go:185 lxc/storage_bucket.go:247
-#: lxc/storage_bucket.go:627 lxc/storage_bucket.go:769
+#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:248
+#: lxc/storage_bucket.go:628 lxc/storage_bucket.go:770
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
@@ -7955,9 +7955,9 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_bucket.go:380 lxc/storage_bucket.go:696
-#: lxc/storage_bucket.go:850 lxc/storage_bucket.go:956
-#: lxc/storage_bucket.go:1020 lxc/storage_bucket.go:1155
+#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:697
+#: lxc/storage_bucket.go:851 lxc/storage_bucket.go:957
+#: lxc/storage_bucket.go:1021 lxc/storage_bucket.go:1156
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
@@ -7965,7 +7965,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_bucket.go:533
+#: lxc/storage_bucket.go:534
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
@@ -7973,7 +7973,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_bucket.go:81
+#: lxc/storage_bucket.go:82
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
@@ -8207,8 +8207,8 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/project.go:91 lxc/project.go:186 lxc/project.go:258 lxc/project.go:785
-#: lxc/project.go:846 lxc/project.go:913
+#: lxc/project.go:92 lxc/project.go:187 lxc/project.go:259 lxc/project.go:786
+#: lxc/project.go:847 lxc/project.go:914
 #, fuzzy
 msgid "[<remote>:]<project>"
 msgstr ""
@@ -8216,7 +8216,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/project.go:394 lxc/project.go:741
+#: lxc/project.go:395 lxc/project.go:742
 #, fuzzy
 msgid "[<remote>:]<project> <key>"
 msgstr ""
@@ -8224,7 +8224,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/project.go:653
+#: lxc/project.go:654
 #, fuzzy
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
@@ -8232,7 +8232,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/project.go:587
+#: lxc/project.go:588
 #, fuzzy
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
@@ -8249,7 +8249,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/warning.go:259 lxc/warning.go:301 lxc/warning.go:354
+#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
 #, fuzzy
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
@@ -8365,7 +8365,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/project.go:555 lxc/remote.go:739
+#: lxc/project.go:556 lxc/remote.go:739
 msgid "current"
 msgstr ""
 
@@ -8412,20 +8412,20 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/auth.go:203
+#: lxc/auth.go:204
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:958
+#: lxc/auth.go:959
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1575
+#: lxc/auth.go:1576
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -8503,20 +8503,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:988
+#: lxc/file.go:989
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:244
+#: lxc/file.go:245
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:470
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -8598,7 +8598,7 @@ msgid ""
 "  List instances with their running state and user comment."
 msgstr ""
 
-#: lxc/monitor.go:37
+#: lxc/monitor.go:38
 msgid ""
 "lxc monitor --type=logging\n"
 "    Only show log messages.\n"
@@ -8678,7 +8678,7 @@ msgid ""
 "    Create record r1 for zone z1 with configuration from config.yaml"
 msgstr ""
 
-#: lxc/operation.go:195
+#: lxc/operation.go:196
 msgid ""
 "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Show details on that operation UUID"
@@ -8721,7 +8721,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:95
+#: lxc/project.go:96
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -8729,7 +8729,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:262
+#: lxc/project.go:263
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -8760,7 +8760,7 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:85
 msgid ""
 "lxc storage bucket create p1 b01\n"
 "\tCreate a new storage bucket name b01 in storage pool p1\n"
@@ -8770,19 +8770,19 @@ msgid ""
 "of config.yaml"
 msgstr ""
 
-#: lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:251
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1023
+#: lxc/storage_bucket.go:1024
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:854
 msgid ""
 "lxc storage bucket key create p1 b01 k1\n"
 "\tCreate a key called k1 for the bucket b01 in the pool p1.\n"
@@ -8792,14 +8792,14 @@ msgid ""
 "of config.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1158
+#: lxc/storage_bucket.go:1159
 msgid ""
 "lxc storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_bucket.go:630
+#: lxc/storage_bucket.go:631
 msgid ""
 "lxc storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
@@ -8869,16 +8869,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1142
+#: lxc/file.go:1143
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1101
+#: lxc/file.go:1102
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1054
+#: lxc/file.go:1055
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-04 08:52-0600\n"
+"POT-Creation-Date: 2024-09-05 08:44-0400\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/linux-containers/"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: lxc/storage_bucket.go:260 lxc/storage_bucket.go:1033
+#: lxc/storage_bucket.go:261 lxc/storage_bucket.go:1034
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -133,7 +133,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:213
+#: lxc/auth.go:214
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -160,7 +160,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:968
+#: lxc/auth.go:969
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -181,7 +181,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1585
+#: lxc/auth.go:1586
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -391,7 +391,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:280
+#: lxc/project.go:281
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -433,12 +433,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:935
+#: lxc/file.go:936
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:825
+#: lxc/file.go:826
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -474,7 +474,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:142 lxc/rebuild.go:64
+#: lxc/init.go:142 lxc/rebuild.go:65
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -527,7 +527,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:465
+#: lxc/file.go:466
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -560,7 +560,7 @@ msgstr ""
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:813
+#: lxc/auth.go:814
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -568,11 +568,11 @@ msgstr ""
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/storage_bucket.go:863
+#: lxc/storage_bucket.go:864
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:941
+#: lxc/storage_bucket.go:942
 #, c-format
 msgid "Access key: %s"
 msgstr ""
@@ -581,7 +581,7 @@ msgstr ""
 msgid "Access the expanded configuration"
 msgstr ""
 
-#: lxc/warning.go:261 lxc/warning.go:262
+#: lxc/warning.go:262 lxc/warning.go:263
 msgid "Acknowledge warning"
 msgstr ""
 
@@ -599,11 +599,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/auth.go:1106 lxc/auth.go:1107
+#: lxc/auth.go:1107 lxc/auth.go:1108
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1874 lxc/auth.go:1875
+#: lxc/auth.go:1875 lxc/auth.go:1876
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -673,7 +673,7 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:515 lxc/auth.go:516
+#: lxc/auth.go:516 lxc/auth.go:517
 msgid "Add permissions to groups"
 msgstr ""
 
@@ -703,7 +703,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:169
+#: lxc/storage_bucket.go:170
 #, c-format
 msgid "Admin access key: %s"
 msgstr ""
@@ -713,7 +713,7 @@ msgstr ""
 msgid "Admin password (or token) for %s:"
 msgstr ""
 
-#: lxc/storage_bucket.go:170
+#: lxc/storage_bucket.go:171
 #, c-format
 msgid "Admin secret key: %s"
 msgstr ""
@@ -772,7 +772,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:342 lxc/rebuild.go:130
+#: lxc/init.go:342 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -872,12 +872,12 @@ msgstr ""
 
 #: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:318
 #: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
-#: lxc/network_zone.go:366 lxc/network_zone.go:1053 lxc/storage_bucket.go:141
+#: lxc/network_zone.go:366 lxc/network_zone.go:1053 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:159
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:160
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -917,7 +917,7 @@ msgstr ""
 msgid "Bytes sent"
 msgstr ""
 
-#: lxc/operation.go:174
+#: lxc/operation.go:175
 msgid "CANCELABLE"
 msgstr ""
 
@@ -929,7 +929,7 @@ msgstr ""
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: lxc/warning.go:209
+#: lxc/warning.go:210
 msgid "COUNT"
 msgstr ""
 
@@ -956,7 +956,7 @@ msgstr "  Χρήση CPU:"
 msgid "CPUs (%s):"
 msgstr ""
 
-#: lxc/operation.go:175
+#: lxc/operation.go:176
 msgid "CREATED"
 msgstr ""
 
@@ -986,7 +986,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:340
+#: lxc/file.go:341
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1011,11 +1011,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:224
+#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:546
+#: lxc/file.go:547
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1024,7 +1024,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:160
+#: lxc/rebuild.go:161
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1147,13 +1147,13 @@ msgstr ""
 #: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
 #: lxc/network_load_balancer.go:1051 lxc/network_load_balancer.go:1125
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
-#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:90
-#: lxc/storage_bucket.go:190 lxc/storage_bucket.go:253
-#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:541
-#: lxc/storage_bucket.go:634 lxc/storage_bucket.go:700
-#: lxc/storage_bucket.go:775 lxc/storage_bucket.go:861
-#: lxc/storage_bucket.go:961 lxc/storage_bucket.go:1026
-#: lxc/storage_bucket.go:1162 lxc/storage_volume.go:394
+#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
+#: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
+#: lxc/storage_bucket.go:385 lxc/storage_bucket.go:542
+#: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
+#: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
+#: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
 #: lxc/storage_volume.go:612 lxc/storage_volume.go:717
 #: lxc/storage_volume.go:1005 lxc/storage_volume.go:1231
 #: lxc/storage_volume.go:1360 lxc/storage_volume.go:1848
@@ -1177,7 +1177,7 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1113 lxc/list.go:132 lxc/storage_volume.go:1589
-#: lxc/warning.go:92
+#: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
@@ -1205,7 +1205,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:100
+#: lxc/project.go:101
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1219,8 +1219,8 @@ msgstr ""
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
-#: lxc/project.go:362 lxc/storage.go:359 lxc/storage_bucket.go:348
-#: lxc/storage_bucket.go:1125 lxc/storage_volume.go:1150
+#: lxc/project.go:363 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1150
 #: lxc/storage_volume.go:1182
 #, c-format
 msgid "Config parsing error: %s"
@@ -1347,12 +1347,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:300 lxc/auth.go:1660
+#: lxc/auth.go:301 lxc/auth.go:1661
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1054
+#: lxc/auth.go:1055
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1401,15 +1401,15 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:248 lxc/file.go:474
+#: lxc/file.go:249 lxc/file.go:475
 msgid "Create any directories necessary"
 msgstr ""
 
-#: lxc/auth.go:97 lxc/auth.go:98
+#: lxc/auth.go:98 lxc/auth.go:99
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1471 lxc/auth.go:1472
+#: lxc/auth.go:1472 lxc/auth.go:1473
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1429,11 +1429,11 @@ msgstr ""
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_bucket.go:851 lxc/storage_bucket.go:852
+#: lxc/storage_bucket.go:852 lxc/storage_bucket.go:853
 msgid "Create key for a storage bucket"
 msgstr ""
 
-#: lxc/storage_bucket.go:82 lxc/storage_bucket.go:83
+#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
 #, fuzzy
 msgid "Create new custom storage buckets"
 msgstr "  Χρήση δικτύου:"
@@ -1480,7 +1480,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:92 lxc/project.go:93
+#: lxc/project.go:93 lxc/project.go:94
 msgid "Create projects"
 msgstr ""
 
@@ -1515,13 +1515,13 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:376 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1135 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
-#: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:172
-#: lxc/profile.go:756 lxc/project.go:572 lxc/storage.go:723
-#: lxc/storage_bucket.go:512 lxc/storage_bucket.go:832
+#: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
+#: lxc/profile.go:756 lxc/project.go:573 lxc/storage.go:723
+#: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1732
 msgid "DESCRIPTION"
 msgstr ""
@@ -1546,7 +1546,7 @@ msgstr ""
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
-#: lxc/operation.go:55 lxc/operation.go:56
+#: lxc/operation.go:56 lxc/operation.go:57
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
@@ -1554,20 +1554,20 @@ msgstr ""
 msgid "Delete a cluster group"
 msgstr ""
 
-#: lxc/warning.go:360
+#: lxc/warning.go:361
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:122 lxc/file.go:123
+#: lxc/file.go:123 lxc/file.go:124
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/auth.go:151 lxc/auth.go:152
+#: lxc/auth.go:152 lxc/auth.go:153
 #, fuzzy
 msgid "Delete groups"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/auth.go:1523 lxc/auth.go:1524
+#: lxc/auth.go:1524 lxc/auth.go:1525
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1587,7 +1587,7 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/storage_bucket.go:957 lxc/storage_bucket.go:958
+#: lxc/storage_bucket.go:958 lxc/storage_bucket.go:959
 msgid "Delete key from a storage bucket"
 msgstr ""
 
@@ -1626,11 +1626,11 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:188 lxc/project.go:189
+#: lxc/project.go:189 lxc/project.go:190
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:187 lxc/storage_bucket.go:188
+#: lxc/storage_bucket.go:188 lxc/storage_bucket.go:189
 #, fuzzy
 msgid "Delete storage buckets"
 msgstr "  Χρήση δικτύου:"
@@ -1643,20 +1643,20 @@ msgstr ""
 msgid "Delete storage volumes"
 msgstr ""
 
-#: lxc/warning.go:356 lxc/warning.go:357
+#: lxc/warning.go:357 lxc/warning.go:358
 msgid "Delete warning"
 msgstr ""
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:30 lxc/auth.go:59 lxc/auth.go:98
-#: lxc/auth.go:152 lxc/auth.go:201 lxc/auth.go:332 lxc/auth.go:392
-#: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
-#: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
-#: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
-#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1434 lxc/auth.go:1472
-#: lxc/auth.go:1524 lxc/auth.go:1573 lxc/auth.go:1692 lxc/auth.go:1752
-#: lxc/auth.go:1801 lxc/auth.go:1852 lxc/auth.go:1875 lxc/auth.go:1928
+#: lxc/alias.go:214 lxc/auth.go:31 lxc/auth.go:60 lxc/auth.go:99
+#: lxc/auth.go:153 lxc/auth.go:202 lxc/auth.go:333 lxc/auth.go:393
+#: lxc/auth.go:442 lxc/auth.go:494 lxc/auth.go:517 lxc/auth.go:576
+#: lxc/auth.go:732 lxc/auth.go:766 lxc/auth.go:833 lxc/auth.go:896
+#: lxc/auth.go:957 lxc/auth.go:1085 lxc/auth.go:1108 lxc/auth.go:1166
+#: lxc/auth.go:1235 lxc/auth.go:1257 lxc/auth.go:1435 lxc/auth.go:1473
+#: lxc/auth.go:1525 lxc/auth.go:1574 lxc/auth.go:1693 lxc/auth.go:1753
+#: lxc/auth.go:1802 lxc/auth.go:1853 lxc/auth.go:1876 lxc/auth.go:1929
 #: lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215 lxc/cluster.go:272
 #: lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:484 lxc/cluster.go:528
 #: lxc/cluster.go:586 lxc/cluster.go:677 lxc/cluster.go:770 lxc/cluster.go:893
@@ -1680,15 +1680,15 @@ msgstr ""
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:83 lxc/file.go:123 lxc/file.go:172
-#: lxc/file.go:242 lxc/file.go:467 lxc/file.go:986 lxc/image.go:38
+#: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
+#: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
 #: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
 #: lxc/image.go:697 lxc/image.go:946 lxc/image.go:1088 lxc/image.go:1415
 #: lxc/image.go:1506 lxc/image.go:1572 lxc/image.go:1636 lxc/image.go:1699
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:38 lxc/network.go:33
+#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33
 #: lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405
 #: lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793
 #: lxc/network.go:874 lxc/network.go:1005 lxc/network.go:1106
@@ -1722,27 +1722,27 @@ msgstr ""
 #: lxc/network_zone.go:909 lxc/network_zone.go:985 lxc/network_zone.go:1083
 #: lxc/network_zone.go:1172 lxc/network_zone.go:1219 lxc/network_zone.go:1349
 #: lxc/network_zone.go:1410 lxc/network_zone.go:1425 lxc/network_zone.go:1483
-#: lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:106
-#: lxc/operation.go:193 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
+#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
+#: lxc/operation.go:194 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
 #: lxc/profile.go:271 lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493
 #: lxc/profile.go:629 lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860
-#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:29
-#: lxc/project.go:93 lxc/project.go:189 lxc/project.go:260 lxc/project.go:396
-#: lxc/project.go:470 lxc/project.go:590 lxc/project.go:655 lxc/project.go:743
-#: lxc/project.go:787 lxc/project.go:848 lxc/project.go:915 lxc/publish.go:34
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:35 lxc/remote.go:91
+#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:30
+#: lxc/project.go:94 lxc/project.go:190 lxc/project.go:261 lxc/project.go:397
+#: lxc/project.go:471 lxc/project.go:591 lxc/project.go:656 lxc/project.go:744
+#: lxc/project.go:788 lxc/project.go:849 lxc/project.go:916 lxc/publish.go:34
+#: lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91
 #: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853
 #: lxc/remote.go:917 lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24
 #: lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203
 #: lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655
 #: lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940
-#: lxc/storage_bucket.go:29 lxc/storage_bucket.go:83 lxc/storage_bucket.go:188
-#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:382
-#: lxc/storage_bucket.go:458 lxc/storage_bucket.go:535
-#: lxc/storage_bucket.go:629 lxc/storage_bucket.go:698
-#: lxc/storage_bucket.go:732 lxc/storage_bucket.go:773
-#: lxc/storage_bucket.go:852 lxc/storage_bucket.go:958
-#: lxc/storage_bucket.go:1022 lxc/storage_bucket.go:1157
+#: lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189
+#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:383
+#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:536
+#: lxc/storage_bucket.go:630 lxc/storage_bucket.go:699
+#: lxc/storage_bucket.go:733 lxc/storage_bucket.go:774
+#: lxc/storage_bucket.go:853 lxc/storage_bucket.go:959
+#: lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158
 #: lxc/storage_volume.go:58 lxc/storage_volume.go:169 lxc/storage_volume.go:283
 #: lxc/storage_volume.go:390 lxc/storage_volume.go:605
 #: lxc/storage_volume.go:714 lxc/storage_volume.go:801
@@ -1753,8 +1753,8 @@ msgstr ""
 #: lxc/storage_volume.go:2064 lxc/storage_volume.go:2222
 #: lxc/storage_volume.go:2343 lxc/storage_volume.go:2405
 #: lxc/storage_volume.go:2541 lxc/storage_volume.go:2624
-#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:29
-#: lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
+#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:30
+#: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
@@ -1842,7 +1842,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:994
+#: lxc/file.go:995
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1911,7 +1911,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:74
+#: lxc/file.go:75
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1921,7 +1921,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:955 lxc/auth.go:956
+#: lxc/auth.go:956 lxc/auth.go:957
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1929,15 +1929,15 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:171 lxc/file.go:172
+#: lxc/file.go:172 lxc/file.go:173
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/auth.go:200 lxc/auth.go:201
+#: lxc/auth.go:201 lxc/auth.go:202
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1572 lxc/auth.go:1573
+#: lxc/auth.go:1573 lxc/auth.go:1574
 #, fuzzy
 msgid "Edit identity provider groups as YAML"
 msgstr "  Χρήση δικτύου:"
@@ -1998,16 +1998,16 @@ msgstr "  Χρήση δικτύου:"
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:259 lxc/project.go:260
+#: lxc/project.go:260 lxc/project.go:261
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:248 lxc/storage_bucket.go:249
+#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:250
 #, fuzzy
 msgid "Edit storage bucket configurations as YAML"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/storage_bucket.go:1021 lxc/storage_bucket.go:1022
+#: lxc/storage_bucket.go:1022 lxc/storage_bucket.go:1023
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
@@ -2024,7 +2024,7 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1147 lxc/list.go:622 lxc/storage_volume.go:1766
-#: lxc/warning.go:235
+#: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2079,7 +2079,7 @@ msgstr ""
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
-#: lxc/project.go:718 lxc/storage.go:812 lxc/storage_bucket.go:602
+#: lxc/project.go:719 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2155 lxc/storage_volume.go:2193
 #, c-format
 msgid "Error setting properties: %v"
@@ -2093,8 +2093,8 @@ msgstr ""
 #: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
-#: lxc/profile.go:981 lxc/project.go:712 lxc/storage.go:806
-#: lxc/storage_bucket.go:596 lxc/storage_volume.go:2149
+#: lxc/profile.go:981 lxc/project.go:713 lxc/storage.go:806
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2149
 #: lxc/storage_volume.go:2187
 #, c-format
 msgid "Error unsetting property: %v"
@@ -2114,7 +2114,7 @@ msgstr ""
 msgid "Evacuating cluster member: %s"
 msgstr ""
 
-#: lxc/monitor.go:50
+#: lxc/monitor.go:51
 msgid "Event type to listen for"
 msgstr ""
 
@@ -2201,16 +2201,16 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/warning.go:210
+#: lxc/warning.go:211
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1237
+#: lxc/file.go:1238
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1260
+#: lxc/file.go:1261
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2225,12 +2225,12 @@ msgstr "  Χρήση δικτύου:"
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/file.go:1287
+#: lxc/file.go:1288
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1072
+#: lxc/file.go:1073
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "  Χρήση δικτύου:"
@@ -2260,7 +2260,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Failed fetching fingerprint %q: %w"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/file.go:1193
+#: lxc/file.go:1194
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2275,7 +2275,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/file.go:1198
+#: lxc/file.go:1199
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2285,12 +2285,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1098
+#: lxc/file.go:1099
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1225
+#: lxc/file.go:1226
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2329,7 +2329,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1210
+#: lxc/file.go:1211
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2344,7 +2344,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:820
+#: lxc/file.go:821
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2359,7 +2359,7 @@ msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
 #: lxc/network.go:1044 lxc/network_acl.go:133 lxc/network_zone.go:124
-#: lxc/operation.go:136
+#: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
 
@@ -2424,21 +2424,21 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
+#: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:770 lxc/auth.go:1697
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1114 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:57
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
-#: lxc/operation.go:108 lxc/profile.go:707 lxc/project.go:472
-#: lxc/project.go:917 lxc/remote.go:690 lxc/storage.go:657
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:774
-#: lxc/storage_volume.go:1608 lxc/warning.go:93
+#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:473
+#: lxc/project.go:918 lxc/remote.go:690 lxc/storage.go:657
+#: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
+#: lxc/storage_volume.go:1608 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
-#: lxc/monitor.go:52
+#: lxc/monitor.go:53
 msgid "Format (json|pretty|yaml)"
 msgstr ""
 
@@ -2482,7 +2482,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:817 lxc/auth.go:1736
+#: lxc/auth.go:818 lxc/auth.go:1737
 msgid "GROUPS"
 msgstr ""
 
@@ -2498,7 +2498,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:914 lxc/project.go:915
+#: lxc/project.go:915 lxc/project.go:916
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2551,11 +2551,11 @@ msgstr "  Χρήση δικτύου:"
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:400
+#: lxc/project.go:401
 msgid "Get the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:385
+#: lxc/storage_bucket.go:386
 #, fuzzy
 msgid "Get the key as a storage bucket property"
 msgstr "  Χρήση δικτύου:"
@@ -2622,11 +2622,11 @@ msgstr "  Χρήση δικτύου:"
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:395 lxc/project.go:396
+#: lxc/project.go:396 lxc/project.go:397
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:382
+#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:383
 #, fuzzy
 msgid "Get values for storage bucket configuration keys"
 msgstr "  Χρήση δικτύου:"
@@ -2644,17 +2644,17 @@ msgstr ""
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: lxc/auth.go:136
+#: lxc/auth.go:137
 #, fuzzy, c-format
 msgid "Group %s created"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/auth.go:186
+#: lxc/auth.go:187
 #, fuzzy, c-format
 msgid "Group %s deleted"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/auth.go:426 lxc/auth.go:1786
+#: lxc/auth.go:427 lxc/auth.go:1787
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2679,27 +2679,27 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1310
+#: lxc/file.go:1311
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1299
+#: lxc/file.go:1300
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1122
+#: lxc/file.go:1123
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1132
+#: lxc/file.go:1133
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:966 lxc/operation.go:170
+#: lxc/network.go:966 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2713,11 +2713,11 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:816
+#: lxc/auth.go:817
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:566
+#: lxc/project.go:567
 msgid "IMAGES"
 msgstr ""
 
@@ -2745,17 +2745,17 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1508
+#: lxc/auth.go:1509
 #, fuzzy, c-format
 msgid "Identity provider group %s created"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/auth.go:1558
+#: lxc/auth.go:1559
 #, fuzzy, c-format
 msgid "Identity provider group %s deleted"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/rebuild.go:32
+#: lxc/rebuild.go:33
 msgid "If an instance is running, stop it and then rebuild it"
 msgstr ""
 
@@ -2876,7 +2876,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1233 lxc/auth.go:1234
+#: lxc/auth.go:1234 lxc/auth.go:1235
 msgid "Inspect permissions"
 msgstr ""
 
@@ -2884,11 +2884,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1124
+#: lxc/file.go:1125
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1301
+#: lxc/file.go:1302
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2906,7 +2906,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1044
+#: lxc/file.go:1045
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2915,7 +2915,7 @@ msgstr ""
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/rebuild.go:74
+#: lxc/rebuild.go:75
 #, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
@@ -2948,7 +2948,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/monitor.go:70
+#: lxc/monitor.go:71
 #, c-format
 msgid "Invalid format: %s"
 msgstr ""
@@ -2958,7 +2958,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1039
+#: lxc/file.go:1040
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3000,7 +3000,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:147
+#: lxc/file.go:148
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -3016,12 +3016,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:313
+#: lxc/file.go:314
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:495
+#: lxc/file.go:496
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3035,7 +3035,7 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/warning.go:212
 msgid "LAST SEEN"
 msgstr ""
 
@@ -3043,7 +3043,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:984
+#: lxc/project.go:985
 msgid "LIMIT"
 msgstr ""
 
@@ -3052,8 +3052,8 @@ msgid "LISTEN ADDRESS"
 msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
-#: lxc/network_load_balancer.go:165 lxc/operation.go:177
-#: lxc/storage_bucket.go:516 lxc/storage_volume.go:1739 lxc/warning.go:220
+#: lxc/network_load_balancer.go:165 lxc/operation.go:178
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1739 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3127,7 +3127,7 @@ msgstr ""
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/warning.go:94
+#: lxc/warning.go:95
 msgid "List all warnings"
 msgstr ""
 
@@ -3173,19 +3173,19 @@ msgstr ""
 msgid "List available storage pools"
 msgstr ""
 
-#: lxc/operation.go:105 lxc/operation.go:106
+#: lxc/operation.go:106 lxc/operation.go:107
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:331 lxc/auth.go:332
+#: lxc/auth.go:332 lxc/auth.go:333
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:764 lxc/auth.go:765
+#: lxc/auth.go:765 lxc/auth.go:766
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1691 lxc/auth.go:1692
+#: lxc/auth.go:1692 lxc/auth.go:1693
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3334,11 +3334,11 @@ msgstr ""
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/operation.go:109
+#: lxc/operation.go:110
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1255 lxc/auth.go:1256
+#: lxc/auth.go:1256 lxc/auth.go:1257
 msgid "List permissions"
 msgstr ""
 
@@ -3346,15 +3346,15 @@ msgstr ""
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:469 lxc/project.go:470
+#: lxc/project.go:470 lxc/project.go:471
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:771 lxc/storage_bucket.go:773
+#: lxc/storage_bucket.go:772 lxc/storage_bucket.go:774
 msgid "List storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:456 lxc/storage_bucket.go:458
+#: lxc/storage_bucket.go:457 lxc/storage_bucket.go:459
 msgid "List storage buckets"
 msgstr ""
 
@@ -3390,11 +3390,11 @@ msgstr ""
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/warning.go:70
+#: lxc/warning.go:71
 msgid "List warnings"
 msgstr ""
 
-#: lxc/warning.go:71
+#: lxc/warning.go:72
 msgid ""
 "List warnings\n"
 "\n"
@@ -3417,7 +3417,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/operation.go:23 lxc/operation.go:24
+#: lxc/operation.go:24 lxc/operation.go:25
 msgid "List, show and delete background operations"
 msgstr ""
 
@@ -3426,7 +3426,7 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/monitor.go:79
+#: lxc/monitor.go:80
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
@@ -3531,24 +3531,24 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:82 lxc/file.go:83
+#: lxc/file.go:83 lxc/file.go:84
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1433 lxc/auth.go:1434
+#: lxc/auth.go:59 lxc/auth.go:60 lxc/auth.go:1434 lxc/auth.go:1435
 #, fuzzy
 msgid "Manage groups"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/auth.go:1083 lxc/auth.go:1084
+#: lxc/auth.go:1084 lxc/auth.go:1085
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:730 lxc/auth.go:731
+#: lxc/auth.go:731 lxc/auth.go:732
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1851 lxc/auth.go:1852
+#: lxc/auth.go:1852 lxc/auth.go:1853
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3646,7 +3646,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Manage network zones"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/auth.go:492 lxc/auth.go:493
+#: lxc/auth.go:493 lxc/auth.go:494
 #, fuzzy
 msgid "Manage permissions"
 msgstr "  Χρήση δικτύου:"
@@ -3655,25 +3655,25 @@ msgstr "  Χρήση δικτύου:"
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:28 lxc/project.go:29
+#: lxc/project.go:29 lxc/project.go:30
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:731
+#: lxc/storage_bucket.go:732
 #, fuzzy
 msgid "Manage storage bucket keys"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/storage_bucket.go:732
+#: lxc/storage_bucket.go:733
 msgid "Manage storage bucket keys."
 msgstr ""
 
-#: lxc/storage_bucket.go:28
+#: lxc/storage_bucket.go:29
 #, fuzzy
 msgid "Manage storage buckets"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:30
 #, fuzzy
 msgid "Manage storage buckets."
 msgstr "  Χρήση δικτύου:"
@@ -3702,12 +3702,12 @@ msgstr ""
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/auth.go:29 lxc/auth.go:30
+#: lxc/auth.go:30 lxc/auth.go:31
 #, fuzzy
 msgid "Manage user authorization"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/warning.go:28 lxc/warning.go:29
+#: lxc/warning.go:29 lxc/warning.go:30
 msgid "Manage warnings"
 msgstr ""
 
@@ -3773,17 +3773,17 @@ msgstr ""
 msgid "Migration operation failure: %w"
 msgstr ""
 
-#: lxc/monitor.go:51
+#: lxc/monitor.go:52
 msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: lxc/storage_bucket.go:116 lxc/storage_bucket.go:216
-#: lxc/storage_bucket.go:292 lxc/storage_bucket.go:411
-#: lxc/storage_bucket.go:568 lxc/storage_bucket.go:660
-#: lxc/storage_bucket.go:802 lxc/storage_bucket.go:889
-#: lxc/storage_bucket.go:986 lxc/storage_bucket.go:1065
-#: lxc/storage_bucket.go:1188
+#: lxc/storage_bucket.go:117 lxc/storage_bucket.go:217
+#: lxc/storage_bucket.go:293 lxc/storage_bucket.go:412
+#: lxc/storage_bucket.go:569 lxc/storage_bucket.go:661
+#: lxc/storage_bucket.go:803 lxc/storage_bucket.go:890
+#: lxc/storage_bucket.go:987 lxc/storage_bucket.go:1066
+#: lxc/storage_bucket.go:1189
 #, fuzzy
 msgid "Missing bucket name"
 msgstr "  Χρήση δικτύου:"
@@ -3804,23 +3804,23 @@ msgstr "  Χρήση δικτύου:"
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1825
+#: lxc/auth.go:123 lxc/auth.go:177 lxc/auth.go:255 lxc/auth.go:417
+#: lxc/auth.go:466 lxc/auth.go:541 lxc/auth.go:600 lxc/auth.go:1826
 #, fuzzy
 msgid "Missing group name"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/auth.go:862 lxc/auth.go:1003 lxc/auth.go:1131 lxc/auth.go:1189
+#: lxc/auth.go:863 lxc/auth.go:1004 lxc/auth.go:1132 lxc/auth.go:1190
 #, fuzzy
 msgid "Missing identity argument"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/auth.go:1495 lxc/auth.go:1548 lxc/auth.go:1614 lxc/auth.go:1776
+#: lxc/auth.go:1496 lxc/auth.go:1549 lxc/auth.go:1615 lxc/auth.go:1777
 #, fuzzy
 msgid "Missing identity provider group name"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/auth.go:1899 lxc/auth.go:1952
+#: lxc/auth.go:1900 lxc/auth.go:1953
 #, fuzzy
 msgid "Missing identity provider group name argument"
 msgstr "  Χρήση δικτύου:"
@@ -3829,12 +3829,12 @@ msgstr "  Χρήση δικτύου:"
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
 #: lxc/config_template.go:377 lxc/profile.go:141 lxc/profile.go:222
-#: lxc/profile.go:808 lxc/rebuild.go:60
+#: lxc/profile.go:808 lxc/rebuild.go:61
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/storage_bucket.go:893 lxc/storage_bucket.go:990
-#: lxc/storage_bucket.go:1069 lxc/storage_bucket.go:1192
+#: lxc/storage_bucket.go:894 lxc/storage_bucket.go:991
+#: lxc/storage_bucket.go:1070 lxc/storage_bucket.go:1193
 #, fuzzy
 msgid "Missing key name"
 msgstr "  Χρήση δικτύου:"
@@ -3901,13 +3901,13 @@ msgid "Missing peer name"
 msgstr ""
 
 #: lxc/storage.go:235 lxc/storage.go:313 lxc/storage.go:431 lxc/storage.go:509
-#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:112
-#: lxc/storage_bucket.go:212 lxc/storage_bucket.go:288
-#: lxc/storage_bucket.go:407 lxc/storage_bucket.go:482
-#: lxc/storage_bucket.go:564 lxc/storage_bucket.go:656
-#: lxc/storage_bucket.go:798 lxc/storage_bucket.go:885
-#: lxc/storage_bucket.go:982 lxc/storage_bucket.go:1061
-#: lxc/storage_bucket.go:1184 lxc/storage_volume.go:209
+#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:113
+#: lxc/storage_bucket.go:213 lxc/storage_bucket.go:289
+#: lxc/storage_bucket.go:408 lxc/storage_bucket.go:483
+#: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
+#: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
+#: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
 #: lxc/storage_volume.go:323 lxc/storage_volume.go:643
 #: lxc/storage_volume.go:750 lxc/storage_volume.go:841
 #: lxc/storage_volume.go:939 lxc/storage_volume.go:1053
@@ -3922,9 +3922,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:404 lxc/project.go:146 lxc/project.go:226 lxc/project.go:316
-#: lxc/project.go:433 lxc/project.go:622 lxc/project.go:691 lxc/project.go:819
-#: lxc/project.go:948
+#: lxc/profile.go:404 lxc/project.go:147 lxc/project.go:227 lxc/project.go:317
+#: lxc/project.go:434 lxc/project.go:623 lxc/project.go:692 lxc/project.go:820
+#: lxc/project.go:949
 msgid "Missing project name"
 msgstr ""
 
@@ -3941,7 +3941,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/file.go:598
+#: lxc/file.go:599
 msgid "Missing target directory"
 msgstr ""
 
@@ -3963,11 +3963,11 @@ msgstr ""
 msgid "Model: %v"
 msgstr ""
 
-#: lxc/monitor.go:32
+#: lxc/monitor.go:33
 msgid "Monitor a local or remote LXD server"
 msgstr ""
 
-#: lxc/monitor.go:33
+#: lxc/monitor.go:34
 msgid ""
 "Monitor a local or remote LXD server\n"
 "\n"
@@ -3979,11 +3979,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:285
+#: lxc/file.go:286
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:985 lxc/file.go:986
+#: lxc/file.go:986 lxc/file.go:987
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4045,13 +4045,13 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:192
+#: lxc/auth.go:376 lxc/auth.go:816 lxc/auth.go:1736 lxc/cluster.go:192
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
-#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:565
-#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:511
-#: lxc/storage_bucket.go:831 lxc/storage_volume.go:1731
+#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:566
+#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1731
 msgid "NAME"
 msgstr ""
 
@@ -4059,11 +4059,11 @@ msgstr ""
 msgid "NAT"
 msgstr ""
 
-#: lxc/project.go:571
+#: lxc/project.go:572
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:570
+#: lxc/project.go:571
 msgid "NETWORKS"
 msgstr ""
 
@@ -4075,9 +4075,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/operation.go:154 lxc/project.go:523
-#: lxc/project.go:528 lxc/project.go:533 lxc/project.go:538 lxc/project.go:543
-#: lxc/project.go:548 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
+#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:524
+#: lxc/project.go:529 lxc/project.go:534 lxc/project.go:539 lxc/project.go:544
+#: lxc/project.go:549 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
 msgid "NO"
 msgstr ""
 
@@ -4324,7 +4324,7 @@ msgstr ""
 msgid "Only managed networks can be modified"
 msgstr ""
 
-#: lxc/operation.go:86
+#: lxc/operation.go:87
 #, c-format
 msgid "Operation %s deleted"
 msgstr ""
@@ -4371,11 +4371,11 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:567
+#: lxc/list.go:576 lxc/project.go:568
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:212
+#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4438,24 +4438,24 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1102
+#: lxc/file.go:1103
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:860
+#: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
-#: lxc/project.go:363 lxc/storage.go:360 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1151
+#: lxc/project.go:364 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1151
 #: lxc/storage_volume.go:1183
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
-#: lxc/monitor.go:48
+#: lxc/monitor.go:49
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
@@ -4541,17 +4541,17 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:172
+#: lxc/project.go:173
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:236
+#: lxc/project.go:237
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:637
+#: lxc/project.go:638
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -4672,20 +4672,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:241 lxc/file.go:242
+#: lxc/file.go:242 lxc/file.go:243
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:416 lxc/file.go:767
+#: lxc/file.go:417 lxc/file.go:768
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:466 lxc/file.go:467
+#: lxc/file.go:467 lxc/file.go:468
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:701 lxc/file.go:867
+#: lxc/file.go:702 lxc/file.go:868
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4698,11 +4698,11 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:983
+#: lxc/project.go:984
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/storage_bucket.go:833
+#: lxc/storage_bucket.go:834
 msgid "ROLE"
 msgstr ""
 
@@ -4715,15 +4715,15 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/rebuild.go:31
+#: lxc/rebuild.go:32
 msgid "Rebuild as an empty instance"
 msgstr ""
 
-#: lxc/rebuild.go:26
+#: lxc/rebuild.go:27
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:249 lxc/file.go:473
+#: lxc/file.go:250 lxc/file.go:474
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4750,7 +4750,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:882 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
+#: lxc/project.go:883 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
 #: lxc/remote.go:994
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4801,7 +4801,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1164 lxc/auth.go:1165
+#: lxc/auth.go:1165 lxc/auth.go:1166
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4840,7 +4840,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1927 lxc/auth.go:1928
+#: lxc/auth.go:1928 lxc/auth.go:1929
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4852,7 +4852,7 @@ msgstr ""
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:574 lxc/auth.go:575
+#: lxc/auth.go:575 lxc/auth.go:576
 msgid "Remove permissions from groups"
 msgstr ""
 
@@ -4899,11 +4899,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:391 lxc/auth.go:392
+#: lxc/auth.go:392 lxc/auth.go:393
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1751 lxc/auth.go:1752
+#: lxc/auth.go:1752 lxc/auth.go:1753
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -4923,7 +4923,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:589 lxc/project.go:590
+#: lxc/project.go:590 lxc/project.go:591
 msgid "Rename projects"
 msgstr ""
 
@@ -5022,7 +5022,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Revoke cluster member join token"
 msgstr ""
 
-#: lxc/storage_bucket.go:862
+#: lxc/storage_bucket.go:863
 msgid "Role (admin or read-only)"
 msgstr ""
 
@@ -5038,7 +5038,7 @@ msgstr ""
 msgid "Run against all projects"
 msgstr ""
 
-#: lxc/warning.go:213
+#: lxc/warning.go:214
 msgid "SEVERITY"
 msgstr ""
 
@@ -5058,12 +5058,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1231
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1231
+#: lxc/file.go:1232
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5077,11 +5077,11 @@ msgstr ""
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:173 lxc/warning.go:214
+#: lxc/operation.go:174 lxc/warning.go:215
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:569
+#: lxc/project.go:570
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5089,7 +5089,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:569
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -5097,11 +5097,11 @@ msgstr ""
 msgid "STP"
 msgstr ""
 
-#: lxc/storage_bucket.go:864
+#: lxc/storage_bucket.go:865
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:942
+#: lxc/storage_bucket.go:943
 #, c-format
 msgid "Secret key: %s"
 msgstr ""
@@ -5140,7 +5140,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/file.go:995
+#: lxc/file.go:996
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5283,11 +5283,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:654
+#: lxc/project.go:655
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:655
+#: lxc/project.go:656
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5296,12 +5296,12 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage_bucket.go:534
+#: lxc/storage_bucket.go:535
 #, fuzzy
 msgid "Set storage bucket configuration keys"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/storage_bucket.go:535
+#: lxc/storage_bucket.go:536
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -5340,15 +5340,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:476
+#: lxc/file.go:477
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:477
+#: lxc/file.go:478
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:475
+#: lxc/file.go:476
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5393,11 +5393,11 @@ msgstr "  Χρήση δικτύου:"
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 msgid "Set the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:542
+#: lxc/storage_bucket.go:543
 #, fuzzy
 msgid "Set the key as a storage bucket property"
 msgstr "  Χρήση δικτύου:"
@@ -5414,7 +5414,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:993
+#: lxc/file.go:994
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5426,7 +5426,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1800 lxc/auth.go:1801
+#: lxc/auth.go:1801 lxc/auth.go:1802
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5443,11 +5443,11 @@ msgstr ""
 msgid "Show details of a cluster member"
 msgstr ""
 
-#: lxc/operation.go:192 lxc/operation.go:193
+#: lxc/operation.go:193 lxc/operation.go:194
 msgid "Show details on a background operation"
 msgstr ""
 
-#: lxc/monitor.go:49
+#: lxc/monitor.go:50
 msgid "Show events from all projects"
 msgstr ""
 
@@ -5455,12 +5455,12 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:440 lxc/auth.go:441
+#: lxc/auth.go:441 lxc/auth.go:442
 #, fuzzy
 msgid "Show group configurations"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/auth.go:832
+#: lxc/auth.go:833
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5547,16 +5547,16 @@ msgstr "  Χρήση δικτύου:"
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:786 lxc/project.go:787
+#: lxc/project.go:787 lxc/project.go:788
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage_bucket.go:628 lxc/storage_bucket.go:629
+#: lxc/storage_bucket.go:629 lxc/storage_bucket.go:630
 #, fuzzy
 msgid "Show storage bucket configurations"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/storage_bucket.go:1156 lxc/storage_bucket.go:1157
+#: lxc/storage_bucket.go:1157 lxc/storage_bucket.go:1158
 #, fuzzy
 msgid "Show storage bucket key configurations"
 msgstr "  Χρήση δικτύου:"
@@ -5573,7 +5573,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:895
+#: lxc/auth.go:896
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5624,7 +5624,7 @@ msgstr ""
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: lxc/warning.go:302 lxc/warning.go:303
+#: lxc/warning.go:303 lxc/warning.go:304
 msgid "Show warning"
 msgstr ""
 
@@ -5708,22 +5708,22 @@ msgstr ""
 msgid "Stopping the instance failed: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:166
+#: lxc/storage_bucket.go:167
 #, fuzzy, c-format
 msgid "Storage bucket %s created"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/storage_bucket.go:233
+#: lxc/storage_bucket.go:234
 #, fuzzy, c-format
 msgid "Storage bucket %s deleted"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/storage_bucket.go:940
+#: lxc/storage_bucket.go:941
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr ""
 
-#: lxc/storage_bucket.go:1006
+#: lxc/storage_bucket.go:1007
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr ""
@@ -5792,7 +5792,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:847 lxc/project.go:848
+#: lxc/project.go:848 lxc/project.go:849
 msgid "Switch the current project"
 msgstr ""
 
@@ -5808,10 +5808,10 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1139
+#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1139
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
-#: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:171
-#: lxc/storage_volume.go:1730 lxc/warning.go:215
+#: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
+#: lxc/storage_volume.go:1730 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
@@ -5819,11 +5819,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1032
+#: lxc/file.go:1033
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1026
+#: lxc/file.go:1027
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5951,12 +5951,12 @@ msgstr "  Χρήση δικτύου:"
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/project.go:446
+#: lxc/project.go:447
 #, fuzzy, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/storage_bucket.go:431
+#: lxc/storage_bucket.go:432
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage bucket %q: %v"
 msgstr "  Χρήση δικτύου:"
@@ -6142,7 +6142,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:961
+#: lxc/project.go:962
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6154,17 +6154,17 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:985 lxc/storage_volume.go:1735
+#: lxc/project.go:986 lxc/storage_volume.go:1735
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:573
+#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:574
 #: lxc/storage.go:724 lxc/storage_volume.go:1734
 msgid "USED BY"
 msgstr ""
 
-#: lxc/warning.go:216
+#: lxc/warning.go:217
 msgid "UUID"
 msgstr ""
 
@@ -6173,7 +6173,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:197
+#: lxc/file.go:198
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6187,13 +6187,13 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1253
+#: lxc/file.go:1254
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1153 lxc/list.go:631 lxc/storage_volume.go:1772
-#: lxc/warning.go:241
+#: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6203,7 +6203,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:807
+#: lxc/file.go:808
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6295,11 +6295,11 @@ msgstr "  Χρήση δικτύου:"
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:742 lxc/project.go:743
+#: lxc/project.go:743 lxc/project.go:744
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:697 lxc/storage_bucket.go:698
+#: lxc/storage_bucket.go:698 lxc/storage_bucket.go:699
 #, fuzzy
 msgid "Unset storage bucket configuration keys"
 msgstr "  Χρήση δικτύου:"
@@ -6354,11 +6354,11 @@ msgstr "  Χρήση δικτύου:"
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:747
+#: lxc/project.go:748
 msgid "Unset the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:701
+#: lxc/storage_bucket.go:702
 #, fuzzy
 msgid "Unset the key as a storage bucket property"
 msgstr "  Χρήση δικτύου:"
@@ -6438,7 +6438,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:71
+#: lxc/file.go:72
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6475,11 +6475,11 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:831
+#: lxc/auth.go:832
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:894
+#: lxc/auth.go:895
 msgid "View the current identity"
 msgstr ""
 
@@ -6510,15 +6510,15 @@ msgstr ""
 msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
-#: lxc/rebuild.go:27
+#: lxc/rebuild.go:28
 msgid ""
 "Wipe the instance root disk and re-initialize. The original image is used to "
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:156 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
+#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:526
+#: lxc/project.go:531 lxc/project.go:536 lxc/project.go:541 lxc/project.go:546
+#: lxc/project.go:551 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
 msgid "YES"
 msgstr ""
 
@@ -6538,7 +6538,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/rebuild.go:119
+#: lxc/rebuild.go:120
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
@@ -6550,12 +6550,12 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1689
+#: lxc/auth.go:330 lxc/auth.go:763 lxc/auth.go:894 lxc/auth.go:1690
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
-#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
+#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
-#: lxc/operation.go:103 lxc/profile.go:700 lxc/project.go:467
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:68
+#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:468
+#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6583,7 +6583,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1254
+#: lxc/auth.go:1255
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6644,11 +6644,11 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:830
+#: lxc/auth.go:831
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1926
+#: lxc/auth.go:1106 lxc/auth.go:1164 lxc/auth.go:1927
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6656,13 +6656,13 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:954 lxc/auth.go:1470 lxc/cluster_group.go:168
+#: lxc/auth.go:97 lxc/auth.go:150 lxc/auth.go:200 lxc/auth.go:440
+#: lxc/auth.go:955 lxc/auth.go:1471 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:514 lxc/auth.go:572
+#: lxc/auth.go:515 lxc/auth.go:573
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
@@ -6672,19 +6672,19 @@ msgstr ""
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:389
+#: lxc/auth.go:390
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1521 lxc/auth.go:1571 lxc/auth.go:1799
+#: lxc/auth.go:1522 lxc/auth.go:1572 lxc/auth.go:1800
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1873
+#: lxc/auth.go:1874
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1749
+#: lxc/auth.go:1750
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -6704,7 +6704,7 @@ msgstr ""
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
-#: lxc/rebuild.go:25
+#: lxc/rebuild.go:26
 msgid "[<remote>:]<image> [<remote>:]<instance>"
 msgstr ""
 
@@ -6787,20 +6787,20 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:170
+#: lxc/file.go:171
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:120
+#: lxc/file.go:121
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:240
+#: lxc/file.go:241
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:984
+#: lxc/file.go:985
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6951,12 +6951,12 @@ msgstr ""
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
-#: lxc/operation.go:53 lxc/operation.go:191
+#: lxc/operation.go:54 lxc/operation.go:192
 msgid "[<remote>:]<operation>"
 msgstr ""
 
 #: lxc/storage.go:200 lxc/storage.go:259 lxc/storage.go:473 lxc/storage.go:844
-#: lxc/storage_bucket.go:454
+#: lxc/storage_bucket.go:455
 msgid "[<remote>:]<pool>"
 msgstr ""
 
@@ -6964,22 +6964,22 @@ msgstr ""
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
-#: lxc/storage_bucket.go:185 lxc/storage_bucket.go:247
-#: lxc/storage_bucket.go:627 lxc/storage_bucket.go:769
+#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:248
+#: lxc/storage_bucket.go:628 lxc/storage_bucket.go:770
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
 
-#: lxc/storage_bucket.go:380 lxc/storage_bucket.go:696
-#: lxc/storage_bucket.go:850 lxc/storage_bucket.go:956
-#: lxc/storage_bucket.go:1020 lxc/storage_bucket.go:1155
+#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:697
+#: lxc/storage_bucket.go:851 lxc/storage_bucket.go:957
+#: lxc/storage_bucket.go:1021 lxc/storage_bucket.go:1156
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
 
-#: lxc/storage_bucket.go:533
+#: lxc/storage_bucket.go:534
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_bucket.go:81
+#: lxc/storage_bucket.go:82
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
 
@@ -7094,20 +7094,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:91 lxc/project.go:186 lxc/project.go:258 lxc/project.go:785
-#: lxc/project.go:846 lxc/project.go:913
+#: lxc/project.go:92 lxc/project.go:187 lxc/project.go:259 lxc/project.go:786
+#: lxc/project.go:847 lxc/project.go:914
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:394 lxc/project.go:741
+#: lxc/project.go:395 lxc/project.go:742
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:653
+#: lxc/project.go:654
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:587
+#: lxc/project.go:588
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7115,7 +7115,7 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:259 lxc/warning.go:301 lxc/warning.go:354
+#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
@@ -7171,7 +7171,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:555 lxc/remote.go:739
+#: lxc/project.go:556 lxc/remote.go:739
 msgid "current"
 msgstr ""
 
@@ -7218,20 +7218,20 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/auth.go:203
+#: lxc/auth.go:204
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:958
+#: lxc/auth.go:959
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1575
+#: lxc/auth.go:1576
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7309,20 +7309,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:988
+#: lxc/file.go:989
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:244
+#: lxc/file.go:245
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:470
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7404,7 +7404,7 @@ msgid ""
 "  List instances with their running state and user comment."
 msgstr ""
 
-#: lxc/monitor.go:37
+#: lxc/monitor.go:38
 msgid ""
 "lxc monitor --type=logging\n"
 "    Only show log messages.\n"
@@ -7480,7 +7480,7 @@ msgid ""
 "    Create record r1 for zone z1 with configuration from config.yaml"
 msgstr ""
 
-#: lxc/operation.go:195
+#: lxc/operation.go:196
 msgid ""
 "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Show details on that operation UUID"
@@ -7523,7 +7523,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:95
+#: lxc/project.go:96
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7531,7 +7531,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:262
+#: lxc/project.go:263
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7562,7 +7562,7 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:85
 msgid ""
 "lxc storage bucket create p1 b01\n"
 "\tCreate a new storage bucket name b01 in storage pool p1\n"
@@ -7572,19 +7572,19 @@ msgid ""
 "of config.yaml"
 msgstr ""
 
-#: lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:251
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1023
+#: lxc/storage_bucket.go:1024
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:854
 msgid ""
 "lxc storage bucket key create p1 b01 k1\n"
 "\tCreate a key called k1 for the bucket b01 in the pool p1.\n"
@@ -7594,14 +7594,14 @@ msgid ""
 "of config.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1158
+#: lxc/storage_bucket.go:1159
 msgid ""
 "lxc storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_bucket.go:630
+#: lxc/storage_bucket.go:631
 msgid ""
 "lxc storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
@@ -7671,16 +7671,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1142
+#: lxc/file.go:1143
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1101
+#: lxc/file.go:1102
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1054
+#: lxc/file.go:1055
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/eo.po
+++ b/po/eo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-04 08:52-0600\n"
+"POT-Creation-Date: 2024-09-05 08:44-0400\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Esperanto <https://hosted.weblate.org/projects/linux-"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: lxc/storage_bucket.go:260 lxc/storage_bucket.go:1033
+#: lxc/storage_bucket.go:261 lxc/storage_bucket.go:1034
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -133,7 +133,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:213
+#: lxc/auth.go:214
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -160,7 +160,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:968
+#: lxc/auth.go:969
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -181,7 +181,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1585
+#: lxc/auth.go:1586
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -391,7 +391,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:280
+#: lxc/project.go:281
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -433,12 +433,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:935
+#: lxc/file.go:936
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:825
+#: lxc/file.go:826
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -474,7 +474,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:142 lxc/rebuild.go:64
+#: lxc/init.go:142 lxc/rebuild.go:65
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -527,7 +527,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:465
+#: lxc/file.go:466
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -560,7 +560,7 @@ msgstr ""
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:813
+#: lxc/auth.go:814
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -568,11 +568,11 @@ msgstr ""
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/storage_bucket.go:863
+#: lxc/storage_bucket.go:864
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:941
+#: lxc/storage_bucket.go:942
 #, c-format
 msgid "Access key: %s"
 msgstr ""
@@ -581,7 +581,7 @@ msgstr ""
 msgid "Access the expanded configuration"
 msgstr ""
 
-#: lxc/warning.go:261 lxc/warning.go:262
+#: lxc/warning.go:262 lxc/warning.go:263
 msgid "Acknowledge warning"
 msgstr ""
 
@@ -598,11 +598,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1106 lxc/auth.go:1107
+#: lxc/auth.go:1107 lxc/auth.go:1108
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1874 lxc/auth.go:1875
+#: lxc/auth.go:1875 lxc/auth.go:1876
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -671,7 +671,7 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:515 lxc/auth.go:516
+#: lxc/auth.go:516 lxc/auth.go:517
 msgid "Add permissions to groups"
 msgstr ""
 
@@ -700,7 +700,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:169
+#: lxc/storage_bucket.go:170
 #, c-format
 msgid "Admin access key: %s"
 msgstr ""
@@ -710,7 +710,7 @@ msgstr ""
 msgid "Admin password (or token) for %s:"
 msgstr ""
 
-#: lxc/storage_bucket.go:170
+#: lxc/storage_bucket.go:171
 #, c-format
 msgid "Admin secret key: %s"
 msgstr ""
@@ -769,7 +769,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:342 lxc/rebuild.go:130
+#: lxc/init.go:342 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -869,12 +869,12 @@ msgstr ""
 
 #: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:318
 #: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
-#: lxc/network_zone.go:366 lxc/network_zone.go:1053 lxc/storage_bucket.go:141
+#: lxc/network_zone.go:366 lxc/network_zone.go:1053 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:159
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:160
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -914,7 +914,7 @@ msgstr ""
 msgid "Bytes sent"
 msgstr ""
 
-#: lxc/operation.go:174
+#: lxc/operation.go:175
 msgid "CANCELABLE"
 msgstr ""
 
@@ -926,7 +926,7 @@ msgstr ""
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: lxc/warning.go:209
+#: lxc/warning.go:210
 msgid "COUNT"
 msgstr ""
 
@@ -952,7 +952,7 @@ msgstr ""
 msgid "CPUs (%s):"
 msgstr ""
 
-#: lxc/operation.go:175
+#: lxc/operation.go:176
 msgid "CREATED"
 msgstr ""
 
@@ -982,7 +982,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:340
+#: lxc/file.go:341
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1007,11 +1007,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:224
+#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:546
+#: lxc/file.go:547
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1020,7 +1020,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:160
+#: lxc/rebuild.go:161
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1143,13 +1143,13 @@ msgstr ""
 #: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
 #: lxc/network_load_balancer.go:1051 lxc/network_load_balancer.go:1125
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
-#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:90
-#: lxc/storage_bucket.go:190 lxc/storage_bucket.go:253
-#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:541
-#: lxc/storage_bucket.go:634 lxc/storage_bucket.go:700
-#: lxc/storage_bucket.go:775 lxc/storage_bucket.go:861
-#: lxc/storage_bucket.go:961 lxc/storage_bucket.go:1026
-#: lxc/storage_bucket.go:1162 lxc/storage_volume.go:394
+#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
+#: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
+#: lxc/storage_bucket.go:385 lxc/storage_bucket.go:542
+#: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
+#: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
+#: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
 #: lxc/storage_volume.go:612 lxc/storage_volume.go:717
 #: lxc/storage_volume.go:1005 lxc/storage_volume.go:1231
 #: lxc/storage_volume.go:1360 lxc/storage_volume.go:1848
@@ -1173,7 +1173,7 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1113 lxc/list.go:132 lxc/storage_volume.go:1589
-#: lxc/warning.go:92
+#: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
@@ -1201,7 +1201,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:100
+#: lxc/project.go:101
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1215,8 +1215,8 @@ msgstr ""
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
-#: lxc/project.go:362 lxc/storage.go:359 lxc/storage_bucket.go:348
-#: lxc/storage_bucket.go:1125 lxc/storage_volume.go:1150
+#: lxc/project.go:363 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1150
 #: lxc/storage_volume.go:1182
 #, c-format
 msgid "Config parsing error: %s"
@@ -1343,12 +1343,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:300 lxc/auth.go:1660
+#: lxc/auth.go:301 lxc/auth.go:1661
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1054
+#: lxc/auth.go:1055
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1397,15 +1397,15 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:248 lxc/file.go:474
+#: lxc/file.go:249 lxc/file.go:475
 msgid "Create any directories necessary"
 msgstr ""
 
-#: lxc/auth.go:97 lxc/auth.go:98
+#: lxc/auth.go:98 lxc/auth.go:99
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1471 lxc/auth.go:1472
+#: lxc/auth.go:1472 lxc/auth.go:1473
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1425,11 +1425,11 @@ msgstr ""
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_bucket.go:851 lxc/storage_bucket.go:852
+#: lxc/storage_bucket.go:852 lxc/storage_bucket.go:853
 msgid "Create key for a storage bucket"
 msgstr ""
 
-#: lxc/storage_bucket.go:82 lxc/storage_bucket.go:83
+#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
 msgid "Create new custom storage buckets"
 msgstr ""
 
@@ -1473,7 +1473,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:92 lxc/project.go:93
+#: lxc/project.go:93 lxc/project.go:94
 msgid "Create projects"
 msgstr ""
 
@@ -1508,13 +1508,13 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:376 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1135 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
-#: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:172
-#: lxc/profile.go:756 lxc/project.go:572 lxc/storage.go:723
-#: lxc/storage_bucket.go:512 lxc/storage_bucket.go:832
+#: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
+#: lxc/profile.go:756 lxc/project.go:573 lxc/storage.go:723
+#: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1732
 msgid "DESCRIPTION"
 msgstr ""
@@ -1539,7 +1539,7 @@ msgstr ""
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
-#: lxc/operation.go:55 lxc/operation.go:56
+#: lxc/operation.go:56 lxc/operation.go:57
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
@@ -1547,19 +1547,19 @@ msgstr ""
 msgid "Delete a cluster group"
 msgstr ""
 
-#: lxc/warning.go:360
+#: lxc/warning.go:361
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:122 lxc/file.go:123
+#: lxc/file.go:123 lxc/file.go:124
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/auth.go:151 lxc/auth.go:152
+#: lxc/auth.go:152 lxc/auth.go:153
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1523 lxc/auth.go:1524
+#: lxc/auth.go:1524 lxc/auth.go:1525
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1579,7 +1579,7 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/storage_bucket.go:957 lxc/storage_bucket.go:958
+#: lxc/storage_bucket.go:958 lxc/storage_bucket.go:959
 msgid "Delete key from a storage bucket"
 msgstr ""
 
@@ -1615,11 +1615,11 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:188 lxc/project.go:189
+#: lxc/project.go:189 lxc/project.go:190
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:187 lxc/storage_bucket.go:188
+#: lxc/storage_bucket.go:188 lxc/storage_bucket.go:189
 msgid "Delete storage buckets"
 msgstr ""
 
@@ -1631,20 +1631,20 @@ msgstr ""
 msgid "Delete storage volumes"
 msgstr ""
 
-#: lxc/warning.go:356 lxc/warning.go:357
+#: lxc/warning.go:357 lxc/warning.go:358
 msgid "Delete warning"
 msgstr ""
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:30 lxc/auth.go:59 lxc/auth.go:98
-#: lxc/auth.go:152 lxc/auth.go:201 lxc/auth.go:332 lxc/auth.go:392
-#: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
-#: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
-#: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
-#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1434 lxc/auth.go:1472
-#: lxc/auth.go:1524 lxc/auth.go:1573 lxc/auth.go:1692 lxc/auth.go:1752
-#: lxc/auth.go:1801 lxc/auth.go:1852 lxc/auth.go:1875 lxc/auth.go:1928
+#: lxc/alias.go:214 lxc/auth.go:31 lxc/auth.go:60 lxc/auth.go:99
+#: lxc/auth.go:153 lxc/auth.go:202 lxc/auth.go:333 lxc/auth.go:393
+#: lxc/auth.go:442 lxc/auth.go:494 lxc/auth.go:517 lxc/auth.go:576
+#: lxc/auth.go:732 lxc/auth.go:766 lxc/auth.go:833 lxc/auth.go:896
+#: lxc/auth.go:957 lxc/auth.go:1085 lxc/auth.go:1108 lxc/auth.go:1166
+#: lxc/auth.go:1235 lxc/auth.go:1257 lxc/auth.go:1435 lxc/auth.go:1473
+#: lxc/auth.go:1525 lxc/auth.go:1574 lxc/auth.go:1693 lxc/auth.go:1753
+#: lxc/auth.go:1802 lxc/auth.go:1853 lxc/auth.go:1876 lxc/auth.go:1929
 #: lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215 lxc/cluster.go:272
 #: lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:484 lxc/cluster.go:528
 #: lxc/cluster.go:586 lxc/cluster.go:677 lxc/cluster.go:770 lxc/cluster.go:893
@@ -1668,15 +1668,15 @@ msgstr ""
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:83 lxc/file.go:123 lxc/file.go:172
-#: lxc/file.go:242 lxc/file.go:467 lxc/file.go:986 lxc/image.go:38
+#: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
+#: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
 #: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
 #: lxc/image.go:697 lxc/image.go:946 lxc/image.go:1088 lxc/image.go:1415
 #: lxc/image.go:1506 lxc/image.go:1572 lxc/image.go:1636 lxc/image.go:1699
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:38 lxc/network.go:33
+#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33
 #: lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405
 #: lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793
 #: lxc/network.go:874 lxc/network.go:1005 lxc/network.go:1106
@@ -1710,27 +1710,27 @@ msgstr ""
 #: lxc/network_zone.go:909 lxc/network_zone.go:985 lxc/network_zone.go:1083
 #: lxc/network_zone.go:1172 lxc/network_zone.go:1219 lxc/network_zone.go:1349
 #: lxc/network_zone.go:1410 lxc/network_zone.go:1425 lxc/network_zone.go:1483
-#: lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:106
-#: lxc/operation.go:193 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
+#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
+#: lxc/operation.go:194 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
 #: lxc/profile.go:271 lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493
 #: lxc/profile.go:629 lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860
-#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:29
-#: lxc/project.go:93 lxc/project.go:189 lxc/project.go:260 lxc/project.go:396
-#: lxc/project.go:470 lxc/project.go:590 lxc/project.go:655 lxc/project.go:743
-#: lxc/project.go:787 lxc/project.go:848 lxc/project.go:915 lxc/publish.go:34
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:35 lxc/remote.go:91
+#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:30
+#: lxc/project.go:94 lxc/project.go:190 lxc/project.go:261 lxc/project.go:397
+#: lxc/project.go:471 lxc/project.go:591 lxc/project.go:656 lxc/project.go:744
+#: lxc/project.go:788 lxc/project.go:849 lxc/project.go:916 lxc/publish.go:34
+#: lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91
 #: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853
 #: lxc/remote.go:917 lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24
 #: lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203
 #: lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655
 #: lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940
-#: lxc/storage_bucket.go:29 lxc/storage_bucket.go:83 lxc/storage_bucket.go:188
-#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:382
-#: lxc/storage_bucket.go:458 lxc/storage_bucket.go:535
-#: lxc/storage_bucket.go:629 lxc/storage_bucket.go:698
-#: lxc/storage_bucket.go:732 lxc/storage_bucket.go:773
-#: lxc/storage_bucket.go:852 lxc/storage_bucket.go:958
-#: lxc/storage_bucket.go:1022 lxc/storage_bucket.go:1157
+#: lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189
+#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:383
+#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:536
+#: lxc/storage_bucket.go:630 lxc/storage_bucket.go:699
+#: lxc/storage_bucket.go:733 lxc/storage_bucket.go:774
+#: lxc/storage_bucket.go:853 lxc/storage_bucket.go:959
+#: lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158
 #: lxc/storage_volume.go:58 lxc/storage_volume.go:169 lxc/storage_volume.go:283
 #: lxc/storage_volume.go:390 lxc/storage_volume.go:605
 #: lxc/storage_volume.go:714 lxc/storage_volume.go:801
@@ -1741,8 +1741,8 @@ msgstr ""
 #: lxc/storage_volume.go:2064 lxc/storage_volume.go:2222
 #: lxc/storage_volume.go:2343 lxc/storage_volume.go:2405
 #: lxc/storage_volume.go:2541 lxc/storage_volume.go:2624
-#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:29
-#: lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
+#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:30
+#: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
@@ -1829,7 +1829,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:994
+#: lxc/file.go:995
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1895,7 +1895,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:74
+#: lxc/file.go:75
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1905,7 +1905,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:955 lxc/auth.go:956
+#: lxc/auth.go:956 lxc/auth.go:957
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1913,15 +1913,15 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:171 lxc/file.go:172
+#: lxc/file.go:172 lxc/file.go:173
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/auth.go:200 lxc/auth.go:201
+#: lxc/auth.go:201 lxc/auth.go:202
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1572 lxc/auth.go:1573
+#: lxc/auth.go:1573 lxc/auth.go:1574
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -1977,15 +1977,15 @@ msgstr ""
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:259 lxc/project.go:260
+#: lxc/project.go:260 lxc/project.go:261
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:248 lxc/storage_bucket.go:249
+#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:250
 msgid "Edit storage bucket configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:1021 lxc/storage_bucket.go:1022
+#: lxc/storage_bucket.go:1022 lxc/storage_bucket.go:1023
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
@@ -2002,7 +2002,7 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1147 lxc/list.go:622 lxc/storage_volume.go:1766
-#: lxc/warning.go:235
+#: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2057,7 +2057,7 @@ msgstr ""
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
-#: lxc/project.go:718 lxc/storage.go:812 lxc/storage_bucket.go:602
+#: lxc/project.go:719 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2155 lxc/storage_volume.go:2193
 #, c-format
 msgid "Error setting properties: %v"
@@ -2071,8 +2071,8 @@ msgstr ""
 #: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
-#: lxc/profile.go:981 lxc/project.go:712 lxc/storage.go:806
-#: lxc/storage_bucket.go:596 lxc/storage_volume.go:2149
+#: lxc/profile.go:981 lxc/project.go:713 lxc/storage.go:806
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2149
 #: lxc/storage_volume.go:2187
 #, c-format
 msgid "Error unsetting property: %v"
@@ -2092,7 +2092,7 @@ msgstr ""
 msgid "Evacuating cluster member: %s"
 msgstr ""
 
-#: lxc/monitor.go:50
+#: lxc/monitor.go:51
 msgid "Event type to listen for"
 msgstr ""
 
@@ -2179,16 +2179,16 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/warning.go:210
+#: lxc/warning.go:211
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1237
+#: lxc/file.go:1238
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1260
+#: lxc/file.go:1261
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2203,12 +2203,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1287
+#: lxc/file.go:1288
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1072
+#: lxc/file.go:1073
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2238,7 +2238,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1193
+#: lxc/file.go:1194
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2253,7 +2253,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1198
+#: lxc/file.go:1199
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2263,12 +2263,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1098
+#: lxc/file.go:1099
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1225
+#: lxc/file.go:1226
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2307,7 +2307,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1210
+#: lxc/file.go:1211
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2322,7 +2322,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:820
+#: lxc/file.go:821
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2337,7 +2337,7 @@ msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
 #: lxc/network.go:1044 lxc/network_acl.go:133 lxc/network_zone.go:124
-#: lxc/operation.go:136
+#: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
 
@@ -2402,21 +2402,21 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
+#: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:770 lxc/auth.go:1697
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1114 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:57
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
-#: lxc/operation.go:108 lxc/profile.go:707 lxc/project.go:472
-#: lxc/project.go:917 lxc/remote.go:690 lxc/storage.go:657
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:774
-#: lxc/storage_volume.go:1608 lxc/warning.go:93
+#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:473
+#: lxc/project.go:918 lxc/remote.go:690 lxc/storage.go:657
+#: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
+#: lxc/storage_volume.go:1608 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
-#: lxc/monitor.go:52
+#: lxc/monitor.go:53
 msgid "Format (json|pretty|yaml)"
 msgstr ""
 
@@ -2460,7 +2460,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:817 lxc/auth.go:1736
+#: lxc/auth.go:818 lxc/auth.go:1737
 msgid "GROUPS"
 msgstr ""
 
@@ -2476,7 +2476,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:914 lxc/project.go:915
+#: lxc/project.go:915 lxc/project.go:916
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2524,11 +2524,11 @@ msgstr ""
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:400
+#: lxc/project.go:401
 msgid "Get the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:385
+#: lxc/storage_bucket.go:386
 msgid "Get the key as a storage bucket property"
 msgstr ""
 
@@ -2588,11 +2588,11 @@ msgstr ""
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:395 lxc/project.go:396
+#: lxc/project.go:396 lxc/project.go:397
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:382
+#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:383
 msgid "Get values for storage bucket configuration keys"
 msgstr ""
 
@@ -2609,17 +2609,17 @@ msgstr ""
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: lxc/auth.go:136
+#: lxc/auth.go:137
 #, c-format
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:186
+#: lxc/auth.go:187
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:426 lxc/auth.go:1786
+#: lxc/auth.go:427 lxc/auth.go:1787
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2644,27 +2644,27 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1310
+#: lxc/file.go:1311
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1299
+#: lxc/file.go:1300
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1122
+#: lxc/file.go:1123
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1132
+#: lxc/file.go:1133
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:966 lxc/operation.go:170
+#: lxc/network.go:966 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2678,11 +2678,11 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:816
+#: lxc/auth.go:817
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:566
+#: lxc/project.go:567
 msgid "IMAGES"
 msgstr ""
 
@@ -2710,17 +2710,17 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1508
+#: lxc/auth.go:1509
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1558
+#: lxc/auth.go:1559
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
 
-#: lxc/rebuild.go:32
+#: lxc/rebuild.go:33
 msgid "If an instance is running, stop it and then rebuild it"
 msgstr ""
 
@@ -2841,7 +2841,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1233 lxc/auth.go:1234
+#: lxc/auth.go:1234 lxc/auth.go:1235
 msgid "Inspect permissions"
 msgstr ""
 
@@ -2849,11 +2849,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1124
+#: lxc/file.go:1125
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1301
+#: lxc/file.go:1302
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2871,7 +2871,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1044
+#: lxc/file.go:1045
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2880,7 +2880,7 @@ msgstr ""
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/rebuild.go:74
+#: lxc/rebuild.go:75
 #, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
@@ -2913,7 +2913,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/monitor.go:70
+#: lxc/monitor.go:71
 #, c-format
 msgid "Invalid format: %s"
 msgstr ""
@@ -2923,7 +2923,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1039
+#: lxc/file.go:1040
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2965,7 +2965,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:147
+#: lxc/file.go:148
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2981,12 +2981,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:313
+#: lxc/file.go:314
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:495
+#: lxc/file.go:496
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3000,7 +3000,7 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/warning.go:212
 msgid "LAST SEEN"
 msgstr ""
 
@@ -3008,7 +3008,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:984
+#: lxc/project.go:985
 msgid "LIMIT"
 msgstr ""
 
@@ -3017,8 +3017,8 @@ msgid "LISTEN ADDRESS"
 msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
-#: lxc/network_load_balancer.go:165 lxc/operation.go:177
-#: lxc/storage_bucket.go:516 lxc/storage_volume.go:1739 lxc/warning.go:220
+#: lxc/network_load_balancer.go:165 lxc/operation.go:178
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1739 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3092,7 +3092,7 @@ msgstr ""
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/warning.go:94
+#: lxc/warning.go:95
 msgid "List all warnings"
 msgstr ""
 
@@ -3136,19 +3136,19 @@ msgstr ""
 msgid "List available storage pools"
 msgstr ""
 
-#: lxc/operation.go:105 lxc/operation.go:106
+#: lxc/operation.go:106 lxc/operation.go:107
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:331 lxc/auth.go:332
+#: lxc/auth.go:332 lxc/auth.go:333
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:764 lxc/auth.go:765
+#: lxc/auth.go:765 lxc/auth.go:766
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1691 lxc/auth.go:1692
+#: lxc/auth.go:1692 lxc/auth.go:1693
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3297,11 +3297,11 @@ msgstr ""
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/operation.go:109
+#: lxc/operation.go:110
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1255 lxc/auth.go:1256
+#: lxc/auth.go:1256 lxc/auth.go:1257
 msgid "List permissions"
 msgstr ""
 
@@ -3309,15 +3309,15 @@ msgstr ""
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:469 lxc/project.go:470
+#: lxc/project.go:470 lxc/project.go:471
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:771 lxc/storage_bucket.go:773
+#: lxc/storage_bucket.go:772 lxc/storage_bucket.go:774
 msgid "List storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:456 lxc/storage_bucket.go:458
+#: lxc/storage_bucket.go:457 lxc/storage_bucket.go:459
 msgid "List storage buckets"
 msgstr ""
 
@@ -3353,11 +3353,11 @@ msgstr ""
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/warning.go:70
+#: lxc/warning.go:71
 msgid "List warnings"
 msgstr ""
 
-#: lxc/warning.go:71
+#: lxc/warning.go:72
 msgid ""
 "List warnings\n"
 "\n"
@@ -3380,7 +3380,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/operation.go:23 lxc/operation.go:24
+#: lxc/operation.go:24 lxc/operation.go:25
 msgid "List, show and delete background operations"
 msgstr ""
 
@@ -3389,7 +3389,7 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/monitor.go:79
+#: lxc/monitor.go:80
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
@@ -3493,23 +3493,23 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:82 lxc/file.go:83
+#: lxc/file.go:83 lxc/file.go:84
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1433 lxc/auth.go:1434
+#: lxc/auth.go:59 lxc/auth.go:60 lxc/auth.go:1434 lxc/auth.go:1435
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1083 lxc/auth.go:1084
+#: lxc/auth.go:1084 lxc/auth.go:1085
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:730 lxc/auth.go:731
+#: lxc/auth.go:731 lxc/auth.go:732
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1851 lxc/auth.go:1852
+#: lxc/auth.go:1852 lxc/auth.go:1853
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3600,7 +3600,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:492 lxc/auth.go:493
+#: lxc/auth.go:493 lxc/auth.go:494
 msgid "Manage permissions"
 msgstr ""
 
@@ -3608,23 +3608,23 @@ msgstr ""
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:28 lxc/project.go:29
+#: lxc/project.go:29 lxc/project.go:30
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:731
+#: lxc/storage_bucket.go:732
 msgid "Manage storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:732
+#: lxc/storage_bucket.go:733
 msgid "Manage storage bucket keys."
 msgstr ""
 
-#: lxc/storage_bucket.go:28
+#: lxc/storage_bucket.go:29
 msgid "Manage storage buckets"
 msgstr ""
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:30
 msgid "Manage storage buckets."
 msgstr ""
 
@@ -3652,11 +3652,11 @@ msgstr ""
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/auth.go:29 lxc/auth.go:30
+#: lxc/auth.go:30 lxc/auth.go:31
 msgid "Manage user authorization"
 msgstr ""
 
-#: lxc/warning.go:28 lxc/warning.go:29
+#: lxc/warning.go:29 lxc/warning.go:30
 msgid "Manage warnings"
 msgstr ""
 
@@ -3720,17 +3720,17 @@ msgstr ""
 msgid "Migration operation failure: %w"
 msgstr ""
 
-#: lxc/monitor.go:51
+#: lxc/monitor.go:52
 msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: lxc/storage_bucket.go:116 lxc/storage_bucket.go:216
-#: lxc/storage_bucket.go:292 lxc/storage_bucket.go:411
-#: lxc/storage_bucket.go:568 lxc/storage_bucket.go:660
-#: lxc/storage_bucket.go:802 lxc/storage_bucket.go:889
-#: lxc/storage_bucket.go:986 lxc/storage_bucket.go:1065
-#: lxc/storage_bucket.go:1188
+#: lxc/storage_bucket.go:117 lxc/storage_bucket.go:217
+#: lxc/storage_bucket.go:293 lxc/storage_bucket.go:412
+#: lxc/storage_bucket.go:569 lxc/storage_bucket.go:661
+#: lxc/storage_bucket.go:803 lxc/storage_bucket.go:890
+#: lxc/storage_bucket.go:987 lxc/storage_bucket.go:1066
+#: lxc/storage_bucket.go:1189
 msgid "Missing bucket name"
 msgstr ""
 
@@ -3749,20 +3749,20 @@ msgstr ""
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1825
+#: lxc/auth.go:123 lxc/auth.go:177 lxc/auth.go:255 lxc/auth.go:417
+#: lxc/auth.go:466 lxc/auth.go:541 lxc/auth.go:600 lxc/auth.go:1826
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:862 lxc/auth.go:1003 lxc/auth.go:1131 lxc/auth.go:1189
+#: lxc/auth.go:863 lxc/auth.go:1004 lxc/auth.go:1132 lxc/auth.go:1190
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1495 lxc/auth.go:1548 lxc/auth.go:1614 lxc/auth.go:1776
+#: lxc/auth.go:1496 lxc/auth.go:1549 lxc/auth.go:1615 lxc/auth.go:1777
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1899 lxc/auth.go:1952
+#: lxc/auth.go:1900 lxc/auth.go:1953
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -3770,12 +3770,12 @@ msgstr ""
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
 #: lxc/config_template.go:377 lxc/profile.go:141 lxc/profile.go:222
-#: lxc/profile.go:808 lxc/rebuild.go:60
+#: lxc/profile.go:808 lxc/rebuild.go:61
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/storage_bucket.go:893 lxc/storage_bucket.go:990
-#: lxc/storage_bucket.go:1069 lxc/storage_bucket.go:1192
+#: lxc/storage_bucket.go:894 lxc/storage_bucket.go:991
+#: lxc/storage_bucket.go:1070 lxc/storage_bucket.go:1193
 msgid "Missing key name"
 msgstr ""
 
@@ -3840,13 +3840,13 @@ msgid "Missing peer name"
 msgstr ""
 
 #: lxc/storage.go:235 lxc/storage.go:313 lxc/storage.go:431 lxc/storage.go:509
-#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:112
-#: lxc/storage_bucket.go:212 lxc/storage_bucket.go:288
-#: lxc/storage_bucket.go:407 lxc/storage_bucket.go:482
-#: lxc/storage_bucket.go:564 lxc/storage_bucket.go:656
-#: lxc/storage_bucket.go:798 lxc/storage_bucket.go:885
-#: lxc/storage_bucket.go:982 lxc/storage_bucket.go:1061
-#: lxc/storage_bucket.go:1184 lxc/storage_volume.go:209
+#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:113
+#: lxc/storage_bucket.go:213 lxc/storage_bucket.go:289
+#: lxc/storage_bucket.go:408 lxc/storage_bucket.go:483
+#: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
+#: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
+#: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
 #: lxc/storage_volume.go:323 lxc/storage_volume.go:643
 #: lxc/storage_volume.go:750 lxc/storage_volume.go:841
 #: lxc/storage_volume.go:939 lxc/storage_volume.go:1053
@@ -3861,9 +3861,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:404 lxc/project.go:146 lxc/project.go:226 lxc/project.go:316
-#: lxc/project.go:433 lxc/project.go:622 lxc/project.go:691 lxc/project.go:819
-#: lxc/project.go:948
+#: lxc/profile.go:404 lxc/project.go:147 lxc/project.go:227 lxc/project.go:317
+#: lxc/project.go:434 lxc/project.go:623 lxc/project.go:692 lxc/project.go:820
+#: lxc/project.go:949
 msgid "Missing project name"
 msgstr ""
 
@@ -3879,7 +3879,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:598
+#: lxc/file.go:599
 msgid "Missing target directory"
 msgstr ""
 
@@ -3901,11 +3901,11 @@ msgstr ""
 msgid "Model: %v"
 msgstr ""
 
-#: lxc/monitor.go:32
+#: lxc/monitor.go:33
 msgid "Monitor a local or remote LXD server"
 msgstr ""
 
-#: lxc/monitor.go:33
+#: lxc/monitor.go:34
 msgid ""
 "Monitor a local or remote LXD server\n"
 "\n"
@@ -3917,11 +3917,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:285
+#: lxc/file.go:286
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:985 lxc/file.go:986
+#: lxc/file.go:986 lxc/file.go:987
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3983,13 +3983,13 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:192
+#: lxc/auth.go:376 lxc/auth.go:816 lxc/auth.go:1736 lxc/cluster.go:192
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
-#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:565
-#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:511
-#: lxc/storage_bucket.go:831 lxc/storage_volume.go:1731
+#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:566
+#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1731
 msgid "NAME"
 msgstr ""
 
@@ -3997,11 +3997,11 @@ msgstr ""
 msgid "NAT"
 msgstr ""
 
-#: lxc/project.go:571
+#: lxc/project.go:572
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:570
+#: lxc/project.go:571
 msgid "NETWORKS"
 msgstr ""
 
@@ -4013,9 +4013,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/operation.go:154 lxc/project.go:523
-#: lxc/project.go:528 lxc/project.go:533 lxc/project.go:538 lxc/project.go:543
-#: lxc/project.go:548 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
+#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:524
+#: lxc/project.go:529 lxc/project.go:534 lxc/project.go:539 lxc/project.go:544
+#: lxc/project.go:549 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
 msgid "NO"
 msgstr ""
 
@@ -4260,7 +4260,7 @@ msgstr ""
 msgid "Only managed networks can be modified"
 msgstr ""
 
-#: lxc/operation.go:86
+#: lxc/operation.go:87
 #, c-format
 msgid "Operation %s deleted"
 msgstr ""
@@ -4307,11 +4307,11 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:567
+#: lxc/list.go:576 lxc/project.go:568
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:212
+#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4373,24 +4373,24 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1102
+#: lxc/file.go:1103
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:860
+#: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
-#: lxc/project.go:363 lxc/storage.go:360 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1151
+#: lxc/project.go:364 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1151
 #: lxc/storage_volume.go:1183
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
-#: lxc/monitor.go:48
+#: lxc/monitor.go:49
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
@@ -4476,17 +4476,17 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:172
+#: lxc/project.go:173
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:236
+#: lxc/project.go:237
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:637
+#: lxc/project.go:638
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -4607,20 +4607,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:241 lxc/file.go:242
+#: lxc/file.go:242 lxc/file.go:243
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:416 lxc/file.go:767
+#: lxc/file.go:417 lxc/file.go:768
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:466 lxc/file.go:467
+#: lxc/file.go:467 lxc/file.go:468
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:701 lxc/file.go:867
+#: lxc/file.go:702 lxc/file.go:868
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4633,11 +4633,11 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:983
+#: lxc/project.go:984
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/storage_bucket.go:833
+#: lxc/storage_bucket.go:834
 msgid "ROLE"
 msgstr ""
 
@@ -4650,15 +4650,15 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/rebuild.go:31
+#: lxc/rebuild.go:32
 msgid "Rebuild as an empty instance"
 msgstr ""
 
-#: lxc/rebuild.go:26
+#: lxc/rebuild.go:27
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:249 lxc/file.go:473
+#: lxc/file.go:250 lxc/file.go:474
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4685,7 +4685,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:882 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
+#: lxc/project.go:883 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
 #: lxc/remote.go:994
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4736,7 +4736,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1164 lxc/auth.go:1165
+#: lxc/auth.go:1165 lxc/auth.go:1166
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4772,7 +4772,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1927 lxc/auth.go:1928
+#: lxc/auth.go:1928 lxc/auth.go:1929
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4784,7 +4784,7 @@ msgstr ""
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:574 lxc/auth.go:575
+#: lxc/auth.go:575 lxc/auth.go:576
 msgid "Remove permissions from groups"
 msgstr ""
 
@@ -4829,11 +4829,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:391 lxc/auth.go:392
+#: lxc/auth.go:392 lxc/auth.go:393
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1751 lxc/auth.go:1752
+#: lxc/auth.go:1752 lxc/auth.go:1753
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -4853,7 +4853,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:589 lxc/project.go:590
+#: lxc/project.go:590 lxc/project.go:591
 msgid "Rename projects"
 msgstr ""
 
@@ -4951,7 +4951,7 @@ msgstr ""
 msgid "Revoke cluster member join token"
 msgstr ""
 
-#: lxc/storage_bucket.go:862
+#: lxc/storage_bucket.go:863
 msgid "Role (admin or read-only)"
 msgstr ""
 
@@ -4967,7 +4967,7 @@ msgstr ""
 msgid "Run against all projects"
 msgstr ""
 
-#: lxc/warning.go:213
+#: lxc/warning.go:214
 msgid "SEVERITY"
 msgstr ""
 
@@ -4987,12 +4987,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1231
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1231
+#: lxc/file.go:1232
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5006,11 +5006,11 @@ msgstr ""
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:173 lxc/warning.go:214
+#: lxc/operation.go:174 lxc/warning.go:215
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:569
+#: lxc/project.go:570
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5018,7 +5018,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:569
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -5026,11 +5026,11 @@ msgstr ""
 msgid "STP"
 msgstr ""
 
-#: lxc/storage_bucket.go:864
+#: lxc/storage_bucket.go:865
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:942
+#: lxc/storage_bucket.go:943
 #, c-format
 msgid "Secret key: %s"
 msgstr ""
@@ -5068,7 +5068,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:995
+#: lxc/file.go:996
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5206,11 +5206,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:654
+#: lxc/project.go:655
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:655
+#: lxc/project.go:656
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5219,11 +5219,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage_bucket.go:534
+#: lxc/storage_bucket.go:535
 msgid "Set storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:535
+#: lxc/storage_bucket.go:536
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -5262,15 +5262,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:476
+#: lxc/file.go:477
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:477
+#: lxc/file.go:478
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:475
+#: lxc/file.go:476
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5310,11 +5310,11 @@ msgstr ""
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 msgid "Set the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:542
+#: lxc/storage_bucket.go:543
 msgid "Set the key as a storage bucket property"
 msgstr ""
 
@@ -5330,7 +5330,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:993
+#: lxc/file.go:994
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5342,7 +5342,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1800 lxc/auth.go:1801
+#: lxc/auth.go:1801 lxc/auth.go:1802
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5358,11 +5358,11 @@ msgstr ""
 msgid "Show details of a cluster member"
 msgstr ""
 
-#: lxc/operation.go:192 lxc/operation.go:193
+#: lxc/operation.go:193 lxc/operation.go:194
 msgid "Show details on a background operation"
 msgstr ""
 
-#: lxc/monitor.go:49
+#: lxc/monitor.go:50
 msgid "Show events from all projects"
 msgstr ""
 
@@ -5370,11 +5370,11 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:440 lxc/auth.go:441
+#: lxc/auth.go:441 lxc/auth.go:442
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:832
+#: lxc/auth.go:833
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5455,15 +5455,15 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:786 lxc/project.go:787
+#: lxc/project.go:787 lxc/project.go:788
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage_bucket.go:628 lxc/storage_bucket.go:629
+#: lxc/storage_bucket.go:629 lxc/storage_bucket.go:630
 msgid "Show storage bucket configurations"
 msgstr ""
 
-#: lxc/storage_bucket.go:1156 lxc/storage_bucket.go:1157
+#: lxc/storage_bucket.go:1157 lxc/storage_bucket.go:1158
 msgid "Show storage bucket key configurations"
 msgstr ""
 
@@ -5479,7 +5479,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:895
+#: lxc/auth.go:896
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5529,7 +5529,7 @@ msgstr ""
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: lxc/warning.go:302 lxc/warning.go:303
+#: lxc/warning.go:303 lxc/warning.go:304
 msgid "Show warning"
 msgstr ""
 
@@ -5613,22 +5613,22 @@ msgstr ""
 msgid "Stopping the instance failed: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:166
+#: lxc/storage_bucket.go:167
 #, c-format
 msgid "Storage bucket %s created"
 msgstr ""
 
-#: lxc/storage_bucket.go:233
+#: lxc/storage_bucket.go:234
 #, c-format
 msgid "Storage bucket %s deleted"
 msgstr ""
 
-#: lxc/storage_bucket.go:940
+#: lxc/storage_bucket.go:941
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr ""
 
-#: lxc/storage_bucket.go:1006
+#: lxc/storage_bucket.go:1007
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr ""
@@ -5697,7 +5697,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:847 lxc/project.go:848
+#: lxc/project.go:848 lxc/project.go:849
 msgid "Switch the current project"
 msgstr ""
 
@@ -5713,10 +5713,10 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1139
+#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1139
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
-#: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:171
-#: lxc/storage_volume.go:1730 lxc/warning.go:215
+#: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
+#: lxc/storage_volume.go:1730 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
@@ -5724,11 +5724,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1032
+#: lxc/file.go:1033
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1026
+#: lxc/file.go:1027
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5856,12 +5856,12 @@ msgstr ""
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:446
+#: lxc/project.go:447
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
 
-#: lxc/storage_bucket.go:431
+#: lxc/storage_bucket.go:432
 #, c-format
 msgid "The property %q does not exist on the storage bucket %q: %v"
 msgstr ""
@@ -6046,7 +6046,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:961
+#: lxc/project.go:962
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6058,17 +6058,17 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:985 lxc/storage_volume.go:1735
+#: lxc/project.go:986 lxc/storage_volume.go:1735
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:573
+#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:574
 #: lxc/storage.go:724 lxc/storage_volume.go:1734
 msgid "USED BY"
 msgstr ""
 
-#: lxc/warning.go:216
+#: lxc/warning.go:217
 msgid "UUID"
 msgstr ""
 
@@ -6077,7 +6077,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:197
+#: lxc/file.go:198
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6091,13 +6091,13 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1253
+#: lxc/file.go:1254
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1153 lxc/list.go:631 lxc/storage_volume.go:1772
-#: lxc/warning.go:241
+#: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6107,7 +6107,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:807
+#: lxc/file.go:808
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6190,11 +6190,11 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:742 lxc/project.go:743
+#: lxc/project.go:743 lxc/project.go:744
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:697 lxc/storage_bucket.go:698
+#: lxc/storage_bucket.go:698 lxc/storage_bucket.go:699
 msgid "Unset storage bucket configuration keys"
 msgstr ""
 
@@ -6242,11 +6242,11 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:747
+#: lxc/project.go:748
 msgid "Unset the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:701
+#: lxc/storage_bucket.go:702
 msgid "Unset the key as a storage bucket property"
 msgstr ""
 
@@ -6325,7 +6325,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:71
+#: lxc/file.go:72
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6362,11 +6362,11 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:831
+#: lxc/auth.go:832
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:894
+#: lxc/auth.go:895
 msgid "View the current identity"
 msgstr ""
 
@@ -6397,15 +6397,15 @@ msgstr ""
 msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
-#: lxc/rebuild.go:27
+#: lxc/rebuild.go:28
 msgid ""
 "Wipe the instance root disk and re-initialize. The original image is used to "
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:156 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
+#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:526
+#: lxc/project.go:531 lxc/project.go:536 lxc/project.go:541 lxc/project.go:546
+#: lxc/project.go:551 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
 msgid "YES"
 msgstr ""
 
@@ -6425,7 +6425,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/rebuild.go:119
+#: lxc/rebuild.go:120
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
@@ -6437,12 +6437,12 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1689
+#: lxc/auth.go:330 lxc/auth.go:763 lxc/auth.go:894 lxc/auth.go:1690
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
-#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
+#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
-#: lxc/operation.go:103 lxc/profile.go:700 lxc/project.go:467
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:68
+#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:468
+#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6470,7 +6470,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1254
+#: lxc/auth.go:1255
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6531,11 +6531,11 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:830
+#: lxc/auth.go:831
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1926
+#: lxc/auth.go:1106 lxc/auth.go:1164 lxc/auth.go:1927
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6543,13 +6543,13 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:954 lxc/auth.go:1470 lxc/cluster_group.go:168
+#: lxc/auth.go:97 lxc/auth.go:150 lxc/auth.go:200 lxc/auth.go:440
+#: lxc/auth.go:955 lxc/auth.go:1471 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:514 lxc/auth.go:572
+#: lxc/auth.go:515 lxc/auth.go:573
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
@@ -6559,19 +6559,19 @@ msgstr ""
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:389
+#: lxc/auth.go:390
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1521 lxc/auth.go:1571 lxc/auth.go:1799
+#: lxc/auth.go:1522 lxc/auth.go:1572 lxc/auth.go:1800
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1873
+#: lxc/auth.go:1874
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1749
+#: lxc/auth.go:1750
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -6591,7 +6591,7 @@ msgstr ""
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
-#: lxc/rebuild.go:25
+#: lxc/rebuild.go:26
 msgid "[<remote>:]<image> [<remote>:]<instance>"
 msgstr ""
 
@@ -6674,20 +6674,20 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:170
+#: lxc/file.go:171
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:120
+#: lxc/file.go:121
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:240
+#: lxc/file.go:241
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:984
+#: lxc/file.go:985
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6838,12 +6838,12 @@ msgstr ""
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
-#: lxc/operation.go:53 lxc/operation.go:191
+#: lxc/operation.go:54 lxc/operation.go:192
 msgid "[<remote>:]<operation>"
 msgstr ""
 
 #: lxc/storage.go:200 lxc/storage.go:259 lxc/storage.go:473 lxc/storage.go:844
-#: lxc/storage_bucket.go:454
+#: lxc/storage_bucket.go:455
 msgid "[<remote>:]<pool>"
 msgstr ""
 
@@ -6851,22 +6851,22 @@ msgstr ""
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
-#: lxc/storage_bucket.go:185 lxc/storage_bucket.go:247
-#: lxc/storage_bucket.go:627 lxc/storage_bucket.go:769
+#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:248
+#: lxc/storage_bucket.go:628 lxc/storage_bucket.go:770
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
 
-#: lxc/storage_bucket.go:380 lxc/storage_bucket.go:696
-#: lxc/storage_bucket.go:850 lxc/storage_bucket.go:956
-#: lxc/storage_bucket.go:1020 lxc/storage_bucket.go:1155
+#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:697
+#: lxc/storage_bucket.go:851 lxc/storage_bucket.go:957
+#: lxc/storage_bucket.go:1021 lxc/storage_bucket.go:1156
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
 
-#: lxc/storage_bucket.go:533
+#: lxc/storage_bucket.go:534
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_bucket.go:81
+#: lxc/storage_bucket.go:82
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
 
@@ -6981,20 +6981,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:91 lxc/project.go:186 lxc/project.go:258 lxc/project.go:785
-#: lxc/project.go:846 lxc/project.go:913
+#: lxc/project.go:92 lxc/project.go:187 lxc/project.go:259 lxc/project.go:786
+#: lxc/project.go:847 lxc/project.go:914
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:394 lxc/project.go:741
+#: lxc/project.go:395 lxc/project.go:742
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:653
+#: lxc/project.go:654
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:587
+#: lxc/project.go:588
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7002,7 +7002,7 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:259 lxc/warning.go:301 lxc/warning.go:354
+#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
@@ -7058,7 +7058,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:555 lxc/remote.go:739
+#: lxc/project.go:556 lxc/remote.go:739
 msgid "current"
 msgstr ""
 
@@ -7105,20 +7105,20 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/auth.go:203
+#: lxc/auth.go:204
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:958
+#: lxc/auth.go:959
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1575
+#: lxc/auth.go:1576
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7196,20 +7196,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:988
+#: lxc/file.go:989
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:244
+#: lxc/file.go:245
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:470
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7291,7 +7291,7 @@ msgid ""
 "  List instances with their running state and user comment."
 msgstr ""
 
-#: lxc/monitor.go:37
+#: lxc/monitor.go:38
 msgid ""
 "lxc monitor --type=logging\n"
 "    Only show log messages.\n"
@@ -7367,7 +7367,7 @@ msgid ""
 "    Create record r1 for zone z1 with configuration from config.yaml"
 msgstr ""
 
-#: lxc/operation.go:195
+#: lxc/operation.go:196
 msgid ""
 "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Show details on that operation UUID"
@@ -7410,7 +7410,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:95
+#: lxc/project.go:96
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7418,7 +7418,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:262
+#: lxc/project.go:263
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7449,7 +7449,7 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:85
 msgid ""
 "lxc storage bucket create p1 b01\n"
 "\tCreate a new storage bucket name b01 in storage pool p1\n"
@@ -7459,19 +7459,19 @@ msgid ""
 "of config.yaml"
 msgstr ""
 
-#: lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:251
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1023
+#: lxc/storage_bucket.go:1024
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:854
 msgid ""
 "lxc storage bucket key create p1 b01 k1\n"
 "\tCreate a key called k1 for the bucket b01 in the pool p1.\n"
@@ -7481,14 +7481,14 @@ msgid ""
 "of config.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1158
+#: lxc/storage_bucket.go:1159
 msgid ""
 "lxc storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_bucket.go:630
+#: lxc/storage_bucket.go:631
 msgid ""
 "lxc storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
@@ -7558,16 +7558,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1142
+#: lxc/file.go:1143
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1101
+#: lxc/file.go:1102
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1054
+#: lxc/file.go:1055
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-04 08:52-0600\n"
+"POT-Creation-Date: 2024-09-05 08:44-0400\n"
 "PO-Revision-Date: 2023-06-16 20:55+0000\n"
 "Last-Translator: Francisco Serrador <fserrador@gmail.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.18.1\n"
 
-#: lxc/storage_bucket.go:260 lxc/storage_bucket.go:1033
+#: lxc/storage_bucket.go:261 lxc/storage_bucket.go:1034
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
@@ -202,7 +202,7 @@ msgstr ""
 "###\n"
 "### Note que el nombre se muestra pero no puede ser cambiado"
 
-#: lxc/auth.go:213
+#: lxc/auth.go:214
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -229,7 +229,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:968
+#: lxc/auth.go:969
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -250,7 +250,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1585
+#: lxc/auth.go:1586
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
@@ -613,7 +613,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/project.go:280
+#: lxc/project.go:281
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the project.\n"
@@ -670,12 +670,12 @@ msgstr "%s (%d más)"
 msgid "%s (%s) (%d available)"
 msgstr "%s (%d más)"
 
-#: lxc/file.go:935
+#: lxc/file.go:936
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s no es un directorio"
 
-#: lxc/file.go:825
+#: lxc/file.go:826
 #, fuzzy, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "%s no es un tipo de archivo soportado."
@@ -713,7 +713,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr "Perfil para aplicar al nuevo contenedor"
 
-#: lxc/init.go:142 lxc/rebuild.go:64
+#: lxc/init.go:142 lxc/rebuild.go:65
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -769,7 +769,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:465
+#: lxc/file.go:466
 #, fuzzy
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -803,7 +803,7 @@ msgstr "ARQUITECTURA"
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:813
+#: lxc/auth.go:814
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -811,11 +811,11 @@ msgstr ""
 msgid "Accept certificate"
 msgstr "Acepta certificado"
 
-#: lxc/storage_bucket.go:863
+#: lxc/storage_bucket.go:864
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:941
+#: lxc/storage_bucket.go:942
 #, fuzzy, c-format
 msgid "Access key: %s"
 msgstr "Expira: %s"
@@ -824,7 +824,7 @@ msgstr "Expira: %s"
 msgid "Access the expanded configuration"
 msgstr ""
 
-#: lxc/warning.go:261 lxc/warning.go:262
+#: lxc/warning.go:262 lxc/warning.go:263
 msgid "Acknowledge warning"
 msgstr ""
 
@@ -842,11 +842,11 @@ msgstr "Accion (predeterminados a GET)"
 msgid "Add a cluster member to a cluster group"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/auth.go:1106 lxc/auth.go:1107
+#: lxc/auth.go:1107 lxc/auth.go:1108
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1874 lxc/auth.go:1875
+#: lxc/auth.go:1875 lxc/auth.go:1876
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -917,7 +917,7 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:515 lxc/auth.go:516
+#: lxc/auth.go:516 lxc/auth.go:517
 msgid "Add permissions to groups"
 msgstr ""
 
@@ -947,7 +947,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr "Expira: %s"
 
-#: lxc/storage_bucket.go:169
+#: lxc/storage_bucket.go:170
 #, fuzzy, c-format
 msgid "Admin access key: %s"
 msgstr "Expira: %s"
@@ -957,7 +957,7 @@ msgstr "Expira: %s"
 msgid "Admin password (or token) for %s:"
 msgstr "Contraseña admin para %s: "
 
-#: lxc/storage_bucket.go:170
+#: lxc/storage_bucket.go:171
 #, fuzzy, c-format
 msgid "Admin secret key: %s"
 msgstr "Creado: %s"
@@ -1017,7 +1017,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:342 lxc/rebuild.go:130
+#: lxc/init.go:342 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -1118,12 +1118,12 @@ msgstr ""
 
 #: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:318
 #: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
-#: lxc/network_zone.go:366 lxc/network_zone.go:1053 lxc/storage_bucket.go:141
+#: lxc/network_zone.go:366 lxc/network_zone.go:1053 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:159
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:160
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "Nombre del contenedor es: %s"
@@ -1164,7 +1164,7 @@ msgstr "Bytes recibidos"
 msgid "Bytes sent"
 msgstr "Bytes enviados"
 
-#: lxc/operation.go:174
+#: lxc/operation.go:175
 msgid "CANCELABLE"
 msgstr "CANCELABLE"
 
@@ -1176,7 +1176,7 @@ msgstr "NOMBRE COMÚN"
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: lxc/warning.go:209
+#: lxc/warning.go:210
 msgid "COUNT"
 msgstr ""
 
@@ -1202,7 +1202,7 @@ msgstr "Uso de CPU:"
 msgid "CPUs (%s):"
 msgstr ""
 
-#: lxc/operation.go:175
+#: lxc/operation.go:176
 msgid "CREATED"
 msgstr "CREADO"
 
@@ -1235,7 +1235,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr "No se puede proporcionar un nombre para la imagen de destino"
 
-#: lxc/file.go:340
+#: lxc/file.go:341
 msgid "Can't pull a directory without --recursive"
 msgstr "No se puede jalar un directorio sin - recursivo"
 
@@ -1261,11 +1261,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr "No se puede especificar un remote diferente para renombrar."
 
-#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:224
+#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:546
+#: lxc/file.go:547
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1274,7 +1274,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:160
+#: lxc/rebuild.go:161
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1399,13 +1399,13 @@ msgstr "Perfil %s eliminado de %s"
 #: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
 #: lxc/network_load_balancer.go:1051 lxc/network_load_balancer.go:1125
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
-#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:90
-#: lxc/storage_bucket.go:190 lxc/storage_bucket.go:253
-#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:541
-#: lxc/storage_bucket.go:634 lxc/storage_bucket.go:700
-#: lxc/storage_bucket.go:775 lxc/storage_bucket.go:861
-#: lxc/storage_bucket.go:961 lxc/storage_bucket.go:1026
-#: lxc/storage_bucket.go:1162 lxc/storage_volume.go:394
+#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
+#: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
+#: lxc/storage_bucket.go:385 lxc/storage_bucket.go:542
+#: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
+#: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
+#: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
 #: lxc/storage_volume.go:612 lxc/storage_volume.go:717
 #: lxc/storage_volume.go:1005 lxc/storage_volume.go:1231
 #: lxc/storage_volume.go:1360 lxc/storage_volume.go:1848
@@ -1429,7 +1429,7 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1113 lxc/list.go:132 lxc/storage_volume.go:1589
-#: lxc/warning.go:92
+#: lxc/warning.go:93
 msgid "Columns"
 msgstr "Columnas"
 
@@ -1458,7 +1458,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr "Perfil para aplicar al nuevo contenedor"
 
-#: lxc/project.go:100
+#: lxc/project.go:101
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1473,8 +1473,8 @@ msgstr "Perfil para aplicar al nuevo contenedor"
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
-#: lxc/project.go:362 lxc/storage.go:359 lxc/storage_bucket.go:348
-#: lxc/storage_bucket.go:1125 lxc/storage_volume.go:1150
+#: lxc/project.go:363 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1150
 #: lxc/storage_volume.go:1182
 #, c-format
 msgid "Config parsing error: %s"
@@ -1603,12 +1603,12 @@ msgstr "Certificado de la huella digital: %s"
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:300 lxc/auth.go:1660
+#: lxc/auth.go:301 lxc/auth.go:1661
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1054
+#: lxc/auth.go:1055
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1659,16 +1659,16 @@ msgstr "Creando el contenedor"
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:248 lxc/file.go:474
+#: lxc/file.go:249 lxc/file.go:475
 msgid "Create any directories necessary"
 msgstr ""
 
-#: lxc/auth.go:97 lxc/auth.go:98
+#: lxc/auth.go:98 lxc/auth.go:99
 #, fuzzy
 msgid "Create groups"
 msgstr "Creado: %s"
 
-#: lxc/auth.go:1471 lxc/auth.go:1472
+#: lxc/auth.go:1472 lxc/auth.go:1473
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1689,11 +1689,11 @@ msgstr ""
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_bucket.go:851 lxc/storage_bucket.go:852
+#: lxc/storage_bucket.go:852 lxc/storage_bucket.go:853
 msgid "Create key for a storage bucket"
 msgstr ""
 
-#: lxc/storage_bucket.go:82 lxc/storage_bucket.go:83
+#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
 #, fuzzy
 msgid "Create new custom storage buckets"
 msgstr "Perfil %s creado"
@@ -1740,7 +1740,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:92 lxc/project.go:93
+#: lxc/project.go:93 lxc/project.go:94
 msgid "Create projects"
 msgstr ""
 
@@ -1776,13 +1776,13 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:376 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1135 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
-#: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:172
-#: lxc/profile.go:756 lxc/project.go:572 lxc/storage.go:723
-#: lxc/storage_bucket.go:512 lxc/storage_bucket.go:832
+#: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
+#: lxc/profile.go:756 lxc/project.go:573 lxc/storage.go:723
+#: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1732
 msgid "DESCRIPTION"
 msgstr "DESCRIPCIÓN"
@@ -1807,7 +1807,7 @@ msgstr ""
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
-#: lxc/operation.go:55 lxc/operation.go:56
+#: lxc/operation.go:56 lxc/operation.go:57
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
@@ -1815,20 +1815,20 @@ msgstr ""
 msgid "Delete a cluster group"
 msgstr ""
 
-#: lxc/warning.go:360
+#: lxc/warning.go:361
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:122 lxc/file.go:123
+#: lxc/file.go:123 lxc/file.go:124
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/auth.go:151 lxc/auth.go:152
+#: lxc/auth.go:152 lxc/auth.go:153
 #, fuzzy
 msgid "Delete groups"
 msgstr "Eliminar imágenes"
 
-#: lxc/auth.go:1523 lxc/auth.go:1524
+#: lxc/auth.go:1524 lxc/auth.go:1525
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1849,7 +1849,7 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_bucket.go:957 lxc/storage_bucket.go:958
+#: lxc/storage_bucket.go:958 lxc/storage_bucket.go:959
 msgid "Delete key from a storage bucket"
 msgstr ""
 
@@ -1888,11 +1888,11 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:188 lxc/project.go:189
+#: lxc/project.go:189 lxc/project.go:190
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:187 lxc/storage_bucket.go:188
+#: lxc/storage_bucket.go:188 lxc/storage_bucket.go:189
 #, fuzzy
 msgid "Delete storage buckets"
 msgstr "Perfil %s creado"
@@ -1905,20 +1905,20 @@ msgstr ""
 msgid "Delete storage volumes"
 msgstr ""
 
-#: lxc/warning.go:356 lxc/warning.go:357
+#: lxc/warning.go:357 lxc/warning.go:358
 msgid "Delete warning"
 msgstr ""
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:30 lxc/auth.go:59 lxc/auth.go:98
-#: lxc/auth.go:152 lxc/auth.go:201 lxc/auth.go:332 lxc/auth.go:392
-#: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
-#: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
-#: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
-#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1434 lxc/auth.go:1472
-#: lxc/auth.go:1524 lxc/auth.go:1573 lxc/auth.go:1692 lxc/auth.go:1752
-#: lxc/auth.go:1801 lxc/auth.go:1852 lxc/auth.go:1875 lxc/auth.go:1928
+#: lxc/alias.go:214 lxc/auth.go:31 lxc/auth.go:60 lxc/auth.go:99
+#: lxc/auth.go:153 lxc/auth.go:202 lxc/auth.go:333 lxc/auth.go:393
+#: lxc/auth.go:442 lxc/auth.go:494 lxc/auth.go:517 lxc/auth.go:576
+#: lxc/auth.go:732 lxc/auth.go:766 lxc/auth.go:833 lxc/auth.go:896
+#: lxc/auth.go:957 lxc/auth.go:1085 lxc/auth.go:1108 lxc/auth.go:1166
+#: lxc/auth.go:1235 lxc/auth.go:1257 lxc/auth.go:1435 lxc/auth.go:1473
+#: lxc/auth.go:1525 lxc/auth.go:1574 lxc/auth.go:1693 lxc/auth.go:1753
+#: lxc/auth.go:1802 lxc/auth.go:1853 lxc/auth.go:1876 lxc/auth.go:1929
 #: lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215 lxc/cluster.go:272
 #: lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:484 lxc/cluster.go:528
 #: lxc/cluster.go:586 lxc/cluster.go:677 lxc/cluster.go:770 lxc/cluster.go:893
@@ -1942,15 +1942,15 @@ msgstr ""
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:83 lxc/file.go:123 lxc/file.go:172
-#: lxc/file.go:242 lxc/file.go:467 lxc/file.go:986 lxc/image.go:38
+#: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
+#: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
 #: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
 #: lxc/image.go:697 lxc/image.go:946 lxc/image.go:1088 lxc/image.go:1415
 #: lxc/image.go:1506 lxc/image.go:1572 lxc/image.go:1636 lxc/image.go:1699
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:38 lxc/network.go:33
+#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33
 #: lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405
 #: lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793
 #: lxc/network.go:874 lxc/network.go:1005 lxc/network.go:1106
@@ -1984,27 +1984,27 @@ msgstr ""
 #: lxc/network_zone.go:909 lxc/network_zone.go:985 lxc/network_zone.go:1083
 #: lxc/network_zone.go:1172 lxc/network_zone.go:1219 lxc/network_zone.go:1349
 #: lxc/network_zone.go:1410 lxc/network_zone.go:1425 lxc/network_zone.go:1483
-#: lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:106
-#: lxc/operation.go:193 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
+#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
+#: lxc/operation.go:194 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
 #: lxc/profile.go:271 lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493
 #: lxc/profile.go:629 lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860
-#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:29
-#: lxc/project.go:93 lxc/project.go:189 lxc/project.go:260 lxc/project.go:396
-#: lxc/project.go:470 lxc/project.go:590 lxc/project.go:655 lxc/project.go:743
-#: lxc/project.go:787 lxc/project.go:848 lxc/project.go:915 lxc/publish.go:34
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:35 lxc/remote.go:91
+#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:30
+#: lxc/project.go:94 lxc/project.go:190 lxc/project.go:261 lxc/project.go:397
+#: lxc/project.go:471 lxc/project.go:591 lxc/project.go:656 lxc/project.go:744
+#: lxc/project.go:788 lxc/project.go:849 lxc/project.go:916 lxc/publish.go:34
+#: lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91
 #: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853
 #: lxc/remote.go:917 lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24
 #: lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203
 #: lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655
 #: lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940
-#: lxc/storage_bucket.go:29 lxc/storage_bucket.go:83 lxc/storage_bucket.go:188
-#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:382
-#: lxc/storage_bucket.go:458 lxc/storage_bucket.go:535
-#: lxc/storage_bucket.go:629 lxc/storage_bucket.go:698
-#: lxc/storage_bucket.go:732 lxc/storage_bucket.go:773
-#: lxc/storage_bucket.go:852 lxc/storage_bucket.go:958
-#: lxc/storage_bucket.go:1022 lxc/storage_bucket.go:1157
+#: lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189
+#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:383
+#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:536
+#: lxc/storage_bucket.go:630 lxc/storage_bucket.go:699
+#: lxc/storage_bucket.go:733 lxc/storage_bucket.go:774
+#: lxc/storage_bucket.go:853 lxc/storage_bucket.go:959
+#: lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158
 #: lxc/storage_volume.go:58 lxc/storage_volume.go:169 lxc/storage_volume.go:283
 #: lxc/storage_volume.go:390 lxc/storage_volume.go:605
 #: lxc/storage_volume.go:714 lxc/storage_volume.go:801
@@ -2015,8 +2015,8 @@ msgstr ""
 #: lxc/storage_volume.go:2064 lxc/storage_volume.go:2222
 #: lxc/storage_volume.go:2343 lxc/storage_volume.go:2405
 #: lxc/storage_volume.go:2541 lxc/storage_volume.go:2624
-#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:29
-#: lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
+#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:30
+#: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr "Descripción"
 
@@ -2105,7 +2105,7 @@ msgstr "El directorio importado no está disponible en esta plataforma"
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:994
+#: lxc/file.go:995
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2173,7 +2173,7 @@ msgstr "FECHA DE EXPIRACIÓN"
 msgid "EXPIRY DATE"
 msgstr "FECHA DE EXPIRACIÓN"
 
-#: lxc/file.go:74
+#: lxc/file.go:75
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -2183,7 +2183,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:955 lxc/auth.go:956
+#: lxc/auth.go:956 lxc/auth.go:957
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -2191,15 +2191,15 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:171 lxc/file.go:172
+#: lxc/file.go:172 lxc/file.go:173
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/auth.go:200 lxc/auth.go:201
+#: lxc/auth.go:201 lxc/auth.go:202
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1572 lxc/auth.go:1573
+#: lxc/auth.go:1573 lxc/auth.go:1574
 #, fuzzy
 msgid "Edit identity provider groups as YAML"
 msgstr "Perfil %s creado"
@@ -2260,16 +2260,16 @@ msgstr "Perfil %s creado"
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:259 lxc/project.go:260
+#: lxc/project.go:260 lxc/project.go:261
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:248 lxc/storage_bucket.go:249
+#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:250
 #, fuzzy
 msgid "Edit storage bucket configurations as YAML"
 msgstr "Perfil %s creado"
 
-#: lxc/storage_bucket.go:1021 lxc/storage_bucket.go:1022
+#: lxc/storage_bucket.go:1022 lxc/storage_bucket.go:1023
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
@@ -2286,7 +2286,7 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1147 lxc/list.go:622 lxc/storage_volume.go:1766
-#: lxc/warning.go:235
+#: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2341,7 +2341,7 @@ msgstr ""
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
-#: lxc/project.go:718 lxc/storage.go:812 lxc/storage_bucket.go:602
+#: lxc/project.go:719 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2155 lxc/storage_volume.go:2193
 #, fuzzy, c-format
 msgid "Error setting properties: %v"
@@ -2355,8 +2355,8 @@ msgstr "Error actualizando el archivo de plantilla: %s"
 #: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
-#: lxc/profile.go:981 lxc/project.go:712 lxc/storage.go:806
-#: lxc/storage_bucket.go:596 lxc/storage_volume.go:2149
+#: lxc/profile.go:981 lxc/project.go:713 lxc/storage.go:806
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2149
 #: lxc/storage_volume.go:2187
 #, c-format
 msgid "Error unsetting property: %v"
@@ -2377,7 +2377,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "Evacuating cluster member: %s"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/monitor.go:50
+#: lxc/monitor.go:51
 msgid "Event type to listen for"
 msgstr ""
 
@@ -2467,16 +2467,16 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr "HUELLA DIGITAL"
 
-#: lxc/warning.go:210
+#: lxc/warning.go:211
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1237
+#: lxc/file.go:1238
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1260
+#: lxc/file.go:1261
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2491,12 +2491,12 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/file.go:1287
+#: lxc/file.go:1288
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1072
+#: lxc/file.go:1073
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "Nombre del Miembro del Cluster"
@@ -2526,7 +2526,7 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "Failed fetching fingerprint %q: %w"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/file.go:1193
+#: lxc/file.go:1194
 #, fuzzy, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "Acepta certificado"
@@ -2541,7 +2541,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/file.go:1198
+#: lxc/file.go:1199
 #, fuzzy, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "Acepta certificado"
@@ -2551,12 +2551,12 @@ msgstr "Acepta certificado"
 msgid "Failed starting command: %w"
 msgstr "Acepta certificado"
 
-#: lxc/file.go:1098
+#: lxc/file.go:1099
 #, fuzzy, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "Acepta certificado"
 
-#: lxc/file.go:1225
+#: lxc/file.go:1226
 #, fuzzy, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "Acepta certificado"
@@ -2595,7 +2595,7 @@ msgstr "Acepta certificado"
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1210
+#: lxc/file.go:1211
 #, fuzzy, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "Acepta certificado"
@@ -2610,7 +2610,7 @@ msgstr "Perfil para aplicar al nuevo contenedor"
 msgid "Failed to remove alias %s: %w"
 msgstr "Acepta certificado"
 
-#: lxc/file.go:820
+#: lxc/file.go:821
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2625,7 +2625,7 @@ msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
 #: lxc/network.go:1044 lxc/network_acl.go:133 lxc/network_zone.go:124
-#: lxc/operation.go:136
+#: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr "El filtrado no está soportado aún"
 
@@ -2691,21 +2691,21 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
+#: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:770 lxc/auth.go:1697
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1114 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:57
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
-#: lxc/operation.go:108 lxc/profile.go:707 lxc/project.go:472
-#: lxc/project.go:917 lxc/remote.go:690 lxc/storage.go:657
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:774
-#: lxc/storage_volume.go:1608 lxc/warning.go:93
+#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:473
+#: lxc/project.go:918 lxc/remote.go:690 lxc/storage.go:657
+#: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
+#: lxc/storage_volume.go:1608 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
-#: lxc/monitor.go:52
+#: lxc/monitor.go:53
 msgid "Format (json|pretty|yaml)"
 msgstr ""
 
@@ -2749,7 +2749,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:817 lxc/auth.go:1736
+#: lxc/auth.go:818 lxc/auth.go:1737
 msgid "GROUPS"
 msgstr ""
 
@@ -2766,7 +2766,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr "Aliases:"
 
-#: lxc/project.go:914 lxc/project.go:915
+#: lxc/project.go:915 lxc/project.go:916
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2819,11 +2819,11 @@ msgstr "Perfil %s creado"
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:400
+#: lxc/project.go:401
 msgid "Get the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:385
+#: lxc/storage_bucket.go:386
 #, fuzzy
 msgid "Get the key as a storage bucket property"
 msgstr "Perfil %s creado"
@@ -2890,11 +2890,11 @@ msgstr "Perfil %s creado"
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:395 lxc/project.go:396
+#: lxc/project.go:396 lxc/project.go:397
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:382
+#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:383
 #, fuzzy
 msgid "Get values for storage bucket configuration keys"
 msgstr "Perfil %s creado"
@@ -2912,17 +2912,17 @@ msgstr ""
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: lxc/auth.go:136
+#: lxc/auth.go:137
 #, fuzzy, c-format
 msgid "Group %s created"
 msgstr "Perfil %s creado"
 
-#: lxc/auth.go:186
+#: lxc/auth.go:187
 #, fuzzy, c-format
 msgid "Group %s deleted"
 msgstr "Perfil %s eliminado"
 
-#: lxc/auth.go:426 lxc/auth.go:1786
+#: lxc/auth.go:427 lxc/auth.go:1787
 #, fuzzy, c-format
 msgid "Group %s renamed to %s"
 msgstr "Perfil %s renombrado a %s"
@@ -2948,27 +2948,27 @@ msgstr "Aliases:"
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1310
+#: lxc/file.go:1311
 #, fuzzy, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "Copiando la imagen: %s"
 
-#: lxc/file.go:1299
+#: lxc/file.go:1300
 #, fuzzy, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "Copiando la imagen: %s"
 
-#: lxc/file.go:1122
+#: lxc/file.go:1123
 #, fuzzy, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "Dispositivo %s añadido a %s"
 
-#: lxc/file.go:1132
+#: lxc/file.go:1133
 #, fuzzy, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "Copiando la imagen: %s"
 
-#: lxc/network.go:966 lxc/operation.go:170
+#: lxc/network.go:966 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2982,11 +2982,11 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:816
+#: lxc/auth.go:817
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:566
+#: lxc/project.go:567
 msgid "IMAGES"
 msgstr ""
 
@@ -3016,17 +3016,17 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1508
+#: lxc/auth.go:1509
 #, fuzzy, c-format
 msgid "Identity provider group %s created"
 msgstr "Perfil %s creado"
 
-#: lxc/auth.go:1558
+#: lxc/auth.go:1559
 #, fuzzy, c-format
 msgid "Identity provider group %s deleted"
 msgstr "Perfil %s creado"
 
-#: lxc/rebuild.go:32
+#: lxc/rebuild.go:33
 msgid "If an instance is running, stop it and then rebuild it"
 msgstr ""
 
@@ -3148,7 +3148,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1233 lxc/auth.go:1234
+#: lxc/auth.go:1234 lxc/auth.go:1235
 msgid "Inspect permissions"
 msgstr ""
 
@@ -3157,11 +3157,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/file.go:1124
+#: lxc/file.go:1125
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1301
+#: lxc/file.go:1302
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3181,7 +3181,7 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Instance name must be specified"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/file.go:1044
+#: lxc/file.go:1045
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3190,7 +3190,7 @@ msgstr ""
 msgid "Instance published with fingerprint: %s"
 msgstr "Contenedor publicado con huella digital: %s"
 
-#: lxc/rebuild.go:74
+#: lxc/rebuild.go:75
 #, fuzzy, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr "Nombre del contenedor es: %s"
@@ -3223,7 +3223,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/monitor.go:70
+#: lxc/monitor.go:71
 #, fuzzy, c-format
 msgid "Invalid format: %s"
 msgstr "Nombre del contenedor es: %s"
@@ -3233,7 +3233,7 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Invalid instance name: %s"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/file.go:1039
+#: lxc/file.go:1040
 #, fuzzy, c-format
 msgid "Invalid instance path: %q"
 msgstr "Nombre del contenedor es: %s"
@@ -3276,7 +3276,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:147
+#: lxc/file.go:148
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -3293,12 +3293,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/file.go:313
+#: lxc/file.go:314
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:495
+#: lxc/file.go:496
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3312,7 +3312,7 @@ msgstr "Cacheado: %s"
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/warning.go:212
 msgid "LAST SEEN"
 msgstr ""
 
@@ -3320,7 +3320,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:984
+#: lxc/project.go:985
 msgid "LIMIT"
 msgstr ""
 
@@ -3329,8 +3329,8 @@ msgid "LISTEN ADDRESS"
 msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
-#: lxc/network_load_balancer.go:165 lxc/operation.go:177
-#: lxc/storage_bucket.go:516 lxc/storage_volume.go:1739 lxc/warning.go:220
+#: lxc/network_load_balancer.go:165 lxc/operation.go:178
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1739 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3409,7 +3409,7 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/warning.go:94
+#: lxc/warning.go:95
 #, fuzzy
 msgid "List all warnings"
 msgstr "Aliases:"
@@ -3456,20 +3456,20 @@ msgstr ""
 msgid "List available storage pools"
 msgstr ""
 
-#: lxc/operation.go:105 lxc/operation.go:106
+#: lxc/operation.go:106 lxc/operation.go:107
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:331 lxc/auth.go:332
+#: lxc/auth.go:332 lxc/auth.go:333
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:764 lxc/auth.go:765
+#: lxc/auth.go:765 lxc/auth.go:766
 #, fuzzy
 msgid "List identities"
 msgstr "Aliases:"
 
-#: lxc/auth.go:1691 lxc/auth.go:1692
+#: lxc/auth.go:1692 lxc/auth.go:1693
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3619,12 +3619,12 @@ msgstr ""
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/operation.go:109
+#: lxc/operation.go:110
 #, fuzzy
 msgid "List operations from all projects"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/auth.go:1255 lxc/auth.go:1256
+#: lxc/auth.go:1256 lxc/auth.go:1257
 #, fuzzy
 msgid "List permissions"
 msgstr "Aliases:"
@@ -3633,15 +3633,15 @@ msgstr "Aliases:"
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:469 lxc/project.go:470
+#: lxc/project.go:470 lxc/project.go:471
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:771 lxc/storage_bucket.go:773
+#: lxc/storage_bucket.go:772 lxc/storage_bucket.go:774
 msgid "List storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:456 lxc/storage_bucket.go:458
+#: lxc/storage_bucket.go:457 lxc/storage_bucket.go:459
 #, fuzzy
 msgid "List storage buckets"
 msgstr "Aliases:"
@@ -3678,12 +3678,12 @@ msgstr ""
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/warning.go:70
+#: lxc/warning.go:71
 #, fuzzy
 msgid "List warnings"
 msgstr "Aliases:"
 
-#: lxc/warning.go:71
+#: lxc/warning.go:72
 msgid ""
 "List warnings\n"
 "\n"
@@ -3706,7 +3706,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/operation.go:23 lxc/operation.go:24
+#: lxc/operation.go:24 lxc/operation.go:25
 msgid "List, show and delete background operations"
 msgstr ""
 
@@ -3715,7 +3715,7 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/monitor.go:79
+#: lxc/monitor.go:80
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
@@ -3821,24 +3821,24 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:82 lxc/file.go:83
+#: lxc/file.go:83 lxc/file.go:84
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1433 lxc/auth.go:1434
+#: lxc/auth.go:59 lxc/auth.go:60 lxc/auth.go:1434 lxc/auth.go:1435
 #, fuzzy
 msgid "Manage groups"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/auth.go:1083 lxc/auth.go:1084
+#: lxc/auth.go:1084 lxc/auth.go:1085
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:730 lxc/auth.go:731
+#: lxc/auth.go:731 lxc/auth.go:732
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1851 lxc/auth.go:1852
+#: lxc/auth.go:1852 lxc/auth.go:1853
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3936,7 +3936,7 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Manage network zones"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/auth.go:492 lxc/auth.go:493
+#: lxc/auth.go:493 lxc/auth.go:494
 #, fuzzy
 msgid "Manage permissions"
 msgstr "Nombre del contenedor es: %s"
@@ -3945,25 +3945,25 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:28 lxc/project.go:29
+#: lxc/project.go:29 lxc/project.go:30
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:731
+#: lxc/storage_bucket.go:732
 #, fuzzy
 msgid "Manage storage bucket keys"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/storage_bucket.go:732
+#: lxc/storage_bucket.go:733
 msgid "Manage storage bucket keys."
 msgstr ""
 
-#: lxc/storage_bucket.go:28
+#: lxc/storage_bucket.go:29
 #, fuzzy
 msgid "Manage storage buckets"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:30
 #, fuzzy
 msgid "Manage storage buckets."
 msgstr "Nombre del contenedor es: %s"
@@ -3992,12 +3992,12 @@ msgstr ""
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/auth.go:29 lxc/auth.go:30
+#: lxc/auth.go:30 lxc/auth.go:31
 #, fuzzy
 msgid "Manage user authorization"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/warning.go:28 lxc/warning.go:29
+#: lxc/warning.go:29 lxc/warning.go:30
 msgid "Manage warnings"
 msgstr ""
 
@@ -4062,17 +4062,17 @@ msgstr ""
 msgid "Migration operation failure: %w"
 msgstr ""
 
-#: lxc/monitor.go:51
+#: lxc/monitor.go:52
 msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: lxc/storage_bucket.go:116 lxc/storage_bucket.go:216
-#: lxc/storage_bucket.go:292 lxc/storage_bucket.go:411
-#: lxc/storage_bucket.go:568 lxc/storage_bucket.go:660
-#: lxc/storage_bucket.go:802 lxc/storage_bucket.go:889
-#: lxc/storage_bucket.go:986 lxc/storage_bucket.go:1065
-#: lxc/storage_bucket.go:1188
+#: lxc/storage_bucket.go:117 lxc/storage_bucket.go:217
+#: lxc/storage_bucket.go:293 lxc/storage_bucket.go:412
+#: lxc/storage_bucket.go:569 lxc/storage_bucket.go:661
+#: lxc/storage_bucket.go:803 lxc/storage_bucket.go:890
+#: lxc/storage_bucket.go:987 lxc/storage_bucket.go:1066
+#: lxc/storage_bucket.go:1189
 #, fuzzy
 msgid "Missing bucket name"
 msgstr "Nombre del contenedor es: %s"
@@ -4095,23 +4095,23 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "Missing cluster member name"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1825
+#: lxc/auth.go:123 lxc/auth.go:177 lxc/auth.go:255 lxc/auth.go:417
+#: lxc/auth.go:466 lxc/auth.go:541 lxc/auth.go:600 lxc/auth.go:1826
 #, fuzzy
 msgid "Missing group name"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/auth.go:862 lxc/auth.go:1003 lxc/auth.go:1131 lxc/auth.go:1189
+#: lxc/auth.go:863 lxc/auth.go:1004 lxc/auth.go:1132 lxc/auth.go:1190
 #, fuzzy
 msgid "Missing identity argument"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/auth.go:1495 lxc/auth.go:1548 lxc/auth.go:1614 lxc/auth.go:1776
+#: lxc/auth.go:1496 lxc/auth.go:1549 lxc/auth.go:1615 lxc/auth.go:1777
 #, fuzzy
 msgid "Missing identity provider group name"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/auth.go:1899 lxc/auth.go:1952
+#: lxc/auth.go:1900 lxc/auth.go:1953
 #, fuzzy
 msgid "Missing identity provider group name argument"
 msgstr "Nombre del Miembro del Cluster"
@@ -4120,13 +4120,13 @@ msgstr "Nombre del Miembro del Cluster"
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
 #: lxc/config_template.go:377 lxc/profile.go:141 lxc/profile.go:222
-#: lxc/profile.go:808 lxc/rebuild.go:60
+#: lxc/profile.go:808 lxc/rebuild.go:61
 #, fuzzy
 msgid "Missing instance name"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/storage_bucket.go:893 lxc/storage_bucket.go:990
-#: lxc/storage_bucket.go:1069 lxc/storage_bucket.go:1192
+#: lxc/storage_bucket.go:894 lxc/storage_bucket.go:991
+#: lxc/storage_bucket.go:1070 lxc/storage_bucket.go:1193
 #, fuzzy
 msgid "Missing key name"
 msgstr "Nombre del contenedor es: %s"
@@ -4197,13 +4197,13 @@ msgid "Missing peer name"
 msgstr "Nombre del contenedor es: %s"
 
 #: lxc/storage.go:235 lxc/storage.go:313 lxc/storage.go:431 lxc/storage.go:509
-#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:112
-#: lxc/storage_bucket.go:212 lxc/storage_bucket.go:288
-#: lxc/storage_bucket.go:407 lxc/storage_bucket.go:482
-#: lxc/storage_bucket.go:564 lxc/storage_bucket.go:656
-#: lxc/storage_bucket.go:798 lxc/storage_bucket.go:885
-#: lxc/storage_bucket.go:982 lxc/storage_bucket.go:1061
-#: lxc/storage_bucket.go:1184 lxc/storage_volume.go:209
+#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:113
+#: lxc/storage_bucket.go:213 lxc/storage_bucket.go:289
+#: lxc/storage_bucket.go:408 lxc/storage_bucket.go:483
+#: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
+#: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
+#: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
 #: lxc/storage_volume.go:323 lxc/storage_volume.go:643
 #: lxc/storage_volume.go:750 lxc/storage_volume.go:841
 #: lxc/storage_volume.go:939 lxc/storage_volume.go:1053
@@ -4218,9 +4218,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:404 lxc/project.go:146 lxc/project.go:226 lxc/project.go:316
-#: lxc/project.go:433 lxc/project.go:622 lxc/project.go:691 lxc/project.go:819
-#: lxc/project.go:948
+#: lxc/profile.go:404 lxc/project.go:147 lxc/project.go:227 lxc/project.go:317
+#: lxc/project.go:434 lxc/project.go:623 lxc/project.go:692 lxc/project.go:820
+#: lxc/project.go:949
 #, fuzzy
 msgid "Missing project name"
 msgstr "Nombre del contenedor es: %s"
@@ -4238,7 +4238,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/file.go:598
+#: lxc/file.go:599
 #, fuzzy
 msgid "Missing target directory"
 msgstr "%s no es un directorio"
@@ -4262,11 +4262,11 @@ msgstr ""
 msgid "Model: %v"
 msgstr ""
 
-#: lxc/monitor.go:32
+#: lxc/monitor.go:33
 msgid "Monitor a local or remote LXD server"
 msgstr ""
 
-#: lxc/monitor.go:33
+#: lxc/monitor.go:34
 msgid ""
 "Monitor a local or remote LXD server\n"
 "\n"
@@ -4278,11 +4278,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:285
+#: lxc/file.go:286
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:985 lxc/file.go:986
+#: lxc/file.go:986 lxc/file.go:987
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "Aliases:"
@@ -4345,13 +4345,13 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:192
+#: lxc/auth.go:376 lxc/auth.go:816 lxc/auth.go:1736 lxc/cluster.go:192
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
-#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:565
-#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:511
-#: lxc/storage_bucket.go:831 lxc/storage_volume.go:1731
+#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:566
+#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1731
 msgid "NAME"
 msgstr ""
 
@@ -4359,11 +4359,11 @@ msgstr ""
 msgid "NAT"
 msgstr ""
 
-#: lxc/project.go:571
+#: lxc/project.go:572
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:570
+#: lxc/project.go:571
 msgid "NETWORKS"
 msgstr ""
 
@@ -4375,9 +4375,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/operation.go:154 lxc/project.go:523
-#: lxc/project.go:528 lxc/project.go:533 lxc/project.go:538 lxc/project.go:543
-#: lxc/project.go:548 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
+#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:524
+#: lxc/project.go:529 lxc/project.go:534 lxc/project.go:539 lxc/project.go:544
+#: lxc/project.go:549 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
 msgid "NO"
 msgstr ""
 
@@ -4622,7 +4622,7 @@ msgstr ""
 msgid "Only managed networks can be modified"
 msgstr ""
 
-#: lxc/operation.go:86
+#: lxc/operation.go:87
 #, c-format
 msgid "Operation %s deleted"
 msgstr ""
@@ -4669,11 +4669,11 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:567
+#: lxc/list.go:576 lxc/project.go:568
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:212
+#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4736,24 +4736,24 @@ msgstr "Auto actualización: %s"
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1102
+#: lxc/file.go:1103
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:860
+#: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
-#: lxc/project.go:363 lxc/storage.go:360 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1151
+#: lxc/project.go:364 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1151
 #: lxc/storage_volume.go:1183
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
-#: lxc/monitor.go:48
+#: lxc/monitor.go:49
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
@@ -4843,17 +4843,17 @@ msgstr ""
 msgid "Profiles: "
 msgstr "Perfil %s creado"
 
-#: lxc/project.go:172
+#: lxc/project.go:173
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:236
+#: lxc/project.go:237
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:637
+#: lxc/project.go:638
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -4974,20 +4974,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/file.go:241 lxc/file.go:242
+#: lxc/file.go:242 lxc/file.go:243
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:416 lxc/file.go:767
+#: lxc/file.go:417 lxc/file.go:768
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:466 lxc/file.go:467
+#: lxc/file.go:467 lxc/file.go:468
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:701 lxc/file.go:867
+#: lxc/file.go:702 lxc/file.go:868
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -5000,11 +5000,11 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:983
+#: lxc/project.go:984
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/storage_bucket.go:833
+#: lxc/storage_bucket.go:834
 msgid "ROLE"
 msgstr ""
 
@@ -5017,17 +5017,17 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/rebuild.go:31
+#: lxc/rebuild.go:32
 #, fuzzy
 msgid "Rebuild as an empty instance"
 msgstr "Creando el contenedor"
 
-#: lxc/rebuild.go:26
+#: lxc/rebuild.go:27
 #, fuzzy
 msgid "Rebuild instances"
 msgstr "Aliases:"
 
-#: lxc/file.go:249 lxc/file.go:473
+#: lxc/file.go:250 lxc/file.go:474
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -5054,7 +5054,7 @@ msgstr "Refrescando la imagen: %s"
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:882 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
+#: lxc/project.go:883 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
 #: lxc/remote.go:994
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -5107,7 +5107,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/auth.go:1164 lxc/auth.go:1165
+#: lxc/auth.go:1165 lxc/auth.go:1166
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -5146,7 +5146,7 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1927 lxc/auth.go:1928
+#: lxc/auth.go:1928 lxc/auth.go:1929
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -5158,7 +5158,7 @@ msgstr ""
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:574 lxc/auth.go:575
+#: lxc/auth.go:575 lxc/auth.go:576
 msgid "Remove permissions from groups"
 msgstr ""
 
@@ -5205,11 +5205,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:391 lxc/auth.go:392
+#: lxc/auth.go:392 lxc/auth.go:393
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1751 lxc/auth.go:1752
+#: lxc/auth.go:1752 lxc/auth.go:1753
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5230,7 +5230,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:589 lxc/project.go:590
+#: lxc/project.go:590 lxc/project.go:591
 msgid "Rename projects"
 msgstr ""
 
@@ -5333,7 +5333,7 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "Revoke cluster member join token"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/storage_bucket.go:862
+#: lxc/storage_bucket.go:863
 msgid "Role (admin or read-only)"
 msgstr ""
 
@@ -5350,7 +5350,7 @@ msgstr ""
 msgid "Run against all projects"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/warning.go:213
+#: lxc/warning.go:214
 msgid "SEVERITY"
 msgstr ""
 
@@ -5370,12 +5370,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1231
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1231
+#: lxc/file.go:1232
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5389,11 +5389,11 @@ msgstr ""
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:173 lxc/warning.go:214
+#: lxc/operation.go:174 lxc/warning.go:215
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:569
+#: lxc/project.go:570
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5401,7 +5401,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:569
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -5409,11 +5409,11 @@ msgstr ""
 msgid "STP"
 msgstr ""
 
-#: lxc/storage_bucket.go:864
+#: lxc/storage_bucket.go:865
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:942
+#: lxc/storage_bucket.go:943
 #, fuzzy, c-format
 msgid "Secret key: %s"
 msgstr "Creado: %s"
@@ -5453,7 +5453,7 @@ msgstr "Aliases:"
 msgid "Set a cluster member's configuration keys"
 msgstr "Perfil %s creado"
 
-#: lxc/file.go:995
+#: lxc/file.go:996
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5596,11 +5596,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:654
+#: lxc/project.go:655
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:655
+#: lxc/project.go:656
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5609,12 +5609,12 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage_bucket.go:534
+#: lxc/storage_bucket.go:535
 #, fuzzy
 msgid "Set storage bucket configuration keys"
 msgstr "Perfil %s creado"
 
-#: lxc/storage_bucket.go:535
+#: lxc/storage_bucket.go:536
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -5653,15 +5653,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:476
+#: lxc/file.go:477
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:477
+#: lxc/file.go:478
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:475
+#: lxc/file.go:476
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5706,11 +5706,11 @@ msgstr "Perfil %s creado"
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 msgid "Set the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:542
+#: lxc/storage_bucket.go:543
 #, fuzzy
 msgid "Set the key as a storage bucket property"
 msgstr "Nombre del contenedor es: %s"
@@ -5727,7 +5727,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:993
+#: lxc/file.go:994
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5739,7 +5739,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1800 lxc/auth.go:1801
+#: lxc/auth.go:1801 lxc/auth.go:1802
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5756,11 +5756,11 @@ msgstr ""
 msgid "Show details of a cluster member"
 msgstr ""
 
-#: lxc/operation.go:192 lxc/operation.go:193
+#: lxc/operation.go:193 lxc/operation.go:194
 msgid "Show details on a background operation"
 msgstr ""
 
-#: lxc/monitor.go:49
+#: lxc/monitor.go:50
 msgid "Show events from all projects"
 msgstr ""
 
@@ -5768,12 +5768,12 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:440 lxc/auth.go:441
+#: lxc/auth.go:441 lxc/auth.go:442
 #, fuzzy
 msgid "Show group configurations"
 msgstr "Perfil %s creado"
 
-#: lxc/auth.go:832
+#: lxc/auth.go:833
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5861,16 +5861,16 @@ msgstr "Perfil %s creado"
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:786 lxc/project.go:787
+#: lxc/project.go:787 lxc/project.go:788
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage_bucket.go:628 lxc/storage_bucket.go:629
+#: lxc/storage_bucket.go:629 lxc/storage_bucket.go:630
 #, fuzzy
 msgid "Show storage bucket configurations"
 msgstr "Perfil %s creado"
 
-#: lxc/storage_bucket.go:1156 lxc/storage_bucket.go:1157
+#: lxc/storage_bucket.go:1157 lxc/storage_bucket.go:1158
 #, fuzzy
 msgid "Show storage bucket key configurations"
 msgstr "Perfil %s creado"
@@ -5887,7 +5887,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:895
+#: lxc/auth.go:896
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5938,7 +5938,7 @@ msgstr ""
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: lxc/warning.go:302 lxc/warning.go:303
+#: lxc/warning.go:303 lxc/warning.go:304
 msgid "Show warning"
 msgstr ""
 
@@ -6023,22 +6023,22 @@ msgstr ""
 msgid "Stopping the instance failed: %s"
 msgstr "Copiando la imagen: %s"
 
-#: lxc/storage_bucket.go:166
+#: lxc/storage_bucket.go:167
 #, fuzzy, c-format
 msgid "Storage bucket %s created"
 msgstr "Perfil %s creado"
 
-#: lxc/storage_bucket.go:233
+#: lxc/storage_bucket.go:234
 #, fuzzy, c-format
 msgid "Storage bucket %s deleted"
 msgstr "Perfil %s eliminado"
 
-#: lxc/storage_bucket.go:940
+#: lxc/storage_bucket.go:941
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr ""
 
-#: lxc/storage_bucket.go:1006
+#: lxc/storage_bucket.go:1007
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr ""
@@ -6107,7 +6107,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:847 lxc/project.go:848
+#: lxc/project.go:848 lxc/project.go:849
 msgid "Switch the current project"
 msgstr ""
 
@@ -6123,10 +6123,10 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1139
+#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1139
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
-#: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:171
-#: lxc/storage_volume.go:1730 lxc/warning.go:215
+#: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
+#: lxc/storage_volume.go:1730 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
@@ -6134,11 +6134,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1032
+#: lxc/file.go:1033
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1026
+#: lxc/file.go:1027
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -6268,12 +6268,12 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/project.go:446
+#: lxc/project.go:447
 #, fuzzy, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/storage_bucket.go:431
+#: lxc/storage_bucket.go:432
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage bucket %q: %v"
 msgstr "Nombre del Miembro del Cluster"
@@ -6462,7 +6462,7 @@ msgstr "Expira: %s"
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:961
+#: lxc/project.go:962
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6474,17 +6474,17 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:985 lxc/storage_volume.go:1735
+#: lxc/project.go:986 lxc/storage_volume.go:1735
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:573
+#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:574
 #: lxc/storage.go:724 lxc/storage_volume.go:1734
 msgid "USED BY"
 msgstr ""
 
-#: lxc/warning.go:216
+#: lxc/warning.go:217
 msgid "UUID"
 msgstr ""
 
@@ -6493,7 +6493,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:197
+#: lxc/file.go:198
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6507,13 +6507,13 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1253
+#: lxc/file.go:1254
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1153 lxc/list.go:631 lxc/storage_volume.go:1772
-#: lxc/warning.go:241
+#: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6523,7 +6523,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:807
+#: lxc/file.go:808
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6616,11 +6616,11 @@ msgstr "Perfil %s creado"
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:742 lxc/project.go:743
+#: lxc/project.go:743 lxc/project.go:744
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:697 lxc/storage_bucket.go:698
+#: lxc/storage_bucket.go:698 lxc/storage_bucket.go:699
 #, fuzzy
 msgid "Unset storage bucket configuration keys"
 msgstr "Perfil %s creado"
@@ -6675,11 +6675,11 @@ msgstr "Perfil %s creado"
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:747
+#: lxc/project.go:748
 msgid "Unset the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:701
+#: lxc/storage_bucket.go:702
 #, fuzzy
 msgid "Unset the key as a storage bucket property"
 msgstr "Perfil %s creado"
@@ -6760,7 +6760,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:71
+#: lxc/file.go:72
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6797,11 +6797,11 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr "Cacheado: %s"
 
-#: lxc/auth.go:831
+#: lxc/auth.go:832
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:894
+#: lxc/auth.go:895
 msgid "View the current identity"
 msgstr ""
 
@@ -6832,15 +6832,15 @@ msgstr ""
 msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
-#: lxc/rebuild.go:27
+#: lxc/rebuild.go:28
 msgid ""
 "Wipe the instance root disk and re-initialize. The original image is used to "
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:156 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
+#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:526
+#: lxc/project.go:531 lxc/project.go:536 lxc/project.go:541 lxc/project.go:546
+#: lxc/project.go:551 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
 msgid "YES"
 msgstr ""
 
@@ -6860,7 +6860,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/rebuild.go:119
+#: lxc/rebuild.go:120
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
@@ -6874,12 +6874,12 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1689
+#: lxc/auth.go:330 lxc/auth.go:763 lxc/auth.go:894 lxc/auth.go:1690
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
-#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
+#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
-#: lxc/operation.go:103 lxc/profile.go:700 lxc/project.go:467
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:68
+#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:468
+#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 #, fuzzy
 msgid "[<remote>:]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -6914,7 +6914,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:] [<filters>...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/auth.go:1254
+#: lxc/auth.go:1255
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6989,11 +6989,11 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<alias> <new-name>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/auth.go:830
+#: lxc/auth.go:831
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1926
+#: lxc/auth.go:1106 lxc/auth.go:1164 lxc/auth.go:1927
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -7002,14 +7002,14 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:954 lxc/auth.go:1470 lxc/cluster_group.go:168
+#: lxc/auth.go:97 lxc/auth.go:150 lxc/auth.go:200 lxc/auth.go:440
+#: lxc/auth.go:955 lxc/auth.go:1471 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 #, fuzzy
 msgid "[<remote>:]<group>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/auth.go:514 lxc/auth.go:572
+#: lxc/auth.go:515 lxc/auth.go:573
 #, fuzzy
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
@@ -7021,22 +7021,22 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<group> <new-name>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/auth.go:389
+#: lxc/auth.go:390
 #, fuzzy
 msgid "[<remote>:]<group> <new_name>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/auth.go:1521 lxc/auth.go:1571 lxc/auth.go:1799
+#: lxc/auth.go:1522 lxc/auth.go:1572 lxc/auth.go:1800
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/auth.go:1873
+#: lxc/auth.go:1874
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/auth.go:1749
+#: lxc/auth.go:1750
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7061,7 +7061,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<image> <remote>:"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/rebuild.go:25
+#: lxc/rebuild.go:26
 #, fuzzy
 msgid "[<remote>:]<image> [<remote>:]<instance>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7163,23 +7163,23 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:170
+#: lxc/file.go:171
 #, fuzzy
 msgid "[<remote>:]<instance>/<path>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/file.go:120
+#: lxc/file.go:121
 #, fuzzy
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/file.go:240
+#: lxc/file.go:241
 #, fuzzy
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/file.go:984
+#: lxc/file.go:985
 #, fuzzy
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7363,13 +7363,13 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<network> [key=value...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/operation.go:53 lxc/operation.go:191
+#: lxc/operation.go:54 lxc/operation.go:192
 #, fuzzy
 msgid "[<remote>:]<operation>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
 #: lxc/storage.go:200 lxc/storage.go:259 lxc/storage.go:473 lxc/storage.go:844
-#: lxc/storage_bucket.go:454
+#: lxc/storage_bucket.go:455
 #, fuzzy
 msgid "[<remote>:]<pool>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7379,25 +7379,25 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_bucket.go:185 lxc/storage_bucket.go:247
-#: lxc/storage_bucket.go:627 lxc/storage_bucket.go:769
+#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:248
+#: lxc/storage_bucket.go:628 lxc/storage_bucket.go:770
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_bucket.go:380 lxc/storage_bucket.go:696
-#: lxc/storage_bucket.go:850 lxc/storage_bucket.go:956
-#: lxc/storage_bucket.go:1020 lxc/storage_bucket.go:1155
+#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:697
+#: lxc/storage_bucket.go:851 lxc/storage_bucket.go:957
+#: lxc/storage_bucket.go:1021 lxc/storage_bucket.go:1156
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_bucket.go:533
+#: lxc/storage_bucket.go:534
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_bucket.go:81
+#: lxc/storage_bucket.go:82
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7540,23 +7540,23 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/project.go:91 lxc/project.go:186 lxc/project.go:258 lxc/project.go:785
-#: lxc/project.go:846 lxc/project.go:913
+#: lxc/project.go:92 lxc/project.go:187 lxc/project.go:259 lxc/project.go:786
+#: lxc/project.go:847 lxc/project.go:914
 #, fuzzy
 msgid "[<remote>:]<project>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/project.go:394 lxc/project.go:741
+#: lxc/project.go:395 lxc/project.go:742
 #, fuzzy
 msgid "[<remote>:]<project> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/project.go:653
+#: lxc/project.go:654
 #, fuzzy
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/project.go:587
+#: lxc/project.go:588
 #, fuzzy
 msgid "[<remote>:]<project> <new-name>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7566,7 +7566,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/warning.go:259 lxc/warning.go:301 lxc/warning.go:354
+#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
 #, fuzzy
 msgid "[<remote>:]<warning-uuid>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7636,7 +7636,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[[<remote>:]<member>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/project.go:555 lxc/remote.go:739
+#: lxc/project.go:556 lxc/remote.go:739
 msgid "current"
 msgstr ""
 
@@ -7683,20 +7683,20 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/auth.go:203
+#: lxc/auth.go:204
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:958
+#: lxc/auth.go:959
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1575
+#: lxc/auth.go:1576
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7774,20 +7774,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:988
+#: lxc/file.go:989
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:244
+#: lxc/file.go:245
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:470
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7869,7 +7869,7 @@ msgid ""
 "  List instances with their running state and user comment."
 msgstr ""
 
-#: lxc/monitor.go:37
+#: lxc/monitor.go:38
 msgid ""
 "lxc monitor --type=logging\n"
 "    Only show log messages.\n"
@@ -7945,7 +7945,7 @@ msgid ""
 "    Create record r1 for zone z1 with configuration from config.yaml"
 msgstr ""
 
-#: lxc/operation.go:195
+#: lxc/operation.go:196
 msgid ""
 "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Show details on that operation UUID"
@@ -7988,7 +7988,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:95
+#: lxc/project.go:96
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7996,7 +7996,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:262
+#: lxc/project.go:263
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -8027,7 +8027,7 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:85
 msgid ""
 "lxc storage bucket create p1 b01\n"
 "\tCreate a new storage bucket name b01 in storage pool p1\n"
@@ -8037,19 +8037,19 @@ msgid ""
 "of config.yaml"
 msgstr ""
 
-#: lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:251
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1023
+#: lxc/storage_bucket.go:1024
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:854
 msgid ""
 "lxc storage bucket key create p1 b01 k1\n"
 "\tCreate a key called k1 for the bucket b01 in the pool p1.\n"
@@ -8059,14 +8059,14 @@ msgid ""
 "of config.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1158
+#: lxc/storage_bucket.go:1159
 msgid ""
 "lxc storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_bucket.go:630
+#: lxc/storage_bucket.go:631
 msgid ""
 "lxc storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
@@ -8136,16 +8136,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1142
+#: lxc/file.go:1143
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1101
+#: lxc/file.go:1102
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1054
+#: lxc/file.go:1055
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/fa.po
+++ b/po/fa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-04 08:52-0600\n"
+"POT-Creation-Date: 2024-09-05 08:44-0400\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Persian <https://hosted.weblate.org/projects/linux-containers/"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: lxc/storage_bucket.go:260 lxc/storage_bucket.go:1033
+#: lxc/storage_bucket.go:261 lxc/storage_bucket.go:1034
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -133,7 +133,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:213
+#: lxc/auth.go:214
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -160,7 +160,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:968
+#: lxc/auth.go:969
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -181,7 +181,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1585
+#: lxc/auth.go:1586
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -391,7 +391,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:280
+#: lxc/project.go:281
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -433,12 +433,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:935
+#: lxc/file.go:936
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:825
+#: lxc/file.go:826
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -474,7 +474,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:142 lxc/rebuild.go:64
+#: lxc/init.go:142 lxc/rebuild.go:65
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -527,7 +527,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:465
+#: lxc/file.go:466
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -560,7 +560,7 @@ msgstr ""
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:813
+#: lxc/auth.go:814
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -568,11 +568,11 @@ msgstr ""
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/storage_bucket.go:863
+#: lxc/storage_bucket.go:864
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:941
+#: lxc/storage_bucket.go:942
 #, c-format
 msgid "Access key: %s"
 msgstr ""
@@ -581,7 +581,7 @@ msgstr ""
 msgid "Access the expanded configuration"
 msgstr ""
 
-#: lxc/warning.go:261 lxc/warning.go:262
+#: lxc/warning.go:262 lxc/warning.go:263
 msgid "Acknowledge warning"
 msgstr ""
 
@@ -598,11 +598,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1106 lxc/auth.go:1107
+#: lxc/auth.go:1107 lxc/auth.go:1108
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1874 lxc/auth.go:1875
+#: lxc/auth.go:1875 lxc/auth.go:1876
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -671,7 +671,7 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:515 lxc/auth.go:516
+#: lxc/auth.go:516 lxc/auth.go:517
 msgid "Add permissions to groups"
 msgstr ""
 
@@ -700,7 +700,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:169
+#: lxc/storage_bucket.go:170
 #, c-format
 msgid "Admin access key: %s"
 msgstr ""
@@ -710,7 +710,7 @@ msgstr ""
 msgid "Admin password (or token) for %s:"
 msgstr ""
 
-#: lxc/storage_bucket.go:170
+#: lxc/storage_bucket.go:171
 #, c-format
 msgid "Admin secret key: %s"
 msgstr ""
@@ -769,7 +769,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:342 lxc/rebuild.go:130
+#: lxc/init.go:342 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -869,12 +869,12 @@ msgstr ""
 
 #: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:318
 #: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
-#: lxc/network_zone.go:366 lxc/network_zone.go:1053 lxc/storage_bucket.go:141
+#: lxc/network_zone.go:366 lxc/network_zone.go:1053 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:159
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:160
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -914,7 +914,7 @@ msgstr ""
 msgid "Bytes sent"
 msgstr ""
 
-#: lxc/operation.go:174
+#: lxc/operation.go:175
 msgid "CANCELABLE"
 msgstr ""
 
@@ -926,7 +926,7 @@ msgstr ""
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: lxc/warning.go:209
+#: lxc/warning.go:210
 msgid "COUNT"
 msgstr ""
 
@@ -952,7 +952,7 @@ msgstr ""
 msgid "CPUs (%s):"
 msgstr ""
 
-#: lxc/operation.go:175
+#: lxc/operation.go:176
 msgid "CREATED"
 msgstr ""
 
@@ -982,7 +982,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:340
+#: lxc/file.go:341
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1007,11 +1007,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:224
+#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:546
+#: lxc/file.go:547
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1020,7 +1020,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:160
+#: lxc/rebuild.go:161
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1143,13 +1143,13 @@ msgstr ""
 #: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
 #: lxc/network_load_balancer.go:1051 lxc/network_load_balancer.go:1125
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
-#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:90
-#: lxc/storage_bucket.go:190 lxc/storage_bucket.go:253
-#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:541
-#: lxc/storage_bucket.go:634 lxc/storage_bucket.go:700
-#: lxc/storage_bucket.go:775 lxc/storage_bucket.go:861
-#: lxc/storage_bucket.go:961 lxc/storage_bucket.go:1026
-#: lxc/storage_bucket.go:1162 lxc/storage_volume.go:394
+#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
+#: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
+#: lxc/storage_bucket.go:385 lxc/storage_bucket.go:542
+#: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
+#: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
+#: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
 #: lxc/storage_volume.go:612 lxc/storage_volume.go:717
 #: lxc/storage_volume.go:1005 lxc/storage_volume.go:1231
 #: lxc/storage_volume.go:1360 lxc/storage_volume.go:1848
@@ -1173,7 +1173,7 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1113 lxc/list.go:132 lxc/storage_volume.go:1589
-#: lxc/warning.go:92
+#: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
@@ -1201,7 +1201,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:100
+#: lxc/project.go:101
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1215,8 +1215,8 @@ msgstr ""
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
-#: lxc/project.go:362 lxc/storage.go:359 lxc/storage_bucket.go:348
-#: lxc/storage_bucket.go:1125 lxc/storage_volume.go:1150
+#: lxc/project.go:363 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1150
 #: lxc/storage_volume.go:1182
 #, c-format
 msgid "Config parsing error: %s"
@@ -1343,12 +1343,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:300 lxc/auth.go:1660
+#: lxc/auth.go:301 lxc/auth.go:1661
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1054
+#: lxc/auth.go:1055
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1397,15 +1397,15 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:248 lxc/file.go:474
+#: lxc/file.go:249 lxc/file.go:475
 msgid "Create any directories necessary"
 msgstr ""
 
-#: lxc/auth.go:97 lxc/auth.go:98
+#: lxc/auth.go:98 lxc/auth.go:99
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1471 lxc/auth.go:1472
+#: lxc/auth.go:1472 lxc/auth.go:1473
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1425,11 +1425,11 @@ msgstr ""
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_bucket.go:851 lxc/storage_bucket.go:852
+#: lxc/storage_bucket.go:852 lxc/storage_bucket.go:853
 msgid "Create key for a storage bucket"
 msgstr ""
 
-#: lxc/storage_bucket.go:82 lxc/storage_bucket.go:83
+#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
 msgid "Create new custom storage buckets"
 msgstr ""
 
@@ -1473,7 +1473,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:92 lxc/project.go:93
+#: lxc/project.go:93 lxc/project.go:94
 msgid "Create projects"
 msgstr ""
 
@@ -1508,13 +1508,13 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:376 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1135 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
-#: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:172
-#: lxc/profile.go:756 lxc/project.go:572 lxc/storage.go:723
-#: lxc/storage_bucket.go:512 lxc/storage_bucket.go:832
+#: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
+#: lxc/profile.go:756 lxc/project.go:573 lxc/storage.go:723
+#: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1732
 msgid "DESCRIPTION"
 msgstr ""
@@ -1539,7 +1539,7 @@ msgstr ""
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
-#: lxc/operation.go:55 lxc/operation.go:56
+#: lxc/operation.go:56 lxc/operation.go:57
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
@@ -1547,19 +1547,19 @@ msgstr ""
 msgid "Delete a cluster group"
 msgstr ""
 
-#: lxc/warning.go:360
+#: lxc/warning.go:361
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:122 lxc/file.go:123
+#: lxc/file.go:123 lxc/file.go:124
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/auth.go:151 lxc/auth.go:152
+#: lxc/auth.go:152 lxc/auth.go:153
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1523 lxc/auth.go:1524
+#: lxc/auth.go:1524 lxc/auth.go:1525
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1579,7 +1579,7 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/storage_bucket.go:957 lxc/storage_bucket.go:958
+#: lxc/storage_bucket.go:958 lxc/storage_bucket.go:959
 msgid "Delete key from a storage bucket"
 msgstr ""
 
@@ -1615,11 +1615,11 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:188 lxc/project.go:189
+#: lxc/project.go:189 lxc/project.go:190
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:187 lxc/storage_bucket.go:188
+#: lxc/storage_bucket.go:188 lxc/storage_bucket.go:189
 msgid "Delete storage buckets"
 msgstr ""
 
@@ -1631,20 +1631,20 @@ msgstr ""
 msgid "Delete storage volumes"
 msgstr ""
 
-#: lxc/warning.go:356 lxc/warning.go:357
+#: lxc/warning.go:357 lxc/warning.go:358
 msgid "Delete warning"
 msgstr ""
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:30 lxc/auth.go:59 lxc/auth.go:98
-#: lxc/auth.go:152 lxc/auth.go:201 lxc/auth.go:332 lxc/auth.go:392
-#: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
-#: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
-#: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
-#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1434 lxc/auth.go:1472
-#: lxc/auth.go:1524 lxc/auth.go:1573 lxc/auth.go:1692 lxc/auth.go:1752
-#: lxc/auth.go:1801 lxc/auth.go:1852 lxc/auth.go:1875 lxc/auth.go:1928
+#: lxc/alias.go:214 lxc/auth.go:31 lxc/auth.go:60 lxc/auth.go:99
+#: lxc/auth.go:153 lxc/auth.go:202 lxc/auth.go:333 lxc/auth.go:393
+#: lxc/auth.go:442 lxc/auth.go:494 lxc/auth.go:517 lxc/auth.go:576
+#: lxc/auth.go:732 lxc/auth.go:766 lxc/auth.go:833 lxc/auth.go:896
+#: lxc/auth.go:957 lxc/auth.go:1085 lxc/auth.go:1108 lxc/auth.go:1166
+#: lxc/auth.go:1235 lxc/auth.go:1257 lxc/auth.go:1435 lxc/auth.go:1473
+#: lxc/auth.go:1525 lxc/auth.go:1574 lxc/auth.go:1693 lxc/auth.go:1753
+#: lxc/auth.go:1802 lxc/auth.go:1853 lxc/auth.go:1876 lxc/auth.go:1929
 #: lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215 lxc/cluster.go:272
 #: lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:484 lxc/cluster.go:528
 #: lxc/cluster.go:586 lxc/cluster.go:677 lxc/cluster.go:770 lxc/cluster.go:893
@@ -1668,15 +1668,15 @@ msgstr ""
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:83 lxc/file.go:123 lxc/file.go:172
-#: lxc/file.go:242 lxc/file.go:467 lxc/file.go:986 lxc/image.go:38
+#: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
+#: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
 #: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
 #: lxc/image.go:697 lxc/image.go:946 lxc/image.go:1088 lxc/image.go:1415
 #: lxc/image.go:1506 lxc/image.go:1572 lxc/image.go:1636 lxc/image.go:1699
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:38 lxc/network.go:33
+#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33
 #: lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405
 #: lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793
 #: lxc/network.go:874 lxc/network.go:1005 lxc/network.go:1106
@@ -1710,27 +1710,27 @@ msgstr ""
 #: lxc/network_zone.go:909 lxc/network_zone.go:985 lxc/network_zone.go:1083
 #: lxc/network_zone.go:1172 lxc/network_zone.go:1219 lxc/network_zone.go:1349
 #: lxc/network_zone.go:1410 lxc/network_zone.go:1425 lxc/network_zone.go:1483
-#: lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:106
-#: lxc/operation.go:193 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
+#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
+#: lxc/operation.go:194 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
 #: lxc/profile.go:271 lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493
 #: lxc/profile.go:629 lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860
-#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:29
-#: lxc/project.go:93 lxc/project.go:189 lxc/project.go:260 lxc/project.go:396
-#: lxc/project.go:470 lxc/project.go:590 lxc/project.go:655 lxc/project.go:743
-#: lxc/project.go:787 lxc/project.go:848 lxc/project.go:915 lxc/publish.go:34
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:35 lxc/remote.go:91
+#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:30
+#: lxc/project.go:94 lxc/project.go:190 lxc/project.go:261 lxc/project.go:397
+#: lxc/project.go:471 lxc/project.go:591 lxc/project.go:656 lxc/project.go:744
+#: lxc/project.go:788 lxc/project.go:849 lxc/project.go:916 lxc/publish.go:34
+#: lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91
 #: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853
 #: lxc/remote.go:917 lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24
 #: lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203
 #: lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655
 #: lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940
-#: lxc/storage_bucket.go:29 lxc/storage_bucket.go:83 lxc/storage_bucket.go:188
-#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:382
-#: lxc/storage_bucket.go:458 lxc/storage_bucket.go:535
-#: lxc/storage_bucket.go:629 lxc/storage_bucket.go:698
-#: lxc/storage_bucket.go:732 lxc/storage_bucket.go:773
-#: lxc/storage_bucket.go:852 lxc/storage_bucket.go:958
-#: lxc/storage_bucket.go:1022 lxc/storage_bucket.go:1157
+#: lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189
+#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:383
+#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:536
+#: lxc/storage_bucket.go:630 lxc/storage_bucket.go:699
+#: lxc/storage_bucket.go:733 lxc/storage_bucket.go:774
+#: lxc/storage_bucket.go:853 lxc/storage_bucket.go:959
+#: lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158
 #: lxc/storage_volume.go:58 lxc/storage_volume.go:169 lxc/storage_volume.go:283
 #: lxc/storage_volume.go:390 lxc/storage_volume.go:605
 #: lxc/storage_volume.go:714 lxc/storage_volume.go:801
@@ -1741,8 +1741,8 @@ msgstr ""
 #: lxc/storage_volume.go:2064 lxc/storage_volume.go:2222
 #: lxc/storage_volume.go:2343 lxc/storage_volume.go:2405
 #: lxc/storage_volume.go:2541 lxc/storage_volume.go:2624
-#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:29
-#: lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
+#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:30
+#: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
@@ -1829,7 +1829,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:994
+#: lxc/file.go:995
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1895,7 +1895,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:74
+#: lxc/file.go:75
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1905,7 +1905,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:955 lxc/auth.go:956
+#: lxc/auth.go:956 lxc/auth.go:957
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1913,15 +1913,15 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:171 lxc/file.go:172
+#: lxc/file.go:172 lxc/file.go:173
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/auth.go:200 lxc/auth.go:201
+#: lxc/auth.go:201 lxc/auth.go:202
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1572 lxc/auth.go:1573
+#: lxc/auth.go:1573 lxc/auth.go:1574
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -1977,15 +1977,15 @@ msgstr ""
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:259 lxc/project.go:260
+#: lxc/project.go:260 lxc/project.go:261
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:248 lxc/storage_bucket.go:249
+#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:250
 msgid "Edit storage bucket configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:1021 lxc/storage_bucket.go:1022
+#: lxc/storage_bucket.go:1022 lxc/storage_bucket.go:1023
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
@@ -2002,7 +2002,7 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1147 lxc/list.go:622 lxc/storage_volume.go:1766
-#: lxc/warning.go:235
+#: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2057,7 +2057,7 @@ msgstr ""
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
-#: lxc/project.go:718 lxc/storage.go:812 lxc/storage_bucket.go:602
+#: lxc/project.go:719 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2155 lxc/storage_volume.go:2193
 #, c-format
 msgid "Error setting properties: %v"
@@ -2071,8 +2071,8 @@ msgstr ""
 #: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
-#: lxc/profile.go:981 lxc/project.go:712 lxc/storage.go:806
-#: lxc/storage_bucket.go:596 lxc/storage_volume.go:2149
+#: lxc/profile.go:981 lxc/project.go:713 lxc/storage.go:806
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2149
 #: lxc/storage_volume.go:2187
 #, c-format
 msgid "Error unsetting property: %v"
@@ -2092,7 +2092,7 @@ msgstr ""
 msgid "Evacuating cluster member: %s"
 msgstr ""
 
-#: lxc/monitor.go:50
+#: lxc/monitor.go:51
 msgid "Event type to listen for"
 msgstr ""
 
@@ -2179,16 +2179,16 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/warning.go:210
+#: lxc/warning.go:211
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1237
+#: lxc/file.go:1238
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1260
+#: lxc/file.go:1261
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2203,12 +2203,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1287
+#: lxc/file.go:1288
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1072
+#: lxc/file.go:1073
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2238,7 +2238,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1193
+#: lxc/file.go:1194
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2253,7 +2253,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1198
+#: lxc/file.go:1199
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2263,12 +2263,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1098
+#: lxc/file.go:1099
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1225
+#: lxc/file.go:1226
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2307,7 +2307,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1210
+#: lxc/file.go:1211
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2322,7 +2322,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:820
+#: lxc/file.go:821
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2337,7 +2337,7 @@ msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
 #: lxc/network.go:1044 lxc/network_acl.go:133 lxc/network_zone.go:124
-#: lxc/operation.go:136
+#: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
 
@@ -2402,21 +2402,21 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
+#: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:770 lxc/auth.go:1697
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1114 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:57
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
-#: lxc/operation.go:108 lxc/profile.go:707 lxc/project.go:472
-#: lxc/project.go:917 lxc/remote.go:690 lxc/storage.go:657
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:774
-#: lxc/storage_volume.go:1608 lxc/warning.go:93
+#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:473
+#: lxc/project.go:918 lxc/remote.go:690 lxc/storage.go:657
+#: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
+#: lxc/storage_volume.go:1608 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
-#: lxc/monitor.go:52
+#: lxc/monitor.go:53
 msgid "Format (json|pretty|yaml)"
 msgstr ""
 
@@ -2460,7 +2460,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:817 lxc/auth.go:1736
+#: lxc/auth.go:818 lxc/auth.go:1737
 msgid "GROUPS"
 msgstr ""
 
@@ -2476,7 +2476,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:914 lxc/project.go:915
+#: lxc/project.go:915 lxc/project.go:916
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2524,11 +2524,11 @@ msgstr ""
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:400
+#: lxc/project.go:401
 msgid "Get the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:385
+#: lxc/storage_bucket.go:386
 msgid "Get the key as a storage bucket property"
 msgstr ""
 
@@ -2588,11 +2588,11 @@ msgstr ""
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:395 lxc/project.go:396
+#: lxc/project.go:396 lxc/project.go:397
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:382
+#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:383
 msgid "Get values for storage bucket configuration keys"
 msgstr ""
 
@@ -2609,17 +2609,17 @@ msgstr ""
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: lxc/auth.go:136
+#: lxc/auth.go:137
 #, c-format
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:186
+#: lxc/auth.go:187
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:426 lxc/auth.go:1786
+#: lxc/auth.go:427 lxc/auth.go:1787
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2644,27 +2644,27 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1310
+#: lxc/file.go:1311
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1299
+#: lxc/file.go:1300
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1122
+#: lxc/file.go:1123
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1132
+#: lxc/file.go:1133
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:966 lxc/operation.go:170
+#: lxc/network.go:966 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2678,11 +2678,11 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:816
+#: lxc/auth.go:817
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:566
+#: lxc/project.go:567
 msgid "IMAGES"
 msgstr ""
 
@@ -2710,17 +2710,17 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1508
+#: lxc/auth.go:1509
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1558
+#: lxc/auth.go:1559
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
 
-#: lxc/rebuild.go:32
+#: lxc/rebuild.go:33
 msgid "If an instance is running, stop it and then rebuild it"
 msgstr ""
 
@@ -2841,7 +2841,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1233 lxc/auth.go:1234
+#: lxc/auth.go:1234 lxc/auth.go:1235
 msgid "Inspect permissions"
 msgstr ""
 
@@ -2849,11 +2849,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1124
+#: lxc/file.go:1125
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1301
+#: lxc/file.go:1302
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2871,7 +2871,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1044
+#: lxc/file.go:1045
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2880,7 +2880,7 @@ msgstr ""
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/rebuild.go:74
+#: lxc/rebuild.go:75
 #, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
@@ -2913,7 +2913,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/monitor.go:70
+#: lxc/monitor.go:71
 #, c-format
 msgid "Invalid format: %s"
 msgstr ""
@@ -2923,7 +2923,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1039
+#: lxc/file.go:1040
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2965,7 +2965,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:147
+#: lxc/file.go:148
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2981,12 +2981,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:313
+#: lxc/file.go:314
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:495
+#: lxc/file.go:496
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3000,7 +3000,7 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/warning.go:212
 msgid "LAST SEEN"
 msgstr ""
 
@@ -3008,7 +3008,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:984
+#: lxc/project.go:985
 msgid "LIMIT"
 msgstr ""
 
@@ -3017,8 +3017,8 @@ msgid "LISTEN ADDRESS"
 msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
-#: lxc/network_load_balancer.go:165 lxc/operation.go:177
-#: lxc/storage_bucket.go:516 lxc/storage_volume.go:1739 lxc/warning.go:220
+#: lxc/network_load_balancer.go:165 lxc/operation.go:178
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1739 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3092,7 +3092,7 @@ msgstr ""
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/warning.go:94
+#: lxc/warning.go:95
 msgid "List all warnings"
 msgstr ""
 
@@ -3136,19 +3136,19 @@ msgstr ""
 msgid "List available storage pools"
 msgstr ""
 
-#: lxc/operation.go:105 lxc/operation.go:106
+#: lxc/operation.go:106 lxc/operation.go:107
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:331 lxc/auth.go:332
+#: lxc/auth.go:332 lxc/auth.go:333
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:764 lxc/auth.go:765
+#: lxc/auth.go:765 lxc/auth.go:766
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1691 lxc/auth.go:1692
+#: lxc/auth.go:1692 lxc/auth.go:1693
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3297,11 +3297,11 @@ msgstr ""
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/operation.go:109
+#: lxc/operation.go:110
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1255 lxc/auth.go:1256
+#: lxc/auth.go:1256 lxc/auth.go:1257
 msgid "List permissions"
 msgstr ""
 
@@ -3309,15 +3309,15 @@ msgstr ""
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:469 lxc/project.go:470
+#: lxc/project.go:470 lxc/project.go:471
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:771 lxc/storage_bucket.go:773
+#: lxc/storage_bucket.go:772 lxc/storage_bucket.go:774
 msgid "List storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:456 lxc/storage_bucket.go:458
+#: lxc/storage_bucket.go:457 lxc/storage_bucket.go:459
 msgid "List storage buckets"
 msgstr ""
 
@@ -3353,11 +3353,11 @@ msgstr ""
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/warning.go:70
+#: lxc/warning.go:71
 msgid "List warnings"
 msgstr ""
 
-#: lxc/warning.go:71
+#: lxc/warning.go:72
 msgid ""
 "List warnings\n"
 "\n"
@@ -3380,7 +3380,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/operation.go:23 lxc/operation.go:24
+#: lxc/operation.go:24 lxc/operation.go:25
 msgid "List, show and delete background operations"
 msgstr ""
 
@@ -3389,7 +3389,7 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/monitor.go:79
+#: lxc/monitor.go:80
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
@@ -3493,23 +3493,23 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:82 lxc/file.go:83
+#: lxc/file.go:83 lxc/file.go:84
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1433 lxc/auth.go:1434
+#: lxc/auth.go:59 lxc/auth.go:60 lxc/auth.go:1434 lxc/auth.go:1435
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1083 lxc/auth.go:1084
+#: lxc/auth.go:1084 lxc/auth.go:1085
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:730 lxc/auth.go:731
+#: lxc/auth.go:731 lxc/auth.go:732
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1851 lxc/auth.go:1852
+#: lxc/auth.go:1852 lxc/auth.go:1853
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3600,7 +3600,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:492 lxc/auth.go:493
+#: lxc/auth.go:493 lxc/auth.go:494
 msgid "Manage permissions"
 msgstr ""
 
@@ -3608,23 +3608,23 @@ msgstr ""
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:28 lxc/project.go:29
+#: lxc/project.go:29 lxc/project.go:30
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:731
+#: lxc/storage_bucket.go:732
 msgid "Manage storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:732
+#: lxc/storage_bucket.go:733
 msgid "Manage storage bucket keys."
 msgstr ""
 
-#: lxc/storage_bucket.go:28
+#: lxc/storage_bucket.go:29
 msgid "Manage storage buckets"
 msgstr ""
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:30
 msgid "Manage storage buckets."
 msgstr ""
 
@@ -3652,11 +3652,11 @@ msgstr ""
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/auth.go:29 lxc/auth.go:30
+#: lxc/auth.go:30 lxc/auth.go:31
 msgid "Manage user authorization"
 msgstr ""
 
-#: lxc/warning.go:28 lxc/warning.go:29
+#: lxc/warning.go:29 lxc/warning.go:30
 msgid "Manage warnings"
 msgstr ""
 
@@ -3720,17 +3720,17 @@ msgstr ""
 msgid "Migration operation failure: %w"
 msgstr ""
 
-#: lxc/monitor.go:51
+#: lxc/monitor.go:52
 msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: lxc/storage_bucket.go:116 lxc/storage_bucket.go:216
-#: lxc/storage_bucket.go:292 lxc/storage_bucket.go:411
-#: lxc/storage_bucket.go:568 lxc/storage_bucket.go:660
-#: lxc/storage_bucket.go:802 lxc/storage_bucket.go:889
-#: lxc/storage_bucket.go:986 lxc/storage_bucket.go:1065
-#: lxc/storage_bucket.go:1188
+#: lxc/storage_bucket.go:117 lxc/storage_bucket.go:217
+#: lxc/storage_bucket.go:293 lxc/storage_bucket.go:412
+#: lxc/storage_bucket.go:569 lxc/storage_bucket.go:661
+#: lxc/storage_bucket.go:803 lxc/storage_bucket.go:890
+#: lxc/storage_bucket.go:987 lxc/storage_bucket.go:1066
+#: lxc/storage_bucket.go:1189
 msgid "Missing bucket name"
 msgstr ""
 
@@ -3749,20 +3749,20 @@ msgstr ""
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1825
+#: lxc/auth.go:123 lxc/auth.go:177 lxc/auth.go:255 lxc/auth.go:417
+#: lxc/auth.go:466 lxc/auth.go:541 lxc/auth.go:600 lxc/auth.go:1826
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:862 lxc/auth.go:1003 lxc/auth.go:1131 lxc/auth.go:1189
+#: lxc/auth.go:863 lxc/auth.go:1004 lxc/auth.go:1132 lxc/auth.go:1190
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1495 lxc/auth.go:1548 lxc/auth.go:1614 lxc/auth.go:1776
+#: lxc/auth.go:1496 lxc/auth.go:1549 lxc/auth.go:1615 lxc/auth.go:1777
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1899 lxc/auth.go:1952
+#: lxc/auth.go:1900 lxc/auth.go:1953
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -3770,12 +3770,12 @@ msgstr ""
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
 #: lxc/config_template.go:377 lxc/profile.go:141 lxc/profile.go:222
-#: lxc/profile.go:808 lxc/rebuild.go:60
+#: lxc/profile.go:808 lxc/rebuild.go:61
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/storage_bucket.go:893 lxc/storage_bucket.go:990
-#: lxc/storage_bucket.go:1069 lxc/storage_bucket.go:1192
+#: lxc/storage_bucket.go:894 lxc/storage_bucket.go:991
+#: lxc/storage_bucket.go:1070 lxc/storage_bucket.go:1193
 msgid "Missing key name"
 msgstr ""
 
@@ -3840,13 +3840,13 @@ msgid "Missing peer name"
 msgstr ""
 
 #: lxc/storage.go:235 lxc/storage.go:313 lxc/storage.go:431 lxc/storage.go:509
-#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:112
-#: lxc/storage_bucket.go:212 lxc/storage_bucket.go:288
-#: lxc/storage_bucket.go:407 lxc/storage_bucket.go:482
-#: lxc/storage_bucket.go:564 lxc/storage_bucket.go:656
-#: lxc/storage_bucket.go:798 lxc/storage_bucket.go:885
-#: lxc/storage_bucket.go:982 lxc/storage_bucket.go:1061
-#: lxc/storage_bucket.go:1184 lxc/storage_volume.go:209
+#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:113
+#: lxc/storage_bucket.go:213 lxc/storage_bucket.go:289
+#: lxc/storage_bucket.go:408 lxc/storage_bucket.go:483
+#: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
+#: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
+#: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
 #: lxc/storage_volume.go:323 lxc/storage_volume.go:643
 #: lxc/storage_volume.go:750 lxc/storage_volume.go:841
 #: lxc/storage_volume.go:939 lxc/storage_volume.go:1053
@@ -3861,9 +3861,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:404 lxc/project.go:146 lxc/project.go:226 lxc/project.go:316
-#: lxc/project.go:433 lxc/project.go:622 lxc/project.go:691 lxc/project.go:819
-#: lxc/project.go:948
+#: lxc/profile.go:404 lxc/project.go:147 lxc/project.go:227 lxc/project.go:317
+#: lxc/project.go:434 lxc/project.go:623 lxc/project.go:692 lxc/project.go:820
+#: lxc/project.go:949
 msgid "Missing project name"
 msgstr ""
 
@@ -3879,7 +3879,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:598
+#: lxc/file.go:599
 msgid "Missing target directory"
 msgstr ""
 
@@ -3901,11 +3901,11 @@ msgstr ""
 msgid "Model: %v"
 msgstr ""
 
-#: lxc/monitor.go:32
+#: lxc/monitor.go:33
 msgid "Monitor a local or remote LXD server"
 msgstr ""
 
-#: lxc/monitor.go:33
+#: lxc/monitor.go:34
 msgid ""
 "Monitor a local or remote LXD server\n"
 "\n"
@@ -3917,11 +3917,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:285
+#: lxc/file.go:286
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:985 lxc/file.go:986
+#: lxc/file.go:986 lxc/file.go:987
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3983,13 +3983,13 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:192
+#: lxc/auth.go:376 lxc/auth.go:816 lxc/auth.go:1736 lxc/cluster.go:192
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
-#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:565
-#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:511
-#: lxc/storage_bucket.go:831 lxc/storage_volume.go:1731
+#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:566
+#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1731
 msgid "NAME"
 msgstr ""
 
@@ -3997,11 +3997,11 @@ msgstr ""
 msgid "NAT"
 msgstr ""
 
-#: lxc/project.go:571
+#: lxc/project.go:572
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:570
+#: lxc/project.go:571
 msgid "NETWORKS"
 msgstr ""
 
@@ -4013,9 +4013,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/operation.go:154 lxc/project.go:523
-#: lxc/project.go:528 lxc/project.go:533 lxc/project.go:538 lxc/project.go:543
-#: lxc/project.go:548 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
+#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:524
+#: lxc/project.go:529 lxc/project.go:534 lxc/project.go:539 lxc/project.go:544
+#: lxc/project.go:549 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
 msgid "NO"
 msgstr ""
 
@@ -4260,7 +4260,7 @@ msgstr ""
 msgid "Only managed networks can be modified"
 msgstr ""
 
-#: lxc/operation.go:86
+#: lxc/operation.go:87
 #, c-format
 msgid "Operation %s deleted"
 msgstr ""
@@ -4307,11 +4307,11 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:567
+#: lxc/list.go:576 lxc/project.go:568
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:212
+#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4373,24 +4373,24 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1102
+#: lxc/file.go:1103
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:860
+#: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
-#: lxc/project.go:363 lxc/storage.go:360 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1151
+#: lxc/project.go:364 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1151
 #: lxc/storage_volume.go:1183
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
-#: lxc/monitor.go:48
+#: lxc/monitor.go:49
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
@@ -4476,17 +4476,17 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:172
+#: lxc/project.go:173
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:236
+#: lxc/project.go:237
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:637
+#: lxc/project.go:638
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -4607,20 +4607,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:241 lxc/file.go:242
+#: lxc/file.go:242 lxc/file.go:243
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:416 lxc/file.go:767
+#: lxc/file.go:417 lxc/file.go:768
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:466 lxc/file.go:467
+#: lxc/file.go:467 lxc/file.go:468
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:701 lxc/file.go:867
+#: lxc/file.go:702 lxc/file.go:868
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4633,11 +4633,11 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:983
+#: lxc/project.go:984
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/storage_bucket.go:833
+#: lxc/storage_bucket.go:834
 msgid "ROLE"
 msgstr ""
 
@@ -4650,15 +4650,15 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/rebuild.go:31
+#: lxc/rebuild.go:32
 msgid "Rebuild as an empty instance"
 msgstr ""
 
-#: lxc/rebuild.go:26
+#: lxc/rebuild.go:27
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:249 lxc/file.go:473
+#: lxc/file.go:250 lxc/file.go:474
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4685,7 +4685,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:882 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
+#: lxc/project.go:883 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
 #: lxc/remote.go:994
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4736,7 +4736,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1164 lxc/auth.go:1165
+#: lxc/auth.go:1165 lxc/auth.go:1166
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4772,7 +4772,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1927 lxc/auth.go:1928
+#: lxc/auth.go:1928 lxc/auth.go:1929
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4784,7 +4784,7 @@ msgstr ""
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:574 lxc/auth.go:575
+#: lxc/auth.go:575 lxc/auth.go:576
 msgid "Remove permissions from groups"
 msgstr ""
 
@@ -4829,11 +4829,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:391 lxc/auth.go:392
+#: lxc/auth.go:392 lxc/auth.go:393
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1751 lxc/auth.go:1752
+#: lxc/auth.go:1752 lxc/auth.go:1753
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -4853,7 +4853,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:589 lxc/project.go:590
+#: lxc/project.go:590 lxc/project.go:591
 msgid "Rename projects"
 msgstr ""
 
@@ -4951,7 +4951,7 @@ msgstr ""
 msgid "Revoke cluster member join token"
 msgstr ""
 
-#: lxc/storage_bucket.go:862
+#: lxc/storage_bucket.go:863
 msgid "Role (admin or read-only)"
 msgstr ""
 
@@ -4967,7 +4967,7 @@ msgstr ""
 msgid "Run against all projects"
 msgstr ""
 
-#: lxc/warning.go:213
+#: lxc/warning.go:214
 msgid "SEVERITY"
 msgstr ""
 
@@ -4987,12 +4987,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1231
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1231
+#: lxc/file.go:1232
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5006,11 +5006,11 @@ msgstr ""
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:173 lxc/warning.go:214
+#: lxc/operation.go:174 lxc/warning.go:215
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:569
+#: lxc/project.go:570
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5018,7 +5018,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:569
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -5026,11 +5026,11 @@ msgstr ""
 msgid "STP"
 msgstr ""
 
-#: lxc/storage_bucket.go:864
+#: lxc/storage_bucket.go:865
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:942
+#: lxc/storage_bucket.go:943
 #, c-format
 msgid "Secret key: %s"
 msgstr ""
@@ -5068,7 +5068,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:995
+#: lxc/file.go:996
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5206,11 +5206,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:654
+#: lxc/project.go:655
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:655
+#: lxc/project.go:656
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5219,11 +5219,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage_bucket.go:534
+#: lxc/storage_bucket.go:535
 msgid "Set storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:535
+#: lxc/storage_bucket.go:536
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -5262,15 +5262,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:476
+#: lxc/file.go:477
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:477
+#: lxc/file.go:478
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:475
+#: lxc/file.go:476
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5310,11 +5310,11 @@ msgstr ""
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 msgid "Set the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:542
+#: lxc/storage_bucket.go:543
 msgid "Set the key as a storage bucket property"
 msgstr ""
 
@@ -5330,7 +5330,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:993
+#: lxc/file.go:994
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5342,7 +5342,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1800 lxc/auth.go:1801
+#: lxc/auth.go:1801 lxc/auth.go:1802
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5358,11 +5358,11 @@ msgstr ""
 msgid "Show details of a cluster member"
 msgstr ""
 
-#: lxc/operation.go:192 lxc/operation.go:193
+#: lxc/operation.go:193 lxc/operation.go:194
 msgid "Show details on a background operation"
 msgstr ""
 
-#: lxc/monitor.go:49
+#: lxc/monitor.go:50
 msgid "Show events from all projects"
 msgstr ""
 
@@ -5370,11 +5370,11 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:440 lxc/auth.go:441
+#: lxc/auth.go:441 lxc/auth.go:442
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:832
+#: lxc/auth.go:833
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5455,15 +5455,15 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:786 lxc/project.go:787
+#: lxc/project.go:787 lxc/project.go:788
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage_bucket.go:628 lxc/storage_bucket.go:629
+#: lxc/storage_bucket.go:629 lxc/storage_bucket.go:630
 msgid "Show storage bucket configurations"
 msgstr ""
 
-#: lxc/storage_bucket.go:1156 lxc/storage_bucket.go:1157
+#: lxc/storage_bucket.go:1157 lxc/storage_bucket.go:1158
 msgid "Show storage bucket key configurations"
 msgstr ""
 
@@ -5479,7 +5479,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:895
+#: lxc/auth.go:896
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5529,7 +5529,7 @@ msgstr ""
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: lxc/warning.go:302 lxc/warning.go:303
+#: lxc/warning.go:303 lxc/warning.go:304
 msgid "Show warning"
 msgstr ""
 
@@ -5613,22 +5613,22 @@ msgstr ""
 msgid "Stopping the instance failed: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:166
+#: lxc/storage_bucket.go:167
 #, c-format
 msgid "Storage bucket %s created"
 msgstr ""
 
-#: lxc/storage_bucket.go:233
+#: lxc/storage_bucket.go:234
 #, c-format
 msgid "Storage bucket %s deleted"
 msgstr ""
 
-#: lxc/storage_bucket.go:940
+#: lxc/storage_bucket.go:941
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr ""
 
-#: lxc/storage_bucket.go:1006
+#: lxc/storage_bucket.go:1007
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr ""
@@ -5697,7 +5697,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:847 lxc/project.go:848
+#: lxc/project.go:848 lxc/project.go:849
 msgid "Switch the current project"
 msgstr ""
 
@@ -5713,10 +5713,10 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1139
+#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1139
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
-#: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:171
-#: lxc/storage_volume.go:1730 lxc/warning.go:215
+#: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
+#: lxc/storage_volume.go:1730 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
@@ -5724,11 +5724,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1032
+#: lxc/file.go:1033
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1026
+#: lxc/file.go:1027
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5856,12 +5856,12 @@ msgstr ""
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:446
+#: lxc/project.go:447
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
 
-#: lxc/storage_bucket.go:431
+#: lxc/storage_bucket.go:432
 #, c-format
 msgid "The property %q does not exist on the storage bucket %q: %v"
 msgstr ""
@@ -6046,7 +6046,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:961
+#: lxc/project.go:962
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6058,17 +6058,17 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:985 lxc/storage_volume.go:1735
+#: lxc/project.go:986 lxc/storage_volume.go:1735
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:573
+#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:574
 #: lxc/storage.go:724 lxc/storage_volume.go:1734
 msgid "USED BY"
 msgstr ""
 
-#: lxc/warning.go:216
+#: lxc/warning.go:217
 msgid "UUID"
 msgstr ""
 
@@ -6077,7 +6077,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:197
+#: lxc/file.go:198
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6091,13 +6091,13 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1253
+#: lxc/file.go:1254
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1153 lxc/list.go:631 lxc/storage_volume.go:1772
-#: lxc/warning.go:241
+#: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6107,7 +6107,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:807
+#: lxc/file.go:808
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6190,11 +6190,11 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:742 lxc/project.go:743
+#: lxc/project.go:743 lxc/project.go:744
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:697 lxc/storage_bucket.go:698
+#: lxc/storage_bucket.go:698 lxc/storage_bucket.go:699
 msgid "Unset storage bucket configuration keys"
 msgstr ""
 
@@ -6242,11 +6242,11 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:747
+#: lxc/project.go:748
 msgid "Unset the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:701
+#: lxc/storage_bucket.go:702
 msgid "Unset the key as a storage bucket property"
 msgstr ""
 
@@ -6325,7 +6325,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:71
+#: lxc/file.go:72
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6362,11 +6362,11 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:831
+#: lxc/auth.go:832
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:894
+#: lxc/auth.go:895
 msgid "View the current identity"
 msgstr ""
 
@@ -6397,15 +6397,15 @@ msgstr ""
 msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
-#: lxc/rebuild.go:27
+#: lxc/rebuild.go:28
 msgid ""
 "Wipe the instance root disk and re-initialize. The original image is used to "
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:156 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
+#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:526
+#: lxc/project.go:531 lxc/project.go:536 lxc/project.go:541 lxc/project.go:546
+#: lxc/project.go:551 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
 msgid "YES"
 msgstr ""
 
@@ -6425,7 +6425,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/rebuild.go:119
+#: lxc/rebuild.go:120
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
@@ -6437,12 +6437,12 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1689
+#: lxc/auth.go:330 lxc/auth.go:763 lxc/auth.go:894 lxc/auth.go:1690
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
-#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
+#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
-#: lxc/operation.go:103 lxc/profile.go:700 lxc/project.go:467
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:68
+#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:468
+#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6470,7 +6470,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1254
+#: lxc/auth.go:1255
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6531,11 +6531,11 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:830
+#: lxc/auth.go:831
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1926
+#: lxc/auth.go:1106 lxc/auth.go:1164 lxc/auth.go:1927
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6543,13 +6543,13 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:954 lxc/auth.go:1470 lxc/cluster_group.go:168
+#: lxc/auth.go:97 lxc/auth.go:150 lxc/auth.go:200 lxc/auth.go:440
+#: lxc/auth.go:955 lxc/auth.go:1471 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:514 lxc/auth.go:572
+#: lxc/auth.go:515 lxc/auth.go:573
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
@@ -6559,19 +6559,19 @@ msgstr ""
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:389
+#: lxc/auth.go:390
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1521 lxc/auth.go:1571 lxc/auth.go:1799
+#: lxc/auth.go:1522 lxc/auth.go:1572 lxc/auth.go:1800
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1873
+#: lxc/auth.go:1874
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1749
+#: lxc/auth.go:1750
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -6591,7 +6591,7 @@ msgstr ""
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
-#: lxc/rebuild.go:25
+#: lxc/rebuild.go:26
 msgid "[<remote>:]<image> [<remote>:]<instance>"
 msgstr ""
 
@@ -6674,20 +6674,20 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:170
+#: lxc/file.go:171
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:120
+#: lxc/file.go:121
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:240
+#: lxc/file.go:241
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:984
+#: lxc/file.go:985
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6838,12 +6838,12 @@ msgstr ""
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
-#: lxc/operation.go:53 lxc/operation.go:191
+#: lxc/operation.go:54 lxc/operation.go:192
 msgid "[<remote>:]<operation>"
 msgstr ""
 
 #: lxc/storage.go:200 lxc/storage.go:259 lxc/storage.go:473 lxc/storage.go:844
-#: lxc/storage_bucket.go:454
+#: lxc/storage_bucket.go:455
 msgid "[<remote>:]<pool>"
 msgstr ""
 
@@ -6851,22 +6851,22 @@ msgstr ""
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
-#: lxc/storage_bucket.go:185 lxc/storage_bucket.go:247
-#: lxc/storage_bucket.go:627 lxc/storage_bucket.go:769
+#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:248
+#: lxc/storage_bucket.go:628 lxc/storage_bucket.go:770
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
 
-#: lxc/storage_bucket.go:380 lxc/storage_bucket.go:696
-#: lxc/storage_bucket.go:850 lxc/storage_bucket.go:956
-#: lxc/storage_bucket.go:1020 lxc/storage_bucket.go:1155
+#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:697
+#: lxc/storage_bucket.go:851 lxc/storage_bucket.go:957
+#: lxc/storage_bucket.go:1021 lxc/storage_bucket.go:1156
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
 
-#: lxc/storage_bucket.go:533
+#: lxc/storage_bucket.go:534
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_bucket.go:81
+#: lxc/storage_bucket.go:82
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
 
@@ -6981,20 +6981,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:91 lxc/project.go:186 lxc/project.go:258 lxc/project.go:785
-#: lxc/project.go:846 lxc/project.go:913
+#: lxc/project.go:92 lxc/project.go:187 lxc/project.go:259 lxc/project.go:786
+#: lxc/project.go:847 lxc/project.go:914
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:394 lxc/project.go:741
+#: lxc/project.go:395 lxc/project.go:742
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:653
+#: lxc/project.go:654
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:587
+#: lxc/project.go:588
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7002,7 +7002,7 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:259 lxc/warning.go:301 lxc/warning.go:354
+#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
@@ -7058,7 +7058,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:555 lxc/remote.go:739
+#: lxc/project.go:556 lxc/remote.go:739
 msgid "current"
 msgstr ""
 
@@ -7105,20 +7105,20 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/auth.go:203
+#: lxc/auth.go:204
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:958
+#: lxc/auth.go:959
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1575
+#: lxc/auth.go:1576
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7196,20 +7196,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:988
+#: lxc/file.go:989
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:244
+#: lxc/file.go:245
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:470
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7291,7 +7291,7 @@ msgid ""
 "  List instances with their running state and user comment."
 msgstr ""
 
-#: lxc/monitor.go:37
+#: lxc/monitor.go:38
 msgid ""
 "lxc monitor --type=logging\n"
 "    Only show log messages.\n"
@@ -7367,7 +7367,7 @@ msgid ""
 "    Create record r1 for zone z1 with configuration from config.yaml"
 msgstr ""
 
-#: lxc/operation.go:195
+#: lxc/operation.go:196
 msgid ""
 "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Show details on that operation UUID"
@@ -7410,7 +7410,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:95
+#: lxc/project.go:96
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7418,7 +7418,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:262
+#: lxc/project.go:263
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7449,7 +7449,7 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:85
 msgid ""
 "lxc storage bucket create p1 b01\n"
 "\tCreate a new storage bucket name b01 in storage pool p1\n"
@@ -7459,19 +7459,19 @@ msgid ""
 "of config.yaml"
 msgstr ""
 
-#: lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:251
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1023
+#: lxc/storage_bucket.go:1024
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:854
 msgid ""
 "lxc storage bucket key create p1 b01 k1\n"
 "\tCreate a key called k1 for the bucket b01 in the pool p1.\n"
@@ -7481,14 +7481,14 @@ msgid ""
 "of config.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1158
+#: lxc/storage_bucket.go:1159
 msgid ""
 "lxc storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_bucket.go:630
+#: lxc/storage_bucket.go:631
 msgid ""
 "lxc storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
@@ -7558,16 +7558,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1142
+#: lxc/file.go:1143
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1101
+#: lxc/file.go:1102
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1054
+#: lxc/file.go:1055
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-04 08:52-0600\n"
+"POT-Creation-Date: 2024-09-05 08:44-0400\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/linux-containers/"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: lxc/storage_bucket.go:260 lxc/storage_bucket.go:1033
+#: lxc/storage_bucket.go:261 lxc/storage_bucket.go:1034
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -133,7 +133,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:213
+#: lxc/auth.go:214
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -160,7 +160,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:968
+#: lxc/auth.go:969
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -181,7 +181,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1585
+#: lxc/auth.go:1586
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -391,7 +391,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:280
+#: lxc/project.go:281
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -433,12 +433,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:935
+#: lxc/file.go:936
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:825
+#: lxc/file.go:826
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -474,7 +474,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:142 lxc/rebuild.go:64
+#: lxc/init.go:142 lxc/rebuild.go:65
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -527,7 +527,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:465
+#: lxc/file.go:466
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -560,7 +560,7 @@ msgstr ""
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:813
+#: lxc/auth.go:814
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -568,11 +568,11 @@ msgstr ""
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/storage_bucket.go:863
+#: lxc/storage_bucket.go:864
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:941
+#: lxc/storage_bucket.go:942
 #, c-format
 msgid "Access key: %s"
 msgstr ""
@@ -581,7 +581,7 @@ msgstr ""
 msgid "Access the expanded configuration"
 msgstr ""
 
-#: lxc/warning.go:261 lxc/warning.go:262
+#: lxc/warning.go:262 lxc/warning.go:263
 msgid "Acknowledge warning"
 msgstr ""
 
@@ -598,11 +598,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1106 lxc/auth.go:1107
+#: lxc/auth.go:1107 lxc/auth.go:1108
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1874 lxc/auth.go:1875
+#: lxc/auth.go:1875 lxc/auth.go:1876
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -671,7 +671,7 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:515 lxc/auth.go:516
+#: lxc/auth.go:516 lxc/auth.go:517
 msgid "Add permissions to groups"
 msgstr ""
 
@@ -700,7 +700,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:169
+#: lxc/storage_bucket.go:170
 #, c-format
 msgid "Admin access key: %s"
 msgstr ""
@@ -710,7 +710,7 @@ msgstr ""
 msgid "Admin password (or token) for %s:"
 msgstr ""
 
-#: lxc/storage_bucket.go:170
+#: lxc/storage_bucket.go:171
 #, c-format
 msgid "Admin secret key: %s"
 msgstr ""
@@ -769,7 +769,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:342 lxc/rebuild.go:130
+#: lxc/init.go:342 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -869,12 +869,12 @@ msgstr ""
 
 #: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:318
 #: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
-#: lxc/network_zone.go:366 lxc/network_zone.go:1053 lxc/storage_bucket.go:141
+#: lxc/network_zone.go:366 lxc/network_zone.go:1053 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:159
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:160
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -914,7 +914,7 @@ msgstr ""
 msgid "Bytes sent"
 msgstr ""
 
-#: lxc/operation.go:174
+#: lxc/operation.go:175
 msgid "CANCELABLE"
 msgstr ""
 
@@ -926,7 +926,7 @@ msgstr ""
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: lxc/warning.go:209
+#: lxc/warning.go:210
 msgid "COUNT"
 msgstr ""
 
@@ -952,7 +952,7 @@ msgstr ""
 msgid "CPUs (%s):"
 msgstr ""
 
-#: lxc/operation.go:175
+#: lxc/operation.go:176
 msgid "CREATED"
 msgstr ""
 
@@ -982,7 +982,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:340
+#: lxc/file.go:341
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1007,11 +1007,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:224
+#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:546
+#: lxc/file.go:547
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1020,7 +1020,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:160
+#: lxc/rebuild.go:161
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1143,13 +1143,13 @@ msgstr ""
 #: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
 #: lxc/network_load_balancer.go:1051 lxc/network_load_balancer.go:1125
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
-#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:90
-#: lxc/storage_bucket.go:190 lxc/storage_bucket.go:253
-#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:541
-#: lxc/storage_bucket.go:634 lxc/storage_bucket.go:700
-#: lxc/storage_bucket.go:775 lxc/storage_bucket.go:861
-#: lxc/storage_bucket.go:961 lxc/storage_bucket.go:1026
-#: lxc/storage_bucket.go:1162 lxc/storage_volume.go:394
+#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
+#: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
+#: lxc/storage_bucket.go:385 lxc/storage_bucket.go:542
+#: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
+#: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
+#: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
 #: lxc/storage_volume.go:612 lxc/storage_volume.go:717
 #: lxc/storage_volume.go:1005 lxc/storage_volume.go:1231
 #: lxc/storage_volume.go:1360 lxc/storage_volume.go:1848
@@ -1173,7 +1173,7 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1113 lxc/list.go:132 lxc/storage_volume.go:1589
-#: lxc/warning.go:92
+#: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
@@ -1201,7 +1201,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:100
+#: lxc/project.go:101
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1215,8 +1215,8 @@ msgstr ""
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
-#: lxc/project.go:362 lxc/storage.go:359 lxc/storage_bucket.go:348
-#: lxc/storage_bucket.go:1125 lxc/storage_volume.go:1150
+#: lxc/project.go:363 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1150
 #: lxc/storage_volume.go:1182
 #, c-format
 msgid "Config parsing error: %s"
@@ -1343,12 +1343,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:300 lxc/auth.go:1660
+#: lxc/auth.go:301 lxc/auth.go:1661
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1054
+#: lxc/auth.go:1055
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1397,15 +1397,15 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:248 lxc/file.go:474
+#: lxc/file.go:249 lxc/file.go:475
 msgid "Create any directories necessary"
 msgstr ""
 
-#: lxc/auth.go:97 lxc/auth.go:98
+#: lxc/auth.go:98 lxc/auth.go:99
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1471 lxc/auth.go:1472
+#: lxc/auth.go:1472 lxc/auth.go:1473
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1425,11 +1425,11 @@ msgstr ""
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_bucket.go:851 lxc/storage_bucket.go:852
+#: lxc/storage_bucket.go:852 lxc/storage_bucket.go:853
 msgid "Create key for a storage bucket"
 msgstr ""
 
-#: lxc/storage_bucket.go:82 lxc/storage_bucket.go:83
+#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
 msgid "Create new custom storage buckets"
 msgstr ""
 
@@ -1473,7 +1473,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:92 lxc/project.go:93
+#: lxc/project.go:93 lxc/project.go:94
 msgid "Create projects"
 msgstr ""
 
@@ -1508,13 +1508,13 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:376 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1135 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
-#: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:172
-#: lxc/profile.go:756 lxc/project.go:572 lxc/storage.go:723
-#: lxc/storage_bucket.go:512 lxc/storage_bucket.go:832
+#: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
+#: lxc/profile.go:756 lxc/project.go:573 lxc/storage.go:723
+#: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1732
 msgid "DESCRIPTION"
 msgstr ""
@@ -1539,7 +1539,7 @@ msgstr ""
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
-#: lxc/operation.go:55 lxc/operation.go:56
+#: lxc/operation.go:56 lxc/operation.go:57
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
@@ -1547,19 +1547,19 @@ msgstr ""
 msgid "Delete a cluster group"
 msgstr ""
 
-#: lxc/warning.go:360
+#: lxc/warning.go:361
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:122 lxc/file.go:123
+#: lxc/file.go:123 lxc/file.go:124
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/auth.go:151 lxc/auth.go:152
+#: lxc/auth.go:152 lxc/auth.go:153
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1523 lxc/auth.go:1524
+#: lxc/auth.go:1524 lxc/auth.go:1525
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1579,7 +1579,7 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/storage_bucket.go:957 lxc/storage_bucket.go:958
+#: lxc/storage_bucket.go:958 lxc/storage_bucket.go:959
 msgid "Delete key from a storage bucket"
 msgstr ""
 
@@ -1615,11 +1615,11 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:188 lxc/project.go:189
+#: lxc/project.go:189 lxc/project.go:190
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:187 lxc/storage_bucket.go:188
+#: lxc/storage_bucket.go:188 lxc/storage_bucket.go:189
 msgid "Delete storage buckets"
 msgstr ""
 
@@ -1631,20 +1631,20 @@ msgstr ""
 msgid "Delete storage volumes"
 msgstr ""
 
-#: lxc/warning.go:356 lxc/warning.go:357
+#: lxc/warning.go:357 lxc/warning.go:358
 msgid "Delete warning"
 msgstr ""
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:30 lxc/auth.go:59 lxc/auth.go:98
-#: lxc/auth.go:152 lxc/auth.go:201 lxc/auth.go:332 lxc/auth.go:392
-#: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
-#: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
-#: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
-#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1434 lxc/auth.go:1472
-#: lxc/auth.go:1524 lxc/auth.go:1573 lxc/auth.go:1692 lxc/auth.go:1752
-#: lxc/auth.go:1801 lxc/auth.go:1852 lxc/auth.go:1875 lxc/auth.go:1928
+#: lxc/alias.go:214 lxc/auth.go:31 lxc/auth.go:60 lxc/auth.go:99
+#: lxc/auth.go:153 lxc/auth.go:202 lxc/auth.go:333 lxc/auth.go:393
+#: lxc/auth.go:442 lxc/auth.go:494 lxc/auth.go:517 lxc/auth.go:576
+#: lxc/auth.go:732 lxc/auth.go:766 lxc/auth.go:833 lxc/auth.go:896
+#: lxc/auth.go:957 lxc/auth.go:1085 lxc/auth.go:1108 lxc/auth.go:1166
+#: lxc/auth.go:1235 lxc/auth.go:1257 lxc/auth.go:1435 lxc/auth.go:1473
+#: lxc/auth.go:1525 lxc/auth.go:1574 lxc/auth.go:1693 lxc/auth.go:1753
+#: lxc/auth.go:1802 lxc/auth.go:1853 lxc/auth.go:1876 lxc/auth.go:1929
 #: lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215 lxc/cluster.go:272
 #: lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:484 lxc/cluster.go:528
 #: lxc/cluster.go:586 lxc/cluster.go:677 lxc/cluster.go:770 lxc/cluster.go:893
@@ -1668,15 +1668,15 @@ msgstr ""
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:83 lxc/file.go:123 lxc/file.go:172
-#: lxc/file.go:242 lxc/file.go:467 lxc/file.go:986 lxc/image.go:38
+#: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
+#: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
 #: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
 #: lxc/image.go:697 lxc/image.go:946 lxc/image.go:1088 lxc/image.go:1415
 #: lxc/image.go:1506 lxc/image.go:1572 lxc/image.go:1636 lxc/image.go:1699
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:38 lxc/network.go:33
+#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33
 #: lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405
 #: lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793
 #: lxc/network.go:874 lxc/network.go:1005 lxc/network.go:1106
@@ -1710,27 +1710,27 @@ msgstr ""
 #: lxc/network_zone.go:909 lxc/network_zone.go:985 lxc/network_zone.go:1083
 #: lxc/network_zone.go:1172 lxc/network_zone.go:1219 lxc/network_zone.go:1349
 #: lxc/network_zone.go:1410 lxc/network_zone.go:1425 lxc/network_zone.go:1483
-#: lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:106
-#: lxc/operation.go:193 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
+#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
+#: lxc/operation.go:194 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
 #: lxc/profile.go:271 lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493
 #: lxc/profile.go:629 lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860
-#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:29
-#: lxc/project.go:93 lxc/project.go:189 lxc/project.go:260 lxc/project.go:396
-#: lxc/project.go:470 lxc/project.go:590 lxc/project.go:655 lxc/project.go:743
-#: lxc/project.go:787 lxc/project.go:848 lxc/project.go:915 lxc/publish.go:34
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:35 lxc/remote.go:91
+#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:30
+#: lxc/project.go:94 lxc/project.go:190 lxc/project.go:261 lxc/project.go:397
+#: lxc/project.go:471 lxc/project.go:591 lxc/project.go:656 lxc/project.go:744
+#: lxc/project.go:788 lxc/project.go:849 lxc/project.go:916 lxc/publish.go:34
+#: lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91
 #: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853
 #: lxc/remote.go:917 lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24
 #: lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203
 #: lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655
 #: lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940
-#: lxc/storage_bucket.go:29 lxc/storage_bucket.go:83 lxc/storage_bucket.go:188
-#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:382
-#: lxc/storage_bucket.go:458 lxc/storage_bucket.go:535
-#: lxc/storage_bucket.go:629 lxc/storage_bucket.go:698
-#: lxc/storage_bucket.go:732 lxc/storage_bucket.go:773
-#: lxc/storage_bucket.go:852 lxc/storage_bucket.go:958
-#: lxc/storage_bucket.go:1022 lxc/storage_bucket.go:1157
+#: lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189
+#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:383
+#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:536
+#: lxc/storage_bucket.go:630 lxc/storage_bucket.go:699
+#: lxc/storage_bucket.go:733 lxc/storage_bucket.go:774
+#: lxc/storage_bucket.go:853 lxc/storage_bucket.go:959
+#: lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158
 #: lxc/storage_volume.go:58 lxc/storage_volume.go:169 lxc/storage_volume.go:283
 #: lxc/storage_volume.go:390 lxc/storage_volume.go:605
 #: lxc/storage_volume.go:714 lxc/storage_volume.go:801
@@ -1741,8 +1741,8 @@ msgstr ""
 #: lxc/storage_volume.go:2064 lxc/storage_volume.go:2222
 #: lxc/storage_volume.go:2343 lxc/storage_volume.go:2405
 #: lxc/storage_volume.go:2541 lxc/storage_volume.go:2624
-#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:29
-#: lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
+#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:30
+#: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
@@ -1829,7 +1829,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:994
+#: lxc/file.go:995
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1895,7 +1895,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:74
+#: lxc/file.go:75
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1905,7 +1905,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:955 lxc/auth.go:956
+#: lxc/auth.go:956 lxc/auth.go:957
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1913,15 +1913,15 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:171 lxc/file.go:172
+#: lxc/file.go:172 lxc/file.go:173
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/auth.go:200 lxc/auth.go:201
+#: lxc/auth.go:201 lxc/auth.go:202
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1572 lxc/auth.go:1573
+#: lxc/auth.go:1573 lxc/auth.go:1574
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -1977,15 +1977,15 @@ msgstr ""
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:259 lxc/project.go:260
+#: lxc/project.go:260 lxc/project.go:261
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:248 lxc/storage_bucket.go:249
+#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:250
 msgid "Edit storage bucket configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:1021 lxc/storage_bucket.go:1022
+#: lxc/storage_bucket.go:1022 lxc/storage_bucket.go:1023
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
@@ -2002,7 +2002,7 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1147 lxc/list.go:622 lxc/storage_volume.go:1766
-#: lxc/warning.go:235
+#: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2057,7 +2057,7 @@ msgstr ""
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
-#: lxc/project.go:718 lxc/storage.go:812 lxc/storage_bucket.go:602
+#: lxc/project.go:719 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2155 lxc/storage_volume.go:2193
 #, c-format
 msgid "Error setting properties: %v"
@@ -2071,8 +2071,8 @@ msgstr ""
 #: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
-#: lxc/profile.go:981 lxc/project.go:712 lxc/storage.go:806
-#: lxc/storage_bucket.go:596 lxc/storage_volume.go:2149
+#: lxc/profile.go:981 lxc/project.go:713 lxc/storage.go:806
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2149
 #: lxc/storage_volume.go:2187
 #, c-format
 msgid "Error unsetting property: %v"
@@ -2092,7 +2092,7 @@ msgstr ""
 msgid "Evacuating cluster member: %s"
 msgstr ""
 
-#: lxc/monitor.go:50
+#: lxc/monitor.go:51
 msgid "Event type to listen for"
 msgstr ""
 
@@ -2179,16 +2179,16 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/warning.go:210
+#: lxc/warning.go:211
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1237
+#: lxc/file.go:1238
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1260
+#: lxc/file.go:1261
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2203,12 +2203,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1287
+#: lxc/file.go:1288
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1072
+#: lxc/file.go:1073
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2238,7 +2238,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1193
+#: lxc/file.go:1194
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2253,7 +2253,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1198
+#: lxc/file.go:1199
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2263,12 +2263,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1098
+#: lxc/file.go:1099
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1225
+#: lxc/file.go:1226
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2307,7 +2307,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1210
+#: lxc/file.go:1211
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2322,7 +2322,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:820
+#: lxc/file.go:821
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2337,7 +2337,7 @@ msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
 #: lxc/network.go:1044 lxc/network_acl.go:133 lxc/network_zone.go:124
-#: lxc/operation.go:136
+#: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
 
@@ -2402,21 +2402,21 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
+#: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:770 lxc/auth.go:1697
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1114 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:57
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
-#: lxc/operation.go:108 lxc/profile.go:707 lxc/project.go:472
-#: lxc/project.go:917 lxc/remote.go:690 lxc/storage.go:657
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:774
-#: lxc/storage_volume.go:1608 lxc/warning.go:93
+#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:473
+#: lxc/project.go:918 lxc/remote.go:690 lxc/storage.go:657
+#: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
+#: lxc/storage_volume.go:1608 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
-#: lxc/monitor.go:52
+#: lxc/monitor.go:53
 msgid "Format (json|pretty|yaml)"
 msgstr ""
 
@@ -2460,7 +2460,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:817 lxc/auth.go:1736
+#: lxc/auth.go:818 lxc/auth.go:1737
 msgid "GROUPS"
 msgstr ""
 
@@ -2476,7 +2476,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:914 lxc/project.go:915
+#: lxc/project.go:915 lxc/project.go:916
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2524,11 +2524,11 @@ msgstr ""
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:400
+#: lxc/project.go:401
 msgid "Get the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:385
+#: lxc/storage_bucket.go:386
 msgid "Get the key as a storage bucket property"
 msgstr ""
 
@@ -2588,11 +2588,11 @@ msgstr ""
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:395 lxc/project.go:396
+#: lxc/project.go:396 lxc/project.go:397
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:382
+#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:383
 msgid "Get values for storage bucket configuration keys"
 msgstr ""
 
@@ -2609,17 +2609,17 @@ msgstr ""
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: lxc/auth.go:136
+#: lxc/auth.go:137
 #, c-format
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:186
+#: lxc/auth.go:187
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:426 lxc/auth.go:1786
+#: lxc/auth.go:427 lxc/auth.go:1787
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2644,27 +2644,27 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1310
+#: lxc/file.go:1311
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1299
+#: lxc/file.go:1300
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1122
+#: lxc/file.go:1123
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1132
+#: lxc/file.go:1133
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:966 lxc/operation.go:170
+#: lxc/network.go:966 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2678,11 +2678,11 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:816
+#: lxc/auth.go:817
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:566
+#: lxc/project.go:567
 msgid "IMAGES"
 msgstr ""
 
@@ -2710,17 +2710,17 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1508
+#: lxc/auth.go:1509
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1558
+#: lxc/auth.go:1559
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
 
-#: lxc/rebuild.go:32
+#: lxc/rebuild.go:33
 msgid "If an instance is running, stop it and then rebuild it"
 msgstr ""
 
@@ -2841,7 +2841,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1233 lxc/auth.go:1234
+#: lxc/auth.go:1234 lxc/auth.go:1235
 msgid "Inspect permissions"
 msgstr ""
 
@@ -2849,11 +2849,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1124
+#: lxc/file.go:1125
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1301
+#: lxc/file.go:1302
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2871,7 +2871,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1044
+#: lxc/file.go:1045
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2880,7 +2880,7 @@ msgstr ""
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/rebuild.go:74
+#: lxc/rebuild.go:75
 #, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
@@ -2913,7 +2913,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/monitor.go:70
+#: lxc/monitor.go:71
 #, c-format
 msgid "Invalid format: %s"
 msgstr ""
@@ -2923,7 +2923,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1039
+#: lxc/file.go:1040
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2965,7 +2965,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:147
+#: lxc/file.go:148
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2981,12 +2981,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:313
+#: lxc/file.go:314
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:495
+#: lxc/file.go:496
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3000,7 +3000,7 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/warning.go:212
 msgid "LAST SEEN"
 msgstr ""
 
@@ -3008,7 +3008,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:984
+#: lxc/project.go:985
 msgid "LIMIT"
 msgstr ""
 
@@ -3017,8 +3017,8 @@ msgid "LISTEN ADDRESS"
 msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
-#: lxc/network_load_balancer.go:165 lxc/operation.go:177
-#: lxc/storage_bucket.go:516 lxc/storage_volume.go:1739 lxc/warning.go:220
+#: lxc/network_load_balancer.go:165 lxc/operation.go:178
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1739 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3092,7 +3092,7 @@ msgstr ""
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/warning.go:94
+#: lxc/warning.go:95
 msgid "List all warnings"
 msgstr ""
 
@@ -3136,19 +3136,19 @@ msgstr ""
 msgid "List available storage pools"
 msgstr ""
 
-#: lxc/operation.go:105 lxc/operation.go:106
+#: lxc/operation.go:106 lxc/operation.go:107
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:331 lxc/auth.go:332
+#: lxc/auth.go:332 lxc/auth.go:333
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:764 lxc/auth.go:765
+#: lxc/auth.go:765 lxc/auth.go:766
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1691 lxc/auth.go:1692
+#: lxc/auth.go:1692 lxc/auth.go:1693
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3297,11 +3297,11 @@ msgstr ""
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/operation.go:109
+#: lxc/operation.go:110
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1255 lxc/auth.go:1256
+#: lxc/auth.go:1256 lxc/auth.go:1257
 msgid "List permissions"
 msgstr ""
 
@@ -3309,15 +3309,15 @@ msgstr ""
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:469 lxc/project.go:470
+#: lxc/project.go:470 lxc/project.go:471
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:771 lxc/storage_bucket.go:773
+#: lxc/storage_bucket.go:772 lxc/storage_bucket.go:774
 msgid "List storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:456 lxc/storage_bucket.go:458
+#: lxc/storage_bucket.go:457 lxc/storage_bucket.go:459
 msgid "List storage buckets"
 msgstr ""
 
@@ -3353,11 +3353,11 @@ msgstr ""
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/warning.go:70
+#: lxc/warning.go:71
 msgid "List warnings"
 msgstr ""
 
-#: lxc/warning.go:71
+#: lxc/warning.go:72
 msgid ""
 "List warnings\n"
 "\n"
@@ -3380,7 +3380,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/operation.go:23 lxc/operation.go:24
+#: lxc/operation.go:24 lxc/operation.go:25
 msgid "List, show and delete background operations"
 msgstr ""
 
@@ -3389,7 +3389,7 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/monitor.go:79
+#: lxc/monitor.go:80
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
@@ -3493,23 +3493,23 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:82 lxc/file.go:83
+#: lxc/file.go:83 lxc/file.go:84
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1433 lxc/auth.go:1434
+#: lxc/auth.go:59 lxc/auth.go:60 lxc/auth.go:1434 lxc/auth.go:1435
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1083 lxc/auth.go:1084
+#: lxc/auth.go:1084 lxc/auth.go:1085
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:730 lxc/auth.go:731
+#: lxc/auth.go:731 lxc/auth.go:732
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1851 lxc/auth.go:1852
+#: lxc/auth.go:1852 lxc/auth.go:1853
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3600,7 +3600,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:492 lxc/auth.go:493
+#: lxc/auth.go:493 lxc/auth.go:494
 msgid "Manage permissions"
 msgstr ""
 
@@ -3608,23 +3608,23 @@ msgstr ""
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:28 lxc/project.go:29
+#: lxc/project.go:29 lxc/project.go:30
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:731
+#: lxc/storage_bucket.go:732
 msgid "Manage storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:732
+#: lxc/storage_bucket.go:733
 msgid "Manage storage bucket keys."
 msgstr ""
 
-#: lxc/storage_bucket.go:28
+#: lxc/storage_bucket.go:29
 msgid "Manage storage buckets"
 msgstr ""
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:30
 msgid "Manage storage buckets."
 msgstr ""
 
@@ -3652,11 +3652,11 @@ msgstr ""
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/auth.go:29 lxc/auth.go:30
+#: lxc/auth.go:30 lxc/auth.go:31
 msgid "Manage user authorization"
 msgstr ""
 
-#: lxc/warning.go:28 lxc/warning.go:29
+#: lxc/warning.go:29 lxc/warning.go:30
 msgid "Manage warnings"
 msgstr ""
 
@@ -3720,17 +3720,17 @@ msgstr ""
 msgid "Migration operation failure: %w"
 msgstr ""
 
-#: lxc/monitor.go:51
+#: lxc/monitor.go:52
 msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: lxc/storage_bucket.go:116 lxc/storage_bucket.go:216
-#: lxc/storage_bucket.go:292 lxc/storage_bucket.go:411
-#: lxc/storage_bucket.go:568 lxc/storage_bucket.go:660
-#: lxc/storage_bucket.go:802 lxc/storage_bucket.go:889
-#: lxc/storage_bucket.go:986 lxc/storage_bucket.go:1065
-#: lxc/storage_bucket.go:1188
+#: lxc/storage_bucket.go:117 lxc/storage_bucket.go:217
+#: lxc/storage_bucket.go:293 lxc/storage_bucket.go:412
+#: lxc/storage_bucket.go:569 lxc/storage_bucket.go:661
+#: lxc/storage_bucket.go:803 lxc/storage_bucket.go:890
+#: lxc/storage_bucket.go:987 lxc/storage_bucket.go:1066
+#: lxc/storage_bucket.go:1189
 msgid "Missing bucket name"
 msgstr ""
 
@@ -3749,20 +3749,20 @@ msgstr ""
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1825
+#: lxc/auth.go:123 lxc/auth.go:177 lxc/auth.go:255 lxc/auth.go:417
+#: lxc/auth.go:466 lxc/auth.go:541 lxc/auth.go:600 lxc/auth.go:1826
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:862 lxc/auth.go:1003 lxc/auth.go:1131 lxc/auth.go:1189
+#: lxc/auth.go:863 lxc/auth.go:1004 lxc/auth.go:1132 lxc/auth.go:1190
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1495 lxc/auth.go:1548 lxc/auth.go:1614 lxc/auth.go:1776
+#: lxc/auth.go:1496 lxc/auth.go:1549 lxc/auth.go:1615 lxc/auth.go:1777
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1899 lxc/auth.go:1952
+#: lxc/auth.go:1900 lxc/auth.go:1953
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -3770,12 +3770,12 @@ msgstr ""
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
 #: lxc/config_template.go:377 lxc/profile.go:141 lxc/profile.go:222
-#: lxc/profile.go:808 lxc/rebuild.go:60
+#: lxc/profile.go:808 lxc/rebuild.go:61
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/storage_bucket.go:893 lxc/storage_bucket.go:990
-#: lxc/storage_bucket.go:1069 lxc/storage_bucket.go:1192
+#: lxc/storage_bucket.go:894 lxc/storage_bucket.go:991
+#: lxc/storage_bucket.go:1070 lxc/storage_bucket.go:1193
 msgid "Missing key name"
 msgstr ""
 
@@ -3840,13 +3840,13 @@ msgid "Missing peer name"
 msgstr ""
 
 #: lxc/storage.go:235 lxc/storage.go:313 lxc/storage.go:431 lxc/storage.go:509
-#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:112
-#: lxc/storage_bucket.go:212 lxc/storage_bucket.go:288
-#: lxc/storage_bucket.go:407 lxc/storage_bucket.go:482
-#: lxc/storage_bucket.go:564 lxc/storage_bucket.go:656
-#: lxc/storage_bucket.go:798 lxc/storage_bucket.go:885
-#: lxc/storage_bucket.go:982 lxc/storage_bucket.go:1061
-#: lxc/storage_bucket.go:1184 lxc/storage_volume.go:209
+#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:113
+#: lxc/storage_bucket.go:213 lxc/storage_bucket.go:289
+#: lxc/storage_bucket.go:408 lxc/storage_bucket.go:483
+#: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
+#: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
+#: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
 #: lxc/storage_volume.go:323 lxc/storage_volume.go:643
 #: lxc/storage_volume.go:750 lxc/storage_volume.go:841
 #: lxc/storage_volume.go:939 lxc/storage_volume.go:1053
@@ -3861,9 +3861,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:404 lxc/project.go:146 lxc/project.go:226 lxc/project.go:316
-#: lxc/project.go:433 lxc/project.go:622 lxc/project.go:691 lxc/project.go:819
-#: lxc/project.go:948
+#: lxc/profile.go:404 lxc/project.go:147 lxc/project.go:227 lxc/project.go:317
+#: lxc/project.go:434 lxc/project.go:623 lxc/project.go:692 lxc/project.go:820
+#: lxc/project.go:949
 msgid "Missing project name"
 msgstr ""
 
@@ -3879,7 +3879,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:598
+#: lxc/file.go:599
 msgid "Missing target directory"
 msgstr ""
 
@@ -3901,11 +3901,11 @@ msgstr ""
 msgid "Model: %v"
 msgstr ""
 
-#: lxc/monitor.go:32
+#: lxc/monitor.go:33
 msgid "Monitor a local or remote LXD server"
 msgstr ""
 
-#: lxc/monitor.go:33
+#: lxc/monitor.go:34
 msgid ""
 "Monitor a local or remote LXD server\n"
 "\n"
@@ -3917,11 +3917,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:285
+#: lxc/file.go:286
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:985 lxc/file.go:986
+#: lxc/file.go:986 lxc/file.go:987
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3983,13 +3983,13 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:192
+#: lxc/auth.go:376 lxc/auth.go:816 lxc/auth.go:1736 lxc/cluster.go:192
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
-#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:565
-#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:511
-#: lxc/storage_bucket.go:831 lxc/storage_volume.go:1731
+#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:566
+#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1731
 msgid "NAME"
 msgstr ""
 
@@ -3997,11 +3997,11 @@ msgstr ""
 msgid "NAT"
 msgstr ""
 
-#: lxc/project.go:571
+#: lxc/project.go:572
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:570
+#: lxc/project.go:571
 msgid "NETWORKS"
 msgstr ""
 
@@ -4013,9 +4013,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/operation.go:154 lxc/project.go:523
-#: lxc/project.go:528 lxc/project.go:533 lxc/project.go:538 lxc/project.go:543
-#: lxc/project.go:548 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
+#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:524
+#: lxc/project.go:529 lxc/project.go:534 lxc/project.go:539 lxc/project.go:544
+#: lxc/project.go:549 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
 msgid "NO"
 msgstr ""
 
@@ -4260,7 +4260,7 @@ msgstr ""
 msgid "Only managed networks can be modified"
 msgstr ""
 
-#: lxc/operation.go:86
+#: lxc/operation.go:87
 #, c-format
 msgid "Operation %s deleted"
 msgstr ""
@@ -4307,11 +4307,11 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:567
+#: lxc/list.go:576 lxc/project.go:568
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:212
+#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4373,24 +4373,24 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1102
+#: lxc/file.go:1103
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:860
+#: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
-#: lxc/project.go:363 lxc/storage.go:360 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1151
+#: lxc/project.go:364 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1151
 #: lxc/storage_volume.go:1183
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
-#: lxc/monitor.go:48
+#: lxc/monitor.go:49
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
@@ -4476,17 +4476,17 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:172
+#: lxc/project.go:173
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:236
+#: lxc/project.go:237
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:637
+#: lxc/project.go:638
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -4607,20 +4607,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:241 lxc/file.go:242
+#: lxc/file.go:242 lxc/file.go:243
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:416 lxc/file.go:767
+#: lxc/file.go:417 lxc/file.go:768
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:466 lxc/file.go:467
+#: lxc/file.go:467 lxc/file.go:468
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:701 lxc/file.go:867
+#: lxc/file.go:702 lxc/file.go:868
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4633,11 +4633,11 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:983
+#: lxc/project.go:984
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/storage_bucket.go:833
+#: lxc/storage_bucket.go:834
 msgid "ROLE"
 msgstr ""
 
@@ -4650,15 +4650,15 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/rebuild.go:31
+#: lxc/rebuild.go:32
 msgid "Rebuild as an empty instance"
 msgstr ""
 
-#: lxc/rebuild.go:26
+#: lxc/rebuild.go:27
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:249 lxc/file.go:473
+#: lxc/file.go:250 lxc/file.go:474
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4685,7 +4685,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:882 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
+#: lxc/project.go:883 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
 #: lxc/remote.go:994
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4736,7 +4736,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1164 lxc/auth.go:1165
+#: lxc/auth.go:1165 lxc/auth.go:1166
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4772,7 +4772,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1927 lxc/auth.go:1928
+#: lxc/auth.go:1928 lxc/auth.go:1929
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4784,7 +4784,7 @@ msgstr ""
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:574 lxc/auth.go:575
+#: lxc/auth.go:575 lxc/auth.go:576
 msgid "Remove permissions from groups"
 msgstr ""
 
@@ -4829,11 +4829,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:391 lxc/auth.go:392
+#: lxc/auth.go:392 lxc/auth.go:393
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1751 lxc/auth.go:1752
+#: lxc/auth.go:1752 lxc/auth.go:1753
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -4853,7 +4853,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:589 lxc/project.go:590
+#: lxc/project.go:590 lxc/project.go:591
 msgid "Rename projects"
 msgstr ""
 
@@ -4951,7 +4951,7 @@ msgstr ""
 msgid "Revoke cluster member join token"
 msgstr ""
 
-#: lxc/storage_bucket.go:862
+#: lxc/storage_bucket.go:863
 msgid "Role (admin or read-only)"
 msgstr ""
 
@@ -4967,7 +4967,7 @@ msgstr ""
 msgid "Run against all projects"
 msgstr ""
 
-#: lxc/warning.go:213
+#: lxc/warning.go:214
 msgid "SEVERITY"
 msgstr ""
 
@@ -4987,12 +4987,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1231
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1231
+#: lxc/file.go:1232
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5006,11 +5006,11 @@ msgstr ""
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:173 lxc/warning.go:214
+#: lxc/operation.go:174 lxc/warning.go:215
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:569
+#: lxc/project.go:570
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5018,7 +5018,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:569
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -5026,11 +5026,11 @@ msgstr ""
 msgid "STP"
 msgstr ""
 
-#: lxc/storage_bucket.go:864
+#: lxc/storage_bucket.go:865
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:942
+#: lxc/storage_bucket.go:943
 #, c-format
 msgid "Secret key: %s"
 msgstr ""
@@ -5068,7 +5068,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:995
+#: lxc/file.go:996
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5206,11 +5206,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:654
+#: lxc/project.go:655
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:655
+#: lxc/project.go:656
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5219,11 +5219,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage_bucket.go:534
+#: lxc/storage_bucket.go:535
 msgid "Set storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:535
+#: lxc/storage_bucket.go:536
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -5262,15 +5262,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:476
+#: lxc/file.go:477
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:477
+#: lxc/file.go:478
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:475
+#: lxc/file.go:476
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5310,11 +5310,11 @@ msgstr ""
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 msgid "Set the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:542
+#: lxc/storage_bucket.go:543
 msgid "Set the key as a storage bucket property"
 msgstr ""
 
@@ -5330,7 +5330,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:993
+#: lxc/file.go:994
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5342,7 +5342,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1800 lxc/auth.go:1801
+#: lxc/auth.go:1801 lxc/auth.go:1802
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5358,11 +5358,11 @@ msgstr ""
 msgid "Show details of a cluster member"
 msgstr ""
 
-#: lxc/operation.go:192 lxc/operation.go:193
+#: lxc/operation.go:193 lxc/operation.go:194
 msgid "Show details on a background operation"
 msgstr ""
 
-#: lxc/monitor.go:49
+#: lxc/monitor.go:50
 msgid "Show events from all projects"
 msgstr ""
 
@@ -5370,11 +5370,11 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:440 lxc/auth.go:441
+#: lxc/auth.go:441 lxc/auth.go:442
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:832
+#: lxc/auth.go:833
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5455,15 +5455,15 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:786 lxc/project.go:787
+#: lxc/project.go:787 lxc/project.go:788
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage_bucket.go:628 lxc/storage_bucket.go:629
+#: lxc/storage_bucket.go:629 lxc/storage_bucket.go:630
 msgid "Show storage bucket configurations"
 msgstr ""
 
-#: lxc/storage_bucket.go:1156 lxc/storage_bucket.go:1157
+#: lxc/storage_bucket.go:1157 lxc/storage_bucket.go:1158
 msgid "Show storage bucket key configurations"
 msgstr ""
 
@@ -5479,7 +5479,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:895
+#: lxc/auth.go:896
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5529,7 +5529,7 @@ msgstr ""
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: lxc/warning.go:302 lxc/warning.go:303
+#: lxc/warning.go:303 lxc/warning.go:304
 msgid "Show warning"
 msgstr ""
 
@@ -5613,22 +5613,22 @@ msgstr ""
 msgid "Stopping the instance failed: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:166
+#: lxc/storage_bucket.go:167
 #, c-format
 msgid "Storage bucket %s created"
 msgstr ""
 
-#: lxc/storage_bucket.go:233
+#: lxc/storage_bucket.go:234
 #, c-format
 msgid "Storage bucket %s deleted"
 msgstr ""
 
-#: lxc/storage_bucket.go:940
+#: lxc/storage_bucket.go:941
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr ""
 
-#: lxc/storage_bucket.go:1006
+#: lxc/storage_bucket.go:1007
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr ""
@@ -5697,7 +5697,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:847 lxc/project.go:848
+#: lxc/project.go:848 lxc/project.go:849
 msgid "Switch the current project"
 msgstr ""
 
@@ -5713,10 +5713,10 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1139
+#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1139
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
-#: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:171
-#: lxc/storage_volume.go:1730 lxc/warning.go:215
+#: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
+#: lxc/storage_volume.go:1730 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
@@ -5724,11 +5724,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1032
+#: lxc/file.go:1033
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1026
+#: lxc/file.go:1027
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5856,12 +5856,12 @@ msgstr ""
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:446
+#: lxc/project.go:447
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
 
-#: lxc/storage_bucket.go:431
+#: lxc/storage_bucket.go:432
 #, c-format
 msgid "The property %q does not exist on the storage bucket %q: %v"
 msgstr ""
@@ -6046,7 +6046,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:961
+#: lxc/project.go:962
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6058,17 +6058,17 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:985 lxc/storage_volume.go:1735
+#: lxc/project.go:986 lxc/storage_volume.go:1735
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:573
+#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:574
 #: lxc/storage.go:724 lxc/storage_volume.go:1734
 msgid "USED BY"
 msgstr ""
 
-#: lxc/warning.go:216
+#: lxc/warning.go:217
 msgid "UUID"
 msgstr ""
 
@@ -6077,7 +6077,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:197
+#: lxc/file.go:198
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6091,13 +6091,13 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1253
+#: lxc/file.go:1254
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1153 lxc/list.go:631 lxc/storage_volume.go:1772
-#: lxc/warning.go:241
+#: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6107,7 +6107,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:807
+#: lxc/file.go:808
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6190,11 +6190,11 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:742 lxc/project.go:743
+#: lxc/project.go:743 lxc/project.go:744
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:697 lxc/storage_bucket.go:698
+#: lxc/storage_bucket.go:698 lxc/storage_bucket.go:699
 msgid "Unset storage bucket configuration keys"
 msgstr ""
 
@@ -6242,11 +6242,11 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:747
+#: lxc/project.go:748
 msgid "Unset the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:701
+#: lxc/storage_bucket.go:702
 msgid "Unset the key as a storage bucket property"
 msgstr ""
 
@@ -6325,7 +6325,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:71
+#: lxc/file.go:72
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6362,11 +6362,11 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:831
+#: lxc/auth.go:832
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:894
+#: lxc/auth.go:895
 msgid "View the current identity"
 msgstr ""
 
@@ -6397,15 +6397,15 @@ msgstr ""
 msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
-#: lxc/rebuild.go:27
+#: lxc/rebuild.go:28
 msgid ""
 "Wipe the instance root disk and re-initialize. The original image is used to "
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:156 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
+#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:526
+#: lxc/project.go:531 lxc/project.go:536 lxc/project.go:541 lxc/project.go:546
+#: lxc/project.go:551 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
 msgid "YES"
 msgstr ""
 
@@ -6425,7 +6425,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/rebuild.go:119
+#: lxc/rebuild.go:120
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
@@ -6437,12 +6437,12 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1689
+#: lxc/auth.go:330 lxc/auth.go:763 lxc/auth.go:894 lxc/auth.go:1690
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
-#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
+#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
-#: lxc/operation.go:103 lxc/profile.go:700 lxc/project.go:467
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:68
+#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:468
+#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6470,7 +6470,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1254
+#: lxc/auth.go:1255
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6531,11 +6531,11 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:830
+#: lxc/auth.go:831
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1926
+#: lxc/auth.go:1106 lxc/auth.go:1164 lxc/auth.go:1927
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6543,13 +6543,13 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:954 lxc/auth.go:1470 lxc/cluster_group.go:168
+#: lxc/auth.go:97 lxc/auth.go:150 lxc/auth.go:200 lxc/auth.go:440
+#: lxc/auth.go:955 lxc/auth.go:1471 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:514 lxc/auth.go:572
+#: lxc/auth.go:515 lxc/auth.go:573
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
@@ -6559,19 +6559,19 @@ msgstr ""
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:389
+#: lxc/auth.go:390
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1521 lxc/auth.go:1571 lxc/auth.go:1799
+#: lxc/auth.go:1522 lxc/auth.go:1572 lxc/auth.go:1800
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1873
+#: lxc/auth.go:1874
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1749
+#: lxc/auth.go:1750
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -6591,7 +6591,7 @@ msgstr ""
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
-#: lxc/rebuild.go:25
+#: lxc/rebuild.go:26
 msgid "[<remote>:]<image> [<remote>:]<instance>"
 msgstr ""
 
@@ -6674,20 +6674,20 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:170
+#: lxc/file.go:171
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:120
+#: lxc/file.go:121
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:240
+#: lxc/file.go:241
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:984
+#: lxc/file.go:985
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6838,12 +6838,12 @@ msgstr ""
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
-#: lxc/operation.go:53 lxc/operation.go:191
+#: lxc/operation.go:54 lxc/operation.go:192
 msgid "[<remote>:]<operation>"
 msgstr ""
 
 #: lxc/storage.go:200 lxc/storage.go:259 lxc/storage.go:473 lxc/storage.go:844
-#: lxc/storage_bucket.go:454
+#: lxc/storage_bucket.go:455
 msgid "[<remote>:]<pool>"
 msgstr ""
 
@@ -6851,22 +6851,22 @@ msgstr ""
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
-#: lxc/storage_bucket.go:185 lxc/storage_bucket.go:247
-#: lxc/storage_bucket.go:627 lxc/storage_bucket.go:769
+#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:248
+#: lxc/storage_bucket.go:628 lxc/storage_bucket.go:770
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
 
-#: lxc/storage_bucket.go:380 lxc/storage_bucket.go:696
-#: lxc/storage_bucket.go:850 lxc/storage_bucket.go:956
-#: lxc/storage_bucket.go:1020 lxc/storage_bucket.go:1155
+#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:697
+#: lxc/storage_bucket.go:851 lxc/storage_bucket.go:957
+#: lxc/storage_bucket.go:1021 lxc/storage_bucket.go:1156
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
 
-#: lxc/storage_bucket.go:533
+#: lxc/storage_bucket.go:534
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_bucket.go:81
+#: lxc/storage_bucket.go:82
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
 
@@ -6981,20 +6981,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:91 lxc/project.go:186 lxc/project.go:258 lxc/project.go:785
-#: lxc/project.go:846 lxc/project.go:913
+#: lxc/project.go:92 lxc/project.go:187 lxc/project.go:259 lxc/project.go:786
+#: lxc/project.go:847 lxc/project.go:914
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:394 lxc/project.go:741
+#: lxc/project.go:395 lxc/project.go:742
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:653
+#: lxc/project.go:654
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:587
+#: lxc/project.go:588
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7002,7 +7002,7 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:259 lxc/warning.go:301 lxc/warning.go:354
+#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
@@ -7058,7 +7058,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:555 lxc/remote.go:739
+#: lxc/project.go:556 lxc/remote.go:739
 msgid "current"
 msgstr ""
 
@@ -7105,20 +7105,20 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/auth.go:203
+#: lxc/auth.go:204
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:958
+#: lxc/auth.go:959
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1575
+#: lxc/auth.go:1576
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7196,20 +7196,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:988
+#: lxc/file.go:989
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:244
+#: lxc/file.go:245
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:470
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7291,7 +7291,7 @@ msgid ""
 "  List instances with their running state and user comment."
 msgstr ""
 
-#: lxc/monitor.go:37
+#: lxc/monitor.go:38
 msgid ""
 "lxc monitor --type=logging\n"
 "    Only show log messages.\n"
@@ -7367,7 +7367,7 @@ msgid ""
 "    Create record r1 for zone z1 with configuration from config.yaml"
 msgstr ""
 
-#: lxc/operation.go:195
+#: lxc/operation.go:196
 msgid ""
 "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Show details on that operation UUID"
@@ -7410,7 +7410,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:95
+#: lxc/project.go:96
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7418,7 +7418,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:262
+#: lxc/project.go:263
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7449,7 +7449,7 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:85
 msgid ""
 "lxc storage bucket create p1 b01\n"
 "\tCreate a new storage bucket name b01 in storage pool p1\n"
@@ -7459,19 +7459,19 @@ msgid ""
 "of config.yaml"
 msgstr ""
 
-#: lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:251
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1023
+#: lxc/storage_bucket.go:1024
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:854
 msgid ""
 "lxc storage bucket key create p1 b01 k1\n"
 "\tCreate a key called k1 for the bucket b01 in the pool p1.\n"
@@ -7481,14 +7481,14 @@ msgid ""
 "of config.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1158
+#: lxc/storage_bucket.go:1159
 msgid ""
 "lxc storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_bucket.go:630
+#: lxc/storage_bucket.go:631
 msgid ""
 "lxc storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
@@ -7558,16 +7558,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1142
+#: lxc/file.go:1143
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1101
+#: lxc/file.go:1102
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1054
+#: lxc/file.go:1055
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-04 08:52-0600\n"
+"POT-Creation-Date: 2024-09-05 08:44-0400\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Wivik <seb+weblate@zedas.fr>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/linux-containers/"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: lxc/storage_bucket.go:260 lxc/storage_bucket.go:1033
+#: lxc/storage_bucket.go:261 lxc/storage_bucket.go:1034
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
@@ -200,7 +200,7 @@ msgstr ""
 "###\n"
 "### Notez que le nom est affiché mais ne peut être modifié"
 
-#: lxc/auth.go:213
+#: lxc/auth.go:214
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -227,7 +227,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:968
+#: lxc/auth.go:969
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -248,7 +248,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1585
+#: lxc/auth.go:1586
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
@@ -618,7 +618,7 @@ msgstr ""
 "###\n"
 "### Notez que le nom est affiché mais ne peut être modifié"
 
-#: lxc/project.go:280
+#: lxc/project.go:281
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the project.\n"
@@ -679,12 +679,12 @@ msgstr "%s (%d de plus)"
 msgid "%s (%s) (%d available)"
 msgstr "%s (%d de plus)"
 
-#: lxc/file.go:935
+#: lxc/file.go:936
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s n'est pas un répertoire"
 
-#: lxc/file.go:825
+#: lxc/file.go:826
 #, fuzzy, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' n'est pas un format de fichier pris en charge."
@@ -721,7 +721,7 @@ msgstr "--console ne peut être utilisé avec --all"
 msgid "--console only works with a single instance"
 msgstr "--console fonctionne seulement avec une instance seule"
 
-#: lxc/init.go:142 lxc/rebuild.go:64
+#: lxc/init.go:142 lxc/rebuild.go:65
 msgid "--empty cannot be combined with an image name"
 msgstr "--empty ne peut être combiné avec le nom d'une image"
 
@@ -778,7 +778,7 @@ msgstr "Serveur distant : %s"
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:465
+#: lxc/file.go:466
 #, fuzzy
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
@@ -822,7 +822,7 @@ msgstr "ARCHITECTURE"
 msgid "AUTH TYPE"
 msgstr "TYPE"
 
-#: lxc/auth.go:813
+#: lxc/auth.go:814
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -830,11 +830,11 @@ msgstr ""
 msgid "Accept certificate"
 msgstr "Accepter le certificat"
 
-#: lxc/storage_bucket.go:863
+#: lxc/storage_bucket.go:864
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:941
+#: lxc/storage_bucket.go:942
 #, fuzzy, c-format
 msgid "Access key: %s"
 msgstr "Expire : %s"
@@ -844,7 +844,7 @@ msgstr "Expire : %s"
 msgid "Access the expanded configuration"
 msgstr "Afficher la configuration étendue"
 
-#: lxc/warning.go:261 lxc/warning.go:262
+#: lxc/warning.go:262 lxc/warning.go:263
 msgid "Acknowledge warning"
 msgstr "Accusé réception d'avertissement"
 
@@ -862,11 +862,11 @@ msgstr "Action (GET par défaut)"
 msgid "Add a cluster member to a cluster group"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/auth.go:1106 lxc/auth.go:1107
+#: lxc/auth.go:1107 lxc/auth.go:1108
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1874 lxc/auth.go:1875
+#: lxc/auth.go:1875 lxc/auth.go:1876
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -947,7 +947,7 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:515 lxc/auth.go:516
+#: lxc/auth.go:516 lxc/auth.go:517
 msgid "Add permissions to groups"
 msgstr ""
 
@@ -979,7 +979,7 @@ msgstr "Création du conteneur"
 msgid "Address: %s"
 msgstr "Expire : %s"
 
-#: lxc/storage_bucket.go:169
+#: lxc/storage_bucket.go:170
 #, fuzzy, c-format
 msgid "Admin access key: %s"
 msgstr "Expire : %s"
@@ -989,7 +989,7 @@ msgstr "Expire : %s"
 msgid "Admin password (or token) for %s:"
 msgstr "Mot de passe administrateur pour %s : "
 
-#: lxc/storage_bucket.go:170
+#: lxc/storage_bucket.go:171
 #, fuzzy, c-format
 msgid "Admin secret key: %s"
 msgstr "Créé : %s"
@@ -1050,7 +1050,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:342 lxc/rebuild.go:130
+#: lxc/init.go:342 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -1157,12 +1157,12 @@ msgstr ""
 
 #: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:318
 #: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
-#: lxc/network_zone.go:366 lxc/network_zone.go:1053 lxc/storage_bucket.go:141
+#: lxc/network_zone.go:366 lxc/network_zone.go:1053 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:159
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:160
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "Clé de configuration invalide"
@@ -1202,7 +1202,7 @@ msgstr "Octets reçus"
 msgid "Bytes sent"
 msgstr "Octets émis"
 
-#: lxc/operation.go:174
+#: lxc/operation.go:175
 msgid "CANCELABLE"
 msgstr ""
 
@@ -1214,7 +1214,7 @@ msgstr "COMMON NAME"
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: lxc/warning.go:209
+#: lxc/warning.go:210
 msgid "COUNT"
 msgstr ""
 
@@ -1240,7 +1240,7 @@ msgstr "CPU utilisé :"
 msgid "CPUs (%s):"
 msgstr ""
 
-#: lxc/operation.go:175
+#: lxc/operation.go:176
 #, fuzzy
 msgid "CREATED"
 msgstr "CRÉÉ À"
@@ -1272,7 +1272,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:340
+#: lxc/file.go:341
 #, fuzzy
 msgid "Can't pull a directory without --recursive"
 msgstr "impossible de récupérer un répertoire sans --recursive"
@@ -1299,11 +1299,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:224
+#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:546
+#: lxc/file.go:547
 #, fuzzy
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr "impossible de spécifier uid/gid/mode en mode récursif"
@@ -1314,7 +1314,7 @@ msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 "Impossible de désaffecter la clé '%s', elle n'est pas définie actuellement."
 
-#: lxc/rebuild.go:160
+#: lxc/rebuild.go:161
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1439,13 +1439,13 @@ msgstr "Périphérique %s retiré de %s"
 #: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
 #: lxc/network_load_balancer.go:1051 lxc/network_load_balancer.go:1125
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
-#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:90
-#: lxc/storage_bucket.go:190 lxc/storage_bucket.go:253
-#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:541
-#: lxc/storage_bucket.go:634 lxc/storage_bucket.go:700
-#: lxc/storage_bucket.go:775 lxc/storage_bucket.go:861
-#: lxc/storage_bucket.go:961 lxc/storage_bucket.go:1026
-#: lxc/storage_bucket.go:1162 lxc/storage_volume.go:394
+#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
+#: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
+#: lxc/storage_bucket.go:385 lxc/storage_bucket.go:542
+#: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
+#: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
+#: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
 #: lxc/storage_volume.go:612 lxc/storage_volume.go:717
 #: lxc/storage_volume.go:1005 lxc/storage_volume.go:1231
 #: lxc/storage_volume.go:1360 lxc/storage_volume.go:1848
@@ -1469,7 +1469,7 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1113 lxc/list.go:132 lxc/storage_volume.go:1589
-#: lxc/warning.go:92
+#: lxc/warning.go:93
 msgid "Columns"
 msgstr "Colonnes"
 
@@ -1506,7 +1506,7 @@ msgstr "Définir un algorithme de compression : pour image ou aucun"
 msgid "Config key/value to apply to the new instance"
 msgstr "Clé/valeur de configuration à appliquer au nouveau conteneur"
 
-#: lxc/project.go:100
+#: lxc/project.go:101
 #, fuzzy
 msgid "Config key/value to apply to the new project"
 msgstr "Clé/valeur de configuration à appliquer au nouveau conteneur"
@@ -1522,8 +1522,8 @@ msgstr "Clé/valeur de configuration à appliquer au nouveau conteneur"
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
-#: lxc/project.go:362 lxc/storage.go:359 lxc/storage_bucket.go:348
-#: lxc/storage_bucket.go:1125 lxc/storage_volume.go:1150
+#: lxc/project.go:363 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1150
 #: lxc/storage_volume.go:1182
 #, c-format
 msgid "Config parsing error: %s"
@@ -1656,12 +1656,12 @@ msgstr "Impossible d'assainir le chemin %s"
 msgid "Could not find certificate key file path: %s"
 msgstr "Impossible d'assainir le chemin %s"
 
-#: lxc/auth.go:300 lxc/auth.go:1660
+#: lxc/auth.go:301 lxc/auth.go:1661
 #, fuzzy, c-format
 msgid "Could not parse group: %s"
 msgstr "Erreur lors de la lecture de la configuration : %s"
 
-#: lxc/auth.go:1054
+#: lxc/auth.go:1055
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1713,16 +1713,16 @@ msgstr "Création du conteneur"
 msgid "Create and start instances from images"
 msgstr "Création du conteneur"
 
-#: lxc/file.go:248 lxc/file.go:474
+#: lxc/file.go:249 lxc/file.go:475
 msgid "Create any directories necessary"
 msgstr "Créer tous répertoires nécessaires"
 
-#: lxc/auth.go:97 lxc/auth.go:98
+#: lxc/auth.go:98 lxc/auth.go:99
 #, fuzzy
 msgid "Create groups"
 msgstr "Créé : %s"
 
-#: lxc/auth.go:1471 lxc/auth.go:1472
+#: lxc/auth.go:1472 lxc/auth.go:1473
 #, fuzzy
 msgid "Create identity provider groups"
 msgstr "Copie de l'image : %s"
@@ -1761,12 +1761,12 @@ msgstr ""
 msgid "Create instances from images"
 msgstr "Création du conteneur"
 
-#: lxc/storage_bucket.go:851 lxc/storage_bucket.go:852
+#: lxc/storage_bucket.go:852 lxc/storage_bucket.go:853
 #, fuzzy
 msgid "Create key for a storage bucket"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_bucket.go:82 lxc/storage_bucket.go:83
+#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
 #, fuzzy
 msgid "Create new custom storage buckets"
 msgstr "Copie de l'image : %s"
@@ -1819,7 +1819,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr "Créé : %s"
 
-#: lxc/project.go:92 lxc/project.go:93
+#: lxc/project.go:93 lxc/project.go:94
 #, fuzzy
 msgid "Create projects"
 msgstr "Créé : %s"
@@ -1858,13 +1858,13 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:376 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1135 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
-#: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:172
-#: lxc/profile.go:756 lxc/project.go:572 lxc/storage.go:723
-#: lxc/storage_bucket.go:512 lxc/storage_bucket.go:832
+#: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
+#: lxc/profile.go:756 lxc/project.go:573 lxc/storage.go:723
+#: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1732
 msgid "DESCRIPTION"
 msgstr "DESCRIPTION"
@@ -1890,7 +1890,7 @@ msgstr ""
 msgid "Define a compression algorithm: for backup or none"
 msgstr "Définir un algorithme de compression : pour image ou aucun"
 
-#: lxc/operation.go:55 lxc/operation.go:56
+#: lxc/operation.go:56 lxc/operation.go:57
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
@@ -1898,22 +1898,22 @@ msgstr ""
 msgid "Delete a cluster group"
 msgstr ""
 
-#: lxc/warning.go:360
+#: lxc/warning.go:361
 #, fuzzy
 msgid "Delete all warnings"
 msgstr "Récupération de l'image : %s"
 
-#: lxc/file.go:122 lxc/file.go:123
+#: lxc/file.go:123 lxc/file.go:124
 #, fuzzy
 msgid "Delete files in instances"
 msgstr "Création du conteneur"
 
-#: lxc/auth.go:151 lxc/auth.go:152
+#: lxc/auth.go:152 lxc/auth.go:153
 #, fuzzy
 msgid "Delete groups"
 msgstr "Récupération de l'image : %s"
 
-#: lxc/auth.go:1523 lxc/auth.go:1524
+#: lxc/auth.go:1524 lxc/auth.go:1525
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1936,7 +1936,7 @@ msgstr "L'arrêt du conteneur a échoué !"
 msgid "Delete instances and snapshots"
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: lxc/storage_bucket.go:957 lxc/storage_bucket.go:958
+#: lxc/storage_bucket.go:958 lxc/storage_bucket.go:959
 #, fuzzy
 msgid "Delete key from a storage bucket"
 msgstr "Copie de l'image : %s"
@@ -1977,12 +1977,12 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:188 lxc/project.go:189
+#: lxc/project.go:189 lxc/project.go:190
 #, fuzzy
 msgid "Delete projects"
 msgstr "Récupération de l'image : %s"
 
-#: lxc/storage_bucket.go:187 lxc/storage_bucket.go:188
+#: lxc/storage_bucket.go:188 lxc/storage_bucket.go:189
 #, fuzzy
 msgid "Delete storage buckets"
 msgstr "Copie de l'image : %s"
@@ -1996,21 +1996,21 @@ msgstr ""
 msgid "Delete storage volumes"
 msgstr "Copie de l'image : %s"
 
-#: lxc/warning.go:356 lxc/warning.go:357
+#: lxc/warning.go:357 lxc/warning.go:358
 #, fuzzy
 msgid "Delete warning"
 msgstr "Récupération de l'image : %s"
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:30 lxc/auth.go:59 lxc/auth.go:98
-#: lxc/auth.go:152 lxc/auth.go:201 lxc/auth.go:332 lxc/auth.go:392
-#: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
-#: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
-#: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
-#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1434 lxc/auth.go:1472
-#: lxc/auth.go:1524 lxc/auth.go:1573 lxc/auth.go:1692 lxc/auth.go:1752
-#: lxc/auth.go:1801 lxc/auth.go:1852 lxc/auth.go:1875 lxc/auth.go:1928
+#: lxc/alias.go:214 lxc/auth.go:31 lxc/auth.go:60 lxc/auth.go:99
+#: lxc/auth.go:153 lxc/auth.go:202 lxc/auth.go:333 lxc/auth.go:393
+#: lxc/auth.go:442 lxc/auth.go:494 lxc/auth.go:517 lxc/auth.go:576
+#: lxc/auth.go:732 lxc/auth.go:766 lxc/auth.go:833 lxc/auth.go:896
+#: lxc/auth.go:957 lxc/auth.go:1085 lxc/auth.go:1108 lxc/auth.go:1166
+#: lxc/auth.go:1235 lxc/auth.go:1257 lxc/auth.go:1435 lxc/auth.go:1473
+#: lxc/auth.go:1525 lxc/auth.go:1574 lxc/auth.go:1693 lxc/auth.go:1753
+#: lxc/auth.go:1802 lxc/auth.go:1853 lxc/auth.go:1876 lxc/auth.go:1929
 #: lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215 lxc/cluster.go:272
 #: lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:484 lxc/cluster.go:528
 #: lxc/cluster.go:586 lxc/cluster.go:677 lxc/cluster.go:770 lxc/cluster.go:893
@@ -2034,15 +2034,15 @@ msgstr "Récupération de l'image : %s"
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:83 lxc/file.go:123 lxc/file.go:172
-#: lxc/file.go:242 lxc/file.go:467 lxc/file.go:986 lxc/image.go:38
+#: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
+#: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
 #: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
 #: lxc/image.go:697 lxc/image.go:946 lxc/image.go:1088 lxc/image.go:1415
 #: lxc/image.go:1506 lxc/image.go:1572 lxc/image.go:1636 lxc/image.go:1699
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:38 lxc/network.go:33
+#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33
 #: lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405
 #: lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793
 #: lxc/network.go:874 lxc/network.go:1005 lxc/network.go:1106
@@ -2076,27 +2076,27 @@ msgstr "Récupération de l'image : %s"
 #: lxc/network_zone.go:909 lxc/network_zone.go:985 lxc/network_zone.go:1083
 #: lxc/network_zone.go:1172 lxc/network_zone.go:1219 lxc/network_zone.go:1349
 #: lxc/network_zone.go:1410 lxc/network_zone.go:1425 lxc/network_zone.go:1483
-#: lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:106
-#: lxc/operation.go:193 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
+#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
+#: lxc/operation.go:194 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
 #: lxc/profile.go:271 lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493
 #: lxc/profile.go:629 lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860
-#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:29
-#: lxc/project.go:93 lxc/project.go:189 lxc/project.go:260 lxc/project.go:396
-#: lxc/project.go:470 lxc/project.go:590 lxc/project.go:655 lxc/project.go:743
-#: lxc/project.go:787 lxc/project.go:848 lxc/project.go:915 lxc/publish.go:34
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:35 lxc/remote.go:91
+#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:30
+#: lxc/project.go:94 lxc/project.go:190 lxc/project.go:261 lxc/project.go:397
+#: lxc/project.go:471 lxc/project.go:591 lxc/project.go:656 lxc/project.go:744
+#: lxc/project.go:788 lxc/project.go:849 lxc/project.go:916 lxc/publish.go:34
+#: lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91
 #: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853
 #: lxc/remote.go:917 lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24
 #: lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203
 #: lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655
 #: lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940
-#: lxc/storage_bucket.go:29 lxc/storage_bucket.go:83 lxc/storage_bucket.go:188
-#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:382
-#: lxc/storage_bucket.go:458 lxc/storage_bucket.go:535
-#: lxc/storage_bucket.go:629 lxc/storage_bucket.go:698
-#: lxc/storage_bucket.go:732 lxc/storage_bucket.go:773
-#: lxc/storage_bucket.go:852 lxc/storage_bucket.go:958
-#: lxc/storage_bucket.go:1022 lxc/storage_bucket.go:1157
+#: lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189
+#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:383
+#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:536
+#: lxc/storage_bucket.go:630 lxc/storage_bucket.go:699
+#: lxc/storage_bucket.go:733 lxc/storage_bucket.go:774
+#: lxc/storage_bucket.go:853 lxc/storage_bucket.go:959
+#: lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158
 #: lxc/storage_volume.go:58 lxc/storage_volume.go:169 lxc/storage_volume.go:283
 #: lxc/storage_volume.go:390 lxc/storage_volume.go:605
 #: lxc/storage_volume.go:714 lxc/storage_volume.go:801
@@ -2107,8 +2107,8 @@ msgstr "Récupération de l'image : %s"
 #: lxc/storage_volume.go:2064 lxc/storage_volume.go:2222
 #: lxc/storage_volume.go:2343 lxc/storage_volume.go:2405
 #: lxc/storage_volume.go:2541 lxc/storage_volume.go:2624
-#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:29
-#: lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
+#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:30
+#: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
@@ -2199,7 +2199,7 @@ msgstr "L'importation de répertoire n'est pas disponible sur cette plateforme"
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:994
+#: lxc/file.go:995
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2271,7 +2271,7 @@ msgstr "DATE D'EXPIRATION"
 msgid "EXPIRY DATE"
 msgstr "DATE D'EXPIRATION"
 
-#: lxc/file.go:74
+#: lxc/file.go:75
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -2281,7 +2281,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:955 lxc/auth.go:956
+#: lxc/auth.go:956 lxc/auth.go:957
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -2290,17 +2290,17 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr "Clé de configuration invalide"
 
-#: lxc/file.go:171 lxc/file.go:172
+#: lxc/file.go:172 lxc/file.go:173
 #, fuzzy
 msgid "Edit files in instances"
 msgstr "Création du conteneur"
 
-#: lxc/auth.go:200 lxc/auth.go:201
+#: lxc/auth.go:201 lxc/auth.go:202
 #, fuzzy
 msgid "Edit groups as YAML"
 msgstr "Clé de configuration invalide"
 
-#: lxc/auth.go:1572 lxc/auth.go:1573
+#: lxc/auth.go:1573 lxc/auth.go:1574
 #, fuzzy
 msgid "Edit identity provider groups as YAML"
 msgstr "Clé de configuration invalide"
@@ -2367,17 +2367,17 @@ msgstr "Clé de configuration invalide"
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:259 lxc/project.go:260
+#: lxc/project.go:260 lxc/project.go:261
 #, fuzzy
 msgid "Edit project configurations as YAML"
 msgstr "Clé de configuration invalide"
 
-#: lxc/storage_bucket.go:248 lxc/storage_bucket.go:249
+#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:250
 #, fuzzy
 msgid "Edit storage bucket configurations as YAML"
 msgstr "Clé de configuration invalide"
 
-#: lxc/storage_bucket.go:1021 lxc/storage_bucket.go:1022
+#: lxc/storage_bucket.go:1022 lxc/storage_bucket.go:1023
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
@@ -2395,7 +2395,7 @@ msgid "Edit trust configurations as YAML"
 msgstr "Clé de configuration invalide"
 
 #: lxc/image.go:1147 lxc/list.go:622 lxc/storage_volume.go:1766
-#: lxc/warning.go:235
+#: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2451,7 +2451,7 @@ msgstr "Récupération de l'image : %s"
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
-#: lxc/project.go:718 lxc/storage.go:812 lxc/storage_bucket.go:602
+#: lxc/project.go:719 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2155 lxc/storage_volume.go:2193
 #, fuzzy, c-format
 msgid "Error setting properties: %v"
@@ -2465,8 +2465,8 @@ msgstr "Récupération de l'image : %s"
 #: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
-#: lxc/profile.go:981 lxc/project.go:712 lxc/storage.go:806
-#: lxc/storage_bucket.go:596 lxc/storage_volume.go:2149
+#: lxc/profile.go:981 lxc/project.go:713 lxc/storage.go:806
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2149
 #: lxc/storage_volume.go:2187
 #, c-format
 msgid "Error unsetting property: %v"
@@ -2494,7 +2494,7 @@ msgstr ""
 msgid "Evacuating cluster member: %s"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/monitor.go:50
+#: lxc/monitor.go:51
 msgid "Event type to listen for"
 msgstr "Type d'évènements à surveiller"
 
@@ -2597,16 +2597,16 @@ msgstr "NOM"
 msgid "FINGERPRINT"
 msgstr "EMPREINTE"
 
-#: lxc/warning.go:210
+#: lxc/warning.go:211
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1237
+#: lxc/file.go:1238
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1260
+#: lxc/file.go:1261
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2621,12 +2621,12 @@ msgstr "Profil à appliquer au nouveau conteneur"
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "Profil à appliquer au nouveau conteneur"
 
-#: lxc/file.go:1287
+#: lxc/file.go:1288
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1072
+#: lxc/file.go:1073
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "Profil à appliquer au nouveau conteneur"
@@ -2656,7 +2656,7 @@ msgstr "Profil à appliquer au nouveau conteneur"
 msgid "Failed fetching fingerprint %q: %w"
 msgstr "Profil à appliquer au nouveau conteneur"
 
-#: lxc/file.go:1193
+#: lxc/file.go:1194
 #, fuzzy, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
@@ -2671,7 +2671,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
-#: lxc/file.go:1198
+#: lxc/file.go:1199
 #, fuzzy, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
@@ -2681,12 +2681,12 @@ msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 msgid "Failed starting command: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
-#: lxc/file.go:1098
+#: lxc/file.go:1099
 #, fuzzy, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
-#: lxc/file.go:1225
+#: lxc/file.go:1226
 #, fuzzy, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "Échec lors de la génération de 'lxc.1': %v"
@@ -2726,7 +2726,7 @@ msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 msgid "Failed to find project: %w"
 msgstr "Échec lors de la génération de 'lxc.1': %v"
 
-#: lxc/file.go:1210
+#: lxc/file.go:1211
 #, fuzzy, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "Échec lors de la génération de 'lxc.1': %v"
@@ -2741,7 +2741,7 @@ msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 msgid "Failed to remove alias %s: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
-#: lxc/file.go:820
+#: lxc/file.go:821
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2757,7 +2757,7 @@ msgid "Fast mode (same as --columns=nsacPt)"
 msgstr "Mode rapide (identique à --columns=nsacPt"
 
 #: lxc/network.go:1044 lxc/network_acl.go:133 lxc/network_zone.go:124
-#: lxc/operation.go:136
+#: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
 
@@ -2826,21 +2826,21 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
+#: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:770 lxc/auth.go:1697
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1114 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:57
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
-#: lxc/operation.go:108 lxc/profile.go:707 lxc/project.go:472
-#: lxc/project.go:917 lxc/remote.go:690 lxc/storage.go:657
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:774
-#: lxc/storage_volume.go:1608 lxc/warning.go:93
+#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:473
+#: lxc/project.go:918 lxc/remote.go:690 lxc/storage.go:657
+#: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
+#: lxc/storage_volume.go:1608 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
-#: lxc/monitor.go:52
+#: lxc/monitor.go:53
 msgid "Format (json|pretty|yaml)"
 msgstr ""
 
@@ -2884,7 +2884,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:817 lxc/auth.go:1736
+#: lxc/auth.go:818 lxc/auth.go:1737
 msgid "GROUPS"
 msgstr ""
 
@@ -2901,7 +2901,7 @@ msgstr "Génération d'un certificat client. Ceci peut prendre une minute…"
 msgid "Get UEFI variables for instance"
 msgstr "Création du conteneur"
 
-#: lxc/project.go:914 lxc/project.go:915
+#: lxc/project.go:915 lxc/project.go:916
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2954,11 +2954,11 @@ msgstr "Clé de configuration invalide"
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:400
+#: lxc/project.go:401
 msgid "Get the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:385
+#: lxc/storage_bucket.go:386
 #, fuzzy
 msgid "Get the key as a storage bucket property"
 msgstr "Copie de l'image : %s"
@@ -3032,12 +3032,12 @@ msgstr "Clé de configuration invalide"
 msgid "Get values for profile configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/project.go:395 lxc/project.go:396
+#: lxc/project.go:396 lxc/project.go:397
 #, fuzzy
 msgid "Get values for project configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:382
+#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:383
 #, fuzzy
 msgid "Get values for storage bucket configuration keys"
 msgstr "Clé de configuration invalide"
@@ -3055,17 +3055,17 @@ msgstr ""
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: lxc/auth.go:136
+#: lxc/auth.go:137
 #, fuzzy, c-format
 msgid "Group %s created"
 msgstr "Profil %s créé"
 
-#: lxc/auth.go:186
+#: lxc/auth.go:187
 #, fuzzy, c-format
 msgid "Group %s deleted"
 msgstr "Profil %s supprimé"
 
-#: lxc/auth.go:426 lxc/auth.go:1786
+#: lxc/auth.go:427 lxc/auth.go:1787
 #, fuzzy, c-format
 msgid "Group %s renamed to %s"
 msgstr "Profil %s ajouté à %s"
@@ -3092,27 +3092,27 @@ msgstr "L'arrêt du conteneur a échoué !"
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1310
+#: lxc/file.go:1311
 #, fuzzy, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/file.go:1299
+#: lxc/file.go:1300
 #, fuzzy, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/file.go:1122
+#: lxc/file.go:1123
 #, fuzzy, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/file.go:1132
+#: lxc/file.go:1133
 #, fuzzy, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/network.go:966 lxc/operation.go:170
+#: lxc/network.go:966 lxc/operation.go:171
 #, fuzzy
 msgid "ID"
 msgstr "PID"
@@ -3127,11 +3127,11 @@ msgstr "Pid : %d"
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:816
+#: lxc/auth.go:817
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:566
+#: lxc/project.go:567
 msgid "IMAGES"
 msgstr ""
 
@@ -3161,17 +3161,17 @@ msgstr "IPv6"
 msgid "ISSUE DATE"
 msgstr "DATE D'ÉMISSION"
 
-#: lxc/auth.go:1508
+#: lxc/auth.go:1509
 #, fuzzy, c-format
 msgid "Identity provider group %s created"
 msgstr "Profil %s créé"
 
-#: lxc/auth.go:1558
+#: lxc/auth.go:1559
 #, fuzzy, c-format
 msgid "Identity provider group %s deleted"
 msgstr "Profil %s créé"
 
-#: lxc/rebuild.go:32
+#: lxc/rebuild.go:33
 msgid "If an instance is running, stop it and then rebuild it"
 msgstr ""
 
@@ -3302,7 +3302,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1233 lxc/auth.go:1234
+#: lxc/auth.go:1234 lxc/auth.go:1235
 msgid "Inspect permissions"
 msgstr ""
 
@@ -3311,12 +3311,12 @@ msgstr ""
 msgid "Instance Only"
 msgstr "Le nom du conteneur est : %s"
 
-#: lxc/file.go:1124
+#: lxc/file.go:1125
 #, fuzzy
 msgid "Instance disconnected"
 msgstr "Mot de passe de l'administrateur distant"
 
-#: lxc/file.go:1301
+#: lxc/file.go:1302
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3336,7 +3336,7 @@ msgstr "Le nom du conteneur est : %s"
 msgid "Instance name must be specified"
 msgstr "Le nom du conteneur est : %s"
 
-#: lxc/file.go:1044
+#: lxc/file.go:1045
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3345,7 +3345,7 @@ msgstr ""
 msgid "Instance published with fingerprint: %s"
 msgstr "Conteneur publié avec l'empreinte : %s"
 
-#: lxc/rebuild.go:74
+#: lxc/rebuild.go:75
 #, fuzzy, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr "Le nom du conteneur est : %s"
@@ -3378,7 +3378,7 @@ msgstr "Clé de configuration invalide"
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/monitor.go:70
+#: lxc/monitor.go:71
 #, fuzzy, c-format
 msgid "Invalid format: %s"
 msgstr "Cible invalide %s"
@@ -3388,7 +3388,7 @@ msgstr "Cible invalide %s"
 msgid "Invalid instance name: %s"
 msgstr "Le nom du conteneur est : %s"
 
-#: lxc/file.go:1039
+#: lxc/file.go:1040
 #, fuzzy, c-format
 msgid "Invalid instance path: %q"
 msgstr "Le nom du conteneur est : %s"
@@ -3432,7 +3432,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr "nombre d'arguments incorrect pour la sous-comande"
 
-#: lxc/file.go:147
+#: lxc/file.go:148
 #, fuzzy, c-format
 msgid "Invalid path %s"
 msgstr "Cible invalide %s"
@@ -3449,12 +3449,12 @@ msgstr "Cible invalide %s"
 msgid "Invalid snapshot name"
 msgstr "Le nom du conteneur est : %s"
 
-#: lxc/file.go:313
+#: lxc/file.go:314
 #, c-format
 msgid "Invalid source %s"
 msgstr "Source invalide %s"
 
-#: lxc/file.go:495
+#: lxc/file.go:496
 #, c-format
 msgid "Invalid target %s"
 msgstr "Cible invalide %s"
@@ -3468,7 +3468,7 @@ msgstr "Créé : %s"
 msgid "Keep the image up to date after initial copy"
 msgstr "Garder l'image à jour après la copie initiale"
 
-#: lxc/warning.go:211
+#: lxc/warning.go:212
 #, fuzzy
 msgid "LAST SEEN"
 msgstr "DERNIÈRE UTILISATION À"
@@ -3477,7 +3477,7 @@ msgstr "DERNIÈRE UTILISATION À"
 msgid "LAST USED AT"
 msgstr "DERNIÈRE UTILISATION À"
 
-#: lxc/project.go:984
+#: lxc/project.go:985
 msgid "LIMIT"
 msgstr ""
 
@@ -3486,8 +3486,8 @@ msgid "LISTEN ADDRESS"
 msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
-#: lxc/network_load_balancer.go:165 lxc/operation.go:177
-#: lxc/storage_bucket.go:516 lxc/storage_volume.go:1739 lxc/warning.go:220
+#: lxc/network_load_balancer.go:165 lxc/operation.go:178
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1739 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3566,7 +3566,7 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/warning.go:94
+#: lxc/warning.go:95
 #, fuzzy
 msgid "List all warnings"
 msgstr "Alias :"
@@ -3613,20 +3613,20 @@ msgstr ""
 msgid "List available storage pools"
 msgstr ""
 
-#: lxc/operation.go:105 lxc/operation.go:106
+#: lxc/operation.go:106 lxc/operation.go:107
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:331 lxc/auth.go:332
+#: lxc/auth.go:332 lxc/auth.go:333
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:764 lxc/auth.go:765
+#: lxc/auth.go:765 lxc/auth.go:766
 #, fuzzy
 msgid "List identities"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/auth.go:1691 lxc/auth.go:1692
+#: lxc/auth.go:1692 lxc/auth.go:1693
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3838,12 +3838,12 @@ msgstr "Clé de configuration invalide"
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/operation.go:109
+#: lxc/operation.go:110
 #, fuzzy
 msgid "List operations from all projects"
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: lxc/auth.go:1255 lxc/auth.go:1256
+#: lxc/auth.go:1256 lxc/auth.go:1257
 #, fuzzy
 msgid "List permissions"
 msgstr "Alias :"
@@ -3852,16 +3852,16 @@ msgstr "Alias :"
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:469 lxc/project.go:470
+#: lxc/project.go:470 lxc/project.go:471
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:771 lxc/storage_bucket.go:773
+#: lxc/storage_bucket.go:772 lxc/storage_bucket.go:774
 #, fuzzy
 msgid "List storage bucket keys"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_bucket.go:456 lxc/storage_bucket.go:458
+#: lxc/storage_bucket.go:457 lxc/storage_bucket.go:459
 #, fuzzy
 msgid "List storage buckets"
 msgstr "Copie de l'image : %s"
@@ -3899,12 +3899,12 @@ msgstr ""
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/warning.go:70
+#: lxc/warning.go:71
 #, fuzzy
 msgid "List warnings"
 msgstr "Alias :"
 
-#: lxc/warning.go:71
+#: lxc/warning.go:72
 msgid ""
 "List warnings\n"
 "\n"
@@ -3927,7 +3927,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/operation.go:23 lxc/operation.go:24
+#: lxc/operation.go:24 lxc/operation.go:25
 msgid "List, show and delete background operations"
 msgstr ""
 
@@ -3936,7 +3936,7 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/monitor.go:79
+#: lxc/monitor.go:80
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
@@ -4046,26 +4046,26 @@ msgstr ""
 msgid "Manage devices"
 msgstr "Création du conteneur"
 
-#: lxc/file.go:82 lxc/file.go:83
+#: lxc/file.go:83 lxc/file.go:84
 #, fuzzy
 msgid "Manage files in instances"
 msgstr "Transfert de l'image : %s"
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1433 lxc/auth.go:1434
+#: lxc/auth.go:59 lxc/auth.go:60 lxc/auth.go:1434 lxc/auth.go:1435
 #, fuzzy
 msgid "Manage groups"
 msgstr "Copie de l'image : %s"
 
-#: lxc/auth.go:1083 lxc/auth.go:1084
+#: lxc/auth.go:1084 lxc/auth.go:1085
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:730 lxc/auth.go:731
+#: lxc/auth.go:731 lxc/auth.go:732
 #, fuzzy
 msgid "Manage identities"
 msgstr "Création du conteneur"
 
-#: lxc/auth.go:1851 lxc/auth.go:1852
+#: lxc/auth.go:1852 lxc/auth.go:1853
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -4173,7 +4173,7 @@ msgstr "Nom du réseau"
 msgid "Manage network zones"
 msgstr "Nom du réseau"
 
-#: lxc/auth.go:492 lxc/auth.go:493
+#: lxc/auth.go:493 lxc/auth.go:494
 #, fuzzy
 msgid "Manage permissions"
 msgstr "Rendre l'image publique"
@@ -4182,27 +4182,27 @@ msgstr "Rendre l'image publique"
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:28 lxc/project.go:29
+#: lxc/project.go:29 lxc/project.go:30
 #, fuzzy
 msgid "Manage projects"
 msgstr "Rendre l'image publique"
 
-#: lxc/storage_bucket.go:731
+#: lxc/storage_bucket.go:732
 #, fuzzy
 msgid "Manage storage bucket keys"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_bucket.go:732
+#: lxc/storage_bucket.go:733
 #, fuzzy
 msgid "Manage storage bucket keys."
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_bucket.go:28
+#: lxc/storage_bucket.go:29
 #, fuzzy
 msgid "Manage storage buckets"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:30
 #, fuzzy
 msgid "Manage storage buckets."
 msgstr "Copie de l'image : %s"
@@ -4233,12 +4233,12 @@ msgstr ""
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/auth.go:29 lxc/auth.go:30
+#: lxc/auth.go:30 lxc/auth.go:31
 #, fuzzy
 msgid "Manage user authorization"
 msgstr "Copie de l'image : %s"
 
-#: lxc/warning.go:28 lxc/warning.go:29
+#: lxc/warning.go:29 lxc/warning.go:30
 #, fuzzy
 msgid "Manage warnings"
 msgstr "Rendre l'image publique"
@@ -4306,17 +4306,17 @@ msgstr "Échec lors de la migration vers l'hôte source: %s"
 msgid "Migration operation failure: %w"
 msgstr "Échec lors de la migration vers l'hôte source: %s"
 
-#: lxc/monitor.go:51
+#: lxc/monitor.go:52
 msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: lxc/storage_bucket.go:116 lxc/storage_bucket.go:216
-#: lxc/storage_bucket.go:292 lxc/storage_bucket.go:411
-#: lxc/storage_bucket.go:568 lxc/storage_bucket.go:660
-#: lxc/storage_bucket.go:802 lxc/storage_bucket.go:889
-#: lxc/storage_bucket.go:986 lxc/storage_bucket.go:1065
-#: lxc/storage_bucket.go:1188
+#: lxc/storage_bucket.go:117 lxc/storage_bucket.go:217
+#: lxc/storage_bucket.go:293 lxc/storage_bucket.go:412
+#: lxc/storage_bucket.go:569 lxc/storage_bucket.go:661
+#: lxc/storage_bucket.go:803 lxc/storage_bucket.go:890
+#: lxc/storage_bucket.go:987 lxc/storage_bucket.go:1066
+#: lxc/storage_bucket.go:1189
 #, fuzzy
 msgid "Missing bucket name"
 msgstr "Résumé manquant."
@@ -4339,23 +4339,23 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 msgid "Missing cluster member name"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1825
+#: lxc/auth.go:123 lxc/auth.go:177 lxc/auth.go:255 lxc/auth.go:417
+#: lxc/auth.go:466 lxc/auth.go:541 lxc/auth.go:600 lxc/auth.go:1826
 #, fuzzy
 msgid "Missing group name"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/auth.go:862 lxc/auth.go:1003 lxc/auth.go:1131 lxc/auth.go:1189
+#: lxc/auth.go:863 lxc/auth.go:1004 lxc/auth.go:1132 lxc/auth.go:1190
 #, fuzzy
 msgid "Missing identity argument"
 msgstr "Résumé manquant."
 
-#: lxc/auth.go:1495 lxc/auth.go:1548 lxc/auth.go:1614 lxc/auth.go:1776
+#: lxc/auth.go:1496 lxc/auth.go:1549 lxc/auth.go:1615 lxc/auth.go:1777
 #, fuzzy
 msgid "Missing identity provider group name"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/auth.go:1899 lxc/auth.go:1952
+#: lxc/auth.go:1900 lxc/auth.go:1953
 #, fuzzy
 msgid "Missing identity provider group name argument"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -4364,13 +4364,13 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
 #: lxc/config_template.go:377 lxc/profile.go:141 lxc/profile.go:222
-#: lxc/profile.go:808 lxc/rebuild.go:60
+#: lxc/profile.go:808 lxc/rebuild.go:61
 #, fuzzy
 msgid "Missing instance name"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/storage_bucket.go:893 lxc/storage_bucket.go:990
-#: lxc/storage_bucket.go:1069 lxc/storage_bucket.go:1192
+#: lxc/storage_bucket.go:894 lxc/storage_bucket.go:991
+#: lxc/storage_bucket.go:1070 lxc/storage_bucket.go:1193
 #, fuzzy
 msgid "Missing key name"
 msgstr "Résumé manquant."
@@ -4443,13 +4443,13 @@ msgid "Missing peer name"
 msgstr "Résumé manquant."
 
 #: lxc/storage.go:235 lxc/storage.go:313 lxc/storage.go:431 lxc/storage.go:509
-#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:112
-#: lxc/storage_bucket.go:212 lxc/storage_bucket.go:288
-#: lxc/storage_bucket.go:407 lxc/storage_bucket.go:482
-#: lxc/storage_bucket.go:564 lxc/storage_bucket.go:656
-#: lxc/storage_bucket.go:798 lxc/storage_bucket.go:885
-#: lxc/storage_bucket.go:982 lxc/storage_bucket.go:1061
-#: lxc/storage_bucket.go:1184 lxc/storage_volume.go:209
+#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:113
+#: lxc/storage_bucket.go:213 lxc/storage_bucket.go:289
+#: lxc/storage_bucket.go:408 lxc/storage_bucket.go:483
+#: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
+#: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
+#: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
 #: lxc/storage_volume.go:323 lxc/storage_volume.go:643
 #: lxc/storage_volume.go:750 lxc/storage_volume.go:841
 #: lxc/storage_volume.go:939 lxc/storage_volume.go:1053
@@ -4465,9 +4465,9 @@ msgstr "Nom de l'ensemble de stockage"
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:404 lxc/project.go:146 lxc/project.go:226 lxc/project.go:316
-#: lxc/project.go:433 lxc/project.go:622 lxc/project.go:691 lxc/project.go:819
-#: lxc/project.go:948
+#: lxc/profile.go:404 lxc/project.go:147 lxc/project.go:227 lxc/project.go:317
+#: lxc/project.go:434 lxc/project.go:623 lxc/project.go:692 lxc/project.go:820
+#: lxc/project.go:949
 #, fuzzy
 msgid "Missing project name"
 msgstr "Nom de l'ensemble de stockage"
@@ -4486,7 +4486,7 @@ msgstr "Copie de l'image : %s"
 msgid "Missing storage pool name"
 msgstr "Nom de l'ensemble de stockage"
 
-#: lxc/file.go:598
+#: lxc/file.go:599
 #, fuzzy
 msgid "Missing target directory"
 msgstr "%s n'est pas un répertoire"
@@ -4511,11 +4511,11 @@ msgstr "Publié : %s"
 msgid "Model: %v"
 msgstr ""
 
-#: lxc/monitor.go:32
+#: lxc/monitor.go:33
 msgid "Monitor a local or remote LXD server"
 msgstr ""
 
-#: lxc/monitor.go:33
+#: lxc/monitor.go:34
 msgid ""
 "Monitor a local or remote LXD server\n"
 "\n"
@@ -4528,12 +4528,12 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr "Plus d'un périphérique correspond, spécifier le nom du périphérique."
 
-#: lxc/file.go:285
+#: lxc/file.go:286
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 "Plusieurs fichiers à télécharger, mais la destination n'est pas un dossier"
 
-#: lxc/file.go:985 lxc/file.go:986
+#: lxc/file.go:986 lxc/file.go:987
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "Création du conteneur"
@@ -4600,13 +4600,13 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:192
+#: lxc/auth.go:376 lxc/auth.go:816 lxc/auth.go:1736 lxc/cluster.go:192
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
-#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:565
-#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:511
-#: lxc/storage_bucket.go:831 lxc/storage_volume.go:1731
+#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:566
+#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1731
 msgid "NAME"
 msgstr "NOM"
 
@@ -4614,11 +4614,11 @@ msgstr "NOM"
 msgid "NAT"
 msgstr ""
 
-#: lxc/project.go:571
+#: lxc/project.go:572
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:570
+#: lxc/project.go:571
 msgid "NETWORKS"
 msgstr ""
 
@@ -4630,9 +4630,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/operation.go:154 lxc/project.go:523
-#: lxc/project.go:528 lxc/project.go:533 lxc/project.go:538 lxc/project.go:543
-#: lxc/project.go:548 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
+#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:524
+#: lxc/project.go:529 lxc/project.go:534 lxc/project.go:539 lxc/project.go:544
+#: lxc/project.go:549 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
 msgid "NO"
 msgstr "NON"
 
@@ -4894,7 +4894,7 @@ msgstr ""
 msgid "Only managed networks can be modified"
 msgstr "Seuls les réseaux gérés par LXD peuvent être modifiés."
 
-#: lxc/operation.go:86
+#: lxc/operation.go:87
 #, fuzzy, c-format
 msgid "Operation %s deleted"
 msgstr "Le réseau %s a été supprimé"
@@ -4942,11 +4942,11 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:567
+#: lxc/list.go:576 lxc/project.go:568
 msgid "PROFILES"
 msgstr "PROFILS"
 
-#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:212
+#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -5012,25 +5012,25 @@ msgstr "État : %s"
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1102
+#: lxc/file.go:1103
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:860
+#: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
-#: lxc/project.go:363 lxc/storage.go:360 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1151
+#: lxc/project.go:364 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1151
 #: lxc/storage_volume.go:1183
 #, fuzzy
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr "Appuyer sur Entrée pour ouvrir à nouveau l'éditeur"
 
-#: lxc/monitor.go:48
+#: lxc/monitor.go:49
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
@@ -5121,17 +5121,17 @@ msgstr "Profils : %s"
 msgid "Profiles: "
 msgstr "Profils : %s"
 
-#: lxc/project.go:172
+#: lxc/project.go:173
 #, fuzzy, c-format
 msgid "Project %s created"
 msgstr "Profil %s créé"
 
-#: lxc/project.go:236
+#: lxc/project.go:237
 #, fuzzy, c-format
 msgid "Project %s deleted"
 msgstr "Profil %s supprimé"
 
-#: lxc/project.go:637
+#: lxc/project.go:638
 #, fuzzy, c-format
 msgid "Project %s renamed to %s"
 msgstr "Profil %s ajouté à %s"
@@ -5253,22 +5253,22 @@ msgstr "Création du conteneur"
 msgid "Publishing instance: %s"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
 
-#: lxc/file.go:241 lxc/file.go:242
+#: lxc/file.go:242 lxc/file.go:243
 #, fuzzy
 msgid "Pull files from instances"
 msgstr "Création du conteneur"
 
-#: lxc/file.go:416 lxc/file.go:767
+#: lxc/file.go:417 lxc/file.go:768
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:466 lxc/file.go:467
+#: lxc/file.go:467 lxc/file.go:468
 #, fuzzy
 msgid "Push files into instances"
 msgstr "Création du conteneur"
 
-#: lxc/file.go:701 lxc/file.go:867
+#: lxc/file.go:702 lxc/file.go:868
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -5281,12 +5281,12 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:983
+#: lxc/project.go:984
 #, fuzzy
 msgid "RESOURCE"
 msgstr "SOURCE"
 
-#: lxc/storage_bucket.go:833
+#: lxc/storage_bucket.go:834
 msgid "ROLE"
 msgstr ""
 
@@ -5299,17 +5299,17 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/rebuild.go:31
+#: lxc/rebuild.go:32
 #, fuzzy
 msgid "Rebuild as an empty instance"
 msgstr "Création du conteneur"
 
-#: lxc/rebuild.go:26
+#: lxc/rebuild.go:27
 #, fuzzy
 msgid "Rebuild instances"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/file.go:249 lxc/file.go:473
+#: lxc/file.go:250 lxc/file.go:474
 #, fuzzy
 msgid "Recursively transfer files"
 msgstr "Pousser ou récupérer des fichiers récursivement"
@@ -5339,7 +5339,7 @@ msgstr "Récupération de l'image : %s"
 msgid "Remote %s already exists"
 msgstr "le serveur distant %s existe déjà"
 
-#: lxc/project.go:882 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
+#: lxc/project.go:883 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
 #: lxc/remote.go:994
 #, fuzzy, c-format
 msgid "Remote %s doesn't exist"
@@ -5392,7 +5392,7 @@ msgstr "Supprimer %s (oui/non) : "
 msgid "Remove a cluster member from a cluster group"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/auth.go:1164 lxc/auth.go:1165
+#: lxc/auth.go:1165 lxc/auth.go:1166
 #, fuzzy
 msgid "Remove a group from an identity"
 msgstr "Création du conteneur"
@@ -5434,7 +5434,7 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 msgid "Remove entries from a network zone record"
 msgstr "Création du conteneur"
 
-#: lxc/auth.go:1927 lxc/auth.go:1928
+#: lxc/auth.go:1928 lxc/auth.go:1929
 #, fuzzy
 msgid "Remove identities from groups"
 msgstr "Création du conteneur"
@@ -5448,7 +5448,7 @@ msgstr "L'arrêt du conteneur a échoué !"
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:574 lxc/auth.go:575
+#: lxc/auth.go:575 lxc/auth.go:576
 #, fuzzy
 msgid "Remove permissions from groups"
 msgstr "Création du conteneur"
@@ -5500,12 +5500,12 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:391 lxc/auth.go:392
+#: lxc/auth.go:392 lxc/auth.go:393
 #, fuzzy
 msgid "Rename groups"
 msgstr "Copie de l'image : %s"
 
-#: lxc/auth.go:1751 lxc/auth.go:1752
+#: lxc/auth.go:1752 lxc/auth.go:1753
 #, fuzzy
 msgid "Rename identity provider groups"
 msgstr "Copie de l'image : %s"
@@ -5527,7 +5527,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:589 lxc/project.go:590
+#: lxc/project.go:590 lxc/project.go:591
 #, fuzzy
 msgid "Rename projects"
 msgstr "Créé : %s"
@@ -5652,7 +5652,7 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 msgid "Revoke cluster member join token"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/storage_bucket.go:862
+#: lxc/storage_bucket.go:863
 msgid "Role (admin or read-only)"
 msgstr ""
 
@@ -5669,7 +5669,7 @@ msgstr ""
 msgid "Run against all projects"
 msgstr "Rendre l'image publique"
 
-#: lxc/warning.go:213
+#: lxc/warning.go:214
 msgid "SEVERITY"
 msgstr ""
 
@@ -5689,12 +5689,12 @@ msgstr "SOURCE"
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1231
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1231
+#: lxc/file.go:1232
 #, fuzzy, c-format
 msgid "SSH client disconnected %q"
 msgstr "Mot de passe de l'administrateur distant"
@@ -5708,12 +5708,12 @@ msgstr "ÉTAT"
 msgid "STATIC"
 msgstr "STATIQUE"
 
-#: lxc/operation.go:173 lxc/warning.go:214
+#: lxc/operation.go:174 lxc/warning.go:215
 #, fuzzy
 msgid "STATUS"
 msgstr "ÉTAT"
 
-#: lxc/project.go:569
+#: lxc/project.go:570
 #, fuzzy
 msgid "STORAGE BUCKETS"
 msgstr "ENSEMBLE DE STOCKAGE"
@@ -5722,7 +5722,7 @@ msgstr "ENSEMBLE DE STOCKAGE"
 msgid "STORAGE POOL"
 msgstr "ENSEMBLE DE STOCKAGE"
 
-#: lxc/project.go:568
+#: lxc/project.go:569
 #, fuzzy
 msgid "STORAGE VOLUMES"
 msgstr "ENSEMBLE DE STOCKAGE"
@@ -5731,11 +5731,11 @@ msgstr "ENSEMBLE DE STOCKAGE"
 msgid "STP"
 msgstr ""
 
-#: lxc/storage_bucket.go:864
+#: lxc/storage_bucket.go:865
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:942
+#: lxc/storage_bucket.go:943
 #, fuzzy, c-format
 msgid "Secret key: %s"
 msgstr "Créé : %s"
@@ -5777,7 +5777,7 @@ msgstr "Création du conteneur"
 msgid "Set a cluster member's configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/file.go:995
+#: lxc/file.go:996
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5925,12 +5925,12 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:654
+#: lxc/project.go:655
 #, fuzzy
 msgid "Set project configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/project.go:655
+#: lxc/project.go:656
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5939,12 +5939,12 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage_bucket.go:534
+#: lxc/storage_bucket.go:535
 #, fuzzy
 msgid "Set storage bucket configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/storage_bucket.go:535
+#: lxc/storage_bucket.go:536
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -5985,15 +5985,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:476
+#: lxc/file.go:477
 msgid "Set the file's gid on push"
 msgstr "Définir le gid du fichier lors de l'envoi"
 
-#: lxc/file.go:477
+#: lxc/file.go:478
 msgid "Set the file's perms on push"
 msgstr "Définir les permissions du fichier lors de l'envoi"
 
-#: lxc/file.go:475
+#: lxc/file.go:476
 msgid "Set the file's uid on push"
 msgstr "Définir l'uid du fichier lors de l'envoi"
 
@@ -6038,11 +6038,11 @@ msgstr "Clé de configuration invalide"
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 msgid "Set the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:542
+#: lxc/storage_bucket.go:543
 #, fuzzy
 msgid "Set the key as a storage bucket property"
 msgstr "Copie de l'image : %s"
@@ -6061,7 +6061,7 @@ msgstr "Copie de l'image : %s"
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:993
+#: lxc/file.go:994
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -6073,7 +6073,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1800 lxc/auth.go:1801
+#: lxc/auth.go:1801 lxc/auth.go:1802
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -6091,11 +6091,11 @@ msgstr "L'arrêt du conteneur a échoué !"
 msgid "Show details of a cluster member"
 msgstr ""
 
-#: lxc/operation.go:192 lxc/operation.go:193
+#: lxc/operation.go:193 lxc/operation.go:194
 msgid "Show details on a background operation"
 msgstr ""
 
-#: lxc/monitor.go:49
+#: lxc/monitor.go:50
 msgid "Show events from all projects"
 msgstr ""
 
@@ -6104,12 +6104,12 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr "Afficher la configuration étendue"
 
-#: lxc/auth.go:440 lxc/auth.go:441
+#: lxc/auth.go:441 lxc/auth.go:442
 #, fuzzy
 msgid "Show group configurations"
 msgstr "Afficher la configuration étendue"
 
-#: lxc/auth.go:832
+#: lxc/auth.go:833
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -6206,17 +6206,17 @@ msgstr "Afficher la configuration étendue"
 msgid "Show profile configurations"
 msgstr "Afficher la configuration étendue"
 
-#: lxc/project.go:786 lxc/project.go:787
+#: lxc/project.go:787 lxc/project.go:788
 #, fuzzy
 msgid "Show project options"
 msgstr "Afficher la configuration étendue"
 
-#: lxc/storage_bucket.go:628 lxc/storage_bucket.go:629
+#: lxc/storage_bucket.go:629 lxc/storage_bucket.go:630
 #, fuzzy
 msgid "Show storage bucket configurations"
 msgstr "Afficher la configuration étendue"
 
-#: lxc/storage_bucket.go:1156 lxc/storage_bucket.go:1157
+#: lxc/storage_bucket.go:1157 lxc/storage_bucket.go:1158
 #, fuzzy
 msgid "Show storage bucket key configurations"
 msgstr "Afficher la configuration étendue"
@@ -6235,7 +6235,7 @@ msgstr "Afficher la configuration étendue"
 msgid "Show storage volume state information"
 msgstr "Afficher la configuration étendue"
 
-#: lxc/auth.go:895
+#: lxc/auth.go:896
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -6289,7 +6289,7 @@ msgstr ""
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: lxc/warning.go:302 lxc/warning.go:303
+#: lxc/warning.go:303 lxc/warning.go:304
 msgid "Show warning"
 msgstr ""
 
@@ -6380,22 +6380,22 @@ msgstr "L'arrêt du conteneur a échoué !"
 msgid "Stopping the instance failed: %s"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/storage_bucket.go:166
+#: lxc/storage_bucket.go:167
 #, fuzzy, c-format
 msgid "Storage bucket %s created"
 msgstr "Profil %s créé"
 
-#: lxc/storage_bucket.go:233
+#: lxc/storage_bucket.go:234
 #, fuzzy, c-format
 msgid "Storage bucket %s deleted"
 msgstr "Profil %s supprimé"
 
-#: lxc/storage_bucket.go:940
+#: lxc/storage_bucket.go:941
 #, fuzzy, c-format
 msgid "Storage bucket key %s added"
 msgstr "Profil %s créé"
 
-#: lxc/storage_bucket.go:1006
+#: lxc/storage_bucket.go:1007
 #, fuzzy, c-format
 msgid "Storage bucket key %s removed"
 msgstr "Profil %s créé"
@@ -6467,7 +6467,7 @@ msgstr "Swap (courant)"
 msgid "Swap (peak)"
 msgstr "Swap (pointe)"
 
-#: lxc/project.go:847 lxc/project.go:848
+#: lxc/project.go:848 lxc/project.go:849
 #, fuzzy
 msgid "Switch the current project"
 msgstr "impossible de supprimer le serveur distant par défaut"
@@ -6485,10 +6485,10 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1139
+#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1139
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
-#: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:171
-#: lxc/storage_volume.go:1730 lxc/warning.go:215
+#: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
+#: lxc/storage_volume.go:1730 lxc/warning.go:216
 msgid "TYPE"
 msgstr "TYPE"
 
@@ -6497,11 +6497,11 @@ msgstr "TYPE"
 msgid "Taken at"
 msgstr "pris à %s"
 
-#: lxc/file.go:1032
+#: lxc/file.go:1033
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1026
+#: lxc/file.go:1027
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -6638,12 +6638,12 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/project.go:446
+#: lxc/project.go:447
 #, fuzzy, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/storage_bucket.go:431
+#: lxc/storage_bucket.go:432
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage bucket %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -6836,7 +6836,7 @@ msgstr "Expire : %s"
 msgid "Type: %s (ephemeral)"
 msgstr "Type : éphémère"
 
-#: lxc/project.go:961
+#: lxc/project.go:962
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6848,17 +6848,17 @@ msgstr "DATE DE PUBLICATION"
 msgid "URL"
 msgstr "URL"
 
-#: lxc/project.go:985 lxc/storage_volume.go:1735
+#: lxc/project.go:986 lxc/storage_volume.go:1735
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:573
+#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:574
 #: lxc/storage.go:724 lxc/storage_volume.go:1734
 msgid "USED BY"
 msgstr "UTILISÉ PAR"
 
-#: lxc/warning.go:216
+#: lxc/warning.go:217
 msgid "UUID"
 msgstr ""
 
@@ -6867,7 +6867,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:197
+#: lxc/file.go:198
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6882,13 +6882,13 @@ msgstr "Ajouter de nouveaux serveurs distants"
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1253
+#: lxc/file.go:1254
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1153 lxc/list.go:631 lxc/storage_volume.go:1772
-#: lxc/warning.go:241
+#: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6898,7 +6898,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:807
+#: lxc/file.go:808
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6997,12 +6997,12 @@ msgstr "Clé de configuration invalide"
 msgid "Unset profile configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/project.go:742 lxc/project.go:743
+#: lxc/project.go:743 lxc/project.go:744
 #, fuzzy
 msgid "Unset project configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/storage_bucket.go:697 lxc/storage_bucket.go:698
+#: lxc/storage_bucket.go:698 lxc/storage_bucket.go:699
 #, fuzzy
 msgid "Unset storage bucket configuration keys"
 msgstr "Clé de configuration invalide"
@@ -7059,11 +7059,11 @@ msgstr "Clé de configuration invalide"
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:747
+#: lxc/project.go:748
 msgid "Unset the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:701
+#: lxc/storage_bucket.go:702
 #, fuzzy
 msgid "Unset the key as a storage bucket property"
 msgstr "Copie de l'image : %s"
@@ -7148,7 +7148,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr "L'utilisateur a annulé l'opération de suppression."
 
-#: lxc/file.go:71
+#: lxc/file.go:72
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -7185,11 +7185,11 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr "Créé : %s"
 
-#: lxc/auth.go:831
+#: lxc/auth.go:832
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:894
+#: lxc/auth.go:895
 #, fuzzy
 msgid "View the current identity"
 msgstr "impossible de supprimer le serveur distant par défaut"
@@ -7226,15 +7226,15 @@ msgstr ""
 msgid "Whether or not to snapshot the instance's running state"
 msgstr "Réaliser ou pas l'instantané de l'état de fonctionnement du conteneur"
 
-#: lxc/rebuild.go:27
+#: lxc/rebuild.go:28
 msgid ""
 "Wipe the instance root disk and re-initialize. The original image is used to "
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:156 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
+#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:526
+#: lxc/project.go:531 lxc/project.go:536 lxc/project.go:541 lxc/project.go:546
+#: lxc/project.go:551 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
 msgid "YES"
 msgstr "OUI"
 
@@ -7257,7 +7257,7 @@ msgstr "vous devez spécifier un nom de conteneur source"
 msgid "You must specify a source instance name"
 msgstr "vous devez spécifier un nom de conteneur source"
 
-#: lxc/rebuild.go:119
+#: lxc/rebuild.go:120
 #, fuzzy
 msgid "You need to specify an image name or use --empty"
 msgstr "vous devez spécifier un nom de conteneur source"
@@ -7278,12 +7278,12 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1689
+#: lxc/auth.go:330 lxc/auth.go:763 lxc/auth.go:894 lxc/auth.go:1690
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
-#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
+#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
-#: lxc/operation.go:103 lxc/profile.go:700 lxc/project.go:467
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:68
+#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:468
+#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 #, fuzzy
 msgid "[<remote>:]"
 msgstr "Serveur distant : %s"
@@ -7348,7 +7348,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/auth.go:1254
+#: lxc/auth.go:1255
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -7474,11 +7474,11 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/auth.go:830
+#: lxc/auth.go:831
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1926
+#: lxc/auth.go:1106 lxc/auth.go:1164 lxc/auth.go:1927
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -7494,8 +7494,8 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:954 lxc/auth.go:1470 lxc/cluster_group.go:168
+#: lxc/auth.go:97 lxc/auth.go:150 lxc/auth.go:200 lxc/auth.go:440
+#: lxc/auth.go:955 lxc/auth.go:1471 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 #, fuzzy
 msgid "[<remote>:]<group>"
@@ -7504,7 +7504,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/auth.go:514 lxc/auth.go:572
+#: lxc/auth.go:515 lxc/auth.go:573
 #, fuzzy
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
@@ -7522,7 +7522,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/auth.go:389
+#: lxc/auth.go:390
 #, fuzzy
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
@@ -7530,7 +7530,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/auth.go:1521 lxc/auth.go:1571 lxc/auth.go:1799
+#: lxc/auth.go:1522 lxc/auth.go:1572 lxc/auth.go:1800
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
@@ -7538,7 +7538,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/auth.go:1873
+#: lxc/auth.go:1874
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
@@ -7550,7 +7550,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/auth.go:1749
+#: lxc/auth.go:1750
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
@@ -7598,7 +7598,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/rebuild.go:25
+#: lxc/rebuild.go:26
 #, fuzzy
 msgid "[<remote>:]<image> [<remote>:]<instance>"
 msgstr ""
@@ -7789,7 +7789,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/file.go:170
+#: lxc/file.go:171
 #, fuzzy
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
@@ -7801,7 +7801,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/file.go:120
+#: lxc/file.go:121
 #, fuzzy
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
@@ -7809,7 +7809,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/file.go:240
+#: lxc/file.go:241
 #, fuzzy
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
@@ -7822,7 +7822,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/file.go:984
+#: lxc/file.go:985
 #, fuzzy
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
@@ -8138,7 +8138,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/operation.go:53 lxc/operation.go:191
+#: lxc/operation.go:54 lxc/operation.go:192
 #, fuzzy
 msgid "[<remote>:]<operation>"
 msgstr ""
@@ -8147,7 +8147,7 @@ msgstr ""
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
 #: lxc/storage.go:200 lxc/storage.go:259 lxc/storage.go:473 lxc/storage.go:844
-#: lxc/storage_bucket.go:454
+#: lxc/storage_bucket.go:455
 #, fuzzy
 msgid "[<remote>:]<pool>"
 msgstr ""
@@ -8163,8 +8163,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_bucket.go:185 lxc/storage_bucket.go:247
-#: lxc/storage_bucket.go:627 lxc/storage_bucket.go:769
+#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:248
+#: lxc/storage_bucket.go:628 lxc/storage_bucket.go:770
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
@@ -8172,9 +8172,9 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_bucket.go:380 lxc/storage_bucket.go:696
-#: lxc/storage_bucket.go:850 lxc/storage_bucket.go:956
-#: lxc/storage_bucket.go:1020 lxc/storage_bucket.go:1155
+#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:697
+#: lxc/storage_bucket.go:851 lxc/storage_bucket.go:957
+#: lxc/storage_bucket.go:1021 lxc/storage_bucket.go:1156
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
@@ -8182,7 +8182,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_bucket.go:533
+#: lxc/storage_bucket.go:534
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
@@ -8190,7 +8190,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_bucket.go:81
+#: lxc/storage_bucket.go:82
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
@@ -8445,8 +8445,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/project.go:91 lxc/project.go:186 lxc/project.go:258 lxc/project.go:785
-#: lxc/project.go:846 lxc/project.go:913
+#: lxc/project.go:92 lxc/project.go:187 lxc/project.go:259 lxc/project.go:786
+#: lxc/project.go:847 lxc/project.go:914
 #, fuzzy
 msgid "[<remote>:]<project>"
 msgstr ""
@@ -8454,7 +8454,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/project.go:394 lxc/project.go:741
+#: lxc/project.go:395 lxc/project.go:742
 #, fuzzy
 msgid "[<remote>:]<project> <key>"
 msgstr ""
@@ -8462,7 +8462,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/project.go:653
+#: lxc/project.go:654
 #, fuzzy
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
@@ -8470,7 +8470,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/project.go:587
+#: lxc/project.go:588
 #, fuzzy
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
@@ -8490,7 +8490,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/warning.go:259 lxc/warning.go:301 lxc/warning.go:354
+#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
 #, fuzzy
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
@@ -8618,7 +8618,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/project.go:555 lxc/remote.go:739
+#: lxc/project.go:556 lxc/remote.go:739
 #, fuzzy
 msgid "current"
 msgstr "Swap (courant)"
@@ -8666,20 +8666,20 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/auth.go:203
+#: lxc/auth.go:204
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:958
+#: lxc/auth.go:959
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1575
+#: lxc/auth.go:1576
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -8757,20 +8757,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:988
+#: lxc/file.go:989
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:244
+#: lxc/file.go:245
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:470
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -8862,7 +8862,7 @@ msgid ""
 "  List instances with their running state and user comment."
 msgstr ""
 
-#: lxc/monitor.go:37
+#: lxc/monitor.go:38
 msgid ""
 "lxc monitor --type=logging\n"
 "    Only show log messages.\n"
@@ -8950,7 +8950,7 @@ msgid ""
 "    Create record r1 for zone z1 with configuration from config.yaml"
 msgstr ""
 
-#: lxc/operation.go:195
+#: lxc/operation.go:196
 msgid ""
 "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Show details on that operation UUID"
@@ -8993,7 +8993,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:95
+#: lxc/project.go:96
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -9001,7 +9001,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:262
+#: lxc/project.go:263
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -9032,7 +9032,7 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:85
 msgid ""
 "lxc storage bucket create p1 b01\n"
 "\tCreate a new storage bucket name b01 in storage pool p1\n"
@@ -9042,19 +9042,19 @@ msgid ""
 "of config.yaml"
 msgstr ""
 
-#: lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:251
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1023
+#: lxc/storage_bucket.go:1024
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:854
 msgid ""
 "lxc storage bucket key create p1 b01 k1\n"
 "\tCreate a key called k1 for the bucket b01 in the pool p1.\n"
@@ -9064,14 +9064,14 @@ msgid ""
 "of config.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1158
+#: lxc/storage_bucket.go:1159
 msgid ""
 "lxc storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_bucket.go:630
+#: lxc/storage_bucket.go:631
 msgid ""
 "lxc storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
@@ -9142,16 +9142,16 @@ msgstr "s'il vous plaît utilisez  `lxc profile`"
 msgid "space used"
 msgstr "espace utilisé"
 
-#: lxc/file.go:1142
+#: lxc/file.go:1143
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1101
+#: lxc/file.go:1102
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1054
+#: lxc/file.go:1055
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/he.po
+++ b/po/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-04 08:52-0600\n"
+"POT-Creation-Date: 2024-09-05 08:44-0400\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hebrew <https://hosted.weblate.org/projects/linux-containers/"
@@ -20,7 +20,7 @@ msgstr ""
 "n % 10 == 0) ? 2 : 3));\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: lxc/storage_bucket.go:260 lxc/storage_bucket.go:1033
+#: lxc/storage_bucket.go:261 lxc/storage_bucket.go:1034
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -134,7 +134,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:213
+#: lxc/auth.go:214
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -161,7 +161,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:968
+#: lxc/auth.go:969
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -182,7 +182,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1585
+#: lxc/auth.go:1586
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -392,7 +392,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:280
+#: lxc/project.go:281
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -434,12 +434,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:935
+#: lxc/file.go:936
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:825
+#: lxc/file.go:826
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -475,7 +475,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:142 lxc/rebuild.go:64
+#: lxc/init.go:142 lxc/rebuild.go:65
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -528,7 +528,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:465
+#: lxc/file.go:466
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -561,7 +561,7 @@ msgstr ""
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:813
+#: lxc/auth.go:814
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -569,11 +569,11 @@ msgstr ""
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/storage_bucket.go:863
+#: lxc/storage_bucket.go:864
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:941
+#: lxc/storage_bucket.go:942
 #, c-format
 msgid "Access key: %s"
 msgstr ""
@@ -582,7 +582,7 @@ msgstr ""
 msgid "Access the expanded configuration"
 msgstr ""
 
-#: lxc/warning.go:261 lxc/warning.go:262
+#: lxc/warning.go:262 lxc/warning.go:263
 msgid "Acknowledge warning"
 msgstr ""
 
@@ -599,11 +599,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1106 lxc/auth.go:1107
+#: lxc/auth.go:1107 lxc/auth.go:1108
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1874 lxc/auth.go:1875
+#: lxc/auth.go:1875 lxc/auth.go:1876
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -672,7 +672,7 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:515 lxc/auth.go:516
+#: lxc/auth.go:516 lxc/auth.go:517
 msgid "Add permissions to groups"
 msgstr ""
 
@@ -701,7 +701,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:169
+#: lxc/storage_bucket.go:170
 #, c-format
 msgid "Admin access key: %s"
 msgstr ""
@@ -711,7 +711,7 @@ msgstr ""
 msgid "Admin password (or token) for %s:"
 msgstr ""
 
-#: lxc/storage_bucket.go:170
+#: lxc/storage_bucket.go:171
 #, c-format
 msgid "Admin secret key: %s"
 msgstr ""
@@ -770,7 +770,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:342 lxc/rebuild.go:130
+#: lxc/init.go:342 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -870,12 +870,12 @@ msgstr ""
 
 #: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:318
 #: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
-#: lxc/network_zone.go:366 lxc/network_zone.go:1053 lxc/storage_bucket.go:141
+#: lxc/network_zone.go:366 lxc/network_zone.go:1053 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:159
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:160
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -915,7 +915,7 @@ msgstr ""
 msgid "Bytes sent"
 msgstr ""
 
-#: lxc/operation.go:174
+#: lxc/operation.go:175
 msgid "CANCELABLE"
 msgstr ""
 
@@ -927,7 +927,7 @@ msgstr ""
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: lxc/warning.go:209
+#: lxc/warning.go:210
 msgid "COUNT"
 msgstr ""
 
@@ -953,7 +953,7 @@ msgstr ""
 msgid "CPUs (%s):"
 msgstr ""
 
-#: lxc/operation.go:175
+#: lxc/operation.go:176
 msgid "CREATED"
 msgstr ""
 
@@ -983,7 +983,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:340
+#: lxc/file.go:341
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1008,11 +1008,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:224
+#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:546
+#: lxc/file.go:547
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1021,7 +1021,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:160
+#: lxc/rebuild.go:161
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1144,13 +1144,13 @@ msgstr ""
 #: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
 #: lxc/network_load_balancer.go:1051 lxc/network_load_balancer.go:1125
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
-#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:90
-#: lxc/storage_bucket.go:190 lxc/storage_bucket.go:253
-#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:541
-#: lxc/storage_bucket.go:634 lxc/storage_bucket.go:700
-#: lxc/storage_bucket.go:775 lxc/storage_bucket.go:861
-#: lxc/storage_bucket.go:961 lxc/storage_bucket.go:1026
-#: lxc/storage_bucket.go:1162 lxc/storage_volume.go:394
+#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
+#: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
+#: lxc/storage_bucket.go:385 lxc/storage_bucket.go:542
+#: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
+#: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
+#: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
 #: lxc/storage_volume.go:612 lxc/storage_volume.go:717
 #: lxc/storage_volume.go:1005 lxc/storage_volume.go:1231
 #: lxc/storage_volume.go:1360 lxc/storage_volume.go:1848
@@ -1174,7 +1174,7 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1113 lxc/list.go:132 lxc/storage_volume.go:1589
-#: lxc/warning.go:92
+#: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
@@ -1202,7 +1202,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:100
+#: lxc/project.go:101
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1216,8 +1216,8 @@ msgstr ""
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
-#: lxc/project.go:362 lxc/storage.go:359 lxc/storage_bucket.go:348
-#: lxc/storage_bucket.go:1125 lxc/storage_volume.go:1150
+#: lxc/project.go:363 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1150
 #: lxc/storage_volume.go:1182
 #, c-format
 msgid "Config parsing error: %s"
@@ -1344,12 +1344,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:300 lxc/auth.go:1660
+#: lxc/auth.go:301 lxc/auth.go:1661
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1054
+#: lxc/auth.go:1055
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1398,15 +1398,15 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:248 lxc/file.go:474
+#: lxc/file.go:249 lxc/file.go:475
 msgid "Create any directories necessary"
 msgstr ""
 
-#: lxc/auth.go:97 lxc/auth.go:98
+#: lxc/auth.go:98 lxc/auth.go:99
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1471 lxc/auth.go:1472
+#: lxc/auth.go:1472 lxc/auth.go:1473
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1426,11 +1426,11 @@ msgstr ""
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_bucket.go:851 lxc/storage_bucket.go:852
+#: lxc/storage_bucket.go:852 lxc/storage_bucket.go:853
 msgid "Create key for a storage bucket"
 msgstr ""
 
-#: lxc/storage_bucket.go:82 lxc/storage_bucket.go:83
+#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
 msgid "Create new custom storage buckets"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:92 lxc/project.go:93
+#: lxc/project.go:93 lxc/project.go:94
 msgid "Create projects"
 msgstr ""
 
@@ -1509,13 +1509,13 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:376 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1135 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
-#: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:172
-#: lxc/profile.go:756 lxc/project.go:572 lxc/storage.go:723
-#: lxc/storage_bucket.go:512 lxc/storage_bucket.go:832
+#: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
+#: lxc/profile.go:756 lxc/project.go:573 lxc/storage.go:723
+#: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1732
 msgid "DESCRIPTION"
 msgstr ""
@@ -1540,7 +1540,7 @@ msgstr ""
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
-#: lxc/operation.go:55 lxc/operation.go:56
+#: lxc/operation.go:56 lxc/operation.go:57
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
@@ -1548,19 +1548,19 @@ msgstr ""
 msgid "Delete a cluster group"
 msgstr ""
 
-#: lxc/warning.go:360
+#: lxc/warning.go:361
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:122 lxc/file.go:123
+#: lxc/file.go:123 lxc/file.go:124
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/auth.go:151 lxc/auth.go:152
+#: lxc/auth.go:152 lxc/auth.go:153
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1523 lxc/auth.go:1524
+#: lxc/auth.go:1524 lxc/auth.go:1525
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1580,7 +1580,7 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/storage_bucket.go:957 lxc/storage_bucket.go:958
+#: lxc/storage_bucket.go:958 lxc/storage_bucket.go:959
 msgid "Delete key from a storage bucket"
 msgstr ""
 
@@ -1616,11 +1616,11 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:188 lxc/project.go:189
+#: lxc/project.go:189 lxc/project.go:190
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:187 lxc/storage_bucket.go:188
+#: lxc/storage_bucket.go:188 lxc/storage_bucket.go:189
 msgid "Delete storage buckets"
 msgstr ""
 
@@ -1632,20 +1632,20 @@ msgstr ""
 msgid "Delete storage volumes"
 msgstr ""
 
-#: lxc/warning.go:356 lxc/warning.go:357
+#: lxc/warning.go:357 lxc/warning.go:358
 msgid "Delete warning"
 msgstr ""
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:30 lxc/auth.go:59 lxc/auth.go:98
-#: lxc/auth.go:152 lxc/auth.go:201 lxc/auth.go:332 lxc/auth.go:392
-#: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
-#: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
-#: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
-#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1434 lxc/auth.go:1472
-#: lxc/auth.go:1524 lxc/auth.go:1573 lxc/auth.go:1692 lxc/auth.go:1752
-#: lxc/auth.go:1801 lxc/auth.go:1852 lxc/auth.go:1875 lxc/auth.go:1928
+#: lxc/alias.go:214 lxc/auth.go:31 lxc/auth.go:60 lxc/auth.go:99
+#: lxc/auth.go:153 lxc/auth.go:202 lxc/auth.go:333 lxc/auth.go:393
+#: lxc/auth.go:442 lxc/auth.go:494 lxc/auth.go:517 lxc/auth.go:576
+#: lxc/auth.go:732 lxc/auth.go:766 lxc/auth.go:833 lxc/auth.go:896
+#: lxc/auth.go:957 lxc/auth.go:1085 lxc/auth.go:1108 lxc/auth.go:1166
+#: lxc/auth.go:1235 lxc/auth.go:1257 lxc/auth.go:1435 lxc/auth.go:1473
+#: lxc/auth.go:1525 lxc/auth.go:1574 lxc/auth.go:1693 lxc/auth.go:1753
+#: lxc/auth.go:1802 lxc/auth.go:1853 lxc/auth.go:1876 lxc/auth.go:1929
 #: lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215 lxc/cluster.go:272
 #: lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:484 lxc/cluster.go:528
 #: lxc/cluster.go:586 lxc/cluster.go:677 lxc/cluster.go:770 lxc/cluster.go:893
@@ -1669,15 +1669,15 @@ msgstr ""
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:83 lxc/file.go:123 lxc/file.go:172
-#: lxc/file.go:242 lxc/file.go:467 lxc/file.go:986 lxc/image.go:38
+#: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
+#: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
 #: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
 #: lxc/image.go:697 lxc/image.go:946 lxc/image.go:1088 lxc/image.go:1415
 #: lxc/image.go:1506 lxc/image.go:1572 lxc/image.go:1636 lxc/image.go:1699
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:38 lxc/network.go:33
+#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33
 #: lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405
 #: lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793
 #: lxc/network.go:874 lxc/network.go:1005 lxc/network.go:1106
@@ -1711,27 +1711,27 @@ msgstr ""
 #: lxc/network_zone.go:909 lxc/network_zone.go:985 lxc/network_zone.go:1083
 #: lxc/network_zone.go:1172 lxc/network_zone.go:1219 lxc/network_zone.go:1349
 #: lxc/network_zone.go:1410 lxc/network_zone.go:1425 lxc/network_zone.go:1483
-#: lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:106
-#: lxc/operation.go:193 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
+#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
+#: lxc/operation.go:194 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
 #: lxc/profile.go:271 lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493
 #: lxc/profile.go:629 lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860
-#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:29
-#: lxc/project.go:93 lxc/project.go:189 lxc/project.go:260 lxc/project.go:396
-#: lxc/project.go:470 lxc/project.go:590 lxc/project.go:655 lxc/project.go:743
-#: lxc/project.go:787 lxc/project.go:848 lxc/project.go:915 lxc/publish.go:34
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:35 lxc/remote.go:91
+#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:30
+#: lxc/project.go:94 lxc/project.go:190 lxc/project.go:261 lxc/project.go:397
+#: lxc/project.go:471 lxc/project.go:591 lxc/project.go:656 lxc/project.go:744
+#: lxc/project.go:788 lxc/project.go:849 lxc/project.go:916 lxc/publish.go:34
+#: lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91
 #: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853
 #: lxc/remote.go:917 lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24
 #: lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203
 #: lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655
 #: lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940
-#: lxc/storage_bucket.go:29 lxc/storage_bucket.go:83 lxc/storage_bucket.go:188
-#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:382
-#: lxc/storage_bucket.go:458 lxc/storage_bucket.go:535
-#: lxc/storage_bucket.go:629 lxc/storage_bucket.go:698
-#: lxc/storage_bucket.go:732 lxc/storage_bucket.go:773
-#: lxc/storage_bucket.go:852 lxc/storage_bucket.go:958
-#: lxc/storage_bucket.go:1022 lxc/storage_bucket.go:1157
+#: lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189
+#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:383
+#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:536
+#: lxc/storage_bucket.go:630 lxc/storage_bucket.go:699
+#: lxc/storage_bucket.go:733 lxc/storage_bucket.go:774
+#: lxc/storage_bucket.go:853 lxc/storage_bucket.go:959
+#: lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158
 #: lxc/storage_volume.go:58 lxc/storage_volume.go:169 lxc/storage_volume.go:283
 #: lxc/storage_volume.go:390 lxc/storage_volume.go:605
 #: lxc/storage_volume.go:714 lxc/storage_volume.go:801
@@ -1742,8 +1742,8 @@ msgstr ""
 #: lxc/storage_volume.go:2064 lxc/storage_volume.go:2222
 #: lxc/storage_volume.go:2343 lxc/storage_volume.go:2405
 #: lxc/storage_volume.go:2541 lxc/storage_volume.go:2624
-#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:29
-#: lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
+#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:30
+#: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
@@ -1830,7 +1830,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:994
+#: lxc/file.go:995
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1896,7 +1896,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:74
+#: lxc/file.go:75
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1906,7 +1906,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:955 lxc/auth.go:956
+#: lxc/auth.go:956 lxc/auth.go:957
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1914,15 +1914,15 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:171 lxc/file.go:172
+#: lxc/file.go:172 lxc/file.go:173
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/auth.go:200 lxc/auth.go:201
+#: lxc/auth.go:201 lxc/auth.go:202
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1572 lxc/auth.go:1573
+#: lxc/auth.go:1573 lxc/auth.go:1574
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -1978,15 +1978,15 @@ msgstr ""
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:259 lxc/project.go:260
+#: lxc/project.go:260 lxc/project.go:261
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:248 lxc/storage_bucket.go:249
+#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:250
 msgid "Edit storage bucket configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:1021 lxc/storage_bucket.go:1022
+#: lxc/storage_bucket.go:1022 lxc/storage_bucket.go:1023
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
@@ -2003,7 +2003,7 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1147 lxc/list.go:622 lxc/storage_volume.go:1766
-#: lxc/warning.go:235
+#: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2058,7 +2058,7 @@ msgstr ""
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
-#: lxc/project.go:718 lxc/storage.go:812 lxc/storage_bucket.go:602
+#: lxc/project.go:719 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2155 lxc/storage_volume.go:2193
 #, c-format
 msgid "Error setting properties: %v"
@@ -2072,8 +2072,8 @@ msgstr ""
 #: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
-#: lxc/profile.go:981 lxc/project.go:712 lxc/storage.go:806
-#: lxc/storage_bucket.go:596 lxc/storage_volume.go:2149
+#: lxc/profile.go:981 lxc/project.go:713 lxc/storage.go:806
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2149
 #: lxc/storage_volume.go:2187
 #, c-format
 msgid "Error unsetting property: %v"
@@ -2093,7 +2093,7 @@ msgstr ""
 msgid "Evacuating cluster member: %s"
 msgstr ""
 
-#: lxc/monitor.go:50
+#: lxc/monitor.go:51
 msgid "Event type to listen for"
 msgstr ""
 
@@ -2180,16 +2180,16 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/warning.go:210
+#: lxc/warning.go:211
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1237
+#: lxc/file.go:1238
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1260
+#: lxc/file.go:1261
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2204,12 +2204,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1287
+#: lxc/file.go:1288
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1072
+#: lxc/file.go:1073
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2239,7 +2239,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1193
+#: lxc/file.go:1194
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2254,7 +2254,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1198
+#: lxc/file.go:1199
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2264,12 +2264,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1098
+#: lxc/file.go:1099
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1225
+#: lxc/file.go:1226
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2308,7 +2308,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1210
+#: lxc/file.go:1211
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2323,7 +2323,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:820
+#: lxc/file.go:821
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2338,7 +2338,7 @@ msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
 #: lxc/network.go:1044 lxc/network_acl.go:133 lxc/network_zone.go:124
-#: lxc/operation.go:136
+#: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
 
@@ -2403,21 +2403,21 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
+#: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:770 lxc/auth.go:1697
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1114 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:57
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
-#: lxc/operation.go:108 lxc/profile.go:707 lxc/project.go:472
-#: lxc/project.go:917 lxc/remote.go:690 lxc/storage.go:657
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:774
-#: lxc/storage_volume.go:1608 lxc/warning.go:93
+#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:473
+#: lxc/project.go:918 lxc/remote.go:690 lxc/storage.go:657
+#: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
+#: lxc/storage_volume.go:1608 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
-#: lxc/monitor.go:52
+#: lxc/monitor.go:53
 msgid "Format (json|pretty|yaml)"
 msgstr ""
 
@@ -2461,7 +2461,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:817 lxc/auth.go:1736
+#: lxc/auth.go:818 lxc/auth.go:1737
 msgid "GROUPS"
 msgstr ""
 
@@ -2477,7 +2477,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:914 lxc/project.go:915
+#: lxc/project.go:915 lxc/project.go:916
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2525,11 +2525,11 @@ msgstr ""
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:400
+#: lxc/project.go:401
 msgid "Get the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:385
+#: lxc/storage_bucket.go:386
 msgid "Get the key as a storage bucket property"
 msgstr ""
 
@@ -2589,11 +2589,11 @@ msgstr ""
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:395 lxc/project.go:396
+#: lxc/project.go:396 lxc/project.go:397
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:382
+#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:383
 msgid "Get values for storage bucket configuration keys"
 msgstr ""
 
@@ -2610,17 +2610,17 @@ msgstr ""
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: lxc/auth.go:136
+#: lxc/auth.go:137
 #, c-format
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:186
+#: lxc/auth.go:187
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:426 lxc/auth.go:1786
+#: lxc/auth.go:427 lxc/auth.go:1787
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2645,27 +2645,27 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1310
+#: lxc/file.go:1311
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1299
+#: lxc/file.go:1300
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1122
+#: lxc/file.go:1123
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1132
+#: lxc/file.go:1133
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:966 lxc/operation.go:170
+#: lxc/network.go:966 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2679,11 +2679,11 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:816
+#: lxc/auth.go:817
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:566
+#: lxc/project.go:567
 msgid "IMAGES"
 msgstr ""
 
@@ -2711,17 +2711,17 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1508
+#: lxc/auth.go:1509
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1558
+#: lxc/auth.go:1559
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
 
-#: lxc/rebuild.go:32
+#: lxc/rebuild.go:33
 msgid "If an instance is running, stop it and then rebuild it"
 msgstr ""
 
@@ -2842,7 +2842,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1233 lxc/auth.go:1234
+#: lxc/auth.go:1234 lxc/auth.go:1235
 msgid "Inspect permissions"
 msgstr ""
 
@@ -2850,11 +2850,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1124
+#: lxc/file.go:1125
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1301
+#: lxc/file.go:1302
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2872,7 +2872,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1044
+#: lxc/file.go:1045
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2881,7 +2881,7 @@ msgstr ""
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/rebuild.go:74
+#: lxc/rebuild.go:75
 #, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
@@ -2914,7 +2914,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/monitor.go:70
+#: lxc/monitor.go:71
 #, c-format
 msgid "Invalid format: %s"
 msgstr ""
@@ -2924,7 +2924,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1039
+#: lxc/file.go:1040
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2966,7 +2966,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:147
+#: lxc/file.go:148
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2982,12 +2982,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:313
+#: lxc/file.go:314
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:495
+#: lxc/file.go:496
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3001,7 +3001,7 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/warning.go:212
 msgid "LAST SEEN"
 msgstr ""
 
@@ -3009,7 +3009,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:984
+#: lxc/project.go:985
 msgid "LIMIT"
 msgstr ""
 
@@ -3018,8 +3018,8 @@ msgid "LISTEN ADDRESS"
 msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
-#: lxc/network_load_balancer.go:165 lxc/operation.go:177
-#: lxc/storage_bucket.go:516 lxc/storage_volume.go:1739 lxc/warning.go:220
+#: lxc/network_load_balancer.go:165 lxc/operation.go:178
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1739 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3093,7 +3093,7 @@ msgstr ""
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/warning.go:94
+#: lxc/warning.go:95
 msgid "List all warnings"
 msgstr ""
 
@@ -3137,19 +3137,19 @@ msgstr ""
 msgid "List available storage pools"
 msgstr ""
 
-#: lxc/operation.go:105 lxc/operation.go:106
+#: lxc/operation.go:106 lxc/operation.go:107
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:331 lxc/auth.go:332
+#: lxc/auth.go:332 lxc/auth.go:333
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:764 lxc/auth.go:765
+#: lxc/auth.go:765 lxc/auth.go:766
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1691 lxc/auth.go:1692
+#: lxc/auth.go:1692 lxc/auth.go:1693
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3298,11 +3298,11 @@ msgstr ""
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/operation.go:109
+#: lxc/operation.go:110
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1255 lxc/auth.go:1256
+#: lxc/auth.go:1256 lxc/auth.go:1257
 msgid "List permissions"
 msgstr ""
 
@@ -3310,15 +3310,15 @@ msgstr ""
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:469 lxc/project.go:470
+#: lxc/project.go:470 lxc/project.go:471
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:771 lxc/storage_bucket.go:773
+#: lxc/storage_bucket.go:772 lxc/storage_bucket.go:774
 msgid "List storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:456 lxc/storage_bucket.go:458
+#: lxc/storage_bucket.go:457 lxc/storage_bucket.go:459
 msgid "List storage buckets"
 msgstr ""
 
@@ -3354,11 +3354,11 @@ msgstr ""
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/warning.go:70
+#: lxc/warning.go:71
 msgid "List warnings"
 msgstr ""
 
-#: lxc/warning.go:71
+#: lxc/warning.go:72
 msgid ""
 "List warnings\n"
 "\n"
@@ -3381,7 +3381,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/operation.go:23 lxc/operation.go:24
+#: lxc/operation.go:24 lxc/operation.go:25
 msgid "List, show and delete background operations"
 msgstr ""
 
@@ -3390,7 +3390,7 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/monitor.go:79
+#: lxc/monitor.go:80
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
@@ -3494,23 +3494,23 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:82 lxc/file.go:83
+#: lxc/file.go:83 lxc/file.go:84
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1433 lxc/auth.go:1434
+#: lxc/auth.go:59 lxc/auth.go:60 lxc/auth.go:1434 lxc/auth.go:1435
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1083 lxc/auth.go:1084
+#: lxc/auth.go:1084 lxc/auth.go:1085
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:730 lxc/auth.go:731
+#: lxc/auth.go:731 lxc/auth.go:732
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1851 lxc/auth.go:1852
+#: lxc/auth.go:1852 lxc/auth.go:1853
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3601,7 +3601,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:492 lxc/auth.go:493
+#: lxc/auth.go:493 lxc/auth.go:494
 msgid "Manage permissions"
 msgstr ""
 
@@ -3609,23 +3609,23 @@ msgstr ""
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:28 lxc/project.go:29
+#: lxc/project.go:29 lxc/project.go:30
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:731
+#: lxc/storage_bucket.go:732
 msgid "Manage storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:732
+#: lxc/storage_bucket.go:733
 msgid "Manage storage bucket keys."
 msgstr ""
 
-#: lxc/storage_bucket.go:28
+#: lxc/storage_bucket.go:29
 msgid "Manage storage buckets"
 msgstr ""
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:30
 msgid "Manage storage buckets."
 msgstr ""
 
@@ -3653,11 +3653,11 @@ msgstr ""
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/auth.go:29 lxc/auth.go:30
+#: lxc/auth.go:30 lxc/auth.go:31
 msgid "Manage user authorization"
 msgstr ""
 
-#: lxc/warning.go:28 lxc/warning.go:29
+#: lxc/warning.go:29 lxc/warning.go:30
 msgid "Manage warnings"
 msgstr ""
 
@@ -3721,17 +3721,17 @@ msgstr ""
 msgid "Migration operation failure: %w"
 msgstr ""
 
-#: lxc/monitor.go:51
+#: lxc/monitor.go:52
 msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: lxc/storage_bucket.go:116 lxc/storage_bucket.go:216
-#: lxc/storage_bucket.go:292 lxc/storage_bucket.go:411
-#: lxc/storage_bucket.go:568 lxc/storage_bucket.go:660
-#: lxc/storage_bucket.go:802 lxc/storage_bucket.go:889
-#: lxc/storage_bucket.go:986 lxc/storage_bucket.go:1065
-#: lxc/storage_bucket.go:1188
+#: lxc/storage_bucket.go:117 lxc/storage_bucket.go:217
+#: lxc/storage_bucket.go:293 lxc/storage_bucket.go:412
+#: lxc/storage_bucket.go:569 lxc/storage_bucket.go:661
+#: lxc/storage_bucket.go:803 lxc/storage_bucket.go:890
+#: lxc/storage_bucket.go:987 lxc/storage_bucket.go:1066
+#: lxc/storage_bucket.go:1189
 msgid "Missing bucket name"
 msgstr ""
 
@@ -3750,20 +3750,20 @@ msgstr ""
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1825
+#: lxc/auth.go:123 lxc/auth.go:177 lxc/auth.go:255 lxc/auth.go:417
+#: lxc/auth.go:466 lxc/auth.go:541 lxc/auth.go:600 lxc/auth.go:1826
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:862 lxc/auth.go:1003 lxc/auth.go:1131 lxc/auth.go:1189
+#: lxc/auth.go:863 lxc/auth.go:1004 lxc/auth.go:1132 lxc/auth.go:1190
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1495 lxc/auth.go:1548 lxc/auth.go:1614 lxc/auth.go:1776
+#: lxc/auth.go:1496 lxc/auth.go:1549 lxc/auth.go:1615 lxc/auth.go:1777
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1899 lxc/auth.go:1952
+#: lxc/auth.go:1900 lxc/auth.go:1953
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -3771,12 +3771,12 @@ msgstr ""
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
 #: lxc/config_template.go:377 lxc/profile.go:141 lxc/profile.go:222
-#: lxc/profile.go:808 lxc/rebuild.go:60
+#: lxc/profile.go:808 lxc/rebuild.go:61
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/storage_bucket.go:893 lxc/storage_bucket.go:990
-#: lxc/storage_bucket.go:1069 lxc/storage_bucket.go:1192
+#: lxc/storage_bucket.go:894 lxc/storage_bucket.go:991
+#: lxc/storage_bucket.go:1070 lxc/storage_bucket.go:1193
 msgid "Missing key name"
 msgstr ""
 
@@ -3841,13 +3841,13 @@ msgid "Missing peer name"
 msgstr ""
 
 #: lxc/storage.go:235 lxc/storage.go:313 lxc/storage.go:431 lxc/storage.go:509
-#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:112
-#: lxc/storage_bucket.go:212 lxc/storage_bucket.go:288
-#: lxc/storage_bucket.go:407 lxc/storage_bucket.go:482
-#: lxc/storage_bucket.go:564 lxc/storage_bucket.go:656
-#: lxc/storage_bucket.go:798 lxc/storage_bucket.go:885
-#: lxc/storage_bucket.go:982 lxc/storage_bucket.go:1061
-#: lxc/storage_bucket.go:1184 lxc/storage_volume.go:209
+#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:113
+#: lxc/storage_bucket.go:213 lxc/storage_bucket.go:289
+#: lxc/storage_bucket.go:408 lxc/storage_bucket.go:483
+#: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
+#: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
+#: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
 #: lxc/storage_volume.go:323 lxc/storage_volume.go:643
 #: lxc/storage_volume.go:750 lxc/storage_volume.go:841
 #: lxc/storage_volume.go:939 lxc/storage_volume.go:1053
@@ -3862,9 +3862,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:404 lxc/project.go:146 lxc/project.go:226 lxc/project.go:316
-#: lxc/project.go:433 lxc/project.go:622 lxc/project.go:691 lxc/project.go:819
-#: lxc/project.go:948
+#: lxc/profile.go:404 lxc/project.go:147 lxc/project.go:227 lxc/project.go:317
+#: lxc/project.go:434 lxc/project.go:623 lxc/project.go:692 lxc/project.go:820
+#: lxc/project.go:949
 msgid "Missing project name"
 msgstr ""
 
@@ -3880,7 +3880,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:598
+#: lxc/file.go:599
 msgid "Missing target directory"
 msgstr ""
 
@@ -3902,11 +3902,11 @@ msgstr ""
 msgid "Model: %v"
 msgstr ""
 
-#: lxc/monitor.go:32
+#: lxc/monitor.go:33
 msgid "Monitor a local or remote LXD server"
 msgstr ""
 
-#: lxc/monitor.go:33
+#: lxc/monitor.go:34
 msgid ""
 "Monitor a local or remote LXD server\n"
 "\n"
@@ -3918,11 +3918,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:285
+#: lxc/file.go:286
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:985 lxc/file.go:986
+#: lxc/file.go:986 lxc/file.go:987
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3984,13 +3984,13 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:192
+#: lxc/auth.go:376 lxc/auth.go:816 lxc/auth.go:1736 lxc/cluster.go:192
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
-#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:565
-#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:511
-#: lxc/storage_bucket.go:831 lxc/storage_volume.go:1731
+#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:566
+#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1731
 msgid "NAME"
 msgstr ""
 
@@ -3998,11 +3998,11 @@ msgstr ""
 msgid "NAT"
 msgstr ""
 
-#: lxc/project.go:571
+#: lxc/project.go:572
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:570
+#: lxc/project.go:571
 msgid "NETWORKS"
 msgstr ""
 
@@ -4014,9 +4014,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/operation.go:154 lxc/project.go:523
-#: lxc/project.go:528 lxc/project.go:533 lxc/project.go:538 lxc/project.go:543
-#: lxc/project.go:548 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
+#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:524
+#: lxc/project.go:529 lxc/project.go:534 lxc/project.go:539 lxc/project.go:544
+#: lxc/project.go:549 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
 msgid "NO"
 msgstr ""
 
@@ -4261,7 +4261,7 @@ msgstr ""
 msgid "Only managed networks can be modified"
 msgstr ""
 
-#: lxc/operation.go:86
+#: lxc/operation.go:87
 #, c-format
 msgid "Operation %s deleted"
 msgstr ""
@@ -4308,11 +4308,11 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:567
+#: lxc/list.go:576 lxc/project.go:568
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:212
+#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4374,24 +4374,24 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1102
+#: lxc/file.go:1103
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:860
+#: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
-#: lxc/project.go:363 lxc/storage.go:360 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1151
+#: lxc/project.go:364 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1151
 #: lxc/storage_volume.go:1183
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
-#: lxc/monitor.go:48
+#: lxc/monitor.go:49
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
@@ -4477,17 +4477,17 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:172
+#: lxc/project.go:173
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:236
+#: lxc/project.go:237
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:637
+#: lxc/project.go:638
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -4608,20 +4608,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:241 lxc/file.go:242
+#: lxc/file.go:242 lxc/file.go:243
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:416 lxc/file.go:767
+#: lxc/file.go:417 lxc/file.go:768
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:466 lxc/file.go:467
+#: lxc/file.go:467 lxc/file.go:468
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:701 lxc/file.go:867
+#: lxc/file.go:702 lxc/file.go:868
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4634,11 +4634,11 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:983
+#: lxc/project.go:984
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/storage_bucket.go:833
+#: lxc/storage_bucket.go:834
 msgid "ROLE"
 msgstr ""
 
@@ -4651,15 +4651,15 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/rebuild.go:31
+#: lxc/rebuild.go:32
 msgid "Rebuild as an empty instance"
 msgstr ""
 
-#: lxc/rebuild.go:26
+#: lxc/rebuild.go:27
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:249 lxc/file.go:473
+#: lxc/file.go:250 lxc/file.go:474
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4686,7 +4686,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:882 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
+#: lxc/project.go:883 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
 #: lxc/remote.go:994
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4737,7 +4737,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1164 lxc/auth.go:1165
+#: lxc/auth.go:1165 lxc/auth.go:1166
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4773,7 +4773,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1927 lxc/auth.go:1928
+#: lxc/auth.go:1928 lxc/auth.go:1929
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4785,7 +4785,7 @@ msgstr ""
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:574 lxc/auth.go:575
+#: lxc/auth.go:575 lxc/auth.go:576
 msgid "Remove permissions from groups"
 msgstr ""
 
@@ -4830,11 +4830,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:391 lxc/auth.go:392
+#: lxc/auth.go:392 lxc/auth.go:393
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1751 lxc/auth.go:1752
+#: lxc/auth.go:1752 lxc/auth.go:1753
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -4854,7 +4854,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:589 lxc/project.go:590
+#: lxc/project.go:590 lxc/project.go:591
 msgid "Rename projects"
 msgstr ""
 
@@ -4952,7 +4952,7 @@ msgstr ""
 msgid "Revoke cluster member join token"
 msgstr ""
 
-#: lxc/storage_bucket.go:862
+#: lxc/storage_bucket.go:863
 msgid "Role (admin or read-only)"
 msgstr ""
 
@@ -4968,7 +4968,7 @@ msgstr ""
 msgid "Run against all projects"
 msgstr ""
 
-#: lxc/warning.go:213
+#: lxc/warning.go:214
 msgid "SEVERITY"
 msgstr ""
 
@@ -4988,12 +4988,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1231
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1231
+#: lxc/file.go:1232
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5007,11 +5007,11 @@ msgstr ""
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:173 lxc/warning.go:214
+#: lxc/operation.go:174 lxc/warning.go:215
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:569
+#: lxc/project.go:570
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5019,7 +5019,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:569
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -5027,11 +5027,11 @@ msgstr ""
 msgid "STP"
 msgstr ""
 
-#: lxc/storage_bucket.go:864
+#: lxc/storage_bucket.go:865
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:942
+#: lxc/storage_bucket.go:943
 #, c-format
 msgid "Secret key: %s"
 msgstr ""
@@ -5069,7 +5069,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:995
+#: lxc/file.go:996
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5207,11 +5207,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:654
+#: lxc/project.go:655
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:655
+#: lxc/project.go:656
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5220,11 +5220,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage_bucket.go:534
+#: lxc/storage_bucket.go:535
 msgid "Set storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:535
+#: lxc/storage_bucket.go:536
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -5263,15 +5263,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:476
+#: lxc/file.go:477
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:477
+#: lxc/file.go:478
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:475
+#: lxc/file.go:476
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5311,11 +5311,11 @@ msgstr ""
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 msgid "Set the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:542
+#: lxc/storage_bucket.go:543
 msgid "Set the key as a storage bucket property"
 msgstr ""
 
@@ -5331,7 +5331,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:993
+#: lxc/file.go:994
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5343,7 +5343,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1800 lxc/auth.go:1801
+#: lxc/auth.go:1801 lxc/auth.go:1802
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5359,11 +5359,11 @@ msgstr ""
 msgid "Show details of a cluster member"
 msgstr ""
 
-#: lxc/operation.go:192 lxc/operation.go:193
+#: lxc/operation.go:193 lxc/operation.go:194
 msgid "Show details on a background operation"
 msgstr ""
 
-#: lxc/monitor.go:49
+#: lxc/monitor.go:50
 msgid "Show events from all projects"
 msgstr ""
 
@@ -5371,11 +5371,11 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:440 lxc/auth.go:441
+#: lxc/auth.go:441 lxc/auth.go:442
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:832
+#: lxc/auth.go:833
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5456,15 +5456,15 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:786 lxc/project.go:787
+#: lxc/project.go:787 lxc/project.go:788
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage_bucket.go:628 lxc/storage_bucket.go:629
+#: lxc/storage_bucket.go:629 lxc/storage_bucket.go:630
 msgid "Show storage bucket configurations"
 msgstr ""
 
-#: lxc/storage_bucket.go:1156 lxc/storage_bucket.go:1157
+#: lxc/storage_bucket.go:1157 lxc/storage_bucket.go:1158
 msgid "Show storage bucket key configurations"
 msgstr ""
 
@@ -5480,7 +5480,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:895
+#: lxc/auth.go:896
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5530,7 +5530,7 @@ msgstr ""
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: lxc/warning.go:302 lxc/warning.go:303
+#: lxc/warning.go:303 lxc/warning.go:304
 msgid "Show warning"
 msgstr ""
 
@@ -5614,22 +5614,22 @@ msgstr ""
 msgid "Stopping the instance failed: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:166
+#: lxc/storage_bucket.go:167
 #, c-format
 msgid "Storage bucket %s created"
 msgstr ""
 
-#: lxc/storage_bucket.go:233
+#: lxc/storage_bucket.go:234
 #, c-format
 msgid "Storage bucket %s deleted"
 msgstr ""
 
-#: lxc/storage_bucket.go:940
+#: lxc/storage_bucket.go:941
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr ""
 
-#: lxc/storage_bucket.go:1006
+#: lxc/storage_bucket.go:1007
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr ""
@@ -5698,7 +5698,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:847 lxc/project.go:848
+#: lxc/project.go:848 lxc/project.go:849
 msgid "Switch the current project"
 msgstr ""
 
@@ -5714,10 +5714,10 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1139
+#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1139
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
-#: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:171
-#: lxc/storage_volume.go:1730 lxc/warning.go:215
+#: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
+#: lxc/storage_volume.go:1730 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
@@ -5725,11 +5725,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1032
+#: lxc/file.go:1033
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1026
+#: lxc/file.go:1027
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5857,12 +5857,12 @@ msgstr ""
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:446
+#: lxc/project.go:447
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
 
-#: lxc/storage_bucket.go:431
+#: lxc/storage_bucket.go:432
 #, c-format
 msgid "The property %q does not exist on the storage bucket %q: %v"
 msgstr ""
@@ -6047,7 +6047,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:961
+#: lxc/project.go:962
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6059,17 +6059,17 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:985 lxc/storage_volume.go:1735
+#: lxc/project.go:986 lxc/storage_volume.go:1735
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:573
+#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:574
 #: lxc/storage.go:724 lxc/storage_volume.go:1734
 msgid "USED BY"
 msgstr ""
 
-#: lxc/warning.go:216
+#: lxc/warning.go:217
 msgid "UUID"
 msgstr ""
 
@@ -6078,7 +6078,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:197
+#: lxc/file.go:198
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6092,13 +6092,13 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1253
+#: lxc/file.go:1254
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1153 lxc/list.go:631 lxc/storage_volume.go:1772
-#: lxc/warning.go:241
+#: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6108,7 +6108,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:807
+#: lxc/file.go:808
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6191,11 +6191,11 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:742 lxc/project.go:743
+#: lxc/project.go:743 lxc/project.go:744
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:697 lxc/storage_bucket.go:698
+#: lxc/storage_bucket.go:698 lxc/storage_bucket.go:699
 msgid "Unset storage bucket configuration keys"
 msgstr ""
 
@@ -6243,11 +6243,11 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:747
+#: lxc/project.go:748
 msgid "Unset the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:701
+#: lxc/storage_bucket.go:702
 msgid "Unset the key as a storage bucket property"
 msgstr ""
 
@@ -6326,7 +6326,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:71
+#: lxc/file.go:72
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6363,11 +6363,11 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:831
+#: lxc/auth.go:832
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:894
+#: lxc/auth.go:895
 msgid "View the current identity"
 msgstr ""
 
@@ -6398,15 +6398,15 @@ msgstr ""
 msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
-#: lxc/rebuild.go:27
+#: lxc/rebuild.go:28
 msgid ""
 "Wipe the instance root disk and re-initialize. The original image is used to "
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:156 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
+#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:526
+#: lxc/project.go:531 lxc/project.go:536 lxc/project.go:541 lxc/project.go:546
+#: lxc/project.go:551 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
 msgid "YES"
 msgstr ""
 
@@ -6426,7 +6426,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/rebuild.go:119
+#: lxc/rebuild.go:120
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
@@ -6438,12 +6438,12 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1689
+#: lxc/auth.go:330 lxc/auth.go:763 lxc/auth.go:894 lxc/auth.go:1690
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
-#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
+#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
-#: lxc/operation.go:103 lxc/profile.go:700 lxc/project.go:467
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:68
+#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:468
+#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6471,7 +6471,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1254
+#: lxc/auth.go:1255
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6532,11 +6532,11 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:830
+#: lxc/auth.go:831
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1926
+#: lxc/auth.go:1106 lxc/auth.go:1164 lxc/auth.go:1927
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6544,13 +6544,13 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:954 lxc/auth.go:1470 lxc/cluster_group.go:168
+#: lxc/auth.go:97 lxc/auth.go:150 lxc/auth.go:200 lxc/auth.go:440
+#: lxc/auth.go:955 lxc/auth.go:1471 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:514 lxc/auth.go:572
+#: lxc/auth.go:515 lxc/auth.go:573
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
@@ -6560,19 +6560,19 @@ msgstr ""
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:389
+#: lxc/auth.go:390
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1521 lxc/auth.go:1571 lxc/auth.go:1799
+#: lxc/auth.go:1522 lxc/auth.go:1572 lxc/auth.go:1800
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1873
+#: lxc/auth.go:1874
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1749
+#: lxc/auth.go:1750
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -6592,7 +6592,7 @@ msgstr ""
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
-#: lxc/rebuild.go:25
+#: lxc/rebuild.go:26
 msgid "[<remote>:]<image> [<remote>:]<instance>"
 msgstr ""
 
@@ -6675,20 +6675,20 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:170
+#: lxc/file.go:171
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:120
+#: lxc/file.go:121
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:240
+#: lxc/file.go:241
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:984
+#: lxc/file.go:985
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6839,12 +6839,12 @@ msgstr ""
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
-#: lxc/operation.go:53 lxc/operation.go:191
+#: lxc/operation.go:54 lxc/operation.go:192
 msgid "[<remote>:]<operation>"
 msgstr ""
 
 #: lxc/storage.go:200 lxc/storage.go:259 lxc/storage.go:473 lxc/storage.go:844
-#: lxc/storage_bucket.go:454
+#: lxc/storage_bucket.go:455
 msgid "[<remote>:]<pool>"
 msgstr ""
 
@@ -6852,22 +6852,22 @@ msgstr ""
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
-#: lxc/storage_bucket.go:185 lxc/storage_bucket.go:247
-#: lxc/storage_bucket.go:627 lxc/storage_bucket.go:769
+#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:248
+#: lxc/storage_bucket.go:628 lxc/storage_bucket.go:770
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
 
-#: lxc/storage_bucket.go:380 lxc/storage_bucket.go:696
-#: lxc/storage_bucket.go:850 lxc/storage_bucket.go:956
-#: lxc/storage_bucket.go:1020 lxc/storage_bucket.go:1155
+#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:697
+#: lxc/storage_bucket.go:851 lxc/storage_bucket.go:957
+#: lxc/storage_bucket.go:1021 lxc/storage_bucket.go:1156
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
 
-#: lxc/storage_bucket.go:533
+#: lxc/storage_bucket.go:534
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_bucket.go:81
+#: lxc/storage_bucket.go:82
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
 
@@ -6982,20 +6982,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:91 lxc/project.go:186 lxc/project.go:258 lxc/project.go:785
-#: lxc/project.go:846 lxc/project.go:913
+#: lxc/project.go:92 lxc/project.go:187 lxc/project.go:259 lxc/project.go:786
+#: lxc/project.go:847 lxc/project.go:914
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:394 lxc/project.go:741
+#: lxc/project.go:395 lxc/project.go:742
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:653
+#: lxc/project.go:654
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:587
+#: lxc/project.go:588
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7003,7 +7003,7 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:259 lxc/warning.go:301 lxc/warning.go:354
+#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
@@ -7059,7 +7059,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:555 lxc/remote.go:739
+#: lxc/project.go:556 lxc/remote.go:739
 msgid "current"
 msgstr ""
 
@@ -7106,20 +7106,20 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/auth.go:203
+#: lxc/auth.go:204
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:958
+#: lxc/auth.go:959
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1575
+#: lxc/auth.go:1576
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7197,20 +7197,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:988
+#: lxc/file.go:989
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:244
+#: lxc/file.go:245
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:470
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7292,7 +7292,7 @@ msgid ""
 "  List instances with their running state and user comment."
 msgstr ""
 
-#: lxc/monitor.go:37
+#: lxc/monitor.go:38
 msgid ""
 "lxc monitor --type=logging\n"
 "    Only show log messages.\n"
@@ -7368,7 +7368,7 @@ msgid ""
 "    Create record r1 for zone z1 with configuration from config.yaml"
 msgstr ""
 
-#: lxc/operation.go:195
+#: lxc/operation.go:196
 msgid ""
 "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Show details on that operation UUID"
@@ -7411,7 +7411,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:95
+#: lxc/project.go:96
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7419,7 +7419,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:262
+#: lxc/project.go:263
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7450,7 +7450,7 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:85
 msgid ""
 "lxc storage bucket create p1 b01\n"
 "\tCreate a new storage bucket name b01 in storage pool p1\n"
@@ -7460,19 +7460,19 @@ msgid ""
 "of config.yaml"
 msgstr ""
 
-#: lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:251
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1023
+#: lxc/storage_bucket.go:1024
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:854
 msgid ""
 "lxc storage bucket key create p1 b01 k1\n"
 "\tCreate a key called k1 for the bucket b01 in the pool p1.\n"
@@ -7482,14 +7482,14 @@ msgid ""
 "of config.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1158
+#: lxc/storage_bucket.go:1159
 msgid ""
 "lxc storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_bucket.go:630
+#: lxc/storage_bucket.go:631
 msgid ""
 "lxc storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
@@ -7559,16 +7559,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1142
+#: lxc/file.go:1143
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1101
+#: lxc/file.go:1102
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1054
+#: lxc/file.go:1055
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/hi.po
+++ b/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-04 08:52-0600\n"
+"POT-Creation-Date: 2024-09-05 08:44-0400\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hindi <https://hosted.weblate.org/projects/linux-containers/"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: lxc/storage_bucket.go:260 lxc/storage_bucket.go:1033
+#: lxc/storage_bucket.go:261 lxc/storage_bucket.go:1034
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -133,7 +133,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:213
+#: lxc/auth.go:214
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -160,7 +160,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:968
+#: lxc/auth.go:969
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -181,7 +181,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1585
+#: lxc/auth.go:1586
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -391,7 +391,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:280
+#: lxc/project.go:281
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -433,12 +433,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:935
+#: lxc/file.go:936
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:825
+#: lxc/file.go:826
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -474,7 +474,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:142 lxc/rebuild.go:64
+#: lxc/init.go:142 lxc/rebuild.go:65
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -527,7 +527,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:465
+#: lxc/file.go:466
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -560,7 +560,7 @@ msgstr ""
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:813
+#: lxc/auth.go:814
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -568,11 +568,11 @@ msgstr ""
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/storage_bucket.go:863
+#: lxc/storage_bucket.go:864
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:941
+#: lxc/storage_bucket.go:942
 #, c-format
 msgid "Access key: %s"
 msgstr ""
@@ -581,7 +581,7 @@ msgstr ""
 msgid "Access the expanded configuration"
 msgstr ""
 
-#: lxc/warning.go:261 lxc/warning.go:262
+#: lxc/warning.go:262 lxc/warning.go:263
 msgid "Acknowledge warning"
 msgstr ""
 
@@ -598,11 +598,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1106 lxc/auth.go:1107
+#: lxc/auth.go:1107 lxc/auth.go:1108
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1874 lxc/auth.go:1875
+#: lxc/auth.go:1875 lxc/auth.go:1876
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -671,7 +671,7 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:515 lxc/auth.go:516
+#: lxc/auth.go:516 lxc/auth.go:517
 msgid "Add permissions to groups"
 msgstr ""
 
@@ -700,7 +700,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:169
+#: lxc/storage_bucket.go:170
 #, c-format
 msgid "Admin access key: %s"
 msgstr ""
@@ -710,7 +710,7 @@ msgstr ""
 msgid "Admin password (or token) for %s:"
 msgstr ""
 
-#: lxc/storage_bucket.go:170
+#: lxc/storage_bucket.go:171
 #, c-format
 msgid "Admin secret key: %s"
 msgstr ""
@@ -769,7 +769,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:342 lxc/rebuild.go:130
+#: lxc/init.go:342 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -869,12 +869,12 @@ msgstr ""
 
 #: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:318
 #: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
-#: lxc/network_zone.go:366 lxc/network_zone.go:1053 lxc/storage_bucket.go:141
+#: lxc/network_zone.go:366 lxc/network_zone.go:1053 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:159
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:160
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -914,7 +914,7 @@ msgstr ""
 msgid "Bytes sent"
 msgstr ""
 
-#: lxc/operation.go:174
+#: lxc/operation.go:175
 msgid "CANCELABLE"
 msgstr ""
 
@@ -926,7 +926,7 @@ msgstr ""
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: lxc/warning.go:209
+#: lxc/warning.go:210
 msgid "COUNT"
 msgstr ""
 
@@ -952,7 +952,7 @@ msgstr ""
 msgid "CPUs (%s):"
 msgstr ""
 
-#: lxc/operation.go:175
+#: lxc/operation.go:176
 msgid "CREATED"
 msgstr ""
 
@@ -982,7 +982,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:340
+#: lxc/file.go:341
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1007,11 +1007,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:224
+#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:546
+#: lxc/file.go:547
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1020,7 +1020,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:160
+#: lxc/rebuild.go:161
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1143,13 +1143,13 @@ msgstr ""
 #: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
 #: lxc/network_load_balancer.go:1051 lxc/network_load_balancer.go:1125
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
-#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:90
-#: lxc/storage_bucket.go:190 lxc/storage_bucket.go:253
-#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:541
-#: lxc/storage_bucket.go:634 lxc/storage_bucket.go:700
-#: lxc/storage_bucket.go:775 lxc/storage_bucket.go:861
-#: lxc/storage_bucket.go:961 lxc/storage_bucket.go:1026
-#: lxc/storage_bucket.go:1162 lxc/storage_volume.go:394
+#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
+#: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
+#: lxc/storage_bucket.go:385 lxc/storage_bucket.go:542
+#: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
+#: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
+#: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
 #: lxc/storage_volume.go:612 lxc/storage_volume.go:717
 #: lxc/storage_volume.go:1005 lxc/storage_volume.go:1231
 #: lxc/storage_volume.go:1360 lxc/storage_volume.go:1848
@@ -1173,7 +1173,7 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1113 lxc/list.go:132 lxc/storage_volume.go:1589
-#: lxc/warning.go:92
+#: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
@@ -1201,7 +1201,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:100
+#: lxc/project.go:101
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1215,8 +1215,8 @@ msgstr ""
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
-#: lxc/project.go:362 lxc/storage.go:359 lxc/storage_bucket.go:348
-#: lxc/storage_bucket.go:1125 lxc/storage_volume.go:1150
+#: lxc/project.go:363 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1150
 #: lxc/storage_volume.go:1182
 #, c-format
 msgid "Config parsing error: %s"
@@ -1343,12 +1343,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:300 lxc/auth.go:1660
+#: lxc/auth.go:301 lxc/auth.go:1661
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1054
+#: lxc/auth.go:1055
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1397,15 +1397,15 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:248 lxc/file.go:474
+#: lxc/file.go:249 lxc/file.go:475
 msgid "Create any directories necessary"
 msgstr ""
 
-#: lxc/auth.go:97 lxc/auth.go:98
+#: lxc/auth.go:98 lxc/auth.go:99
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1471 lxc/auth.go:1472
+#: lxc/auth.go:1472 lxc/auth.go:1473
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1425,11 +1425,11 @@ msgstr ""
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_bucket.go:851 lxc/storage_bucket.go:852
+#: lxc/storage_bucket.go:852 lxc/storage_bucket.go:853
 msgid "Create key for a storage bucket"
 msgstr ""
 
-#: lxc/storage_bucket.go:82 lxc/storage_bucket.go:83
+#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
 msgid "Create new custom storage buckets"
 msgstr ""
 
@@ -1473,7 +1473,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:92 lxc/project.go:93
+#: lxc/project.go:93 lxc/project.go:94
 msgid "Create projects"
 msgstr ""
 
@@ -1508,13 +1508,13 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:376 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1135 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
-#: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:172
-#: lxc/profile.go:756 lxc/project.go:572 lxc/storage.go:723
-#: lxc/storage_bucket.go:512 lxc/storage_bucket.go:832
+#: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
+#: lxc/profile.go:756 lxc/project.go:573 lxc/storage.go:723
+#: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1732
 msgid "DESCRIPTION"
 msgstr ""
@@ -1539,7 +1539,7 @@ msgstr ""
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
-#: lxc/operation.go:55 lxc/operation.go:56
+#: lxc/operation.go:56 lxc/operation.go:57
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
@@ -1547,19 +1547,19 @@ msgstr ""
 msgid "Delete a cluster group"
 msgstr ""
 
-#: lxc/warning.go:360
+#: lxc/warning.go:361
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:122 lxc/file.go:123
+#: lxc/file.go:123 lxc/file.go:124
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/auth.go:151 lxc/auth.go:152
+#: lxc/auth.go:152 lxc/auth.go:153
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1523 lxc/auth.go:1524
+#: lxc/auth.go:1524 lxc/auth.go:1525
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1579,7 +1579,7 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/storage_bucket.go:957 lxc/storage_bucket.go:958
+#: lxc/storage_bucket.go:958 lxc/storage_bucket.go:959
 msgid "Delete key from a storage bucket"
 msgstr ""
 
@@ -1615,11 +1615,11 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:188 lxc/project.go:189
+#: lxc/project.go:189 lxc/project.go:190
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:187 lxc/storage_bucket.go:188
+#: lxc/storage_bucket.go:188 lxc/storage_bucket.go:189
 msgid "Delete storage buckets"
 msgstr ""
 
@@ -1631,20 +1631,20 @@ msgstr ""
 msgid "Delete storage volumes"
 msgstr ""
 
-#: lxc/warning.go:356 lxc/warning.go:357
+#: lxc/warning.go:357 lxc/warning.go:358
 msgid "Delete warning"
 msgstr ""
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:30 lxc/auth.go:59 lxc/auth.go:98
-#: lxc/auth.go:152 lxc/auth.go:201 lxc/auth.go:332 lxc/auth.go:392
-#: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
-#: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
-#: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
-#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1434 lxc/auth.go:1472
-#: lxc/auth.go:1524 lxc/auth.go:1573 lxc/auth.go:1692 lxc/auth.go:1752
-#: lxc/auth.go:1801 lxc/auth.go:1852 lxc/auth.go:1875 lxc/auth.go:1928
+#: lxc/alias.go:214 lxc/auth.go:31 lxc/auth.go:60 lxc/auth.go:99
+#: lxc/auth.go:153 lxc/auth.go:202 lxc/auth.go:333 lxc/auth.go:393
+#: lxc/auth.go:442 lxc/auth.go:494 lxc/auth.go:517 lxc/auth.go:576
+#: lxc/auth.go:732 lxc/auth.go:766 lxc/auth.go:833 lxc/auth.go:896
+#: lxc/auth.go:957 lxc/auth.go:1085 lxc/auth.go:1108 lxc/auth.go:1166
+#: lxc/auth.go:1235 lxc/auth.go:1257 lxc/auth.go:1435 lxc/auth.go:1473
+#: lxc/auth.go:1525 lxc/auth.go:1574 lxc/auth.go:1693 lxc/auth.go:1753
+#: lxc/auth.go:1802 lxc/auth.go:1853 lxc/auth.go:1876 lxc/auth.go:1929
 #: lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215 lxc/cluster.go:272
 #: lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:484 lxc/cluster.go:528
 #: lxc/cluster.go:586 lxc/cluster.go:677 lxc/cluster.go:770 lxc/cluster.go:893
@@ -1668,15 +1668,15 @@ msgstr ""
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:83 lxc/file.go:123 lxc/file.go:172
-#: lxc/file.go:242 lxc/file.go:467 lxc/file.go:986 lxc/image.go:38
+#: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
+#: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
 #: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
 #: lxc/image.go:697 lxc/image.go:946 lxc/image.go:1088 lxc/image.go:1415
 #: lxc/image.go:1506 lxc/image.go:1572 lxc/image.go:1636 lxc/image.go:1699
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:38 lxc/network.go:33
+#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33
 #: lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405
 #: lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793
 #: lxc/network.go:874 lxc/network.go:1005 lxc/network.go:1106
@@ -1710,27 +1710,27 @@ msgstr ""
 #: lxc/network_zone.go:909 lxc/network_zone.go:985 lxc/network_zone.go:1083
 #: lxc/network_zone.go:1172 lxc/network_zone.go:1219 lxc/network_zone.go:1349
 #: lxc/network_zone.go:1410 lxc/network_zone.go:1425 lxc/network_zone.go:1483
-#: lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:106
-#: lxc/operation.go:193 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
+#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
+#: lxc/operation.go:194 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
 #: lxc/profile.go:271 lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493
 #: lxc/profile.go:629 lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860
-#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:29
-#: lxc/project.go:93 lxc/project.go:189 lxc/project.go:260 lxc/project.go:396
-#: lxc/project.go:470 lxc/project.go:590 lxc/project.go:655 lxc/project.go:743
-#: lxc/project.go:787 lxc/project.go:848 lxc/project.go:915 lxc/publish.go:34
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:35 lxc/remote.go:91
+#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:30
+#: lxc/project.go:94 lxc/project.go:190 lxc/project.go:261 lxc/project.go:397
+#: lxc/project.go:471 lxc/project.go:591 lxc/project.go:656 lxc/project.go:744
+#: lxc/project.go:788 lxc/project.go:849 lxc/project.go:916 lxc/publish.go:34
+#: lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91
 #: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853
 #: lxc/remote.go:917 lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24
 #: lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203
 #: lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655
 #: lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940
-#: lxc/storage_bucket.go:29 lxc/storage_bucket.go:83 lxc/storage_bucket.go:188
-#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:382
-#: lxc/storage_bucket.go:458 lxc/storage_bucket.go:535
-#: lxc/storage_bucket.go:629 lxc/storage_bucket.go:698
-#: lxc/storage_bucket.go:732 lxc/storage_bucket.go:773
-#: lxc/storage_bucket.go:852 lxc/storage_bucket.go:958
-#: lxc/storage_bucket.go:1022 lxc/storage_bucket.go:1157
+#: lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189
+#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:383
+#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:536
+#: lxc/storage_bucket.go:630 lxc/storage_bucket.go:699
+#: lxc/storage_bucket.go:733 lxc/storage_bucket.go:774
+#: lxc/storage_bucket.go:853 lxc/storage_bucket.go:959
+#: lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158
 #: lxc/storage_volume.go:58 lxc/storage_volume.go:169 lxc/storage_volume.go:283
 #: lxc/storage_volume.go:390 lxc/storage_volume.go:605
 #: lxc/storage_volume.go:714 lxc/storage_volume.go:801
@@ -1741,8 +1741,8 @@ msgstr ""
 #: lxc/storage_volume.go:2064 lxc/storage_volume.go:2222
 #: lxc/storage_volume.go:2343 lxc/storage_volume.go:2405
 #: lxc/storage_volume.go:2541 lxc/storage_volume.go:2624
-#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:29
-#: lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
+#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:30
+#: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
@@ -1829,7 +1829,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:994
+#: lxc/file.go:995
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1895,7 +1895,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:74
+#: lxc/file.go:75
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1905,7 +1905,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:955 lxc/auth.go:956
+#: lxc/auth.go:956 lxc/auth.go:957
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1913,15 +1913,15 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:171 lxc/file.go:172
+#: lxc/file.go:172 lxc/file.go:173
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/auth.go:200 lxc/auth.go:201
+#: lxc/auth.go:201 lxc/auth.go:202
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1572 lxc/auth.go:1573
+#: lxc/auth.go:1573 lxc/auth.go:1574
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -1977,15 +1977,15 @@ msgstr ""
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:259 lxc/project.go:260
+#: lxc/project.go:260 lxc/project.go:261
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:248 lxc/storage_bucket.go:249
+#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:250
 msgid "Edit storage bucket configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:1021 lxc/storage_bucket.go:1022
+#: lxc/storage_bucket.go:1022 lxc/storage_bucket.go:1023
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
@@ -2002,7 +2002,7 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1147 lxc/list.go:622 lxc/storage_volume.go:1766
-#: lxc/warning.go:235
+#: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2057,7 +2057,7 @@ msgstr ""
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
-#: lxc/project.go:718 lxc/storage.go:812 lxc/storage_bucket.go:602
+#: lxc/project.go:719 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2155 lxc/storage_volume.go:2193
 #, c-format
 msgid "Error setting properties: %v"
@@ -2071,8 +2071,8 @@ msgstr ""
 #: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
-#: lxc/profile.go:981 lxc/project.go:712 lxc/storage.go:806
-#: lxc/storage_bucket.go:596 lxc/storage_volume.go:2149
+#: lxc/profile.go:981 lxc/project.go:713 lxc/storage.go:806
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2149
 #: lxc/storage_volume.go:2187
 #, c-format
 msgid "Error unsetting property: %v"
@@ -2092,7 +2092,7 @@ msgstr ""
 msgid "Evacuating cluster member: %s"
 msgstr ""
 
-#: lxc/monitor.go:50
+#: lxc/monitor.go:51
 msgid "Event type to listen for"
 msgstr ""
 
@@ -2179,16 +2179,16 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/warning.go:210
+#: lxc/warning.go:211
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1237
+#: lxc/file.go:1238
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1260
+#: lxc/file.go:1261
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2203,12 +2203,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1287
+#: lxc/file.go:1288
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1072
+#: lxc/file.go:1073
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2238,7 +2238,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1193
+#: lxc/file.go:1194
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2253,7 +2253,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1198
+#: lxc/file.go:1199
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2263,12 +2263,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1098
+#: lxc/file.go:1099
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1225
+#: lxc/file.go:1226
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2307,7 +2307,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1210
+#: lxc/file.go:1211
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2322,7 +2322,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:820
+#: lxc/file.go:821
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2337,7 +2337,7 @@ msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
 #: lxc/network.go:1044 lxc/network_acl.go:133 lxc/network_zone.go:124
-#: lxc/operation.go:136
+#: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
 
@@ -2402,21 +2402,21 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
+#: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:770 lxc/auth.go:1697
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1114 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:57
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
-#: lxc/operation.go:108 lxc/profile.go:707 lxc/project.go:472
-#: lxc/project.go:917 lxc/remote.go:690 lxc/storage.go:657
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:774
-#: lxc/storage_volume.go:1608 lxc/warning.go:93
+#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:473
+#: lxc/project.go:918 lxc/remote.go:690 lxc/storage.go:657
+#: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
+#: lxc/storage_volume.go:1608 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
-#: lxc/monitor.go:52
+#: lxc/monitor.go:53
 msgid "Format (json|pretty|yaml)"
 msgstr ""
 
@@ -2460,7 +2460,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:817 lxc/auth.go:1736
+#: lxc/auth.go:818 lxc/auth.go:1737
 msgid "GROUPS"
 msgstr ""
 
@@ -2476,7 +2476,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:914 lxc/project.go:915
+#: lxc/project.go:915 lxc/project.go:916
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2524,11 +2524,11 @@ msgstr ""
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:400
+#: lxc/project.go:401
 msgid "Get the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:385
+#: lxc/storage_bucket.go:386
 msgid "Get the key as a storage bucket property"
 msgstr ""
 
@@ -2588,11 +2588,11 @@ msgstr ""
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:395 lxc/project.go:396
+#: lxc/project.go:396 lxc/project.go:397
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:382
+#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:383
 msgid "Get values for storage bucket configuration keys"
 msgstr ""
 
@@ -2609,17 +2609,17 @@ msgstr ""
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: lxc/auth.go:136
+#: lxc/auth.go:137
 #, c-format
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:186
+#: lxc/auth.go:187
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:426 lxc/auth.go:1786
+#: lxc/auth.go:427 lxc/auth.go:1787
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2644,27 +2644,27 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1310
+#: lxc/file.go:1311
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1299
+#: lxc/file.go:1300
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1122
+#: lxc/file.go:1123
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1132
+#: lxc/file.go:1133
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:966 lxc/operation.go:170
+#: lxc/network.go:966 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2678,11 +2678,11 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:816
+#: lxc/auth.go:817
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:566
+#: lxc/project.go:567
 msgid "IMAGES"
 msgstr ""
 
@@ -2710,17 +2710,17 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1508
+#: lxc/auth.go:1509
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1558
+#: lxc/auth.go:1559
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
 
-#: lxc/rebuild.go:32
+#: lxc/rebuild.go:33
 msgid "If an instance is running, stop it and then rebuild it"
 msgstr ""
 
@@ -2841,7 +2841,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1233 lxc/auth.go:1234
+#: lxc/auth.go:1234 lxc/auth.go:1235
 msgid "Inspect permissions"
 msgstr ""
 
@@ -2849,11 +2849,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1124
+#: lxc/file.go:1125
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1301
+#: lxc/file.go:1302
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2871,7 +2871,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1044
+#: lxc/file.go:1045
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2880,7 +2880,7 @@ msgstr ""
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/rebuild.go:74
+#: lxc/rebuild.go:75
 #, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
@@ -2913,7 +2913,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/monitor.go:70
+#: lxc/monitor.go:71
 #, c-format
 msgid "Invalid format: %s"
 msgstr ""
@@ -2923,7 +2923,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1039
+#: lxc/file.go:1040
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2965,7 +2965,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:147
+#: lxc/file.go:148
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2981,12 +2981,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:313
+#: lxc/file.go:314
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:495
+#: lxc/file.go:496
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3000,7 +3000,7 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/warning.go:212
 msgid "LAST SEEN"
 msgstr ""
 
@@ -3008,7 +3008,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:984
+#: lxc/project.go:985
 msgid "LIMIT"
 msgstr ""
 
@@ -3017,8 +3017,8 @@ msgid "LISTEN ADDRESS"
 msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
-#: lxc/network_load_balancer.go:165 lxc/operation.go:177
-#: lxc/storage_bucket.go:516 lxc/storage_volume.go:1739 lxc/warning.go:220
+#: lxc/network_load_balancer.go:165 lxc/operation.go:178
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1739 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3092,7 +3092,7 @@ msgstr ""
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/warning.go:94
+#: lxc/warning.go:95
 msgid "List all warnings"
 msgstr ""
 
@@ -3136,19 +3136,19 @@ msgstr ""
 msgid "List available storage pools"
 msgstr ""
 
-#: lxc/operation.go:105 lxc/operation.go:106
+#: lxc/operation.go:106 lxc/operation.go:107
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:331 lxc/auth.go:332
+#: lxc/auth.go:332 lxc/auth.go:333
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:764 lxc/auth.go:765
+#: lxc/auth.go:765 lxc/auth.go:766
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1691 lxc/auth.go:1692
+#: lxc/auth.go:1692 lxc/auth.go:1693
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3297,11 +3297,11 @@ msgstr ""
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/operation.go:109
+#: lxc/operation.go:110
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1255 lxc/auth.go:1256
+#: lxc/auth.go:1256 lxc/auth.go:1257
 msgid "List permissions"
 msgstr ""
 
@@ -3309,15 +3309,15 @@ msgstr ""
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:469 lxc/project.go:470
+#: lxc/project.go:470 lxc/project.go:471
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:771 lxc/storage_bucket.go:773
+#: lxc/storage_bucket.go:772 lxc/storage_bucket.go:774
 msgid "List storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:456 lxc/storage_bucket.go:458
+#: lxc/storage_bucket.go:457 lxc/storage_bucket.go:459
 msgid "List storage buckets"
 msgstr ""
 
@@ -3353,11 +3353,11 @@ msgstr ""
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/warning.go:70
+#: lxc/warning.go:71
 msgid "List warnings"
 msgstr ""
 
-#: lxc/warning.go:71
+#: lxc/warning.go:72
 msgid ""
 "List warnings\n"
 "\n"
@@ -3380,7 +3380,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/operation.go:23 lxc/operation.go:24
+#: lxc/operation.go:24 lxc/operation.go:25
 msgid "List, show and delete background operations"
 msgstr ""
 
@@ -3389,7 +3389,7 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/monitor.go:79
+#: lxc/monitor.go:80
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
@@ -3493,23 +3493,23 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:82 lxc/file.go:83
+#: lxc/file.go:83 lxc/file.go:84
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1433 lxc/auth.go:1434
+#: lxc/auth.go:59 lxc/auth.go:60 lxc/auth.go:1434 lxc/auth.go:1435
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1083 lxc/auth.go:1084
+#: lxc/auth.go:1084 lxc/auth.go:1085
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:730 lxc/auth.go:731
+#: lxc/auth.go:731 lxc/auth.go:732
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1851 lxc/auth.go:1852
+#: lxc/auth.go:1852 lxc/auth.go:1853
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3600,7 +3600,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:492 lxc/auth.go:493
+#: lxc/auth.go:493 lxc/auth.go:494
 msgid "Manage permissions"
 msgstr ""
 
@@ -3608,23 +3608,23 @@ msgstr ""
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:28 lxc/project.go:29
+#: lxc/project.go:29 lxc/project.go:30
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:731
+#: lxc/storage_bucket.go:732
 msgid "Manage storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:732
+#: lxc/storage_bucket.go:733
 msgid "Manage storage bucket keys."
 msgstr ""
 
-#: lxc/storage_bucket.go:28
+#: lxc/storage_bucket.go:29
 msgid "Manage storage buckets"
 msgstr ""
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:30
 msgid "Manage storage buckets."
 msgstr ""
 
@@ -3652,11 +3652,11 @@ msgstr ""
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/auth.go:29 lxc/auth.go:30
+#: lxc/auth.go:30 lxc/auth.go:31
 msgid "Manage user authorization"
 msgstr ""
 
-#: lxc/warning.go:28 lxc/warning.go:29
+#: lxc/warning.go:29 lxc/warning.go:30
 msgid "Manage warnings"
 msgstr ""
 
@@ -3720,17 +3720,17 @@ msgstr ""
 msgid "Migration operation failure: %w"
 msgstr ""
 
-#: lxc/monitor.go:51
+#: lxc/monitor.go:52
 msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: lxc/storage_bucket.go:116 lxc/storage_bucket.go:216
-#: lxc/storage_bucket.go:292 lxc/storage_bucket.go:411
-#: lxc/storage_bucket.go:568 lxc/storage_bucket.go:660
-#: lxc/storage_bucket.go:802 lxc/storage_bucket.go:889
-#: lxc/storage_bucket.go:986 lxc/storage_bucket.go:1065
-#: lxc/storage_bucket.go:1188
+#: lxc/storage_bucket.go:117 lxc/storage_bucket.go:217
+#: lxc/storage_bucket.go:293 lxc/storage_bucket.go:412
+#: lxc/storage_bucket.go:569 lxc/storage_bucket.go:661
+#: lxc/storage_bucket.go:803 lxc/storage_bucket.go:890
+#: lxc/storage_bucket.go:987 lxc/storage_bucket.go:1066
+#: lxc/storage_bucket.go:1189
 msgid "Missing bucket name"
 msgstr ""
 
@@ -3749,20 +3749,20 @@ msgstr ""
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1825
+#: lxc/auth.go:123 lxc/auth.go:177 lxc/auth.go:255 lxc/auth.go:417
+#: lxc/auth.go:466 lxc/auth.go:541 lxc/auth.go:600 lxc/auth.go:1826
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:862 lxc/auth.go:1003 lxc/auth.go:1131 lxc/auth.go:1189
+#: lxc/auth.go:863 lxc/auth.go:1004 lxc/auth.go:1132 lxc/auth.go:1190
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1495 lxc/auth.go:1548 lxc/auth.go:1614 lxc/auth.go:1776
+#: lxc/auth.go:1496 lxc/auth.go:1549 lxc/auth.go:1615 lxc/auth.go:1777
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1899 lxc/auth.go:1952
+#: lxc/auth.go:1900 lxc/auth.go:1953
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -3770,12 +3770,12 @@ msgstr ""
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
 #: lxc/config_template.go:377 lxc/profile.go:141 lxc/profile.go:222
-#: lxc/profile.go:808 lxc/rebuild.go:60
+#: lxc/profile.go:808 lxc/rebuild.go:61
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/storage_bucket.go:893 lxc/storage_bucket.go:990
-#: lxc/storage_bucket.go:1069 lxc/storage_bucket.go:1192
+#: lxc/storage_bucket.go:894 lxc/storage_bucket.go:991
+#: lxc/storage_bucket.go:1070 lxc/storage_bucket.go:1193
 msgid "Missing key name"
 msgstr ""
 
@@ -3840,13 +3840,13 @@ msgid "Missing peer name"
 msgstr ""
 
 #: lxc/storage.go:235 lxc/storage.go:313 lxc/storage.go:431 lxc/storage.go:509
-#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:112
-#: lxc/storage_bucket.go:212 lxc/storage_bucket.go:288
-#: lxc/storage_bucket.go:407 lxc/storage_bucket.go:482
-#: lxc/storage_bucket.go:564 lxc/storage_bucket.go:656
-#: lxc/storage_bucket.go:798 lxc/storage_bucket.go:885
-#: lxc/storage_bucket.go:982 lxc/storage_bucket.go:1061
-#: lxc/storage_bucket.go:1184 lxc/storage_volume.go:209
+#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:113
+#: lxc/storage_bucket.go:213 lxc/storage_bucket.go:289
+#: lxc/storage_bucket.go:408 lxc/storage_bucket.go:483
+#: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
+#: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
+#: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
 #: lxc/storage_volume.go:323 lxc/storage_volume.go:643
 #: lxc/storage_volume.go:750 lxc/storage_volume.go:841
 #: lxc/storage_volume.go:939 lxc/storage_volume.go:1053
@@ -3861,9 +3861,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:404 lxc/project.go:146 lxc/project.go:226 lxc/project.go:316
-#: lxc/project.go:433 lxc/project.go:622 lxc/project.go:691 lxc/project.go:819
-#: lxc/project.go:948
+#: lxc/profile.go:404 lxc/project.go:147 lxc/project.go:227 lxc/project.go:317
+#: lxc/project.go:434 lxc/project.go:623 lxc/project.go:692 lxc/project.go:820
+#: lxc/project.go:949
 msgid "Missing project name"
 msgstr ""
 
@@ -3879,7 +3879,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:598
+#: lxc/file.go:599
 msgid "Missing target directory"
 msgstr ""
 
@@ -3901,11 +3901,11 @@ msgstr ""
 msgid "Model: %v"
 msgstr ""
 
-#: lxc/monitor.go:32
+#: lxc/monitor.go:33
 msgid "Monitor a local or remote LXD server"
 msgstr ""
 
-#: lxc/monitor.go:33
+#: lxc/monitor.go:34
 msgid ""
 "Monitor a local or remote LXD server\n"
 "\n"
@@ -3917,11 +3917,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:285
+#: lxc/file.go:286
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:985 lxc/file.go:986
+#: lxc/file.go:986 lxc/file.go:987
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3983,13 +3983,13 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:192
+#: lxc/auth.go:376 lxc/auth.go:816 lxc/auth.go:1736 lxc/cluster.go:192
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
-#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:565
-#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:511
-#: lxc/storage_bucket.go:831 lxc/storage_volume.go:1731
+#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:566
+#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1731
 msgid "NAME"
 msgstr ""
 
@@ -3997,11 +3997,11 @@ msgstr ""
 msgid "NAT"
 msgstr ""
 
-#: lxc/project.go:571
+#: lxc/project.go:572
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:570
+#: lxc/project.go:571
 msgid "NETWORKS"
 msgstr ""
 
@@ -4013,9 +4013,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/operation.go:154 lxc/project.go:523
-#: lxc/project.go:528 lxc/project.go:533 lxc/project.go:538 lxc/project.go:543
-#: lxc/project.go:548 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
+#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:524
+#: lxc/project.go:529 lxc/project.go:534 lxc/project.go:539 lxc/project.go:544
+#: lxc/project.go:549 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
 msgid "NO"
 msgstr ""
 
@@ -4260,7 +4260,7 @@ msgstr ""
 msgid "Only managed networks can be modified"
 msgstr ""
 
-#: lxc/operation.go:86
+#: lxc/operation.go:87
 #, c-format
 msgid "Operation %s deleted"
 msgstr ""
@@ -4307,11 +4307,11 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:567
+#: lxc/list.go:576 lxc/project.go:568
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:212
+#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4373,24 +4373,24 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1102
+#: lxc/file.go:1103
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:860
+#: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
-#: lxc/project.go:363 lxc/storage.go:360 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1151
+#: lxc/project.go:364 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1151
 #: lxc/storage_volume.go:1183
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
-#: lxc/monitor.go:48
+#: lxc/monitor.go:49
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
@@ -4476,17 +4476,17 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:172
+#: lxc/project.go:173
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:236
+#: lxc/project.go:237
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:637
+#: lxc/project.go:638
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -4607,20 +4607,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:241 lxc/file.go:242
+#: lxc/file.go:242 lxc/file.go:243
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:416 lxc/file.go:767
+#: lxc/file.go:417 lxc/file.go:768
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:466 lxc/file.go:467
+#: lxc/file.go:467 lxc/file.go:468
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:701 lxc/file.go:867
+#: lxc/file.go:702 lxc/file.go:868
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4633,11 +4633,11 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:983
+#: lxc/project.go:984
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/storage_bucket.go:833
+#: lxc/storage_bucket.go:834
 msgid "ROLE"
 msgstr ""
 
@@ -4650,15 +4650,15 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/rebuild.go:31
+#: lxc/rebuild.go:32
 msgid "Rebuild as an empty instance"
 msgstr ""
 
-#: lxc/rebuild.go:26
+#: lxc/rebuild.go:27
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:249 lxc/file.go:473
+#: lxc/file.go:250 lxc/file.go:474
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4685,7 +4685,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:882 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
+#: lxc/project.go:883 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
 #: lxc/remote.go:994
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4736,7 +4736,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1164 lxc/auth.go:1165
+#: lxc/auth.go:1165 lxc/auth.go:1166
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4772,7 +4772,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1927 lxc/auth.go:1928
+#: lxc/auth.go:1928 lxc/auth.go:1929
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4784,7 +4784,7 @@ msgstr ""
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:574 lxc/auth.go:575
+#: lxc/auth.go:575 lxc/auth.go:576
 msgid "Remove permissions from groups"
 msgstr ""
 
@@ -4829,11 +4829,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:391 lxc/auth.go:392
+#: lxc/auth.go:392 lxc/auth.go:393
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1751 lxc/auth.go:1752
+#: lxc/auth.go:1752 lxc/auth.go:1753
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -4853,7 +4853,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:589 lxc/project.go:590
+#: lxc/project.go:590 lxc/project.go:591
 msgid "Rename projects"
 msgstr ""
 
@@ -4951,7 +4951,7 @@ msgstr ""
 msgid "Revoke cluster member join token"
 msgstr ""
 
-#: lxc/storage_bucket.go:862
+#: lxc/storage_bucket.go:863
 msgid "Role (admin or read-only)"
 msgstr ""
 
@@ -4967,7 +4967,7 @@ msgstr ""
 msgid "Run against all projects"
 msgstr ""
 
-#: lxc/warning.go:213
+#: lxc/warning.go:214
 msgid "SEVERITY"
 msgstr ""
 
@@ -4987,12 +4987,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1231
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1231
+#: lxc/file.go:1232
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5006,11 +5006,11 @@ msgstr ""
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:173 lxc/warning.go:214
+#: lxc/operation.go:174 lxc/warning.go:215
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:569
+#: lxc/project.go:570
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5018,7 +5018,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:569
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -5026,11 +5026,11 @@ msgstr ""
 msgid "STP"
 msgstr ""
 
-#: lxc/storage_bucket.go:864
+#: lxc/storage_bucket.go:865
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:942
+#: lxc/storage_bucket.go:943
 #, c-format
 msgid "Secret key: %s"
 msgstr ""
@@ -5068,7 +5068,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:995
+#: lxc/file.go:996
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5206,11 +5206,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:654
+#: lxc/project.go:655
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:655
+#: lxc/project.go:656
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5219,11 +5219,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage_bucket.go:534
+#: lxc/storage_bucket.go:535
 msgid "Set storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:535
+#: lxc/storage_bucket.go:536
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -5262,15 +5262,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:476
+#: lxc/file.go:477
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:477
+#: lxc/file.go:478
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:475
+#: lxc/file.go:476
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5310,11 +5310,11 @@ msgstr ""
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 msgid "Set the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:542
+#: lxc/storage_bucket.go:543
 msgid "Set the key as a storage bucket property"
 msgstr ""
 
@@ -5330,7 +5330,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:993
+#: lxc/file.go:994
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5342,7 +5342,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1800 lxc/auth.go:1801
+#: lxc/auth.go:1801 lxc/auth.go:1802
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5358,11 +5358,11 @@ msgstr ""
 msgid "Show details of a cluster member"
 msgstr ""
 
-#: lxc/operation.go:192 lxc/operation.go:193
+#: lxc/operation.go:193 lxc/operation.go:194
 msgid "Show details on a background operation"
 msgstr ""
 
-#: lxc/monitor.go:49
+#: lxc/monitor.go:50
 msgid "Show events from all projects"
 msgstr ""
 
@@ -5370,11 +5370,11 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:440 lxc/auth.go:441
+#: lxc/auth.go:441 lxc/auth.go:442
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:832
+#: lxc/auth.go:833
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5455,15 +5455,15 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:786 lxc/project.go:787
+#: lxc/project.go:787 lxc/project.go:788
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage_bucket.go:628 lxc/storage_bucket.go:629
+#: lxc/storage_bucket.go:629 lxc/storage_bucket.go:630
 msgid "Show storage bucket configurations"
 msgstr ""
 
-#: lxc/storage_bucket.go:1156 lxc/storage_bucket.go:1157
+#: lxc/storage_bucket.go:1157 lxc/storage_bucket.go:1158
 msgid "Show storage bucket key configurations"
 msgstr ""
 
@@ -5479,7 +5479,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:895
+#: lxc/auth.go:896
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5529,7 +5529,7 @@ msgstr ""
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: lxc/warning.go:302 lxc/warning.go:303
+#: lxc/warning.go:303 lxc/warning.go:304
 msgid "Show warning"
 msgstr ""
 
@@ -5613,22 +5613,22 @@ msgstr ""
 msgid "Stopping the instance failed: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:166
+#: lxc/storage_bucket.go:167
 #, c-format
 msgid "Storage bucket %s created"
 msgstr ""
 
-#: lxc/storage_bucket.go:233
+#: lxc/storage_bucket.go:234
 #, c-format
 msgid "Storage bucket %s deleted"
 msgstr ""
 
-#: lxc/storage_bucket.go:940
+#: lxc/storage_bucket.go:941
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr ""
 
-#: lxc/storage_bucket.go:1006
+#: lxc/storage_bucket.go:1007
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr ""
@@ -5697,7 +5697,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:847 lxc/project.go:848
+#: lxc/project.go:848 lxc/project.go:849
 msgid "Switch the current project"
 msgstr ""
 
@@ -5713,10 +5713,10 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1139
+#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1139
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
-#: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:171
-#: lxc/storage_volume.go:1730 lxc/warning.go:215
+#: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
+#: lxc/storage_volume.go:1730 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
@@ -5724,11 +5724,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1032
+#: lxc/file.go:1033
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1026
+#: lxc/file.go:1027
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5856,12 +5856,12 @@ msgstr ""
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:446
+#: lxc/project.go:447
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
 
-#: lxc/storage_bucket.go:431
+#: lxc/storage_bucket.go:432
 #, c-format
 msgid "The property %q does not exist on the storage bucket %q: %v"
 msgstr ""
@@ -6046,7 +6046,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:961
+#: lxc/project.go:962
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6058,17 +6058,17 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:985 lxc/storage_volume.go:1735
+#: lxc/project.go:986 lxc/storage_volume.go:1735
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:573
+#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:574
 #: lxc/storage.go:724 lxc/storage_volume.go:1734
 msgid "USED BY"
 msgstr ""
 
-#: lxc/warning.go:216
+#: lxc/warning.go:217
 msgid "UUID"
 msgstr ""
 
@@ -6077,7 +6077,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:197
+#: lxc/file.go:198
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6091,13 +6091,13 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1253
+#: lxc/file.go:1254
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1153 lxc/list.go:631 lxc/storage_volume.go:1772
-#: lxc/warning.go:241
+#: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6107,7 +6107,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:807
+#: lxc/file.go:808
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6190,11 +6190,11 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:742 lxc/project.go:743
+#: lxc/project.go:743 lxc/project.go:744
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:697 lxc/storage_bucket.go:698
+#: lxc/storage_bucket.go:698 lxc/storage_bucket.go:699
 msgid "Unset storage bucket configuration keys"
 msgstr ""
 
@@ -6242,11 +6242,11 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:747
+#: lxc/project.go:748
 msgid "Unset the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:701
+#: lxc/storage_bucket.go:702
 msgid "Unset the key as a storage bucket property"
 msgstr ""
 
@@ -6325,7 +6325,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:71
+#: lxc/file.go:72
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6362,11 +6362,11 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:831
+#: lxc/auth.go:832
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:894
+#: lxc/auth.go:895
 msgid "View the current identity"
 msgstr ""
 
@@ -6397,15 +6397,15 @@ msgstr ""
 msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
-#: lxc/rebuild.go:27
+#: lxc/rebuild.go:28
 msgid ""
 "Wipe the instance root disk and re-initialize. The original image is used to "
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:156 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
+#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:526
+#: lxc/project.go:531 lxc/project.go:536 lxc/project.go:541 lxc/project.go:546
+#: lxc/project.go:551 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
 msgid "YES"
 msgstr ""
 
@@ -6425,7 +6425,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/rebuild.go:119
+#: lxc/rebuild.go:120
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
@@ -6437,12 +6437,12 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1689
+#: lxc/auth.go:330 lxc/auth.go:763 lxc/auth.go:894 lxc/auth.go:1690
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
-#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
+#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
-#: lxc/operation.go:103 lxc/profile.go:700 lxc/project.go:467
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:68
+#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:468
+#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6470,7 +6470,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1254
+#: lxc/auth.go:1255
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6531,11 +6531,11 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:830
+#: lxc/auth.go:831
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1926
+#: lxc/auth.go:1106 lxc/auth.go:1164 lxc/auth.go:1927
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6543,13 +6543,13 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:954 lxc/auth.go:1470 lxc/cluster_group.go:168
+#: lxc/auth.go:97 lxc/auth.go:150 lxc/auth.go:200 lxc/auth.go:440
+#: lxc/auth.go:955 lxc/auth.go:1471 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:514 lxc/auth.go:572
+#: lxc/auth.go:515 lxc/auth.go:573
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
@@ -6559,19 +6559,19 @@ msgstr ""
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:389
+#: lxc/auth.go:390
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1521 lxc/auth.go:1571 lxc/auth.go:1799
+#: lxc/auth.go:1522 lxc/auth.go:1572 lxc/auth.go:1800
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1873
+#: lxc/auth.go:1874
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1749
+#: lxc/auth.go:1750
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -6591,7 +6591,7 @@ msgstr ""
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
-#: lxc/rebuild.go:25
+#: lxc/rebuild.go:26
 msgid "[<remote>:]<image> [<remote>:]<instance>"
 msgstr ""
 
@@ -6674,20 +6674,20 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:170
+#: lxc/file.go:171
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:120
+#: lxc/file.go:121
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:240
+#: lxc/file.go:241
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:984
+#: lxc/file.go:985
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6838,12 +6838,12 @@ msgstr ""
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
-#: lxc/operation.go:53 lxc/operation.go:191
+#: lxc/operation.go:54 lxc/operation.go:192
 msgid "[<remote>:]<operation>"
 msgstr ""
 
 #: lxc/storage.go:200 lxc/storage.go:259 lxc/storage.go:473 lxc/storage.go:844
-#: lxc/storage_bucket.go:454
+#: lxc/storage_bucket.go:455
 msgid "[<remote>:]<pool>"
 msgstr ""
 
@@ -6851,22 +6851,22 @@ msgstr ""
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
-#: lxc/storage_bucket.go:185 lxc/storage_bucket.go:247
-#: lxc/storage_bucket.go:627 lxc/storage_bucket.go:769
+#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:248
+#: lxc/storage_bucket.go:628 lxc/storage_bucket.go:770
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
 
-#: lxc/storage_bucket.go:380 lxc/storage_bucket.go:696
-#: lxc/storage_bucket.go:850 lxc/storage_bucket.go:956
-#: lxc/storage_bucket.go:1020 lxc/storage_bucket.go:1155
+#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:697
+#: lxc/storage_bucket.go:851 lxc/storage_bucket.go:957
+#: lxc/storage_bucket.go:1021 lxc/storage_bucket.go:1156
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
 
-#: lxc/storage_bucket.go:533
+#: lxc/storage_bucket.go:534
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_bucket.go:81
+#: lxc/storage_bucket.go:82
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
 
@@ -6981,20 +6981,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:91 lxc/project.go:186 lxc/project.go:258 lxc/project.go:785
-#: lxc/project.go:846 lxc/project.go:913
+#: lxc/project.go:92 lxc/project.go:187 lxc/project.go:259 lxc/project.go:786
+#: lxc/project.go:847 lxc/project.go:914
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:394 lxc/project.go:741
+#: lxc/project.go:395 lxc/project.go:742
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:653
+#: lxc/project.go:654
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:587
+#: lxc/project.go:588
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7002,7 +7002,7 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:259 lxc/warning.go:301 lxc/warning.go:354
+#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
@@ -7058,7 +7058,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:555 lxc/remote.go:739
+#: lxc/project.go:556 lxc/remote.go:739
 msgid "current"
 msgstr ""
 
@@ -7105,20 +7105,20 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/auth.go:203
+#: lxc/auth.go:204
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:958
+#: lxc/auth.go:959
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1575
+#: lxc/auth.go:1576
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7196,20 +7196,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:988
+#: lxc/file.go:989
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:244
+#: lxc/file.go:245
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:470
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7291,7 +7291,7 @@ msgid ""
 "  List instances with their running state and user comment."
 msgstr ""
 
-#: lxc/monitor.go:37
+#: lxc/monitor.go:38
 msgid ""
 "lxc monitor --type=logging\n"
 "    Only show log messages.\n"
@@ -7367,7 +7367,7 @@ msgid ""
 "    Create record r1 for zone z1 with configuration from config.yaml"
 msgstr ""
 
-#: lxc/operation.go:195
+#: lxc/operation.go:196
 msgid ""
 "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Show details on that operation UUID"
@@ -7410,7 +7410,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:95
+#: lxc/project.go:96
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7418,7 +7418,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:262
+#: lxc/project.go:263
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7449,7 +7449,7 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:85
 msgid ""
 "lxc storage bucket create p1 b01\n"
 "\tCreate a new storage bucket name b01 in storage pool p1\n"
@@ -7459,19 +7459,19 @@ msgid ""
 "of config.yaml"
 msgstr ""
 
-#: lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:251
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1023
+#: lxc/storage_bucket.go:1024
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:854
 msgid ""
 "lxc storage bucket key create p1 b01 k1\n"
 "\tCreate a key called k1 for the bucket b01 in the pool p1.\n"
@@ -7481,14 +7481,14 @@ msgid ""
 "of config.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1158
+#: lxc/storage_bucket.go:1159
 msgid ""
 "lxc storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_bucket.go:630
+#: lxc/storage_bucket.go:631
 msgid ""
 "lxc storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
@@ -7558,16 +7558,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1142
+#: lxc/file.go:1143
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1101
+#: lxc/file.go:1102
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1054
+#: lxc/file.go:1055
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-04 08:52-0600\n"
+"POT-Creation-Date: 2024-09-05 08:44-0400\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Indonesian <https://hosted.weblate.org/projects/linux-"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: lxc/storage_bucket.go:260 lxc/storage_bucket.go:1033
+#: lxc/storage_bucket.go:261 lxc/storage_bucket.go:1034
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -133,7 +133,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:213
+#: lxc/auth.go:214
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -160,7 +160,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:968
+#: lxc/auth.go:969
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -181,7 +181,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1585
+#: lxc/auth.go:1586
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -391,7 +391,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:280
+#: lxc/project.go:281
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -433,12 +433,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:935
+#: lxc/file.go:936
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:825
+#: lxc/file.go:826
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -474,7 +474,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:142 lxc/rebuild.go:64
+#: lxc/init.go:142 lxc/rebuild.go:65
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -527,7 +527,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:465
+#: lxc/file.go:466
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -560,7 +560,7 @@ msgstr ""
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:813
+#: lxc/auth.go:814
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -568,11 +568,11 @@ msgstr ""
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/storage_bucket.go:863
+#: lxc/storage_bucket.go:864
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:941
+#: lxc/storage_bucket.go:942
 #, c-format
 msgid "Access key: %s"
 msgstr ""
@@ -581,7 +581,7 @@ msgstr ""
 msgid "Access the expanded configuration"
 msgstr ""
 
-#: lxc/warning.go:261 lxc/warning.go:262
+#: lxc/warning.go:262 lxc/warning.go:263
 msgid "Acknowledge warning"
 msgstr ""
 
@@ -598,11 +598,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1106 lxc/auth.go:1107
+#: lxc/auth.go:1107 lxc/auth.go:1108
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1874 lxc/auth.go:1875
+#: lxc/auth.go:1875 lxc/auth.go:1876
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -671,7 +671,7 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:515 lxc/auth.go:516
+#: lxc/auth.go:516 lxc/auth.go:517
 msgid "Add permissions to groups"
 msgstr ""
 
@@ -700,7 +700,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:169
+#: lxc/storage_bucket.go:170
 #, c-format
 msgid "Admin access key: %s"
 msgstr ""
@@ -710,7 +710,7 @@ msgstr ""
 msgid "Admin password (or token) for %s:"
 msgstr ""
 
-#: lxc/storage_bucket.go:170
+#: lxc/storage_bucket.go:171
 #, c-format
 msgid "Admin secret key: %s"
 msgstr ""
@@ -769,7 +769,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:342 lxc/rebuild.go:130
+#: lxc/init.go:342 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -869,12 +869,12 @@ msgstr ""
 
 #: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:318
 #: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
-#: lxc/network_zone.go:366 lxc/network_zone.go:1053 lxc/storage_bucket.go:141
+#: lxc/network_zone.go:366 lxc/network_zone.go:1053 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:159
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:160
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -914,7 +914,7 @@ msgstr ""
 msgid "Bytes sent"
 msgstr ""
 
-#: lxc/operation.go:174
+#: lxc/operation.go:175
 msgid "CANCELABLE"
 msgstr ""
 
@@ -926,7 +926,7 @@ msgstr ""
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: lxc/warning.go:209
+#: lxc/warning.go:210
 msgid "COUNT"
 msgstr ""
 
@@ -952,7 +952,7 @@ msgstr ""
 msgid "CPUs (%s):"
 msgstr ""
 
-#: lxc/operation.go:175
+#: lxc/operation.go:176
 msgid "CREATED"
 msgstr ""
 
@@ -982,7 +982,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:340
+#: lxc/file.go:341
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1007,11 +1007,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:224
+#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:546
+#: lxc/file.go:547
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1020,7 +1020,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:160
+#: lxc/rebuild.go:161
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1143,13 +1143,13 @@ msgstr ""
 #: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
 #: lxc/network_load_balancer.go:1051 lxc/network_load_balancer.go:1125
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
-#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:90
-#: lxc/storage_bucket.go:190 lxc/storage_bucket.go:253
-#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:541
-#: lxc/storage_bucket.go:634 lxc/storage_bucket.go:700
-#: lxc/storage_bucket.go:775 lxc/storage_bucket.go:861
-#: lxc/storage_bucket.go:961 lxc/storage_bucket.go:1026
-#: lxc/storage_bucket.go:1162 lxc/storage_volume.go:394
+#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
+#: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
+#: lxc/storage_bucket.go:385 lxc/storage_bucket.go:542
+#: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
+#: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
+#: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
 #: lxc/storage_volume.go:612 lxc/storage_volume.go:717
 #: lxc/storage_volume.go:1005 lxc/storage_volume.go:1231
 #: lxc/storage_volume.go:1360 lxc/storage_volume.go:1848
@@ -1173,7 +1173,7 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1113 lxc/list.go:132 lxc/storage_volume.go:1589
-#: lxc/warning.go:92
+#: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
@@ -1201,7 +1201,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:100
+#: lxc/project.go:101
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1215,8 +1215,8 @@ msgstr ""
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
-#: lxc/project.go:362 lxc/storage.go:359 lxc/storage_bucket.go:348
-#: lxc/storage_bucket.go:1125 lxc/storage_volume.go:1150
+#: lxc/project.go:363 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1150
 #: lxc/storage_volume.go:1182
 #, c-format
 msgid "Config parsing error: %s"
@@ -1343,12 +1343,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:300 lxc/auth.go:1660
+#: lxc/auth.go:301 lxc/auth.go:1661
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1054
+#: lxc/auth.go:1055
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1397,15 +1397,15 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:248 lxc/file.go:474
+#: lxc/file.go:249 lxc/file.go:475
 msgid "Create any directories necessary"
 msgstr ""
 
-#: lxc/auth.go:97 lxc/auth.go:98
+#: lxc/auth.go:98 lxc/auth.go:99
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1471 lxc/auth.go:1472
+#: lxc/auth.go:1472 lxc/auth.go:1473
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1425,11 +1425,11 @@ msgstr ""
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_bucket.go:851 lxc/storage_bucket.go:852
+#: lxc/storage_bucket.go:852 lxc/storage_bucket.go:853
 msgid "Create key for a storage bucket"
 msgstr ""
 
-#: lxc/storage_bucket.go:82 lxc/storage_bucket.go:83
+#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
 msgid "Create new custom storage buckets"
 msgstr ""
 
@@ -1473,7 +1473,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:92 lxc/project.go:93
+#: lxc/project.go:93 lxc/project.go:94
 msgid "Create projects"
 msgstr ""
 
@@ -1508,13 +1508,13 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:376 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1135 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
-#: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:172
-#: lxc/profile.go:756 lxc/project.go:572 lxc/storage.go:723
-#: lxc/storage_bucket.go:512 lxc/storage_bucket.go:832
+#: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
+#: lxc/profile.go:756 lxc/project.go:573 lxc/storage.go:723
+#: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1732
 msgid "DESCRIPTION"
 msgstr ""
@@ -1539,7 +1539,7 @@ msgstr ""
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
-#: lxc/operation.go:55 lxc/operation.go:56
+#: lxc/operation.go:56 lxc/operation.go:57
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
@@ -1547,19 +1547,19 @@ msgstr ""
 msgid "Delete a cluster group"
 msgstr ""
 
-#: lxc/warning.go:360
+#: lxc/warning.go:361
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:122 lxc/file.go:123
+#: lxc/file.go:123 lxc/file.go:124
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/auth.go:151 lxc/auth.go:152
+#: lxc/auth.go:152 lxc/auth.go:153
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1523 lxc/auth.go:1524
+#: lxc/auth.go:1524 lxc/auth.go:1525
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1579,7 +1579,7 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/storage_bucket.go:957 lxc/storage_bucket.go:958
+#: lxc/storage_bucket.go:958 lxc/storage_bucket.go:959
 msgid "Delete key from a storage bucket"
 msgstr ""
 
@@ -1615,11 +1615,11 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:188 lxc/project.go:189
+#: lxc/project.go:189 lxc/project.go:190
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:187 lxc/storage_bucket.go:188
+#: lxc/storage_bucket.go:188 lxc/storage_bucket.go:189
 msgid "Delete storage buckets"
 msgstr ""
 
@@ -1631,20 +1631,20 @@ msgstr ""
 msgid "Delete storage volumes"
 msgstr ""
 
-#: lxc/warning.go:356 lxc/warning.go:357
+#: lxc/warning.go:357 lxc/warning.go:358
 msgid "Delete warning"
 msgstr ""
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:30 lxc/auth.go:59 lxc/auth.go:98
-#: lxc/auth.go:152 lxc/auth.go:201 lxc/auth.go:332 lxc/auth.go:392
-#: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
-#: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
-#: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
-#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1434 lxc/auth.go:1472
-#: lxc/auth.go:1524 lxc/auth.go:1573 lxc/auth.go:1692 lxc/auth.go:1752
-#: lxc/auth.go:1801 lxc/auth.go:1852 lxc/auth.go:1875 lxc/auth.go:1928
+#: lxc/alias.go:214 lxc/auth.go:31 lxc/auth.go:60 lxc/auth.go:99
+#: lxc/auth.go:153 lxc/auth.go:202 lxc/auth.go:333 lxc/auth.go:393
+#: lxc/auth.go:442 lxc/auth.go:494 lxc/auth.go:517 lxc/auth.go:576
+#: lxc/auth.go:732 lxc/auth.go:766 lxc/auth.go:833 lxc/auth.go:896
+#: lxc/auth.go:957 lxc/auth.go:1085 lxc/auth.go:1108 lxc/auth.go:1166
+#: lxc/auth.go:1235 lxc/auth.go:1257 lxc/auth.go:1435 lxc/auth.go:1473
+#: lxc/auth.go:1525 lxc/auth.go:1574 lxc/auth.go:1693 lxc/auth.go:1753
+#: lxc/auth.go:1802 lxc/auth.go:1853 lxc/auth.go:1876 lxc/auth.go:1929
 #: lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215 lxc/cluster.go:272
 #: lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:484 lxc/cluster.go:528
 #: lxc/cluster.go:586 lxc/cluster.go:677 lxc/cluster.go:770 lxc/cluster.go:893
@@ -1668,15 +1668,15 @@ msgstr ""
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:83 lxc/file.go:123 lxc/file.go:172
-#: lxc/file.go:242 lxc/file.go:467 lxc/file.go:986 lxc/image.go:38
+#: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
+#: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
 #: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
 #: lxc/image.go:697 lxc/image.go:946 lxc/image.go:1088 lxc/image.go:1415
 #: lxc/image.go:1506 lxc/image.go:1572 lxc/image.go:1636 lxc/image.go:1699
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:38 lxc/network.go:33
+#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33
 #: lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405
 #: lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793
 #: lxc/network.go:874 lxc/network.go:1005 lxc/network.go:1106
@@ -1710,27 +1710,27 @@ msgstr ""
 #: lxc/network_zone.go:909 lxc/network_zone.go:985 lxc/network_zone.go:1083
 #: lxc/network_zone.go:1172 lxc/network_zone.go:1219 lxc/network_zone.go:1349
 #: lxc/network_zone.go:1410 lxc/network_zone.go:1425 lxc/network_zone.go:1483
-#: lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:106
-#: lxc/operation.go:193 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
+#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
+#: lxc/operation.go:194 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
 #: lxc/profile.go:271 lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493
 #: lxc/profile.go:629 lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860
-#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:29
-#: lxc/project.go:93 lxc/project.go:189 lxc/project.go:260 lxc/project.go:396
-#: lxc/project.go:470 lxc/project.go:590 lxc/project.go:655 lxc/project.go:743
-#: lxc/project.go:787 lxc/project.go:848 lxc/project.go:915 lxc/publish.go:34
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:35 lxc/remote.go:91
+#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:30
+#: lxc/project.go:94 lxc/project.go:190 lxc/project.go:261 lxc/project.go:397
+#: lxc/project.go:471 lxc/project.go:591 lxc/project.go:656 lxc/project.go:744
+#: lxc/project.go:788 lxc/project.go:849 lxc/project.go:916 lxc/publish.go:34
+#: lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91
 #: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853
 #: lxc/remote.go:917 lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24
 #: lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203
 #: lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655
 #: lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940
-#: lxc/storage_bucket.go:29 lxc/storage_bucket.go:83 lxc/storage_bucket.go:188
-#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:382
-#: lxc/storage_bucket.go:458 lxc/storage_bucket.go:535
-#: lxc/storage_bucket.go:629 lxc/storage_bucket.go:698
-#: lxc/storage_bucket.go:732 lxc/storage_bucket.go:773
-#: lxc/storage_bucket.go:852 lxc/storage_bucket.go:958
-#: lxc/storage_bucket.go:1022 lxc/storage_bucket.go:1157
+#: lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189
+#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:383
+#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:536
+#: lxc/storage_bucket.go:630 lxc/storage_bucket.go:699
+#: lxc/storage_bucket.go:733 lxc/storage_bucket.go:774
+#: lxc/storage_bucket.go:853 lxc/storage_bucket.go:959
+#: lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158
 #: lxc/storage_volume.go:58 lxc/storage_volume.go:169 lxc/storage_volume.go:283
 #: lxc/storage_volume.go:390 lxc/storage_volume.go:605
 #: lxc/storage_volume.go:714 lxc/storage_volume.go:801
@@ -1741,8 +1741,8 @@ msgstr ""
 #: lxc/storage_volume.go:2064 lxc/storage_volume.go:2222
 #: lxc/storage_volume.go:2343 lxc/storage_volume.go:2405
 #: lxc/storage_volume.go:2541 lxc/storage_volume.go:2624
-#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:29
-#: lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
+#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:30
+#: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
@@ -1829,7 +1829,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:994
+#: lxc/file.go:995
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1895,7 +1895,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:74
+#: lxc/file.go:75
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1905,7 +1905,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:955 lxc/auth.go:956
+#: lxc/auth.go:956 lxc/auth.go:957
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1913,15 +1913,15 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:171 lxc/file.go:172
+#: lxc/file.go:172 lxc/file.go:173
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/auth.go:200 lxc/auth.go:201
+#: lxc/auth.go:201 lxc/auth.go:202
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1572 lxc/auth.go:1573
+#: lxc/auth.go:1573 lxc/auth.go:1574
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -1977,15 +1977,15 @@ msgstr ""
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:259 lxc/project.go:260
+#: lxc/project.go:260 lxc/project.go:261
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:248 lxc/storage_bucket.go:249
+#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:250
 msgid "Edit storage bucket configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:1021 lxc/storage_bucket.go:1022
+#: lxc/storage_bucket.go:1022 lxc/storage_bucket.go:1023
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
@@ -2002,7 +2002,7 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1147 lxc/list.go:622 lxc/storage_volume.go:1766
-#: lxc/warning.go:235
+#: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2057,7 +2057,7 @@ msgstr ""
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
-#: lxc/project.go:718 lxc/storage.go:812 lxc/storage_bucket.go:602
+#: lxc/project.go:719 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2155 lxc/storage_volume.go:2193
 #, c-format
 msgid "Error setting properties: %v"
@@ -2071,8 +2071,8 @@ msgstr ""
 #: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
-#: lxc/profile.go:981 lxc/project.go:712 lxc/storage.go:806
-#: lxc/storage_bucket.go:596 lxc/storage_volume.go:2149
+#: lxc/profile.go:981 lxc/project.go:713 lxc/storage.go:806
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2149
 #: lxc/storage_volume.go:2187
 #, c-format
 msgid "Error unsetting property: %v"
@@ -2092,7 +2092,7 @@ msgstr ""
 msgid "Evacuating cluster member: %s"
 msgstr ""
 
-#: lxc/monitor.go:50
+#: lxc/monitor.go:51
 msgid "Event type to listen for"
 msgstr ""
 
@@ -2179,16 +2179,16 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/warning.go:210
+#: lxc/warning.go:211
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1237
+#: lxc/file.go:1238
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1260
+#: lxc/file.go:1261
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2203,12 +2203,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1287
+#: lxc/file.go:1288
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1072
+#: lxc/file.go:1073
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2238,7 +2238,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1193
+#: lxc/file.go:1194
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2253,7 +2253,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1198
+#: lxc/file.go:1199
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2263,12 +2263,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1098
+#: lxc/file.go:1099
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1225
+#: lxc/file.go:1226
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2307,7 +2307,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1210
+#: lxc/file.go:1211
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2322,7 +2322,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:820
+#: lxc/file.go:821
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2337,7 +2337,7 @@ msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
 #: lxc/network.go:1044 lxc/network_acl.go:133 lxc/network_zone.go:124
-#: lxc/operation.go:136
+#: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
 
@@ -2402,21 +2402,21 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
+#: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:770 lxc/auth.go:1697
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1114 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:57
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
-#: lxc/operation.go:108 lxc/profile.go:707 lxc/project.go:472
-#: lxc/project.go:917 lxc/remote.go:690 lxc/storage.go:657
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:774
-#: lxc/storage_volume.go:1608 lxc/warning.go:93
+#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:473
+#: lxc/project.go:918 lxc/remote.go:690 lxc/storage.go:657
+#: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
+#: lxc/storage_volume.go:1608 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
-#: lxc/monitor.go:52
+#: lxc/monitor.go:53
 msgid "Format (json|pretty|yaml)"
 msgstr ""
 
@@ -2460,7 +2460,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:817 lxc/auth.go:1736
+#: lxc/auth.go:818 lxc/auth.go:1737
 msgid "GROUPS"
 msgstr ""
 
@@ -2476,7 +2476,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:914 lxc/project.go:915
+#: lxc/project.go:915 lxc/project.go:916
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2524,11 +2524,11 @@ msgstr ""
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:400
+#: lxc/project.go:401
 msgid "Get the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:385
+#: lxc/storage_bucket.go:386
 msgid "Get the key as a storage bucket property"
 msgstr ""
 
@@ -2588,11 +2588,11 @@ msgstr ""
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:395 lxc/project.go:396
+#: lxc/project.go:396 lxc/project.go:397
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:382
+#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:383
 msgid "Get values for storage bucket configuration keys"
 msgstr ""
 
@@ -2609,17 +2609,17 @@ msgstr ""
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: lxc/auth.go:136
+#: lxc/auth.go:137
 #, c-format
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:186
+#: lxc/auth.go:187
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:426 lxc/auth.go:1786
+#: lxc/auth.go:427 lxc/auth.go:1787
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2644,27 +2644,27 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1310
+#: lxc/file.go:1311
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1299
+#: lxc/file.go:1300
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1122
+#: lxc/file.go:1123
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1132
+#: lxc/file.go:1133
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:966 lxc/operation.go:170
+#: lxc/network.go:966 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2678,11 +2678,11 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:816
+#: lxc/auth.go:817
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:566
+#: lxc/project.go:567
 msgid "IMAGES"
 msgstr ""
 
@@ -2710,17 +2710,17 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1508
+#: lxc/auth.go:1509
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1558
+#: lxc/auth.go:1559
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
 
-#: lxc/rebuild.go:32
+#: lxc/rebuild.go:33
 msgid "If an instance is running, stop it and then rebuild it"
 msgstr ""
 
@@ -2841,7 +2841,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1233 lxc/auth.go:1234
+#: lxc/auth.go:1234 lxc/auth.go:1235
 msgid "Inspect permissions"
 msgstr ""
 
@@ -2849,11 +2849,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1124
+#: lxc/file.go:1125
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1301
+#: lxc/file.go:1302
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2871,7 +2871,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1044
+#: lxc/file.go:1045
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2880,7 +2880,7 @@ msgstr ""
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/rebuild.go:74
+#: lxc/rebuild.go:75
 #, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
@@ -2913,7 +2913,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/monitor.go:70
+#: lxc/monitor.go:71
 #, c-format
 msgid "Invalid format: %s"
 msgstr ""
@@ -2923,7 +2923,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1039
+#: lxc/file.go:1040
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2965,7 +2965,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:147
+#: lxc/file.go:148
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2981,12 +2981,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:313
+#: lxc/file.go:314
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:495
+#: lxc/file.go:496
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3000,7 +3000,7 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/warning.go:212
 msgid "LAST SEEN"
 msgstr ""
 
@@ -3008,7 +3008,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:984
+#: lxc/project.go:985
 msgid "LIMIT"
 msgstr ""
 
@@ -3017,8 +3017,8 @@ msgid "LISTEN ADDRESS"
 msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
-#: lxc/network_load_balancer.go:165 lxc/operation.go:177
-#: lxc/storage_bucket.go:516 lxc/storage_volume.go:1739 lxc/warning.go:220
+#: lxc/network_load_balancer.go:165 lxc/operation.go:178
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1739 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3092,7 +3092,7 @@ msgstr ""
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/warning.go:94
+#: lxc/warning.go:95
 msgid "List all warnings"
 msgstr ""
 
@@ -3136,19 +3136,19 @@ msgstr ""
 msgid "List available storage pools"
 msgstr ""
 
-#: lxc/operation.go:105 lxc/operation.go:106
+#: lxc/operation.go:106 lxc/operation.go:107
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:331 lxc/auth.go:332
+#: lxc/auth.go:332 lxc/auth.go:333
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:764 lxc/auth.go:765
+#: lxc/auth.go:765 lxc/auth.go:766
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1691 lxc/auth.go:1692
+#: lxc/auth.go:1692 lxc/auth.go:1693
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3297,11 +3297,11 @@ msgstr ""
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/operation.go:109
+#: lxc/operation.go:110
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1255 lxc/auth.go:1256
+#: lxc/auth.go:1256 lxc/auth.go:1257
 msgid "List permissions"
 msgstr ""
 
@@ -3309,15 +3309,15 @@ msgstr ""
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:469 lxc/project.go:470
+#: lxc/project.go:470 lxc/project.go:471
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:771 lxc/storage_bucket.go:773
+#: lxc/storage_bucket.go:772 lxc/storage_bucket.go:774
 msgid "List storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:456 lxc/storage_bucket.go:458
+#: lxc/storage_bucket.go:457 lxc/storage_bucket.go:459
 msgid "List storage buckets"
 msgstr ""
 
@@ -3353,11 +3353,11 @@ msgstr ""
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/warning.go:70
+#: lxc/warning.go:71
 msgid "List warnings"
 msgstr ""
 
-#: lxc/warning.go:71
+#: lxc/warning.go:72
 msgid ""
 "List warnings\n"
 "\n"
@@ -3380,7 +3380,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/operation.go:23 lxc/operation.go:24
+#: lxc/operation.go:24 lxc/operation.go:25
 msgid "List, show and delete background operations"
 msgstr ""
 
@@ -3389,7 +3389,7 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/monitor.go:79
+#: lxc/monitor.go:80
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
@@ -3493,23 +3493,23 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:82 lxc/file.go:83
+#: lxc/file.go:83 lxc/file.go:84
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1433 lxc/auth.go:1434
+#: lxc/auth.go:59 lxc/auth.go:60 lxc/auth.go:1434 lxc/auth.go:1435
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1083 lxc/auth.go:1084
+#: lxc/auth.go:1084 lxc/auth.go:1085
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:730 lxc/auth.go:731
+#: lxc/auth.go:731 lxc/auth.go:732
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1851 lxc/auth.go:1852
+#: lxc/auth.go:1852 lxc/auth.go:1853
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3600,7 +3600,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:492 lxc/auth.go:493
+#: lxc/auth.go:493 lxc/auth.go:494
 msgid "Manage permissions"
 msgstr ""
 
@@ -3608,23 +3608,23 @@ msgstr ""
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:28 lxc/project.go:29
+#: lxc/project.go:29 lxc/project.go:30
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:731
+#: lxc/storage_bucket.go:732
 msgid "Manage storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:732
+#: lxc/storage_bucket.go:733
 msgid "Manage storage bucket keys."
 msgstr ""
 
-#: lxc/storage_bucket.go:28
+#: lxc/storage_bucket.go:29
 msgid "Manage storage buckets"
 msgstr ""
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:30
 msgid "Manage storage buckets."
 msgstr ""
 
@@ -3652,11 +3652,11 @@ msgstr ""
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/auth.go:29 lxc/auth.go:30
+#: lxc/auth.go:30 lxc/auth.go:31
 msgid "Manage user authorization"
 msgstr ""
 
-#: lxc/warning.go:28 lxc/warning.go:29
+#: lxc/warning.go:29 lxc/warning.go:30
 msgid "Manage warnings"
 msgstr ""
 
@@ -3720,17 +3720,17 @@ msgstr ""
 msgid "Migration operation failure: %w"
 msgstr ""
 
-#: lxc/monitor.go:51
+#: lxc/monitor.go:52
 msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: lxc/storage_bucket.go:116 lxc/storage_bucket.go:216
-#: lxc/storage_bucket.go:292 lxc/storage_bucket.go:411
-#: lxc/storage_bucket.go:568 lxc/storage_bucket.go:660
-#: lxc/storage_bucket.go:802 lxc/storage_bucket.go:889
-#: lxc/storage_bucket.go:986 lxc/storage_bucket.go:1065
-#: lxc/storage_bucket.go:1188
+#: lxc/storage_bucket.go:117 lxc/storage_bucket.go:217
+#: lxc/storage_bucket.go:293 lxc/storage_bucket.go:412
+#: lxc/storage_bucket.go:569 lxc/storage_bucket.go:661
+#: lxc/storage_bucket.go:803 lxc/storage_bucket.go:890
+#: lxc/storage_bucket.go:987 lxc/storage_bucket.go:1066
+#: lxc/storage_bucket.go:1189
 msgid "Missing bucket name"
 msgstr ""
 
@@ -3749,20 +3749,20 @@ msgstr ""
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1825
+#: lxc/auth.go:123 lxc/auth.go:177 lxc/auth.go:255 lxc/auth.go:417
+#: lxc/auth.go:466 lxc/auth.go:541 lxc/auth.go:600 lxc/auth.go:1826
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:862 lxc/auth.go:1003 lxc/auth.go:1131 lxc/auth.go:1189
+#: lxc/auth.go:863 lxc/auth.go:1004 lxc/auth.go:1132 lxc/auth.go:1190
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1495 lxc/auth.go:1548 lxc/auth.go:1614 lxc/auth.go:1776
+#: lxc/auth.go:1496 lxc/auth.go:1549 lxc/auth.go:1615 lxc/auth.go:1777
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1899 lxc/auth.go:1952
+#: lxc/auth.go:1900 lxc/auth.go:1953
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -3770,12 +3770,12 @@ msgstr ""
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
 #: lxc/config_template.go:377 lxc/profile.go:141 lxc/profile.go:222
-#: lxc/profile.go:808 lxc/rebuild.go:60
+#: lxc/profile.go:808 lxc/rebuild.go:61
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/storage_bucket.go:893 lxc/storage_bucket.go:990
-#: lxc/storage_bucket.go:1069 lxc/storage_bucket.go:1192
+#: lxc/storage_bucket.go:894 lxc/storage_bucket.go:991
+#: lxc/storage_bucket.go:1070 lxc/storage_bucket.go:1193
 msgid "Missing key name"
 msgstr ""
 
@@ -3840,13 +3840,13 @@ msgid "Missing peer name"
 msgstr ""
 
 #: lxc/storage.go:235 lxc/storage.go:313 lxc/storage.go:431 lxc/storage.go:509
-#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:112
-#: lxc/storage_bucket.go:212 lxc/storage_bucket.go:288
-#: lxc/storage_bucket.go:407 lxc/storage_bucket.go:482
-#: lxc/storage_bucket.go:564 lxc/storage_bucket.go:656
-#: lxc/storage_bucket.go:798 lxc/storage_bucket.go:885
-#: lxc/storage_bucket.go:982 lxc/storage_bucket.go:1061
-#: lxc/storage_bucket.go:1184 lxc/storage_volume.go:209
+#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:113
+#: lxc/storage_bucket.go:213 lxc/storage_bucket.go:289
+#: lxc/storage_bucket.go:408 lxc/storage_bucket.go:483
+#: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
+#: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
+#: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
 #: lxc/storage_volume.go:323 lxc/storage_volume.go:643
 #: lxc/storage_volume.go:750 lxc/storage_volume.go:841
 #: lxc/storage_volume.go:939 lxc/storage_volume.go:1053
@@ -3861,9 +3861,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:404 lxc/project.go:146 lxc/project.go:226 lxc/project.go:316
-#: lxc/project.go:433 lxc/project.go:622 lxc/project.go:691 lxc/project.go:819
-#: lxc/project.go:948
+#: lxc/profile.go:404 lxc/project.go:147 lxc/project.go:227 lxc/project.go:317
+#: lxc/project.go:434 lxc/project.go:623 lxc/project.go:692 lxc/project.go:820
+#: lxc/project.go:949
 msgid "Missing project name"
 msgstr ""
 
@@ -3879,7 +3879,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:598
+#: lxc/file.go:599
 msgid "Missing target directory"
 msgstr ""
 
@@ -3901,11 +3901,11 @@ msgstr ""
 msgid "Model: %v"
 msgstr ""
 
-#: lxc/monitor.go:32
+#: lxc/monitor.go:33
 msgid "Monitor a local or remote LXD server"
 msgstr ""
 
-#: lxc/monitor.go:33
+#: lxc/monitor.go:34
 msgid ""
 "Monitor a local or remote LXD server\n"
 "\n"
@@ -3917,11 +3917,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:285
+#: lxc/file.go:286
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:985 lxc/file.go:986
+#: lxc/file.go:986 lxc/file.go:987
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3983,13 +3983,13 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:192
+#: lxc/auth.go:376 lxc/auth.go:816 lxc/auth.go:1736 lxc/cluster.go:192
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
-#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:565
-#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:511
-#: lxc/storage_bucket.go:831 lxc/storage_volume.go:1731
+#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:566
+#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1731
 msgid "NAME"
 msgstr ""
 
@@ -3997,11 +3997,11 @@ msgstr ""
 msgid "NAT"
 msgstr ""
 
-#: lxc/project.go:571
+#: lxc/project.go:572
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:570
+#: lxc/project.go:571
 msgid "NETWORKS"
 msgstr ""
 
@@ -4013,9 +4013,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/operation.go:154 lxc/project.go:523
-#: lxc/project.go:528 lxc/project.go:533 lxc/project.go:538 lxc/project.go:543
-#: lxc/project.go:548 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
+#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:524
+#: lxc/project.go:529 lxc/project.go:534 lxc/project.go:539 lxc/project.go:544
+#: lxc/project.go:549 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
 msgid "NO"
 msgstr ""
 
@@ -4260,7 +4260,7 @@ msgstr ""
 msgid "Only managed networks can be modified"
 msgstr ""
 
-#: lxc/operation.go:86
+#: lxc/operation.go:87
 #, c-format
 msgid "Operation %s deleted"
 msgstr ""
@@ -4307,11 +4307,11 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:567
+#: lxc/list.go:576 lxc/project.go:568
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:212
+#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4373,24 +4373,24 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1102
+#: lxc/file.go:1103
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:860
+#: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
-#: lxc/project.go:363 lxc/storage.go:360 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1151
+#: lxc/project.go:364 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1151
 #: lxc/storage_volume.go:1183
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
-#: lxc/monitor.go:48
+#: lxc/monitor.go:49
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
@@ -4476,17 +4476,17 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:172
+#: lxc/project.go:173
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:236
+#: lxc/project.go:237
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:637
+#: lxc/project.go:638
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -4607,20 +4607,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:241 lxc/file.go:242
+#: lxc/file.go:242 lxc/file.go:243
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:416 lxc/file.go:767
+#: lxc/file.go:417 lxc/file.go:768
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:466 lxc/file.go:467
+#: lxc/file.go:467 lxc/file.go:468
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:701 lxc/file.go:867
+#: lxc/file.go:702 lxc/file.go:868
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4633,11 +4633,11 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:983
+#: lxc/project.go:984
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/storage_bucket.go:833
+#: lxc/storage_bucket.go:834
 msgid "ROLE"
 msgstr ""
 
@@ -4650,15 +4650,15 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/rebuild.go:31
+#: lxc/rebuild.go:32
 msgid "Rebuild as an empty instance"
 msgstr ""
 
-#: lxc/rebuild.go:26
+#: lxc/rebuild.go:27
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:249 lxc/file.go:473
+#: lxc/file.go:250 lxc/file.go:474
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4685,7 +4685,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:882 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
+#: lxc/project.go:883 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
 #: lxc/remote.go:994
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4736,7 +4736,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1164 lxc/auth.go:1165
+#: lxc/auth.go:1165 lxc/auth.go:1166
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4772,7 +4772,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1927 lxc/auth.go:1928
+#: lxc/auth.go:1928 lxc/auth.go:1929
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4784,7 +4784,7 @@ msgstr ""
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:574 lxc/auth.go:575
+#: lxc/auth.go:575 lxc/auth.go:576
 msgid "Remove permissions from groups"
 msgstr ""
 
@@ -4829,11 +4829,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:391 lxc/auth.go:392
+#: lxc/auth.go:392 lxc/auth.go:393
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1751 lxc/auth.go:1752
+#: lxc/auth.go:1752 lxc/auth.go:1753
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -4853,7 +4853,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:589 lxc/project.go:590
+#: lxc/project.go:590 lxc/project.go:591
 msgid "Rename projects"
 msgstr ""
 
@@ -4951,7 +4951,7 @@ msgstr ""
 msgid "Revoke cluster member join token"
 msgstr ""
 
-#: lxc/storage_bucket.go:862
+#: lxc/storage_bucket.go:863
 msgid "Role (admin or read-only)"
 msgstr ""
 
@@ -4967,7 +4967,7 @@ msgstr ""
 msgid "Run against all projects"
 msgstr ""
 
-#: lxc/warning.go:213
+#: lxc/warning.go:214
 msgid "SEVERITY"
 msgstr ""
 
@@ -4987,12 +4987,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1231
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1231
+#: lxc/file.go:1232
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5006,11 +5006,11 @@ msgstr ""
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:173 lxc/warning.go:214
+#: lxc/operation.go:174 lxc/warning.go:215
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:569
+#: lxc/project.go:570
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5018,7 +5018,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:569
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -5026,11 +5026,11 @@ msgstr ""
 msgid "STP"
 msgstr ""
 
-#: lxc/storage_bucket.go:864
+#: lxc/storage_bucket.go:865
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:942
+#: lxc/storage_bucket.go:943
 #, c-format
 msgid "Secret key: %s"
 msgstr ""
@@ -5068,7 +5068,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:995
+#: lxc/file.go:996
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5206,11 +5206,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:654
+#: lxc/project.go:655
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:655
+#: lxc/project.go:656
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5219,11 +5219,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage_bucket.go:534
+#: lxc/storage_bucket.go:535
 msgid "Set storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:535
+#: lxc/storage_bucket.go:536
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -5262,15 +5262,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:476
+#: lxc/file.go:477
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:477
+#: lxc/file.go:478
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:475
+#: lxc/file.go:476
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5310,11 +5310,11 @@ msgstr ""
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 msgid "Set the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:542
+#: lxc/storage_bucket.go:543
 msgid "Set the key as a storage bucket property"
 msgstr ""
 
@@ -5330,7 +5330,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:993
+#: lxc/file.go:994
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5342,7 +5342,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1800 lxc/auth.go:1801
+#: lxc/auth.go:1801 lxc/auth.go:1802
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5358,11 +5358,11 @@ msgstr ""
 msgid "Show details of a cluster member"
 msgstr ""
 
-#: lxc/operation.go:192 lxc/operation.go:193
+#: lxc/operation.go:193 lxc/operation.go:194
 msgid "Show details on a background operation"
 msgstr ""
 
-#: lxc/monitor.go:49
+#: lxc/monitor.go:50
 msgid "Show events from all projects"
 msgstr ""
 
@@ -5370,11 +5370,11 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:440 lxc/auth.go:441
+#: lxc/auth.go:441 lxc/auth.go:442
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:832
+#: lxc/auth.go:833
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5455,15 +5455,15 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:786 lxc/project.go:787
+#: lxc/project.go:787 lxc/project.go:788
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage_bucket.go:628 lxc/storage_bucket.go:629
+#: lxc/storage_bucket.go:629 lxc/storage_bucket.go:630
 msgid "Show storage bucket configurations"
 msgstr ""
 
-#: lxc/storage_bucket.go:1156 lxc/storage_bucket.go:1157
+#: lxc/storage_bucket.go:1157 lxc/storage_bucket.go:1158
 msgid "Show storage bucket key configurations"
 msgstr ""
 
@@ -5479,7 +5479,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:895
+#: lxc/auth.go:896
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5529,7 +5529,7 @@ msgstr ""
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: lxc/warning.go:302 lxc/warning.go:303
+#: lxc/warning.go:303 lxc/warning.go:304
 msgid "Show warning"
 msgstr ""
 
@@ -5613,22 +5613,22 @@ msgstr ""
 msgid "Stopping the instance failed: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:166
+#: lxc/storage_bucket.go:167
 #, c-format
 msgid "Storage bucket %s created"
 msgstr ""
 
-#: lxc/storage_bucket.go:233
+#: lxc/storage_bucket.go:234
 #, c-format
 msgid "Storage bucket %s deleted"
 msgstr ""
 
-#: lxc/storage_bucket.go:940
+#: lxc/storage_bucket.go:941
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr ""
 
-#: lxc/storage_bucket.go:1006
+#: lxc/storage_bucket.go:1007
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr ""
@@ -5697,7 +5697,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:847 lxc/project.go:848
+#: lxc/project.go:848 lxc/project.go:849
 msgid "Switch the current project"
 msgstr ""
 
@@ -5713,10 +5713,10 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1139
+#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1139
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
-#: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:171
-#: lxc/storage_volume.go:1730 lxc/warning.go:215
+#: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
+#: lxc/storage_volume.go:1730 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
@@ -5724,11 +5724,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1032
+#: lxc/file.go:1033
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1026
+#: lxc/file.go:1027
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5856,12 +5856,12 @@ msgstr ""
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:446
+#: lxc/project.go:447
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
 
-#: lxc/storage_bucket.go:431
+#: lxc/storage_bucket.go:432
 #, c-format
 msgid "The property %q does not exist on the storage bucket %q: %v"
 msgstr ""
@@ -6046,7 +6046,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:961
+#: lxc/project.go:962
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6058,17 +6058,17 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:985 lxc/storage_volume.go:1735
+#: lxc/project.go:986 lxc/storage_volume.go:1735
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:573
+#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:574
 #: lxc/storage.go:724 lxc/storage_volume.go:1734
 msgid "USED BY"
 msgstr ""
 
-#: lxc/warning.go:216
+#: lxc/warning.go:217
 msgid "UUID"
 msgstr ""
 
@@ -6077,7 +6077,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:197
+#: lxc/file.go:198
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6091,13 +6091,13 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1253
+#: lxc/file.go:1254
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1153 lxc/list.go:631 lxc/storage_volume.go:1772
-#: lxc/warning.go:241
+#: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6107,7 +6107,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:807
+#: lxc/file.go:808
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6190,11 +6190,11 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:742 lxc/project.go:743
+#: lxc/project.go:743 lxc/project.go:744
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:697 lxc/storage_bucket.go:698
+#: lxc/storage_bucket.go:698 lxc/storage_bucket.go:699
 msgid "Unset storage bucket configuration keys"
 msgstr ""
 
@@ -6242,11 +6242,11 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:747
+#: lxc/project.go:748
 msgid "Unset the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:701
+#: lxc/storage_bucket.go:702
 msgid "Unset the key as a storage bucket property"
 msgstr ""
 
@@ -6325,7 +6325,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:71
+#: lxc/file.go:72
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6362,11 +6362,11 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:831
+#: lxc/auth.go:832
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:894
+#: lxc/auth.go:895
 msgid "View the current identity"
 msgstr ""
 
@@ -6397,15 +6397,15 @@ msgstr ""
 msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
-#: lxc/rebuild.go:27
+#: lxc/rebuild.go:28
 msgid ""
 "Wipe the instance root disk and re-initialize. The original image is used to "
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:156 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
+#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:526
+#: lxc/project.go:531 lxc/project.go:536 lxc/project.go:541 lxc/project.go:546
+#: lxc/project.go:551 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
 msgid "YES"
 msgstr ""
 
@@ -6425,7 +6425,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/rebuild.go:119
+#: lxc/rebuild.go:120
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
@@ -6437,12 +6437,12 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1689
+#: lxc/auth.go:330 lxc/auth.go:763 lxc/auth.go:894 lxc/auth.go:1690
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
-#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
+#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
-#: lxc/operation.go:103 lxc/profile.go:700 lxc/project.go:467
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:68
+#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:468
+#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6470,7 +6470,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1254
+#: lxc/auth.go:1255
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6531,11 +6531,11 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:830
+#: lxc/auth.go:831
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1926
+#: lxc/auth.go:1106 lxc/auth.go:1164 lxc/auth.go:1927
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6543,13 +6543,13 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:954 lxc/auth.go:1470 lxc/cluster_group.go:168
+#: lxc/auth.go:97 lxc/auth.go:150 lxc/auth.go:200 lxc/auth.go:440
+#: lxc/auth.go:955 lxc/auth.go:1471 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:514 lxc/auth.go:572
+#: lxc/auth.go:515 lxc/auth.go:573
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
@@ -6559,19 +6559,19 @@ msgstr ""
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:389
+#: lxc/auth.go:390
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1521 lxc/auth.go:1571 lxc/auth.go:1799
+#: lxc/auth.go:1522 lxc/auth.go:1572 lxc/auth.go:1800
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1873
+#: lxc/auth.go:1874
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1749
+#: lxc/auth.go:1750
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -6591,7 +6591,7 @@ msgstr ""
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
-#: lxc/rebuild.go:25
+#: lxc/rebuild.go:26
 msgid "[<remote>:]<image> [<remote>:]<instance>"
 msgstr ""
 
@@ -6674,20 +6674,20 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:170
+#: lxc/file.go:171
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:120
+#: lxc/file.go:121
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:240
+#: lxc/file.go:241
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:984
+#: lxc/file.go:985
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6838,12 +6838,12 @@ msgstr ""
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
-#: lxc/operation.go:53 lxc/operation.go:191
+#: lxc/operation.go:54 lxc/operation.go:192
 msgid "[<remote>:]<operation>"
 msgstr ""
 
 #: lxc/storage.go:200 lxc/storage.go:259 lxc/storage.go:473 lxc/storage.go:844
-#: lxc/storage_bucket.go:454
+#: lxc/storage_bucket.go:455
 msgid "[<remote>:]<pool>"
 msgstr ""
 
@@ -6851,22 +6851,22 @@ msgstr ""
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
-#: lxc/storage_bucket.go:185 lxc/storage_bucket.go:247
-#: lxc/storage_bucket.go:627 lxc/storage_bucket.go:769
+#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:248
+#: lxc/storage_bucket.go:628 lxc/storage_bucket.go:770
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
 
-#: lxc/storage_bucket.go:380 lxc/storage_bucket.go:696
-#: lxc/storage_bucket.go:850 lxc/storage_bucket.go:956
-#: lxc/storage_bucket.go:1020 lxc/storage_bucket.go:1155
+#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:697
+#: lxc/storage_bucket.go:851 lxc/storage_bucket.go:957
+#: lxc/storage_bucket.go:1021 lxc/storage_bucket.go:1156
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
 
-#: lxc/storage_bucket.go:533
+#: lxc/storage_bucket.go:534
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_bucket.go:81
+#: lxc/storage_bucket.go:82
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
 
@@ -6981,20 +6981,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:91 lxc/project.go:186 lxc/project.go:258 lxc/project.go:785
-#: lxc/project.go:846 lxc/project.go:913
+#: lxc/project.go:92 lxc/project.go:187 lxc/project.go:259 lxc/project.go:786
+#: lxc/project.go:847 lxc/project.go:914
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:394 lxc/project.go:741
+#: lxc/project.go:395 lxc/project.go:742
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:653
+#: lxc/project.go:654
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:587
+#: lxc/project.go:588
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7002,7 +7002,7 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:259 lxc/warning.go:301 lxc/warning.go:354
+#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
@@ -7058,7 +7058,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:555 lxc/remote.go:739
+#: lxc/project.go:556 lxc/remote.go:739
 msgid "current"
 msgstr ""
 
@@ -7105,20 +7105,20 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/auth.go:203
+#: lxc/auth.go:204
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:958
+#: lxc/auth.go:959
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1575
+#: lxc/auth.go:1576
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7196,20 +7196,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:988
+#: lxc/file.go:989
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:244
+#: lxc/file.go:245
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:470
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7291,7 +7291,7 @@ msgid ""
 "  List instances with their running state and user comment."
 msgstr ""
 
-#: lxc/monitor.go:37
+#: lxc/monitor.go:38
 msgid ""
 "lxc monitor --type=logging\n"
 "    Only show log messages.\n"
@@ -7367,7 +7367,7 @@ msgid ""
 "    Create record r1 for zone z1 with configuration from config.yaml"
 msgstr ""
 
-#: lxc/operation.go:195
+#: lxc/operation.go:196
 msgid ""
 "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Show details on that operation UUID"
@@ -7410,7 +7410,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:95
+#: lxc/project.go:96
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7418,7 +7418,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:262
+#: lxc/project.go:263
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7449,7 +7449,7 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:85
 msgid ""
 "lxc storage bucket create p1 b01\n"
 "\tCreate a new storage bucket name b01 in storage pool p1\n"
@@ -7459,19 +7459,19 @@ msgid ""
 "of config.yaml"
 msgstr ""
 
-#: lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:251
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1023
+#: lxc/storage_bucket.go:1024
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:854
 msgid ""
 "lxc storage bucket key create p1 b01 k1\n"
 "\tCreate a key called k1 for the bucket b01 in the pool p1.\n"
@@ -7481,14 +7481,14 @@ msgid ""
 "of config.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1158
+#: lxc/storage_bucket.go:1159
 msgid ""
 "lxc storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_bucket.go:630
+#: lxc/storage_bucket.go:631
 msgid ""
 "lxc storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
@@ -7558,16 +7558,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1142
+#: lxc/file.go:1143
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1101
+#: lxc/file.go:1102
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1054
+#: lxc/file.go:1055
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-04 08:52-0600\n"
+"POT-Creation-Date: 2024-09-05 08:44-0400\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Luigi Operoso <brokenpip3@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/linux-containers/"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: lxc/storage_bucket.go:260 lxc/storage_bucket.go:1033
+#: lxc/storage_bucket.go:261 lxc/storage_bucket.go:1034
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
@@ -209,7 +209,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/auth.go:213
+#: lxc/auth.go:214
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -236,7 +236,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:968
+#: lxc/auth.go:969
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -257,7 +257,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1585
+#: lxc/auth.go:1586
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
@@ -618,7 +618,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/project.go:280
+#: lxc/project.go:281
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the project.\n"
@@ -675,12 +675,12 @@ msgstr "%s (altri %d)"
 msgid "%s (%s) (%d available)"
 msgstr "%s (altri %d)"
 
-#: lxc/file.go:935
+#: lxc/file.go:936
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s non è una directory"
 
-#: lxc/file.go:825
+#: lxc/file.go:826
 #, fuzzy, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' non è un tipo di file supportato."
@@ -717,7 +717,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr "non tutti i profili dell'origine esistono nella destinazione"
 
-#: lxc/init.go:142 lxc/rebuild.go:64
+#: lxc/init.go:142 lxc/rebuild.go:65
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -771,7 +771,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:465
+#: lxc/file.go:466
 #, fuzzy
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr "Creazione del container in corso"
@@ -805,7 +805,7 @@ msgstr "ARCHITETTURA"
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:813
+#: lxc/auth.go:814
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -813,11 +813,11 @@ msgstr ""
 msgid "Accept certificate"
 msgstr "Accetta certificato"
 
-#: lxc/storage_bucket.go:863
+#: lxc/storage_bucket.go:864
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:941
+#: lxc/storage_bucket.go:942
 #, c-format
 msgid "Access key: %s"
 msgstr ""
@@ -826,7 +826,7 @@ msgstr ""
 msgid "Access the expanded configuration"
 msgstr ""
 
-#: lxc/warning.go:261 lxc/warning.go:262
+#: lxc/warning.go:262 lxc/warning.go:263
 msgid "Acknowledge warning"
 msgstr ""
 
@@ -844,11 +844,11 @@ msgstr "Azione (default a GET)"
 msgid "Add a cluster member to a cluster group"
 msgstr "Il nome del container è: %s"
 
-#: lxc/auth.go:1106 lxc/auth.go:1107
+#: lxc/auth.go:1107 lxc/auth.go:1108
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1874 lxc/auth.go:1875
+#: lxc/auth.go:1875 lxc/auth.go:1876
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -919,7 +919,7 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:515 lxc/auth.go:516
+#: lxc/auth.go:516 lxc/auth.go:517
 msgid "Add permissions to groups"
 msgstr ""
 
@@ -949,7 +949,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:169
+#: lxc/storage_bucket.go:170
 #, fuzzy, c-format
 msgid "Admin access key: %s"
 msgstr "Password amministratore per %s: "
@@ -959,7 +959,7 @@ msgstr "Password amministratore per %s: "
 msgid "Admin password (or token) for %s:"
 msgstr "Password amministratore per %s: "
 
-#: lxc/storage_bucket.go:170
+#: lxc/storage_bucket.go:171
 #, fuzzy, c-format
 msgid "Admin secret key: %s"
 msgstr "Aggiornamento automatico: %s"
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:342 lxc/rebuild.go:130
+#: lxc/init.go:342 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -1120,12 +1120,12 @@ msgstr ""
 
 #: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:318
 #: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
-#: lxc/network_zone.go:366 lxc/network_zone.go:1053 lxc/storage_bucket.go:141
+#: lxc/network_zone.go:366 lxc/network_zone.go:1053 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:159
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:160
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "Proprietà errata: %s"
@@ -1165,7 +1165,7 @@ msgstr "Bytes ricevuti"
 msgid "Bytes sent"
 msgstr "Byte inviati"
 
-#: lxc/operation.go:174
+#: lxc/operation.go:175
 msgid "CANCELABLE"
 msgstr ""
 
@@ -1177,7 +1177,7 @@ msgstr "NOME COMUNE"
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: lxc/warning.go:209
+#: lxc/warning.go:210
 msgid "COUNT"
 msgstr ""
 
@@ -1203,7 +1203,7 @@ msgstr "Utilizzo CPU:"
 msgid "CPUs (%s):"
 msgstr ""
 
-#: lxc/operation.go:175
+#: lxc/operation.go:176
 #, fuzzy
 msgid "CREATED"
 msgstr "CREATO IL"
@@ -1234,7 +1234,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:340
+#: lxc/file.go:341
 msgid "Can't pull a directory without --recursive"
 msgstr "Impossibile effettuare il pull di una directory senza --recursive"
 
@@ -1259,11 +1259,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:224
+#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:546
+#: lxc/file.go:547
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1272,7 +1272,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:160
+#: lxc/rebuild.go:161
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1397,13 +1397,13 @@ msgstr ""
 #: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
 #: lxc/network_load_balancer.go:1051 lxc/network_load_balancer.go:1125
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
-#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:90
-#: lxc/storage_bucket.go:190 lxc/storage_bucket.go:253
-#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:541
-#: lxc/storage_bucket.go:634 lxc/storage_bucket.go:700
-#: lxc/storage_bucket.go:775 lxc/storage_bucket.go:861
-#: lxc/storage_bucket.go:961 lxc/storage_bucket.go:1026
-#: lxc/storage_bucket.go:1162 lxc/storage_volume.go:394
+#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
+#: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
+#: lxc/storage_bucket.go:385 lxc/storage_bucket.go:542
+#: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
+#: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
+#: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
 #: lxc/storage_volume.go:612 lxc/storage_volume.go:717
 #: lxc/storage_volume.go:1005 lxc/storage_volume.go:1231
 #: lxc/storage_volume.go:1360 lxc/storage_volume.go:1848
@@ -1427,7 +1427,7 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1113 lxc/list.go:132 lxc/storage_volume.go:1589
-#: lxc/warning.go:92
+#: lxc/warning.go:93
 msgid "Columns"
 msgstr "Colonne"
 
@@ -1455,7 +1455,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:100
+#: lxc/project.go:101
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1469,8 +1469,8 @@ msgstr ""
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
-#: lxc/project.go:362 lxc/storage.go:359 lxc/storage_bucket.go:348
-#: lxc/storage_bucket.go:1125 lxc/storage_volume.go:1150
+#: lxc/project.go:363 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1150
 #: lxc/storage_volume.go:1182
 #, c-format
 msgid "Config parsing error: %s"
@@ -1597,12 +1597,12 @@ msgstr "Certificato del client salvato dal server: "
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:300 lxc/auth.go:1660
+#: lxc/auth.go:301 lxc/auth.go:1661
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1054
+#: lxc/auth.go:1055
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1654,15 +1654,15 @@ msgstr "Creazione del container in corso"
 msgid "Create and start instances from images"
 msgstr "Creazione del container in corso"
 
-#: lxc/file.go:248 lxc/file.go:474
+#: lxc/file.go:249 lxc/file.go:475
 msgid "Create any directories necessary"
 msgstr ""
 
-#: lxc/auth.go:97 lxc/auth.go:98
+#: lxc/auth.go:98 lxc/auth.go:99
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1471 lxc/auth.go:1472
+#: lxc/auth.go:1472 lxc/auth.go:1473
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1684,11 +1684,11 @@ msgstr ""
 msgid "Create instances from images"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_bucket.go:851 lxc/storage_bucket.go:852
+#: lxc/storage_bucket.go:852 lxc/storage_bucket.go:853
 msgid "Create key for a storage bucket"
 msgstr ""
 
-#: lxc/storage_bucket.go:82 lxc/storage_bucket.go:83
+#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
 #, fuzzy
 msgid "Create new custom storage buckets"
 msgstr "Creazione del container in corso"
@@ -1736,7 +1736,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:92 lxc/project.go:93
+#: lxc/project.go:93 lxc/project.go:94
 msgid "Create projects"
 msgstr ""
 
@@ -1772,13 +1772,13 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:376 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1135 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
-#: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:172
-#: lxc/profile.go:756 lxc/project.go:572 lxc/storage.go:723
-#: lxc/storage_bucket.go:512 lxc/storage_bucket.go:832
+#: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
+#: lxc/profile.go:756 lxc/project.go:573 lxc/storage.go:723
+#: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1732
 msgid "DESCRIPTION"
 msgstr "DESCRIZIONE"
@@ -1803,7 +1803,7 @@ msgstr ""
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
-#: lxc/operation.go:55 lxc/operation.go:56
+#: lxc/operation.go:56 lxc/operation.go:57
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
@@ -1811,20 +1811,20 @@ msgstr ""
 msgid "Delete a cluster group"
 msgstr ""
 
-#: lxc/warning.go:360
+#: lxc/warning.go:361
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:122 lxc/file.go:123
+#: lxc/file.go:123 lxc/file.go:124
 #, fuzzy
 msgid "Delete files in instances"
 msgstr "Creazione del container in corso"
 
-#: lxc/auth.go:151 lxc/auth.go:152
+#: lxc/auth.go:152 lxc/auth.go:153
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1523 lxc/auth.go:1524
+#: lxc/auth.go:1524 lxc/auth.go:1525
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1845,7 +1845,7 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_bucket.go:957 lxc/storage_bucket.go:958
+#: lxc/storage_bucket.go:958 lxc/storage_bucket.go:959
 msgid "Delete key from a storage bucket"
 msgstr ""
 
@@ -1883,11 +1883,11 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:188 lxc/project.go:189
+#: lxc/project.go:189 lxc/project.go:190
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:187 lxc/storage_bucket.go:188
+#: lxc/storage_bucket.go:188 lxc/storage_bucket.go:189
 #, fuzzy
 msgid "Delete storage buckets"
 msgstr "Il nome del container è: %s"
@@ -1900,20 +1900,20 @@ msgstr ""
 msgid "Delete storage volumes"
 msgstr ""
 
-#: lxc/warning.go:356 lxc/warning.go:357
+#: lxc/warning.go:357 lxc/warning.go:358
 msgid "Delete warning"
 msgstr ""
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:30 lxc/auth.go:59 lxc/auth.go:98
-#: lxc/auth.go:152 lxc/auth.go:201 lxc/auth.go:332 lxc/auth.go:392
-#: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
-#: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
-#: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
-#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1434 lxc/auth.go:1472
-#: lxc/auth.go:1524 lxc/auth.go:1573 lxc/auth.go:1692 lxc/auth.go:1752
-#: lxc/auth.go:1801 lxc/auth.go:1852 lxc/auth.go:1875 lxc/auth.go:1928
+#: lxc/alias.go:214 lxc/auth.go:31 lxc/auth.go:60 lxc/auth.go:99
+#: lxc/auth.go:153 lxc/auth.go:202 lxc/auth.go:333 lxc/auth.go:393
+#: lxc/auth.go:442 lxc/auth.go:494 lxc/auth.go:517 lxc/auth.go:576
+#: lxc/auth.go:732 lxc/auth.go:766 lxc/auth.go:833 lxc/auth.go:896
+#: lxc/auth.go:957 lxc/auth.go:1085 lxc/auth.go:1108 lxc/auth.go:1166
+#: lxc/auth.go:1235 lxc/auth.go:1257 lxc/auth.go:1435 lxc/auth.go:1473
+#: lxc/auth.go:1525 lxc/auth.go:1574 lxc/auth.go:1693 lxc/auth.go:1753
+#: lxc/auth.go:1802 lxc/auth.go:1853 lxc/auth.go:1876 lxc/auth.go:1929
 #: lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215 lxc/cluster.go:272
 #: lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:484 lxc/cluster.go:528
 #: lxc/cluster.go:586 lxc/cluster.go:677 lxc/cluster.go:770 lxc/cluster.go:893
@@ -1937,15 +1937,15 @@ msgstr ""
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:83 lxc/file.go:123 lxc/file.go:172
-#: lxc/file.go:242 lxc/file.go:467 lxc/file.go:986 lxc/image.go:38
+#: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
+#: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
 #: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
 #: lxc/image.go:697 lxc/image.go:946 lxc/image.go:1088 lxc/image.go:1415
 #: lxc/image.go:1506 lxc/image.go:1572 lxc/image.go:1636 lxc/image.go:1699
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:38 lxc/network.go:33
+#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33
 #: lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405
 #: lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793
 #: lxc/network.go:874 lxc/network.go:1005 lxc/network.go:1106
@@ -1979,27 +1979,27 @@ msgstr ""
 #: lxc/network_zone.go:909 lxc/network_zone.go:985 lxc/network_zone.go:1083
 #: lxc/network_zone.go:1172 lxc/network_zone.go:1219 lxc/network_zone.go:1349
 #: lxc/network_zone.go:1410 lxc/network_zone.go:1425 lxc/network_zone.go:1483
-#: lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:106
-#: lxc/operation.go:193 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
+#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
+#: lxc/operation.go:194 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
 #: lxc/profile.go:271 lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493
 #: lxc/profile.go:629 lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860
-#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:29
-#: lxc/project.go:93 lxc/project.go:189 lxc/project.go:260 lxc/project.go:396
-#: lxc/project.go:470 lxc/project.go:590 lxc/project.go:655 lxc/project.go:743
-#: lxc/project.go:787 lxc/project.go:848 lxc/project.go:915 lxc/publish.go:34
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:35 lxc/remote.go:91
+#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:30
+#: lxc/project.go:94 lxc/project.go:190 lxc/project.go:261 lxc/project.go:397
+#: lxc/project.go:471 lxc/project.go:591 lxc/project.go:656 lxc/project.go:744
+#: lxc/project.go:788 lxc/project.go:849 lxc/project.go:916 lxc/publish.go:34
+#: lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91
 #: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853
 #: lxc/remote.go:917 lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24
 #: lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203
 #: lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655
 #: lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940
-#: lxc/storage_bucket.go:29 lxc/storage_bucket.go:83 lxc/storage_bucket.go:188
-#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:382
-#: lxc/storage_bucket.go:458 lxc/storage_bucket.go:535
-#: lxc/storage_bucket.go:629 lxc/storage_bucket.go:698
-#: lxc/storage_bucket.go:732 lxc/storage_bucket.go:773
-#: lxc/storage_bucket.go:852 lxc/storage_bucket.go:958
-#: lxc/storage_bucket.go:1022 lxc/storage_bucket.go:1157
+#: lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189
+#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:383
+#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:536
+#: lxc/storage_bucket.go:630 lxc/storage_bucket.go:699
+#: lxc/storage_bucket.go:733 lxc/storage_bucket.go:774
+#: lxc/storage_bucket.go:853 lxc/storage_bucket.go:959
+#: lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158
 #: lxc/storage_volume.go:58 lxc/storage_volume.go:169 lxc/storage_volume.go:283
 #: lxc/storage_volume.go:390 lxc/storage_volume.go:605
 #: lxc/storage_volume.go:714 lxc/storage_volume.go:801
@@ -2010,8 +2010,8 @@ msgstr ""
 #: lxc/storage_volume.go:2064 lxc/storage_volume.go:2222
 #: lxc/storage_volume.go:2343 lxc/storage_volume.go:2405
 #: lxc/storage_volume.go:2541 lxc/storage_volume.go:2624
-#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:29
-#: lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
+#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:30
+#: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
@@ -2100,7 +2100,7 @@ msgstr "Import da directory non disponibile su questa piattaforma"
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:994
+#: lxc/file.go:995
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2170,7 +2170,7 @@ msgstr "DATA DI SCADENZA"
 msgid "EXPIRY DATE"
 msgstr "DATA DI SCADENZA"
 
-#: lxc/file.go:74
+#: lxc/file.go:75
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -2180,7 +2180,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:955 lxc/auth.go:956
+#: lxc/auth.go:956 lxc/auth.go:957
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -2188,16 +2188,16 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:171 lxc/file.go:172
+#: lxc/file.go:172 lxc/file.go:173
 #, fuzzy
 msgid "Edit files in instances"
 msgstr "Creazione del container in corso"
 
-#: lxc/auth.go:200 lxc/auth.go:201
+#: lxc/auth.go:201 lxc/auth.go:202
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1572 lxc/auth.go:1573
+#: lxc/auth.go:1573 lxc/auth.go:1574
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2257,16 +2257,16 @@ msgstr "Il nome del container è: %s"
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:259 lxc/project.go:260
+#: lxc/project.go:260 lxc/project.go:261
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:248 lxc/storage_bucket.go:249
+#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:250
 #, fuzzy
 msgid "Edit storage bucket configurations as YAML"
 msgstr "Il nome del container è: %s"
 
-#: lxc/storage_bucket.go:1021 lxc/storage_bucket.go:1022
+#: lxc/storage_bucket.go:1022 lxc/storage_bucket.go:1023
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
@@ -2283,7 +2283,7 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1147 lxc/list.go:622 lxc/storage_volume.go:1766
-#: lxc/warning.go:235
+#: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2338,7 +2338,7 @@ msgstr ""
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
-#: lxc/project.go:718 lxc/storage.go:812 lxc/storage_bucket.go:602
+#: lxc/project.go:719 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2155 lxc/storage_volume.go:2193
 #, c-format
 msgid "Error setting properties: %v"
@@ -2352,8 +2352,8 @@ msgstr ""
 #: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
-#: lxc/profile.go:981 lxc/project.go:712 lxc/storage.go:806
-#: lxc/storage_bucket.go:596 lxc/storage_volume.go:2149
+#: lxc/profile.go:981 lxc/project.go:713 lxc/storage.go:806
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2149
 #: lxc/storage_volume.go:2187
 #, c-format
 msgid "Error unsetting property: %v"
@@ -2374,7 +2374,7 @@ msgstr "Creazione del container in corso"
 msgid "Evacuating cluster member: %s"
 msgstr "Il nome del container è: %s"
 
-#: lxc/monitor.go:50
+#: lxc/monitor.go:51
 msgid "Event type to listen for"
 msgstr ""
 
@@ -2463,16 +2463,16 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/warning.go:210
+#: lxc/warning.go:211
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1237
+#: lxc/file.go:1238
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1260
+#: lxc/file.go:1261
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2487,12 +2487,12 @@ msgstr "Il nome del container è: %s"
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "Il nome del container è: %s"
 
-#: lxc/file.go:1287
+#: lxc/file.go:1288
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1072
+#: lxc/file.go:1073
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "Il nome del container è: %s"
@@ -2522,7 +2522,7 @@ msgstr "Il nome del container è: %s"
 msgid "Failed fetching fingerprint %q: %w"
 msgstr "Il nome del container è: %s"
 
-#: lxc/file.go:1193
+#: lxc/file.go:1194
 #, fuzzy, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "Accetta certificato"
@@ -2537,7 +2537,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr "Il nome del container è: %s"
 
-#: lxc/file.go:1198
+#: lxc/file.go:1199
 #, fuzzy, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "Accetta certificato"
@@ -2547,12 +2547,12 @@ msgstr "Accetta certificato"
 msgid "Failed starting command: %w"
 msgstr "Accetta certificato"
 
-#: lxc/file.go:1098
+#: lxc/file.go:1099
 #, fuzzy, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "Accetta certificato"
 
-#: lxc/file.go:1225
+#: lxc/file.go:1226
 #, fuzzy, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "Accetta certificato"
@@ -2591,7 +2591,7 @@ msgstr "Accetta certificato"
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1210
+#: lxc/file.go:1211
 #, fuzzy, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "Accetta certificato"
@@ -2606,7 +2606,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr "Accetta certificato"
 
-#: lxc/file.go:820
+#: lxc/file.go:821
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2621,7 +2621,7 @@ msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
 #: lxc/network.go:1044 lxc/network_acl.go:133 lxc/network_zone.go:124
-#: lxc/operation.go:136
+#: lxc/operation.go:137
 #, fuzzy
 msgid "Filtering isn't supported yet"
 msgstr "'%s' non è un tipo di file supportato."
@@ -2688,21 +2688,21 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
+#: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:770 lxc/auth.go:1697
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1114 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:57
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
-#: lxc/operation.go:108 lxc/profile.go:707 lxc/project.go:472
-#: lxc/project.go:917 lxc/remote.go:690 lxc/storage.go:657
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:774
-#: lxc/storage_volume.go:1608 lxc/warning.go:93
+#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:473
+#: lxc/project.go:918 lxc/remote.go:690 lxc/storage.go:657
+#: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
+#: lxc/storage_volume.go:1608 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
-#: lxc/monitor.go:52
+#: lxc/monitor.go:53
 msgid "Format (json|pretty|yaml)"
 msgstr ""
 
@@ -2746,7 +2746,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:817 lxc/auth.go:1736
+#: lxc/auth.go:818 lxc/auth.go:1737
 msgid "GROUPS"
 msgstr ""
 
@@ -2763,7 +2763,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr "Creazione del container in corso"
 
-#: lxc/project.go:914 lxc/project.go:915
+#: lxc/project.go:915 lxc/project.go:916
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2814,11 +2814,11 @@ msgstr "Il nome del container è: %s"
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:400
+#: lxc/project.go:401
 msgid "Get the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:385
+#: lxc/storage_bucket.go:386
 #, fuzzy
 msgid "Get the key as a storage bucket property"
 msgstr "Il nome del container è: %s"
@@ -2884,11 +2884,11 @@ msgstr "Il nome del container è: %s"
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:395 lxc/project.go:396
+#: lxc/project.go:396 lxc/project.go:397
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:382
+#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:383
 #, fuzzy
 msgid "Get values for storage bucket configuration keys"
 msgstr "Il nome del container è: %s"
@@ -2906,17 +2906,17 @@ msgstr ""
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: lxc/auth.go:136
+#: lxc/auth.go:137
 #, c-format
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:186
+#: lxc/auth.go:187
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:426 lxc/auth.go:1786
+#: lxc/auth.go:427 lxc/auth.go:1787
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2942,27 +2942,27 @@ msgstr "Creazione del container in corso"
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1310
+#: lxc/file.go:1311
 #, fuzzy, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "errore di processamento degli alias %s\n"
 
-#: lxc/file.go:1299
+#: lxc/file.go:1300
 #, fuzzy, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "errore di processamento degli alias %s\n"
 
-#: lxc/file.go:1122
+#: lxc/file.go:1123
 #, fuzzy, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "errore di processamento degli alias %s\n"
 
-#: lxc/file.go:1132
+#: lxc/file.go:1133
 #, fuzzy, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "errore di processamento degli alias %s\n"
 
-#: lxc/network.go:966 lxc/operation.go:170
+#: lxc/network.go:966 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2976,11 +2976,11 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:816
+#: lxc/auth.go:817
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:566
+#: lxc/project.go:567
 msgid "IMAGES"
 msgstr ""
 
@@ -3008,17 +3008,17 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1508
+#: lxc/auth.go:1509
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1558
+#: lxc/auth.go:1559
 #, fuzzy, c-format
 msgid "Identity provider group %s deleted"
 msgstr "Il nome del container è: %s"
 
-#: lxc/rebuild.go:32
+#: lxc/rebuild.go:33
 msgid "If an instance is running, stop it and then rebuild it"
 msgstr ""
 
@@ -3141,7 +3141,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1233 lxc/auth.go:1234
+#: lxc/auth.go:1234 lxc/auth.go:1235
 msgid "Inspect permissions"
 msgstr ""
 
@@ -3150,11 +3150,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr "Il nome del container è: %s"
 
-#: lxc/file.go:1124
+#: lxc/file.go:1125
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1301
+#: lxc/file.go:1302
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3173,7 +3173,7 @@ msgstr "Il nome del container è: %s"
 msgid "Instance name must be specified"
 msgstr "Il nome del container è: %s"
 
-#: lxc/file.go:1044
+#: lxc/file.go:1045
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3182,7 +3182,7 @@ msgstr ""
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/rebuild.go:74
+#: lxc/rebuild.go:75
 #, fuzzy, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr "Il nome del container è: %s"
@@ -3215,7 +3215,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/monitor.go:70
+#: lxc/monitor.go:71
 #, fuzzy, c-format
 msgid "Invalid format: %s"
 msgstr "Proprietà errata: %s"
@@ -3225,7 +3225,7 @@ msgstr "Proprietà errata: %s"
 msgid "Invalid instance name: %s"
 msgstr "Il nome del container è: %s"
 
-#: lxc/file.go:1039
+#: lxc/file.go:1040
 #, fuzzy, c-format
 msgid "Invalid instance path: %q"
 msgstr "Il nome del container è: %s"
@@ -3269,7 +3269,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr "numero errato di argomenti del sottocomando"
 
-#: lxc/file.go:147
+#: lxc/file.go:148
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -3286,12 +3286,12 @@ msgstr "Proprietà errata: %s"
 msgid "Invalid snapshot name"
 msgstr "Il nome del container è: %s"
 
-#: lxc/file.go:313
+#: lxc/file.go:314
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:495
+#: lxc/file.go:496
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3305,7 +3305,7 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/warning.go:212
 msgid "LAST SEEN"
 msgstr ""
 
@@ -3313,7 +3313,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:984
+#: lxc/project.go:985
 msgid "LIMIT"
 msgstr ""
 
@@ -3322,8 +3322,8 @@ msgid "LISTEN ADDRESS"
 msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
-#: lxc/network_load_balancer.go:165 lxc/operation.go:177
-#: lxc/storage_bucket.go:516 lxc/storage_volume.go:1739 lxc/warning.go:220
+#: lxc/network_load_balancer.go:165 lxc/operation.go:178
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1739 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3402,7 +3402,7 @@ msgstr "Il nome del container è: %s"
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/warning.go:94
+#: lxc/warning.go:95
 #, fuzzy
 msgid "List all warnings"
 msgstr "Alias:"
@@ -3449,20 +3449,20 @@ msgstr ""
 msgid "List available storage pools"
 msgstr ""
 
-#: lxc/operation.go:105 lxc/operation.go:106
+#: lxc/operation.go:106 lxc/operation.go:107
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:331 lxc/auth.go:332
+#: lxc/auth.go:332 lxc/auth.go:333
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:764 lxc/auth.go:765
+#: lxc/auth.go:765 lxc/auth.go:766
 #, fuzzy
 msgid "List identities"
 msgstr "Creazione del container in corso"
 
-#: lxc/auth.go:1691 lxc/auth.go:1692
+#: lxc/auth.go:1692 lxc/auth.go:1693
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3613,12 +3613,12 @@ msgstr ""
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/operation.go:109
+#: lxc/operation.go:110
 #, fuzzy
 msgid "List operations from all projects"
 msgstr "Creazione del container in corso"
 
-#: lxc/auth.go:1255 lxc/auth.go:1256
+#: lxc/auth.go:1256 lxc/auth.go:1257
 #, fuzzy
 msgid "List permissions"
 msgstr "Alias:"
@@ -3627,15 +3627,15 @@ msgstr "Alias:"
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:469 lxc/project.go:470
+#: lxc/project.go:470 lxc/project.go:471
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:771 lxc/storage_bucket.go:773
+#: lxc/storage_bucket.go:772 lxc/storage_bucket.go:774
 msgid "List storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:456 lxc/storage_bucket.go:458
+#: lxc/storage_bucket.go:457 lxc/storage_bucket.go:459
 #, fuzzy
 msgid "List storage buckets"
 msgstr "Creazione del container in corso"
@@ -3672,12 +3672,12 @@ msgstr ""
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/warning.go:70
+#: lxc/warning.go:71
 #, fuzzy
 msgid "List warnings"
 msgstr "Alias:"
 
-#: lxc/warning.go:71
+#: lxc/warning.go:72
 msgid ""
 "List warnings\n"
 "\n"
@@ -3700,7 +3700,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/operation.go:23 lxc/operation.go:24
+#: lxc/operation.go:24 lxc/operation.go:25
 msgid "List, show and delete background operations"
 msgstr ""
 
@@ -3709,7 +3709,7 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/monitor.go:79
+#: lxc/monitor.go:80
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
@@ -3817,26 +3817,26 @@ msgstr ""
 msgid "Manage devices"
 msgstr "Creazione del container in corso"
 
-#: lxc/file.go:82 lxc/file.go:83
+#: lxc/file.go:83 lxc/file.go:84
 #, fuzzy
 msgid "Manage files in instances"
 msgstr "Creazione del container in corso"
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1433 lxc/auth.go:1434
+#: lxc/auth.go:59 lxc/auth.go:60 lxc/auth.go:1434 lxc/auth.go:1435
 #, fuzzy
 msgid "Manage groups"
 msgstr "Creazione del container in corso"
 
-#: lxc/auth.go:1083 lxc/auth.go:1084
+#: lxc/auth.go:1084 lxc/auth.go:1085
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:730 lxc/auth.go:731
+#: lxc/auth.go:731 lxc/auth.go:732
 #, fuzzy
 msgid "Manage identities"
 msgstr "Creazione del container in corso"
 
-#: lxc/auth.go:1851 lxc/auth.go:1852
+#: lxc/auth.go:1852 lxc/auth.go:1853
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3936,7 +3936,7 @@ msgstr "Creazione del container in corso"
 msgid "Manage network zones"
 msgstr "Creazione del container in corso"
 
-#: lxc/auth.go:492 lxc/auth.go:493
+#: lxc/auth.go:493 lxc/auth.go:494
 #, fuzzy
 msgid "Manage permissions"
 msgstr "Creazione del container in corso"
@@ -3945,25 +3945,25 @@ msgstr "Creazione del container in corso"
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:28 lxc/project.go:29
+#: lxc/project.go:29 lxc/project.go:30
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:731
+#: lxc/storage_bucket.go:732
 #, fuzzy
 msgid "Manage storage bucket keys"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_bucket.go:732
+#: lxc/storage_bucket.go:733
 msgid "Manage storage bucket keys."
 msgstr ""
 
-#: lxc/storage_bucket.go:28
+#: lxc/storage_bucket.go:29
 #, fuzzy
 msgid "Manage storage buckets"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:30
 #, fuzzy
 msgid "Manage storage buckets."
 msgstr "Creazione del container in corso"
@@ -3992,12 +3992,12 @@ msgstr ""
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/auth.go:29 lxc/auth.go:30
+#: lxc/auth.go:30 lxc/auth.go:31
 #, fuzzy
 msgid "Manage user authorization"
 msgstr "Il nome del container è: %s"
 
-#: lxc/warning.go:28 lxc/warning.go:29
+#: lxc/warning.go:29 lxc/warning.go:30
 #, fuzzy
 msgid "Manage warnings"
 msgstr "Creazione del container in corso"
@@ -4062,17 +4062,17 @@ msgstr ""
 msgid "Migration operation failure: %w"
 msgstr ""
 
-#: lxc/monitor.go:51
+#: lxc/monitor.go:52
 msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: lxc/storage_bucket.go:116 lxc/storage_bucket.go:216
-#: lxc/storage_bucket.go:292 lxc/storage_bucket.go:411
-#: lxc/storage_bucket.go:568 lxc/storage_bucket.go:660
-#: lxc/storage_bucket.go:802 lxc/storage_bucket.go:889
-#: lxc/storage_bucket.go:986 lxc/storage_bucket.go:1065
-#: lxc/storage_bucket.go:1188
+#: lxc/storage_bucket.go:117 lxc/storage_bucket.go:217
+#: lxc/storage_bucket.go:293 lxc/storage_bucket.go:412
+#: lxc/storage_bucket.go:569 lxc/storage_bucket.go:661
+#: lxc/storage_bucket.go:803 lxc/storage_bucket.go:890
+#: lxc/storage_bucket.go:987 lxc/storage_bucket.go:1066
+#: lxc/storage_bucket.go:1189
 #, fuzzy
 msgid "Missing bucket name"
 msgstr "Il nome del container è: %s"
@@ -4094,23 +4094,23 @@ msgstr "Il nome del container è: %s"
 msgid "Missing cluster member name"
 msgstr "Il nome del container è: %s"
 
-#: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1825
+#: lxc/auth.go:123 lxc/auth.go:177 lxc/auth.go:255 lxc/auth.go:417
+#: lxc/auth.go:466 lxc/auth.go:541 lxc/auth.go:600 lxc/auth.go:1826
 #, fuzzy
 msgid "Missing group name"
 msgstr "Il nome del container è: %s"
 
-#: lxc/auth.go:862 lxc/auth.go:1003 lxc/auth.go:1131 lxc/auth.go:1189
+#: lxc/auth.go:863 lxc/auth.go:1004 lxc/auth.go:1132 lxc/auth.go:1190
 #, fuzzy
 msgid "Missing identity argument"
 msgstr "Il nome del container è: %s"
 
-#: lxc/auth.go:1495 lxc/auth.go:1548 lxc/auth.go:1614 lxc/auth.go:1776
+#: lxc/auth.go:1496 lxc/auth.go:1549 lxc/auth.go:1615 lxc/auth.go:1777
 #, fuzzy
 msgid "Missing identity provider group name"
 msgstr "Il nome del container è: %s"
 
-#: lxc/auth.go:1899 lxc/auth.go:1952
+#: lxc/auth.go:1900 lxc/auth.go:1953
 #, fuzzy
 msgid "Missing identity provider group name argument"
 msgstr "Il nome del container è: %s"
@@ -4119,13 +4119,13 @@ msgstr "Il nome del container è: %s"
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
 #: lxc/config_template.go:377 lxc/profile.go:141 lxc/profile.go:222
-#: lxc/profile.go:808 lxc/rebuild.go:60
+#: lxc/profile.go:808 lxc/rebuild.go:61
 #, fuzzy
 msgid "Missing instance name"
 msgstr "Il nome del container è: %s"
 
-#: lxc/storage_bucket.go:893 lxc/storage_bucket.go:990
-#: lxc/storage_bucket.go:1069 lxc/storage_bucket.go:1192
+#: lxc/storage_bucket.go:894 lxc/storage_bucket.go:991
+#: lxc/storage_bucket.go:1070 lxc/storage_bucket.go:1193
 #, fuzzy
 msgid "Missing key name"
 msgstr "Il nome del container è: %s"
@@ -4196,13 +4196,13 @@ msgid "Missing peer name"
 msgstr "Il nome del container è: %s"
 
 #: lxc/storage.go:235 lxc/storage.go:313 lxc/storage.go:431 lxc/storage.go:509
-#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:112
-#: lxc/storage_bucket.go:212 lxc/storage_bucket.go:288
-#: lxc/storage_bucket.go:407 lxc/storage_bucket.go:482
-#: lxc/storage_bucket.go:564 lxc/storage_bucket.go:656
-#: lxc/storage_bucket.go:798 lxc/storage_bucket.go:885
-#: lxc/storage_bucket.go:982 lxc/storage_bucket.go:1061
-#: lxc/storage_bucket.go:1184 lxc/storage_volume.go:209
+#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:113
+#: lxc/storage_bucket.go:213 lxc/storage_bucket.go:289
+#: lxc/storage_bucket.go:408 lxc/storage_bucket.go:483
+#: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
+#: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
+#: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
 #: lxc/storage_volume.go:323 lxc/storage_volume.go:643
 #: lxc/storage_volume.go:750 lxc/storage_volume.go:841
 #: lxc/storage_volume.go:939 lxc/storage_volume.go:1053
@@ -4217,9 +4217,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:404 lxc/project.go:146 lxc/project.go:226 lxc/project.go:316
-#: lxc/project.go:433 lxc/project.go:622 lxc/project.go:691 lxc/project.go:819
-#: lxc/project.go:948
+#: lxc/profile.go:404 lxc/project.go:147 lxc/project.go:227 lxc/project.go:317
+#: lxc/project.go:434 lxc/project.go:623 lxc/project.go:692 lxc/project.go:820
+#: lxc/project.go:949
 #, fuzzy
 msgid "Missing project name"
 msgstr "Il nome del container è: %s"
@@ -4237,7 +4237,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr "Il nome del container è: %s"
 
-#: lxc/file.go:598
+#: lxc/file.go:599
 msgid "Missing target directory"
 msgstr ""
 
@@ -4260,11 +4260,11 @@ msgstr ""
 msgid "Model: %v"
 msgstr ""
 
-#: lxc/monitor.go:32
+#: lxc/monitor.go:33
 msgid "Monitor a local or remote LXD server"
 msgstr ""
 
-#: lxc/monitor.go:33
+#: lxc/monitor.go:34
 msgid ""
 "Monitor a local or remote LXD server\n"
 "\n"
@@ -4276,11 +4276,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:285
+#: lxc/file.go:286
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:985 lxc/file.go:986
+#: lxc/file.go:986 lxc/file.go:987
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "Creazione del container in corso"
@@ -4343,13 +4343,13 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:192
+#: lxc/auth.go:376 lxc/auth.go:816 lxc/auth.go:1736 lxc/cluster.go:192
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
-#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:565
-#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:511
-#: lxc/storage_bucket.go:831 lxc/storage_volume.go:1731
+#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:566
+#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1731
 msgid "NAME"
 msgstr ""
 
@@ -4357,11 +4357,11 @@ msgstr ""
 msgid "NAT"
 msgstr ""
 
-#: lxc/project.go:571
+#: lxc/project.go:572
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:570
+#: lxc/project.go:571
 msgid "NETWORKS"
 msgstr ""
 
@@ -4373,9 +4373,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/operation.go:154 lxc/project.go:523
-#: lxc/project.go:528 lxc/project.go:533 lxc/project.go:538 lxc/project.go:543
-#: lxc/project.go:548 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
+#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:524
+#: lxc/project.go:529 lxc/project.go:534 lxc/project.go:539 lxc/project.go:544
+#: lxc/project.go:549 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
 msgid "NO"
 msgstr ""
 
@@ -4621,7 +4621,7 @@ msgstr ""
 msgid "Only managed networks can be modified"
 msgstr ""
 
-#: lxc/operation.go:86
+#: lxc/operation.go:87
 #, c-format
 msgid "Operation %s deleted"
 msgstr ""
@@ -4668,11 +4668,11 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:567
+#: lxc/list.go:576 lxc/project.go:568
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:212
+#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4736,24 +4736,24 @@ msgstr "Aggiornamento automatico: %s"
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1102
+#: lxc/file.go:1103
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:860
+#: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
-#: lxc/project.go:363 lxc/storage.go:360 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1151
+#: lxc/project.go:364 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1151
 #: lxc/storage_volume.go:1183
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
-#: lxc/monitor.go:48
+#: lxc/monitor.go:49
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
@@ -4841,17 +4841,17 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:172
+#: lxc/project.go:173
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:236
+#: lxc/project.go:237
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:637
+#: lxc/project.go:638
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -4972,21 +4972,21 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr "Creazione del container in corso"
 
-#: lxc/file.go:241 lxc/file.go:242
+#: lxc/file.go:242 lxc/file.go:243
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:416 lxc/file.go:767
+#: lxc/file.go:417 lxc/file.go:768
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:466 lxc/file.go:467
+#: lxc/file.go:467 lxc/file.go:468
 #, fuzzy
 msgid "Push files into instances"
 msgstr "Creazione del container in corso"
 
-#: lxc/file.go:701 lxc/file.go:867
+#: lxc/file.go:702 lxc/file.go:868
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4999,11 +4999,11 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:983
+#: lxc/project.go:984
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/storage_bucket.go:833
+#: lxc/storage_bucket.go:834
 msgid "ROLE"
 msgstr ""
 
@@ -5016,17 +5016,17 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/rebuild.go:31
+#: lxc/rebuild.go:32
 #, fuzzy
 msgid "Rebuild as an empty instance"
 msgstr "Creazione del container in corso"
 
-#: lxc/rebuild.go:26
+#: lxc/rebuild.go:27
 #, fuzzy
 msgid "Rebuild instances"
 msgstr "Creazione del container in corso"
 
-#: lxc/file.go:249 lxc/file.go:473
+#: lxc/file.go:250 lxc/file.go:474
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -5053,7 +5053,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr "il remote %s esiste già"
 
-#: lxc/project.go:882 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
+#: lxc/project.go:883 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
 #: lxc/remote.go:994
 #, fuzzy, c-format
 msgid "Remote %s doesn't exist"
@@ -5106,7 +5106,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr "Il nome del container è: %s"
 
-#: lxc/auth.go:1164 lxc/auth.go:1165
+#: lxc/auth.go:1165 lxc/auth.go:1166
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -5145,7 +5145,7 @@ msgstr "Il nome del container è: %s"
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1927 lxc/auth.go:1928
+#: lxc/auth.go:1928 lxc/auth.go:1929
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -5158,7 +5158,7 @@ msgstr "Creazione del container in corso"
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:574 lxc/auth.go:575
+#: lxc/auth.go:575 lxc/auth.go:576
 msgid "Remove permissions from groups"
 msgstr ""
 
@@ -5205,11 +5205,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:391 lxc/auth.go:392
+#: lxc/auth.go:392 lxc/auth.go:393
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1751 lxc/auth.go:1752
+#: lxc/auth.go:1752 lxc/auth.go:1753
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5230,7 +5230,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:589 lxc/project.go:590
+#: lxc/project.go:590 lxc/project.go:591
 msgid "Rename projects"
 msgstr ""
 
@@ -5333,7 +5333,7 @@ msgstr "Il nome del container è: %s"
 msgid "Revoke cluster member join token"
 msgstr "Il nome del container è: %s"
 
-#: lxc/storage_bucket.go:862
+#: lxc/storage_bucket.go:863
 msgid "Role (admin or read-only)"
 msgstr ""
 
@@ -5350,7 +5350,7 @@ msgstr ""
 msgid "Run against all projects"
 msgstr "Creazione del container in corso"
 
-#: lxc/warning.go:213
+#: lxc/warning.go:214
 msgid "SEVERITY"
 msgstr ""
 
@@ -5370,12 +5370,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1231
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1231
+#: lxc/file.go:1232
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5389,11 +5389,11 @@ msgstr ""
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:173 lxc/warning.go:214
+#: lxc/operation.go:174 lxc/warning.go:215
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:569
+#: lxc/project.go:570
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5401,7 +5401,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:569
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -5409,11 +5409,11 @@ msgstr ""
 msgid "STP"
 msgstr ""
 
-#: lxc/storage_bucket.go:864
+#: lxc/storage_bucket.go:865
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:942
+#: lxc/storage_bucket.go:943
 #, fuzzy, c-format
 msgid "Secret key: %s"
 msgstr "Aggiornamento automatico: %s"
@@ -5453,7 +5453,7 @@ msgstr "Creazione del container in corso"
 msgid "Set a cluster member's configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: lxc/file.go:995
+#: lxc/file.go:996
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5594,11 +5594,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:654
+#: lxc/project.go:655
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:655
+#: lxc/project.go:656
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5607,12 +5607,12 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage_bucket.go:534
+#: lxc/storage_bucket.go:535
 #, fuzzy
 msgid "Set storage bucket configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: lxc/storage_bucket.go:535
+#: lxc/storage_bucket.go:536
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -5651,15 +5651,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:476
+#: lxc/file.go:477
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:477
+#: lxc/file.go:478
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:475
+#: lxc/file.go:476
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5702,11 +5702,11 @@ msgstr "Il nome del container è: %s"
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 msgid "Set the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:542
+#: lxc/storage_bucket.go:543
 #, fuzzy
 msgid "Set the key as a storage bucket property"
 msgstr "Creazione del container in corso"
@@ -5723,7 +5723,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:993
+#: lxc/file.go:994
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5735,7 +5735,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1800 lxc/auth.go:1801
+#: lxc/auth.go:1801 lxc/auth.go:1802
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5752,11 +5752,11 @@ msgstr ""
 msgid "Show details of a cluster member"
 msgstr ""
 
-#: lxc/operation.go:192 lxc/operation.go:193
+#: lxc/operation.go:193 lxc/operation.go:194
 msgid "Show details on a background operation"
 msgstr ""
 
-#: lxc/monitor.go:49
+#: lxc/monitor.go:50
 msgid "Show events from all projects"
 msgstr ""
 
@@ -5764,12 +5764,12 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:440 lxc/auth.go:441
+#: lxc/auth.go:441 lxc/auth.go:442
 #, fuzzy
 msgid "Show group configurations"
 msgstr "Il nome del container è: %s"
 
-#: lxc/auth.go:832
+#: lxc/auth.go:833
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5857,16 +5857,16 @@ msgstr "Il nome del container è: %s"
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:786 lxc/project.go:787
+#: lxc/project.go:787 lxc/project.go:788
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage_bucket.go:628 lxc/storage_bucket.go:629
+#: lxc/storage_bucket.go:629 lxc/storage_bucket.go:630
 #, fuzzy
 msgid "Show storage bucket configurations"
 msgstr "Il nome del container è: %s"
 
-#: lxc/storage_bucket.go:1156 lxc/storage_bucket.go:1157
+#: lxc/storage_bucket.go:1157 lxc/storage_bucket.go:1158
 #, fuzzy
 msgid "Show storage bucket key configurations"
 msgstr "Il nome del container è: %s"
@@ -5883,7 +5883,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:895
+#: lxc/auth.go:896
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5934,7 +5934,7 @@ msgstr ""
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: lxc/warning.go:302 lxc/warning.go:303
+#: lxc/warning.go:303 lxc/warning.go:304
 msgid "Show warning"
 msgstr ""
 
@@ -6020,22 +6020,22 @@ msgstr ""
 msgid "Stopping the instance failed: %s"
 msgstr "errore di processamento degli alias %s\n"
 
-#: lxc/storage_bucket.go:166
+#: lxc/storage_bucket.go:167
 #, c-format
 msgid "Storage bucket %s created"
 msgstr ""
 
-#: lxc/storage_bucket.go:233
+#: lxc/storage_bucket.go:234
 #, c-format
 msgid "Storage bucket %s deleted"
 msgstr ""
 
-#: lxc/storage_bucket.go:940
+#: lxc/storage_bucket.go:941
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr ""
 
-#: lxc/storage_bucket.go:1006
+#: lxc/storage_bucket.go:1007
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr ""
@@ -6105,7 +6105,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:847 lxc/project.go:848
+#: lxc/project.go:848 lxc/project.go:849
 msgid "Switch the current project"
 msgstr ""
 
@@ -6121,10 +6121,10 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1139
+#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1139
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
-#: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:171
-#: lxc/storage_volume.go:1730 lxc/warning.go:215
+#: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
+#: lxc/storage_volume.go:1730 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
@@ -6133,11 +6133,11 @@ msgstr ""
 msgid "Taken at"
 msgstr "salvato alle %s"
 
-#: lxc/file.go:1032
+#: lxc/file.go:1033
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1026
+#: lxc/file.go:1027
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -6266,12 +6266,12 @@ msgstr "Il nome del container è: %s"
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr "Il nome del container è: %s"
 
-#: lxc/project.go:446
+#: lxc/project.go:447
 #, fuzzy, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr "Il nome del container è: %s"
 
-#: lxc/storage_bucket.go:431
+#: lxc/storage_bucket.go:432
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage bucket %q: %v"
 msgstr "Il nome del container è: %s"
@@ -6459,7 +6459,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:961
+#: lxc/project.go:962
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6471,17 +6471,17 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:985 lxc/storage_volume.go:1735
+#: lxc/project.go:986 lxc/storage_volume.go:1735
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:573
+#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:574
 #: lxc/storage.go:724 lxc/storage_volume.go:1734
 msgid "USED BY"
 msgstr ""
 
-#: lxc/warning.go:216
+#: lxc/warning.go:217
 msgid "UUID"
 msgstr ""
 
@@ -6490,7 +6490,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:197
+#: lxc/file.go:198
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6505,13 +6505,13 @@ msgstr "Aggiungi un nuovo server remoto"
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1253
+#: lxc/file.go:1254
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1153 lxc/list.go:631 lxc/storage_volume.go:1772
-#: lxc/warning.go:241
+#: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6521,7 +6521,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:807
+#: lxc/file.go:808
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6612,11 +6612,11 @@ msgstr "Il nome del container è: %s"
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:742 lxc/project.go:743
+#: lxc/project.go:743 lxc/project.go:744
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:697 lxc/storage_bucket.go:698
+#: lxc/storage_bucket.go:698 lxc/storage_bucket.go:699
 #, fuzzy
 msgid "Unset storage bucket configuration keys"
 msgstr "Il nome del container è: %s"
@@ -6668,11 +6668,11 @@ msgstr "Il nome del container è: %s"
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:747
+#: lxc/project.go:748
 msgid "Unset the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:701
+#: lxc/storage_bucket.go:702
 #, fuzzy
 msgid "Unset the key as a storage bucket property"
 msgstr "Il nome del container è: %s"
@@ -6754,7 +6754,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:71
+#: lxc/file.go:72
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6791,11 +6791,11 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:831
+#: lxc/auth.go:832
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:894
+#: lxc/auth.go:895
 msgid "View the current identity"
 msgstr ""
 
@@ -6826,15 +6826,15 @@ msgstr ""
 msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
-#: lxc/rebuild.go:27
+#: lxc/rebuild.go:28
 msgid ""
 "Wipe the instance root disk and re-initialize. The original image is used to "
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:156 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
+#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:526
+#: lxc/project.go:531 lxc/project.go:536 lxc/project.go:541 lxc/project.go:546
+#: lxc/project.go:551 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
 msgid "YES"
 msgstr ""
 
@@ -6856,7 +6856,7 @@ msgstr "Occorre specificare un nome di container come origine"
 msgid "You must specify a source instance name"
 msgstr "Occorre specificare un nome di container come origine"
 
-#: lxc/rebuild.go:119
+#: lxc/rebuild.go:120
 #, fuzzy
 msgid "You need to specify an image name or use --empty"
 msgstr "Occorre specificare un nome di container come origine"
@@ -6871,12 +6871,12 @@ msgstr "Creazione del container in corso"
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1689
+#: lxc/auth.go:330 lxc/auth.go:763 lxc/auth.go:894 lxc/auth.go:1690
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
-#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
+#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
-#: lxc/operation.go:103 lxc/profile.go:700 lxc/project.go:467
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:68
+#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:468
+#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 #, fuzzy
 msgid "[<remote>:]"
 msgstr "Creazione del container in corso"
@@ -6911,7 +6911,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:] [<filters>...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/auth.go:1254
+#: lxc/auth.go:1255
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6986,11 +6986,11 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<alias> <new-name>"
 msgstr "Creazione del container in corso"
 
-#: lxc/auth.go:830
+#: lxc/auth.go:831
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1926
+#: lxc/auth.go:1106 lxc/auth.go:1164 lxc/auth.go:1927
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6999,14 +6999,14 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr "Creazione del container in corso"
 
-#: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:954 lxc/auth.go:1470 lxc/cluster_group.go:168
+#: lxc/auth.go:97 lxc/auth.go:150 lxc/auth.go:200 lxc/auth.go:440
+#: lxc/auth.go:955 lxc/auth.go:1471 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 #, fuzzy
 msgid "[<remote>:]<group>"
 msgstr "Creazione del container in corso"
 
-#: lxc/auth.go:514 lxc/auth.go:572
+#: lxc/auth.go:515 lxc/auth.go:573
 #, fuzzy
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
@@ -7018,22 +7018,22 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<group> <new-name>"
 msgstr "Creazione del container in corso"
 
-#: lxc/auth.go:389
+#: lxc/auth.go:390
 #, fuzzy
 msgid "[<remote>:]<group> <new_name>"
 msgstr "Creazione del container in corso"
 
-#: lxc/auth.go:1521 lxc/auth.go:1571 lxc/auth.go:1799
+#: lxc/auth.go:1522 lxc/auth.go:1572 lxc/auth.go:1800
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group>"
 msgstr "Creazione del container in corso"
 
-#: lxc/auth.go:1873
+#: lxc/auth.go:1874
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr "Creazione del container in corso"
 
-#: lxc/auth.go:1749
+#: lxc/auth.go:1750
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr "Creazione del container in corso"
@@ -7058,7 +7058,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<image> <remote>:"
 msgstr "Creazione del container in corso"
 
-#: lxc/rebuild.go:25
+#: lxc/rebuild.go:26
 #, fuzzy
 msgid "[<remote>:]<image> [<remote>:]<instance>"
 msgstr "Creazione del container in corso"
@@ -7160,23 +7160,23 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:170
+#: lxc/file.go:171
 #, fuzzy
 msgid "[<remote>:]<instance>/<path>"
 msgstr "Creazione del container in corso"
 
-#: lxc/file.go:120
+#: lxc/file.go:121
 #, fuzzy
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/file.go:240
+#: lxc/file.go:241
 #, fuzzy
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr "Creazione del container in corso"
 
-#: lxc/file.go:984
+#: lxc/file.go:985
 #, fuzzy
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr "Creazione del container in corso"
@@ -7360,13 +7360,13 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<network> [key=value...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/operation.go:53 lxc/operation.go:191
+#: lxc/operation.go:54 lxc/operation.go:192
 #, fuzzy
 msgid "[<remote>:]<operation>"
 msgstr "Creazione del container in corso"
 
 #: lxc/storage.go:200 lxc/storage.go:259 lxc/storage.go:473 lxc/storage.go:844
-#: lxc/storage_bucket.go:454
+#: lxc/storage_bucket.go:455
 #, fuzzy
 msgid "[<remote>:]<pool>"
 msgstr "Creazione del container in corso"
@@ -7376,25 +7376,25 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_bucket.go:185 lxc/storage_bucket.go:247
-#: lxc/storage_bucket.go:627 lxc/storage_bucket.go:769
+#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:248
+#: lxc/storage_bucket.go:628 lxc/storage_bucket.go:770
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket>"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_bucket.go:380 lxc/storage_bucket.go:696
-#: lxc/storage_bucket.go:850 lxc/storage_bucket.go:956
-#: lxc/storage_bucket.go:1020 lxc/storage_bucket.go:1155
+#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:697
+#: lxc/storage_bucket.go:851 lxc/storage_bucket.go:957
+#: lxc/storage_bucket.go:1021 lxc/storage_bucket.go:1156
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_bucket.go:533
+#: lxc/storage_bucket.go:534
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_bucket.go:81
+#: lxc/storage_bucket.go:82
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr "Creazione del container in corso"
@@ -7537,23 +7537,23 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr "Creazione del container in corso"
 
-#: lxc/project.go:91 lxc/project.go:186 lxc/project.go:258 lxc/project.go:785
-#: lxc/project.go:846 lxc/project.go:913
+#: lxc/project.go:92 lxc/project.go:187 lxc/project.go:259 lxc/project.go:786
+#: lxc/project.go:847 lxc/project.go:914
 #, fuzzy
 msgid "[<remote>:]<project>"
 msgstr "Creazione del container in corso"
 
-#: lxc/project.go:394 lxc/project.go:741
+#: lxc/project.go:395 lxc/project.go:742
 #, fuzzy
 msgid "[<remote>:]<project> <key>"
 msgstr "Creazione del container in corso"
 
-#: lxc/project.go:653
+#: lxc/project.go:654
 #, fuzzy
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: lxc/project.go:587
+#: lxc/project.go:588
 #, fuzzy
 msgid "[<remote>:]<project> <new-name>"
 msgstr "Creazione del container in corso"
@@ -7563,7 +7563,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/warning.go:259 lxc/warning.go:301 lxc/warning.go:354
+#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
 #, fuzzy
 msgid "[<remote>:]<warning-uuid>"
 msgstr "Creazione del container in corso"
@@ -7633,7 +7633,7 @@ msgstr "Creazione del container in corso"
 msgid "[[<remote>:]<member>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/project.go:555 lxc/remote.go:739
+#: lxc/project.go:556 lxc/remote.go:739
 msgid "current"
 msgstr ""
 
@@ -7680,20 +7680,20 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/auth.go:203
+#: lxc/auth.go:204
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:958
+#: lxc/auth.go:959
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1575
+#: lxc/auth.go:1576
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7771,20 +7771,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:988
+#: lxc/file.go:989
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:244
+#: lxc/file.go:245
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:470
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7866,7 +7866,7 @@ msgid ""
 "  List instances with their running state and user comment."
 msgstr ""
 
-#: lxc/monitor.go:37
+#: lxc/monitor.go:38
 msgid ""
 "lxc monitor --type=logging\n"
 "    Only show log messages.\n"
@@ -7942,7 +7942,7 @@ msgid ""
 "    Create record r1 for zone z1 with configuration from config.yaml"
 msgstr ""
 
-#: lxc/operation.go:195
+#: lxc/operation.go:196
 msgid ""
 "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Show details on that operation UUID"
@@ -7985,7 +7985,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:95
+#: lxc/project.go:96
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7993,7 +7993,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:262
+#: lxc/project.go:263
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -8024,7 +8024,7 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:85
 msgid ""
 "lxc storage bucket create p1 b01\n"
 "\tCreate a new storage bucket name b01 in storage pool p1\n"
@@ -8034,19 +8034,19 @@ msgid ""
 "of config.yaml"
 msgstr ""
 
-#: lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:251
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1023
+#: lxc/storage_bucket.go:1024
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:854
 msgid ""
 "lxc storage bucket key create p1 b01 k1\n"
 "\tCreate a key called k1 for the bucket b01 in the pool p1.\n"
@@ -8056,14 +8056,14 @@ msgid ""
 "of config.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1158
+#: lxc/storage_bucket.go:1159
 msgid ""
 "lxc storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_bucket.go:630
+#: lxc/storage_bucket.go:631
 msgid ""
 "lxc storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
@@ -8134,16 +8134,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1142
+#: lxc/file.go:1143
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1101
+#: lxc/file.go:1102
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1054
+#: lxc/file.go:1055
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-04 08:52-0600\n"
+"POT-Creation-Date: 2024-09-05 08:44-0400\n"
 "PO-Revision-Date: 2023-03-10 15:14+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/linux-"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 4.16.2-dev\n"
 
-#: lxc/storage_bucket.go:260 lxc/storage_bucket.go:1033
+#: lxc/storage_bucket.go:261 lxc/storage_bucket.go:1034
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -188,7 +188,7 @@ msgstr ""
 "###\n"
 "### Note that the name is shown but cannot be changed"
 
-#: lxc/auth.go:213
+#: lxc/auth.go:214
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -215,7 +215,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:968
+#: lxc/auth.go:969
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -236,7 +236,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1585
+#: lxc/auth.go:1586
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
@@ -609,7 +609,7 @@ msgstr ""
 "###\n"
 "### Note that the name is shown but cannot be changed"
 
-#: lxc/project.go:280
+#: lxc/project.go:281
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the project.\n"
@@ -667,12 +667,12 @@ msgstr "%s (他%d個)"
 msgid "%s (%s) (%d available)"
 msgstr "%s (%d個使用可能)"
 
-#: lxc/file.go:935
+#: lxc/file.go:936
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s はディレクトリではありません"
 
-#: lxc/file.go:825
+#: lxc/file.go:826
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' はサポートされないタイプのファイルです"
@@ -708,7 +708,7 @@ msgstr "--console と --all は同時に指定できません"
 msgid "--console only works with a single instance"
 msgstr "--console は単一のインスタンスのときのみ指定できます"
 
-#: lxc/init.go:142 lxc/rebuild.go:64
+#: lxc/init.go:142 lxc/rebuild.go:65
 msgid "--empty cannot be combined with an image name"
 msgstr "--empty はイメージ名と同時に指定できません"
 
@@ -761,7 +761,7 @@ msgstr "<remote> <URL>"
 msgid "<remote> <new-name>"
 msgstr "<remote> <new-name>"
 
-#: lxc/file.go:465
+#: lxc/file.go:466
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr "<source path>... [<remote>:]<instance>/<path>"
 
@@ -796,7 +796,7 @@ msgstr "ARCHITECTURE"
 msgid "AUTH TYPE"
 msgstr "AUTH TYPE"
 
-#: lxc/auth.go:813
+#: lxc/auth.go:814
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -804,11 +804,11 @@ msgstr ""
 msgid "Accept certificate"
 msgstr "証明書を受け入れます"
 
-#: lxc/storage_bucket.go:863
+#: lxc/storage_bucket.go:864
 msgid "Access key (auto-generated if empty)"
 msgstr "アクセスキー（空白の場合自動生成）"
 
-#: lxc/storage_bucket.go:941
+#: lxc/storage_bucket.go:942
 #, c-format
 msgid "Access key: %s"
 msgstr "アクセスキー: %s"
@@ -817,7 +817,7 @@ msgstr "アクセスキー: %s"
 msgid "Access the expanded configuration"
 msgstr "拡張した設定を表示する"
 
-#: lxc/warning.go:261 lxc/warning.go:262
+#: lxc/warning.go:262 lxc/warning.go:263
 msgid "Acknowledge warning"
 msgstr "警告を確認します"
 
@@ -835,11 +835,11 @@ msgstr "使用するHTTPのメソッド (デフォルト: GET)"
 msgid "Add a cluster member to a cluster group"
 msgstr "クラスタグループからメンバを削除します"
 
-#: lxc/auth.go:1106 lxc/auth.go:1107
+#: lxc/auth.go:1107 lxc/auth.go:1108
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1874 lxc/auth.go:1875
+#: lxc/auth.go:1875 lxc/auth.go:1876
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -927,7 +927,7 @@ msgstr ""
 "使ったトークンは無効化されます。\n"
 "証明書と同様に、トークンも 1 つ以上のプロジェクトに制限できます。\n"
 
-#: lxc/auth.go:515 lxc/auth.go:516
+#: lxc/auth.go:516 lxc/auth.go:517
 #, fuzzy
 msgid "Add permissions to groups"
 msgstr "グループからメンバーを削除します"
@@ -957,7 +957,7 @@ msgstr "ACLにルールを追加します"
 msgid "Address: %s"
 msgstr "アドレス: %s"
 
-#: lxc/storage_bucket.go:169
+#: lxc/storage_bucket.go:170
 #, c-format
 msgid "Admin access key: %s"
 msgstr "管理者アクセスキー: %s"
@@ -967,7 +967,7 @@ msgstr "管理者アクセスキー: %s"
 msgid "Admin password (or token) for %s:"
 msgstr "%s の管理者パスワード（もしくはトークン）:"
 
-#: lxc/storage_bucket.go:170
+#: lxc/storage_bucket.go:171
 #, c-format
 msgid "Admin secret key: %s"
 msgstr "管理者秘密鍵: %s"
@@ -1027,7 +1027,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr "どちらもみつかりませんでした。raw SPICE ソケットはこちらにあります:"
 
-#: lxc/init.go:342 lxc/rebuild.go:130
+#: lxc/init.go:342 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr "VMを要求しましたが、イメージタイプがコンテナです"
 
@@ -1133,12 +1133,12 @@ msgstr ""
 
 #: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:318
 #: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
-#: lxc/network_zone.go:366 lxc/network_zone.go:1053 lxc/storage_bucket.go:141
+#: lxc/network_zone.go:366 lxc/network_zone.go:1053 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr "不適切なキー/値のペア: %s"
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:159
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:160
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "不適切な キー=値 のペア: %s"
@@ -1178,7 +1178,7 @@ msgstr "受信バイト数"
 msgid "Bytes sent"
 msgstr "送信バイト数"
 
-#: lxc/operation.go:174
+#: lxc/operation.go:175
 msgid "CANCELABLE"
 msgstr "CANCELABLE"
 
@@ -1190,7 +1190,7 @@ msgstr "COMMON NAME"
 msgid "CONTENT-TYPE"
 msgstr "CONTENT-TYPE"
 
-#: lxc/warning.go:209
+#: lxc/warning.go:210
 msgid "COUNT"
 msgstr "COUNT"
 
@@ -1216,7 +1216,7 @@ msgstr "CPU使用量:"
 msgid "CPUs (%s):"
 msgstr "CPUs (%s):"
 
-#: lxc/operation.go:175
+#: lxc/operation.go:176
 msgid "CREATED"
 msgstr "CREATED"
 
@@ -1246,7 +1246,7 @@ msgstr "ローカル上のリネームでは、設定やプロファイルの上
 msgid "Can't provide a name for the target image"
 msgstr "ターゲットイメージの名前を取得できません"
 
-#: lxc/file.go:340
+#: lxc/file.go:341
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 "ディレクトリを pull する場合は --recursive オプションを使用してください"
@@ -1272,11 +1272,11 @@ msgstr "--project と --all-project は同時に指定できません"
 msgid "Can't specify a different remote for rename"
 msgstr "リネームの場合は異なるリモートを指定できません"
 
-#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:224
+#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr "クラスタでない場合はカラムとして L は指定できません"
 
-#: lxc/file.go:546
+#: lxc/file.go:547
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr "再帰 (recursive) モードでは uid/gid/mode を指定できません"
 
@@ -1285,7 +1285,7 @@ msgstr "再帰 (recursive) モードでは uid/gid/mode を指定できません
 msgid "Can't unset key '%s', it's not currently set"
 msgstr "キー '%s' が設定されていないので削除できません"
 
-#: lxc/rebuild.go:160
+#: lxc/rebuild.go:161
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1413,13 +1413,13 @@ msgstr "クラスターメンバー %s がグループ %s から削除されま�
 #: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
 #: lxc/network_load_balancer.go:1051 lxc/network_load_balancer.go:1125
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
-#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:90
-#: lxc/storage_bucket.go:190 lxc/storage_bucket.go:253
-#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:541
-#: lxc/storage_bucket.go:634 lxc/storage_bucket.go:700
-#: lxc/storage_bucket.go:775 lxc/storage_bucket.go:861
-#: lxc/storage_bucket.go:961 lxc/storage_bucket.go:1026
-#: lxc/storage_bucket.go:1162 lxc/storage_volume.go:394
+#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
+#: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
+#: lxc/storage_bucket.go:385 lxc/storage_bucket.go:542
+#: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
+#: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
+#: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
 #: lxc/storage_volume.go:612 lxc/storage_volume.go:717
 #: lxc/storage_volume.go:1005 lxc/storage_volume.go:1231
 #: lxc/storage_volume.go:1360 lxc/storage_volume.go:1848
@@ -1443,7 +1443,7 @@ msgid "Clustering enabled"
 msgstr "クラスタリングが有効になりました"
 
 #: lxc/image.go:1113 lxc/list.go:132 lxc/storage_volume.go:1589
-#: lxc/warning.go:92
+#: lxc/warning.go:93
 msgid "Columns"
 msgstr "カラムレイアウト"
 
@@ -1475,7 +1475,7 @@ msgstr "使用する圧縮アルゴリズムを指定します (圧縮しない�
 msgid "Config key/value to apply to the new instance"
 msgstr "新しいインスタンスに適用するキー/値の設定"
 
-#: lxc/project.go:100
+#: lxc/project.go:101
 msgid "Config key/value to apply to the new project"
 msgstr "新しいプロジェクトに適用するキー/値の設定"
 
@@ -1489,8 +1489,8 @@ msgstr "移動先のインスタンスに適用するキー/値の設定"
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
-#: lxc/project.go:362 lxc/storage.go:359 lxc/storage_bucket.go:348
-#: lxc/storage_bucket.go:1125 lxc/storage_volume.go:1150
+#: lxc/project.go:363 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1150
 #: lxc/storage_volume.go:1182
 #, c-format
 msgid "Config parsing error: %s"
@@ -1632,12 +1632,12 @@ msgstr "証明書のファイルパスが見つかりません: %s"
 msgid "Could not find certificate key file path: %s"
 msgstr "証明書の鍵のパスが見つかりません: %s"
 
-#: lxc/auth.go:300 lxc/auth.go:1660
+#: lxc/auth.go:301 lxc/auth.go:1661
 #, fuzzy, c-format
 msgid "Could not parse group: %s"
 msgstr "設定の構文エラー: %s"
 
-#: lxc/auth.go:1054
+#: lxc/auth.go:1055
 #, fuzzy, c-format
 msgid "Could not parse identity: %s"
 msgstr "設定キーを設定できません: %s"
@@ -1686,16 +1686,16 @@ msgstr "空のインスタンスを作成"
 msgid "Create and start instances from images"
 msgstr "イメージからインスタンスを作成し、起動します"
 
-#: lxc/file.go:248 lxc/file.go:474
+#: lxc/file.go:249 lxc/file.go:475
 msgid "Create any directories necessary"
 msgstr "必要なディレクトリをすべて作成します"
 
-#: lxc/auth.go:97 lxc/auth.go:98
+#: lxc/auth.go:98 lxc/auth.go:99
 #, fuzzy
 msgid "Create groups"
 msgstr "プロファイルを作成します"
 
-#: lxc/auth.go:1471 lxc/auth.go:1472
+#: lxc/auth.go:1472 lxc/auth.go:1473
 #, fuzzy
 msgid "Create identity provider groups"
 msgstr "新たにクラスターグループを作成します"
@@ -1720,11 +1720,11 @@ msgstr ""
 msgid "Create instances from images"
 msgstr "イメージからインスタンスを作成します"
 
-#: lxc/storage_bucket.go:851 lxc/storage_bucket.go:852
+#: lxc/storage_bucket.go:852 lxc/storage_bucket.go:853
 msgid "Create key for a storage bucket"
 msgstr "ストレージバケットに対する鍵を作成します"
 
-#: lxc/storage_bucket.go:82 lxc/storage_bucket.go:83
+#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
 msgid "Create new custom storage buckets"
 msgstr "新たにカスタムストレージバケットを作成します"
 
@@ -1768,7 +1768,7 @@ msgstr "新たにネットワークを作成します"
 msgid "Create profiles"
 msgstr "プロファイルを作成します"
 
-#: lxc/project.go:92 lxc/project.go:93
+#: lxc/project.go:93 lxc/project.go:94
 msgid "Create projects"
 msgstr "プロジェクトを作成します"
 
@@ -1803,13 +1803,13 @@ msgstr "現在の VF 数: %d"
 msgid "DEFAULT TARGET ADDRESS"
 msgstr "DEFAULT TARGET ADDRESS"
 
-#: lxc/auth.go:376 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1135 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
-#: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:172
-#: lxc/profile.go:756 lxc/project.go:572 lxc/storage.go:723
-#: lxc/storage_bucket.go:512 lxc/storage_bucket.go:832
+#: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
+#: lxc/profile.go:756 lxc/project.go:573 lxc/storage.go:723
+#: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1732
 msgid "DESCRIPTION"
 msgstr "DESCRIPTION"
@@ -1834,7 +1834,7 @@ msgstr "デフォルト VLAN ID"
 msgid "Define a compression algorithm: for backup or none"
 msgstr "圧縮アルゴリズムを指定します: backup or none"
 
-#: lxc/operation.go:55 lxc/operation.go:56
+#: lxc/operation.go:56 lxc/operation.go:57
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr "バックグラウンドの操作を削除します（キャンセルを試みます）"
 
@@ -1842,20 +1842,20 @@ msgstr "バックグラウンドの操作を削除します（キャンセルを
 msgid "Delete a cluster group"
 msgstr "クラスタグループを削除します"
 
-#: lxc/warning.go:360
+#: lxc/warning.go:361
 msgid "Delete all warnings"
 msgstr "警告をすべて削除します"
 
-#: lxc/file.go:122 lxc/file.go:123
+#: lxc/file.go:123 lxc/file.go:124
 msgid "Delete files in instances"
 msgstr "インスタンス内のファイルを削除します"
 
-#: lxc/auth.go:151 lxc/auth.go:152
+#: lxc/auth.go:152 lxc/auth.go:153
 #, fuzzy
 msgid "Delete groups"
 msgstr "プロファイルを削除します"
 
-#: lxc/auth.go:1523 lxc/auth.go:1524
+#: lxc/auth.go:1524 lxc/auth.go:1525
 #, fuzzy
 msgid "Delete identity provider groups"
 msgstr "クラスタグループを削除します"
@@ -1876,7 +1876,7 @@ msgstr "インスタンスのファイルテンプレートを削除します"
 msgid "Delete instances and snapshots"
 msgstr "インスタンスとスナップショットを削除します"
 
-#: lxc/storage_bucket.go:957 lxc/storage_bucket.go:958
+#: lxc/storage_bucket.go:958 lxc/storage_bucket.go:959
 msgid "Delete key from a storage bucket"
 msgstr "ストレージバケットからキーを削除します"
 
@@ -1912,11 +1912,11 @@ msgstr "ネットワークを削除します"
 msgid "Delete profiles"
 msgstr "プロファイルを削除します"
 
-#: lxc/project.go:188 lxc/project.go:189
+#: lxc/project.go:189 lxc/project.go:190
 msgid "Delete projects"
 msgstr "プロジェクトを削除します"
 
-#: lxc/storage_bucket.go:187 lxc/storage_bucket.go:188
+#: lxc/storage_bucket.go:188 lxc/storage_bucket.go:189
 msgid "Delete storage buckets"
 msgstr "ストレージバケットを削除します"
 
@@ -1928,20 +1928,20 @@ msgstr "ストレージプールを削除します"
 msgid "Delete storage volumes"
 msgstr "ストレージボリュームを削除します"
 
-#: lxc/warning.go:356 lxc/warning.go:357
+#: lxc/warning.go:357 lxc/warning.go:358
 msgid "Delete warning"
 msgstr "警告を削除します"
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:30 lxc/auth.go:59 lxc/auth.go:98
-#: lxc/auth.go:152 lxc/auth.go:201 lxc/auth.go:332 lxc/auth.go:392
-#: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
-#: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
-#: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
-#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1434 lxc/auth.go:1472
-#: lxc/auth.go:1524 lxc/auth.go:1573 lxc/auth.go:1692 lxc/auth.go:1752
-#: lxc/auth.go:1801 lxc/auth.go:1852 lxc/auth.go:1875 lxc/auth.go:1928
+#: lxc/alias.go:214 lxc/auth.go:31 lxc/auth.go:60 lxc/auth.go:99
+#: lxc/auth.go:153 lxc/auth.go:202 lxc/auth.go:333 lxc/auth.go:393
+#: lxc/auth.go:442 lxc/auth.go:494 lxc/auth.go:517 lxc/auth.go:576
+#: lxc/auth.go:732 lxc/auth.go:766 lxc/auth.go:833 lxc/auth.go:896
+#: lxc/auth.go:957 lxc/auth.go:1085 lxc/auth.go:1108 lxc/auth.go:1166
+#: lxc/auth.go:1235 lxc/auth.go:1257 lxc/auth.go:1435 lxc/auth.go:1473
+#: lxc/auth.go:1525 lxc/auth.go:1574 lxc/auth.go:1693 lxc/auth.go:1753
+#: lxc/auth.go:1802 lxc/auth.go:1853 lxc/auth.go:1876 lxc/auth.go:1929
 #: lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215 lxc/cluster.go:272
 #: lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:484 lxc/cluster.go:528
 #: lxc/cluster.go:586 lxc/cluster.go:677 lxc/cluster.go:770 lxc/cluster.go:893
@@ -1965,15 +1965,15 @@ msgstr "警告を削除します"
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:83 lxc/file.go:123 lxc/file.go:172
-#: lxc/file.go:242 lxc/file.go:467 lxc/file.go:986 lxc/image.go:38
+#: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
+#: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
 #: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
 #: lxc/image.go:697 lxc/image.go:946 lxc/image.go:1088 lxc/image.go:1415
 #: lxc/image.go:1506 lxc/image.go:1572 lxc/image.go:1636 lxc/image.go:1699
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:38 lxc/network.go:33
+#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33
 #: lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405
 #: lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793
 #: lxc/network.go:874 lxc/network.go:1005 lxc/network.go:1106
@@ -2007,27 +2007,27 @@ msgstr "警告を削除します"
 #: lxc/network_zone.go:909 lxc/network_zone.go:985 lxc/network_zone.go:1083
 #: lxc/network_zone.go:1172 lxc/network_zone.go:1219 lxc/network_zone.go:1349
 #: lxc/network_zone.go:1410 lxc/network_zone.go:1425 lxc/network_zone.go:1483
-#: lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:106
-#: lxc/operation.go:193 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
+#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
+#: lxc/operation.go:194 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
 #: lxc/profile.go:271 lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493
 #: lxc/profile.go:629 lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860
-#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:29
-#: lxc/project.go:93 lxc/project.go:189 lxc/project.go:260 lxc/project.go:396
-#: lxc/project.go:470 lxc/project.go:590 lxc/project.go:655 lxc/project.go:743
-#: lxc/project.go:787 lxc/project.go:848 lxc/project.go:915 lxc/publish.go:34
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:35 lxc/remote.go:91
+#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:30
+#: lxc/project.go:94 lxc/project.go:190 lxc/project.go:261 lxc/project.go:397
+#: lxc/project.go:471 lxc/project.go:591 lxc/project.go:656 lxc/project.go:744
+#: lxc/project.go:788 lxc/project.go:849 lxc/project.go:916 lxc/publish.go:34
+#: lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91
 #: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853
 #: lxc/remote.go:917 lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24
 #: lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203
 #: lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655
 #: lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940
-#: lxc/storage_bucket.go:29 lxc/storage_bucket.go:83 lxc/storage_bucket.go:188
-#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:382
-#: lxc/storage_bucket.go:458 lxc/storage_bucket.go:535
-#: lxc/storage_bucket.go:629 lxc/storage_bucket.go:698
-#: lxc/storage_bucket.go:732 lxc/storage_bucket.go:773
-#: lxc/storage_bucket.go:852 lxc/storage_bucket.go:958
-#: lxc/storage_bucket.go:1022 lxc/storage_bucket.go:1157
+#: lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189
+#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:383
+#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:536
+#: lxc/storage_bucket.go:630 lxc/storage_bucket.go:699
+#: lxc/storage_bucket.go:733 lxc/storage_bucket.go:774
+#: lxc/storage_bucket.go:853 lxc/storage_bucket.go:959
+#: lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158
 #: lxc/storage_volume.go:58 lxc/storage_volume.go:169 lxc/storage_volume.go:283
 #: lxc/storage_volume.go:390 lxc/storage_volume.go:605
 #: lxc/storage_volume.go:714 lxc/storage_volume.go:801
@@ -2038,8 +2038,8 @@ msgstr "警告を削除します"
 #: lxc/storage_volume.go:2064 lxc/storage_volume.go:2222
 #: lxc/storage_volume.go:2343 lxc/storage_volume.go:2405
 #: lxc/storage_volume.go:2541 lxc/storage_volume.go:2624
-#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:29
-#: lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
+#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:30
+#: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr "説明"
 
@@ -2132,7 +2132,7 @@ msgstr "このプラットフォーム上ではディレクトリのインポー
 msgid "Directory to run the command in (default /root)"
 msgstr "コマンドを実行するディレクトリ (デフォルト /root)"
 
-#: lxc/file.go:994
+#: lxc/file.go:995
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr "SSH SFTP リスナーを使う際に認証を無効化します"
 
@@ -2198,7 +2198,7 @@ msgstr "EXPIRES AT"
 msgid "EXPIRY DATE"
 msgstr "EXPIRY DATE"
 
-#: lxc/file.go:74
+#: lxc/file.go:75
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -2210,7 +2210,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr "クラスタグループを編集します"
 
-#: lxc/auth.go:955 lxc/auth.go:956
+#: lxc/auth.go:956 lxc/auth.go:957
 #, fuzzy
 msgid "Edit an identity as YAML"
 msgstr "ストレージバケットの設定をYAMLで編集します"
@@ -2219,16 +2219,16 @@ msgstr "ストレージバケットの設定をYAMLで編集します"
 msgid "Edit cluster member configurations as YAML"
 msgstr "クラスターメンバーの設定をYAMLファイルで編集します"
 
-#: lxc/file.go:171 lxc/file.go:172
+#: lxc/file.go:172 lxc/file.go:173
 msgid "Edit files in instances"
 msgstr "インスタンス内のファイルを編集します"
 
-#: lxc/auth.go:200 lxc/auth.go:201
+#: lxc/auth.go:201 lxc/auth.go:202
 #, fuzzy
 msgid "Edit groups as YAML"
 msgstr "信頼済みクライアント設定をYAMLで編集します"
 
-#: lxc/auth.go:1572 lxc/auth.go:1573
+#: lxc/auth.go:1573 lxc/auth.go:1574
 #, fuzzy
 msgid "Edit identity provider groups as YAML"
 msgstr "プロファイル設定をYAMLで編集します"
@@ -2286,15 +2286,15 @@ msgstr "ネットワークゾーンレコードをYAMLで編集します"
 msgid "Edit profile configurations as YAML"
 msgstr "プロファイル設定をYAMLで編集します"
 
-#: lxc/project.go:259 lxc/project.go:260
+#: lxc/project.go:260 lxc/project.go:261
 msgid "Edit project configurations as YAML"
 msgstr "プロジェクト設定をYAMLで編集します"
 
-#: lxc/storage_bucket.go:248 lxc/storage_bucket.go:249
+#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:250
 msgid "Edit storage bucket configurations as YAML"
 msgstr "ストレージバケットの設定をYAMLで編集します"
 
-#: lxc/storage_bucket.go:1021 lxc/storage_bucket.go:1022
+#: lxc/storage_bucket.go:1022 lxc/storage_bucket.go:1023
 msgid "Edit storage bucket key as YAML"
 msgstr "ストレージバケットの設定をYAMLで編集します"
 
@@ -2311,7 +2311,7 @@ msgid "Edit trust configurations as YAML"
 msgstr "信頼済みクライアント設定をYAMLで編集します"
 
 #: lxc/image.go:1147 lxc/list.go:622 lxc/storage_volume.go:1766
-#: lxc/warning.go:235
+#: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2377,7 +2377,7 @@ msgstr "イメージの取得中: %s"
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
-#: lxc/project.go:718 lxc/storage.go:812 lxc/storage_bucket.go:602
+#: lxc/project.go:719 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2155 lxc/storage_volume.go:2193
 #, fuzzy, c-format
 msgid "Error setting properties: %v"
@@ -2391,8 +2391,8 @@ msgstr "イメージのプロパティを削除します"
 #: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
-#: lxc/profile.go:981 lxc/project.go:712 lxc/storage.go:806
-#: lxc/storage_bucket.go:596 lxc/storage_volume.go:2149
+#: lxc/profile.go:981 lxc/project.go:713 lxc/storage.go:806
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2149
 #: lxc/storage_volume.go:2187
 #, c-format
 msgid "Error unsetting property: %v"
@@ -2412,7 +2412,7 @@ msgstr "クラスターのメンバーを待避させます"
 msgid "Evacuating cluster member: %s"
 msgstr "クラスターメンバーを待避させています: %s"
 
-#: lxc/monitor.go:50
+#: lxc/monitor.go:51
 msgid "Event type to listen for"
 msgstr "Listenするイベントタイプ"
 
@@ -2514,16 +2514,16 @@ msgstr "FILENAME"
 msgid "FINGERPRINT"
 msgstr "FINGERPRINT"
 
-#: lxc/warning.go:210
+#: lxc/warning.go:211
 msgid "FIRST SEEN"
 msgstr "FIRST SEEN"
 
-#: lxc/file.go:1237
+#: lxc/file.go:1238
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr "クライアント %q との SSH ハンドシェイクに失敗しました: %v"
 
-#: lxc/file.go:1260
+#: lxc/file.go:1261
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr "クライアント %q のチャンネルの受け入れに失敗しました: %v"
@@ -2538,12 +2538,12 @@ msgstr "インスタンスの存在確認に失敗しました \"%s:%s\": %w"
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "インスタンスのスナップショットの存在確認に失敗しました \"%s:%s\": %w"
 
-#: lxc/file.go:1287
+#: lxc/file.go:1288
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr "クライアント %q に対する SFTP インスタンスの接続に失敗しました: %v"
 
-#: lxc/file.go:1072
+#: lxc/file.go:1073
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "インスタンスの SFTP への接続に失敗しました: %w"
@@ -2573,7 +2573,7 @@ msgstr "クライアント %q のチャンネルの受け入れに失敗しま�
 msgid "Failed fetching fingerprint %q: %w"
 msgstr "クライアント %q のチャンネルの受け入れに失敗しました: %v"
 
-#: lxc/file.go:1193
+#: lxc/file.go:1194
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "SSH ホスト鍵の生成に失敗しました: %w"
@@ -2588,7 +2588,7 @@ msgstr "ピアのステータスの取得に失敗しました: %w"
 msgid "Failed loading profile %q: %w"
 msgstr "デバイス上書きのためのプロファイル %q のロードに失敗しました: %w"
 
-#: lxc/file.go:1198
+#: lxc/file.go:1199
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "SSH ホスト鍵の読み取りに失敗しました: %w"
@@ -2598,12 +2598,12 @@ msgstr "SSH ホスト鍵の読み取りに失敗しました: %w"
 msgid "Failed starting command: %w"
 msgstr "コマンドの実行に失敗しました: %w"
 
-#: lxc/file.go:1098
+#: lxc/file.go:1099
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "sshfs の起動に失敗しました: %w"
 
-#: lxc/file.go:1225
+#: lxc/file.go:1226
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "受信接続の受け入れに失敗しました: %w"
@@ -2642,7 +2642,7 @@ msgstr "証明書の作成に失敗しました: %w"
 msgid "Failed to find project: %w"
 msgstr "プロジェクトが見つけられませんでした: %w"
 
-#: lxc/file.go:1210
+#: lxc/file.go:1211
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "コネクションのリッスンに失敗しました: %w"
@@ -2657,7 +2657,7 @@ msgstr "コピー先のインスタンス '%s' のリフレッシュに失敗し
 msgid "Failed to remove alias %s: %w"
 msgstr "エイリアス %s の削除に失敗しました: %w"
 
-#: lxc/file.go:820
+#: lxc/file.go:821
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr "パス %s にアクセスできませんでした: %s"
@@ -2672,7 +2672,7 @@ msgid "Fast mode (same as --columns=nsacPt)"
 msgstr "Fast モード (--columns=nsacPt と同じ)"
 
 #: lxc/network.go:1044 lxc/network_acl.go:133 lxc/network_zone.go:124
-#: lxc/operation.go:136
+#: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr "情報表示のフィルタリングはまだサポートされていません"
 
@@ -2753,21 +2753,21 @@ msgstr ""
 "\n"
 "本当に強制的に %s を削除してもよろしいですか? (yes/no): "
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
+#: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:770 lxc/auth.go:1697
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1114 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:57
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
-#: lxc/operation.go:108 lxc/profile.go:707 lxc/project.go:472
-#: lxc/project.go:917 lxc/remote.go:690 lxc/storage.go:657
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:774
-#: lxc/storage_volume.go:1608 lxc/warning.go:93
+#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:473
+#: lxc/project.go:918 lxc/remote.go:690 lxc/storage.go:657
+#: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
+#: lxc/storage_volume.go:1608 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr "フォーマット (csv|json|table|yaml|compact)"
 
-#: lxc/monitor.go:52
+#: lxc/monitor.go:53
 msgid "Format (json|pretty|yaml)"
 msgstr "フォーマット (json|pretty|yaml)"
 
@@ -2811,7 +2811,7 @@ msgstr "GPU:"
 msgid "GPUs:"
 msgstr "GPUs:"
 
-#: lxc/auth.go:817 lxc/auth.go:1736
+#: lxc/auth.go:818 lxc/auth.go:1737
 msgid "GROUPS"
 msgstr ""
 
@@ -2828,7 +2828,7 @@ msgstr "クライアント証明書を生成します。1分ぐらいかかり�
 msgid "Get UEFI variables for instance"
 msgstr "インスタンスからファイルをマウントします"
 
-#: lxc/project.go:914 lxc/project.go:915
+#: lxc/project.go:915 lxc/project.go:916
 msgid "Get a summary of resource allocations"
 msgstr "リソース割当の状況を表示します"
 
@@ -2882,11 +2882,11 @@ msgstr "ネットワークゾーンレコードエントリを削除します"
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:400
+#: lxc/project.go:401
 msgid "Get the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:385
+#: lxc/storage_bucket.go:386
 #, fuzzy
 msgid "Get the key as a storage bucket property"
 msgstr "ストレージバケットに対する鍵を作成します"
@@ -2949,11 +2949,11 @@ msgstr "ネットワークゾーンレコードの設定値を取得します"
 msgid "Get values for profile configuration keys"
 msgstr "プロファイルの設定値を取得します"
 
-#: lxc/project.go:395 lxc/project.go:396
+#: lxc/project.go:396 lxc/project.go:397
 msgid "Get values for project configuration keys"
 msgstr "プロジェクトの設定値を取得します"
 
-#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:382
+#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:383
 msgid "Get values for storage bucket configuration keys"
 msgstr "ストレージバケットの設定値を取得します"
 
@@ -2970,17 +2970,17 @@ msgstr "ストレージボリュームの設定値を取得します"
 msgid "Given target %q does not match source volume location %q"
 msgstr "指定したコピー先 %q がコピー元のボリュームの場所 %q と一致しません"
 
-#: lxc/auth.go:136
+#: lxc/auth.go:137
 #, fuzzy, c-format
 msgid "Group %s created"
 msgstr "プロファイル %s を作成しました"
 
-#: lxc/auth.go:186
+#: lxc/auth.go:187
 #, fuzzy, c-format
 msgid "Group %s deleted"
 msgstr "プロファイル %s を削除しました"
 
-#: lxc/auth.go:426 lxc/auth.go:1786
+#: lxc/auth.go:427 lxc/auth.go:1787
 #, fuzzy, c-format
 msgid "Group %s renamed to %s"
 msgstr "プロファイル名 %s を %s に変更しました"
@@ -3006,27 +3006,27 @@ msgstr "ホストインターフェース"
 msgid "Hugepages:\n"
 msgstr "Hugepages:\n"
 
-#: lxc/file.go:1310
+#: lxc/file.go:1311
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "SSH 経由のインスタンスへの I/O コピーが失敗しました: %v"
 
-#: lxc/file.go:1299
+#: lxc/file.go:1300
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "インスタンスから SSH 経由の I/O コピーに失敗しました: %v"
 
-#: lxc/file.go:1122
+#: lxc/file.go:1123
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "インスタンスから sshfs への I/O コピーに失敗しました: %v"
 
-#: lxc/file.go:1132
+#: lxc/file.go:1133
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "sshfs からインスタンスへの I/O コピーに失敗しました: %v"
 
-#: lxc/network.go:966 lxc/operation.go:170
+#: lxc/network.go:966 lxc/operation.go:171
 msgid "ID"
 msgstr "ID"
 
@@ -3040,11 +3040,11 @@ msgstr "ID: %d"
 msgid "ID: %s"
 msgstr "ID: %s"
 
-#: lxc/auth.go:816
+#: lxc/auth.go:817
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:566
+#: lxc/project.go:567
 msgid "IMAGES"
 msgstr "IMAGES"
 
@@ -3072,17 +3072,17 @@ msgstr "IPV6"
 msgid "ISSUE DATE"
 msgstr "ISSUE DATE"
 
-#: lxc/auth.go:1508
+#: lxc/auth.go:1509
 #, fuzzy, c-format
 msgid "Identity provider group %s created"
 msgstr "クラスターグループ %s を作成しました"
 
-#: lxc/auth.go:1558
+#: lxc/auth.go:1559
 #, fuzzy, c-format
 msgid "Identity provider group %s deleted"
 msgstr "クラスターグループ %s を作成しました"
 
-#: lxc/rebuild.go:32
+#: lxc/rebuild.go:33
 msgid "If an instance is running, stop it and then rebuild it"
 msgstr ""
 
@@ -3215,7 +3215,7 @@ msgstr "Infiniband:"
 msgid "Input data"
 msgstr "入力するデータ"
 
-#: lxc/auth.go:1233 lxc/auth.go:1234
+#: lxc/auth.go:1234 lxc/auth.go:1235
 msgid "Inspect permissions"
 msgstr ""
 
@@ -3223,11 +3223,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr "インスタンスのみ"
 
-#: lxc/file.go:1124
+#: lxc/file.go:1125
 msgid "Instance disconnected"
 msgstr "インスタンスが切断されました"
 
-#: lxc/file.go:1301
+#: lxc/file.go:1302
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr "クライアント %q に対するインスタンスが切断されました"
@@ -3246,7 +3246,7 @@ msgstr "インスタンス名: %s"
 msgid "Instance name must be specified"
 msgstr "インスタンス名: %s"
 
-#: lxc/file.go:1044
+#: lxc/file.go:1045
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr "SSH SFTP リスナーモードではインスタンスのパスを使用できません"
 
@@ -3255,7 +3255,7 @@ msgstr "SSH SFTP リスナーモードではインスタンスのパスを使用
 msgid "Instance published with fingerprint: %s"
 msgstr "インスタンスは以下のフィンガープリントで publish されます: %s"
 
-#: lxc/rebuild.go:74
+#: lxc/rebuild.go:75
 #, fuzzy, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr "インスタンス名: %s"
@@ -3289,7 +3289,7 @@ msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 "不正な設定項目のカラムフォーマットです (フィールド数が多すぎます): '%s'"
 
-#: lxc/monitor.go:70
+#: lxc/monitor.go:71
 #, c-format
 msgid "Invalid format: %s"
 msgstr "不正なフォーマット %s"
@@ -3299,7 +3299,7 @@ msgstr "不正なフォーマット %s"
 msgid "Invalid instance name: %s"
 msgstr "不正なインスタンス名: %s"
 
-#: lxc/file.go:1039
+#: lxc/file.go:1040
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr "不正なインスタンスのパス: %q"
@@ -3348,7 +3348,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr "引数の数が不正です"
 
-#: lxc/file.go:147
+#: lxc/file.go:148
 #, c-format
 msgid "Invalid path %s"
 msgstr "不正なパス %s"
@@ -3364,12 +3364,12 @@ msgstr "不正なプロトコル: %s"
 msgid "Invalid snapshot name"
 msgstr "不正なスナップショット名"
 
-#: lxc/file.go:313
+#: lxc/file.go:314
 #, c-format
 msgid "Invalid source %s"
 msgstr "不正なソース %s"
 
-#: lxc/file.go:495
+#: lxc/file.go:496
 #, c-format
 msgid "Invalid target %s"
 msgstr "不正な送り先 %s"
@@ -3383,7 +3383,7 @@ msgstr "IsSM: %s (%s)"
 msgid "Keep the image up to date after initial copy"
 msgstr "最初にコピーした後も常にイメージを最新の状態に保つ"
 
-#: lxc/warning.go:211
+#: lxc/warning.go:212
 msgid "LAST SEEN"
 msgstr "LAST SEEN"
 
@@ -3391,7 +3391,7 @@ msgstr "LAST SEEN"
 msgid "LAST USED AT"
 msgstr "LAST USED AT"
 
-#: lxc/project.go:984
+#: lxc/project.go:985
 msgid "LIMIT"
 msgstr "LIMIT"
 
@@ -3400,8 +3400,8 @@ msgid "LISTEN ADDRESS"
 msgstr "LISTEN ADDRESS"
 
 #: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
-#: lxc/network_load_balancer.go:165 lxc/operation.go:177
-#: lxc/storage_bucket.go:516 lxc/storage_volume.go:1739 lxc/warning.go:220
+#: lxc/network_load_balancer.go:165 lxc/operation.go:178
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1739 lxc/warning.go:221
 msgid "LOCATION"
 msgstr "LOCATION"
 
@@ -3478,7 +3478,7 @@ msgstr "クラスタグループをすべて一覧表示します"
 msgid "List all the cluster members"
 msgstr "クラスタのメンバをすべて一覧表示します"
 
-#: lxc/warning.go:94
+#: lxc/warning.go:95
 msgid "List all warnings"
 msgstr "警告を一覧表示します"
 
@@ -3522,21 +3522,21 @@ msgstr "利用可能なネットワークを一覧表示します"
 msgid "List available storage pools"
 msgstr "利用可能なストレージプールを一覧表示します"
 
-#: lxc/operation.go:105 lxc/operation.go:106
+#: lxc/operation.go:106 lxc/operation.go:107
 msgid "List background operations"
 msgstr "バックグラウンド操作を一覧表示します"
 
-#: lxc/auth.go:331 lxc/auth.go:332
+#: lxc/auth.go:332 lxc/auth.go:333
 #, fuzzy
 msgid "List groups"
 msgstr "プロファイルを一覧表示します"
 
-#: lxc/auth.go:764 lxc/auth.go:765
+#: lxc/auth.go:765 lxc/auth.go:766
 #, fuzzy
 msgid "List identities"
 msgstr "インスタンスを一覧表示します"
 
-#: lxc/auth.go:1691 lxc/auth.go:1692
+#: lxc/auth.go:1692 lxc/auth.go:1693
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3791,12 +3791,12 @@ msgstr "ネットワーク設定をYAMLで編集します"
 msgid "List of projects to restrict the certificate to"
 msgstr "証明書の使用を制限するプロジェクトのリスト"
 
-#: lxc/operation.go:109
+#: lxc/operation.go:110
 #, fuzzy
 msgid "List operations from all projects"
 msgstr "すべてのプロジェクトのインスタンスを表示します"
 
-#: lxc/auth.go:1255 lxc/auth.go:1256
+#: lxc/auth.go:1256 lxc/auth.go:1257
 #, fuzzy
 msgid "List permissions"
 msgstr "プロファイルを一覧表示します"
@@ -3805,15 +3805,15 @@ msgstr "プロファイルを一覧表示します"
 msgid "List profiles"
 msgstr "プロファイルを一覧表示します"
 
-#: lxc/project.go:469 lxc/project.go:470
+#: lxc/project.go:470 lxc/project.go:471
 msgid "List projects"
 msgstr "プロジェクトを一覧表示します"
 
-#: lxc/storage_bucket.go:771 lxc/storage_bucket.go:773
+#: lxc/storage_bucket.go:772 lxc/storage_bucket.go:774
 msgid "List storage bucket keys"
 msgstr "ストレージバケットの鍵を一覧表示します"
 
-#: lxc/storage_bucket.go:456 lxc/storage_bucket.go:458
+#: lxc/storage_bucket.go:457 lxc/storage_bucket.go:459
 msgid "List storage buckets"
 msgstr "ストレージバケットを一覧表示します"
 
@@ -3864,11 +3864,11 @@ msgstr "利用可能なリモートサーバを一覧表示します"
 msgid "List trusted clients"
 msgstr "信頼済みクライアントを一覧表示します"
 
-#: lxc/warning.go:70
+#: lxc/warning.go:71
 msgid "List warnings"
 msgstr "警告を一覧表示します"
 
-#: lxc/warning.go:71
+#: lxc/warning.go:72
 msgid ""
 "List warnings\n"
 "\n"
@@ -3909,7 +3909,7 @@ msgstr ""
 "    u - UUID\n"
 "    t - タイプ"
 
-#: lxc/operation.go:23 lxc/operation.go:24
+#: lxc/operation.go:24 lxc/operation.go:25
 msgid "List, show and delete background operations"
 msgstr "バックグラウンド操作の一覧表示、表示、削除を行います"
 
@@ -3918,7 +3918,7 @@ msgstr "バックグラウンド操作の一覧表示、表示、削除を行い
 msgid "Location: %s"
 msgstr "ロケーション: %s"
 
-#: lxc/monitor.go:79
+#: lxc/monitor.go:80
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr "ログレベルのフィルタリングは pretty フォーマットでのみ使えます"
 
@@ -4022,26 +4022,26 @@ msgstr "コマンドのエイリアスを管理します"
 msgid "Manage devices"
 msgstr "デバイスを管理します"
 
-#: lxc/file.go:82 lxc/file.go:83
+#: lxc/file.go:83 lxc/file.go:84
 msgid "Manage files in instances"
 msgstr "インスタンス内のファイルを管理します"
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1433 lxc/auth.go:1434
+#: lxc/auth.go:59 lxc/auth.go:60 lxc/auth.go:1434 lxc/auth.go:1435
 #, fuzzy
 msgid "Manage groups"
 msgstr "クラスタグループを管理します"
 
-#: lxc/auth.go:1083 lxc/auth.go:1084
+#: lxc/auth.go:1084 lxc/auth.go:1085
 #, fuzzy
 msgid "Manage groups for the identity"
 msgstr "信頼済みのクライアントを管理します"
 
-#: lxc/auth.go:730 lxc/auth.go:731
+#: lxc/auth.go:731 lxc/auth.go:732
 #, fuzzy
 msgid "Manage identities"
 msgstr "デバイスを管理します"
 
-#: lxc/auth.go:1851 lxc/auth.go:1852
+#: lxc/auth.go:1852 lxc/auth.go:1853
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -4146,7 +4146,7 @@ msgstr "ネットワークゾーンレコードを管理します"
 msgid "Manage network zones"
 msgstr "ネットワークゾーンを管理します"
 
-#: lxc/auth.go:492 lxc/auth.go:493
+#: lxc/auth.go:493 lxc/auth.go:494
 #, fuzzy
 msgid "Manage permissions"
 msgstr "プロファイルを管理します"
@@ -4155,23 +4155,23 @@ msgstr "プロファイルを管理します"
 msgid "Manage profiles"
 msgstr "プロファイルを管理します"
 
-#: lxc/project.go:28 lxc/project.go:29
+#: lxc/project.go:29 lxc/project.go:30
 msgid "Manage projects"
 msgstr "プロジェクトを管理します"
 
-#: lxc/storage_bucket.go:731
+#: lxc/storage_bucket.go:732
 msgid "Manage storage bucket keys"
 msgstr "ストレージバケットの鍵を管理します"
 
-#: lxc/storage_bucket.go:732
+#: lxc/storage_bucket.go:733
 msgid "Manage storage bucket keys."
 msgstr "ストレージバケットの鍵を管理します。"
 
-#: lxc/storage_bucket.go:28
+#: lxc/storage_bucket.go:29
 msgid "Manage storage buckets"
 msgstr "ストレージバケットを管理します"
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:30
 msgid "Manage storage buckets."
 msgstr "ストレージバケットを管理します。"
 
@@ -4203,12 +4203,12 @@ msgstr "リモートサーバのリストを管理します"
 msgid "Manage trusted clients"
 msgstr "信頼済みのクライアントを管理します"
 
-#: lxc/auth.go:29 lxc/auth.go:30
+#: lxc/auth.go:30 lxc/auth.go:31
 #, fuzzy
 msgid "Manage user authorization"
 msgstr "クラスタロールを管理します"
 
-#: lxc/warning.go:28 lxc/warning.go:29
+#: lxc/warning.go:29 lxc/warning.go:30
 msgid "Manage warnings"
 msgstr "警告を管理します"
 
@@ -4272,17 +4272,17 @@ msgstr "マイグレーション API が失敗しました: %w"
 msgid "Migration operation failure: %w"
 msgstr "マイグレーションが失敗しました: %w"
 
-#: lxc/monitor.go:51
+#: lxc/monitor.go:52
 msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr "ログメッセージの最小レベル（pretty フォーマット使用時のみ利用可能）"
 
-#: lxc/storage_bucket.go:116 lxc/storage_bucket.go:216
-#: lxc/storage_bucket.go:292 lxc/storage_bucket.go:411
-#: lxc/storage_bucket.go:568 lxc/storage_bucket.go:660
-#: lxc/storage_bucket.go:802 lxc/storage_bucket.go:889
-#: lxc/storage_bucket.go:986 lxc/storage_bucket.go:1065
-#: lxc/storage_bucket.go:1188
+#: lxc/storage_bucket.go:117 lxc/storage_bucket.go:217
+#: lxc/storage_bucket.go:293 lxc/storage_bucket.go:412
+#: lxc/storage_bucket.go:569 lxc/storage_bucket.go:661
+#: lxc/storage_bucket.go:803 lxc/storage_bucket.go:890
+#: lxc/storage_bucket.go:987 lxc/storage_bucket.go:1066
+#: lxc/storage_bucket.go:1189
 msgid "Missing bucket name"
 msgstr "バケット名を指定する必要があります"
 
@@ -4301,23 +4301,23 @@ msgstr "クラスターグループ名がありません"
 msgid "Missing cluster member name"
 msgstr "クラスターメンバー名がありません"
 
-#: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1825
+#: lxc/auth.go:123 lxc/auth.go:177 lxc/auth.go:255 lxc/auth.go:417
+#: lxc/auth.go:466 lxc/auth.go:541 lxc/auth.go:600 lxc/auth.go:1826
 #, fuzzy
 msgid "Missing group name"
 msgstr "クラスターグループ名がありません"
 
-#: lxc/auth.go:862 lxc/auth.go:1003 lxc/auth.go:1131 lxc/auth.go:1189
+#: lxc/auth.go:863 lxc/auth.go:1004 lxc/auth.go:1132 lxc/auth.go:1190
 #, fuzzy
 msgid "Missing identity argument"
 msgstr "鍵の名前を指定する必要があります"
 
-#: lxc/auth.go:1495 lxc/auth.go:1548 lxc/auth.go:1614 lxc/auth.go:1776
+#: lxc/auth.go:1496 lxc/auth.go:1549 lxc/auth.go:1615 lxc/auth.go:1777
 #, fuzzy
 msgid "Missing identity provider group name"
 msgstr "クラスターグループ名がありません"
 
-#: lxc/auth.go:1899 lxc/auth.go:1952
+#: lxc/auth.go:1900 lxc/auth.go:1953
 #, fuzzy
 msgid "Missing identity provider group name argument"
 msgstr "クラスターグループ名がありません"
@@ -4326,12 +4326,12 @@ msgstr "クラスターグループ名がありません"
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
 #: lxc/config_template.go:377 lxc/profile.go:141 lxc/profile.go:222
-#: lxc/profile.go:808 lxc/rebuild.go:60
+#: lxc/profile.go:808 lxc/rebuild.go:61
 msgid "Missing instance name"
 msgstr "インスタンス名を指定する必要があります"
 
-#: lxc/storage_bucket.go:893 lxc/storage_bucket.go:990
-#: lxc/storage_bucket.go:1069 lxc/storage_bucket.go:1192
+#: lxc/storage_bucket.go:894 lxc/storage_bucket.go:991
+#: lxc/storage_bucket.go:1070 lxc/storage_bucket.go:1193
 msgid "Missing key name"
 msgstr "鍵の名前を指定する必要があります"
 
@@ -4396,13 +4396,13 @@ msgid "Missing peer name"
 msgstr "ピア名を指定する必要があります"
 
 #: lxc/storage.go:235 lxc/storage.go:313 lxc/storage.go:431 lxc/storage.go:509
-#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:112
-#: lxc/storage_bucket.go:212 lxc/storage_bucket.go:288
-#: lxc/storage_bucket.go:407 lxc/storage_bucket.go:482
-#: lxc/storage_bucket.go:564 lxc/storage_bucket.go:656
-#: lxc/storage_bucket.go:798 lxc/storage_bucket.go:885
-#: lxc/storage_bucket.go:982 lxc/storage_bucket.go:1061
-#: lxc/storage_bucket.go:1184 lxc/storage_volume.go:209
+#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:113
+#: lxc/storage_bucket.go:213 lxc/storage_bucket.go:289
+#: lxc/storage_bucket.go:408 lxc/storage_bucket.go:483
+#: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
+#: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
+#: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
 #: lxc/storage_volume.go:323 lxc/storage_volume.go:643
 #: lxc/storage_volume.go:750 lxc/storage_volume.go:841
 #: lxc/storage_volume.go:939 lxc/storage_volume.go:1053
@@ -4417,9 +4417,9 @@ msgstr "ストレージプール名を指定する必要があります"
 msgid "Missing profile name"
 msgstr "プロファイル名を指定する必要があります"
 
-#: lxc/profile.go:404 lxc/project.go:146 lxc/project.go:226 lxc/project.go:316
-#: lxc/project.go:433 lxc/project.go:622 lxc/project.go:691 lxc/project.go:819
-#: lxc/project.go:948
+#: lxc/profile.go:404 lxc/project.go:147 lxc/project.go:227 lxc/project.go:317
+#: lxc/project.go:434 lxc/project.go:623 lxc/project.go:692 lxc/project.go:820
+#: lxc/project.go:949
 msgid "Missing project name"
 msgstr "プロジェクト名を指定する必要があります"
 
@@ -4435,7 +4435,7 @@ msgstr "コピー元のボリューム名を指定する必要があります"
 msgid "Missing storage pool name"
 msgstr "ストレージプール名を指定する必要があります"
 
-#: lxc/file.go:598
+#: lxc/file.go:599
 msgid "Missing target directory"
 msgstr "コピー先のディレクトリを指定する必要があります"
 
@@ -4457,11 +4457,11 @@ msgstr "モデル: %s"
 msgid "Model: %v"
 msgstr "モデル: %v"
 
-#: lxc/monitor.go:32
+#: lxc/monitor.go:33
 msgid "Monitor a local or remote LXD server"
 msgstr "ローカルもしくはリモートの LXD サーバをモニタリングします"
 
-#: lxc/monitor.go:33
+#: lxc/monitor.go:34
 msgid ""
 "Monitor a local or remote LXD server\n"
 "\n"
@@ -4476,13 +4476,13 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr "複数のデバイスとマッチします。デバイス名を指定してください"
 
-#: lxc/file.go:285
+#: lxc/file.go:286
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 "ダウンロード対象のファイルが複数ありますが、コピー先がディレクトリではありま"
 "せん"
 
-#: lxc/file.go:985 lxc/file.go:986
+#: lxc/file.go:986 lxc/file.go:987
 msgid "Mount files from instances"
 msgstr "インスタンスからファイルをマウントします"
 
@@ -4557,13 +4557,13 @@ msgstr "ディレクトリからのインポートは root で実行する必要
 msgid "Must supply instance name for: "
 msgstr "インスタンス名を指定する必要があります: "
 
-#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:192
+#: lxc/auth.go:376 lxc/auth.go:816 lxc/auth.go:1736 lxc/cluster.go:192
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
-#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:565
-#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:511
-#: lxc/storage_bucket.go:831 lxc/storage_volume.go:1731
+#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:566
+#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1731
 msgid "NAME"
 msgstr "NAME"
 
@@ -4571,11 +4571,11 @@ msgstr "NAME"
 msgid "NAT"
 msgstr ""
 
-#: lxc/project.go:571
+#: lxc/project.go:572
 msgid "NETWORK ZONES"
 msgstr "NETWORK ZONES"
 
-#: lxc/project.go:570
+#: lxc/project.go:571
 msgid "NETWORKS"
 msgstr "NETWORKS"
 
@@ -4587,9 +4587,9 @@ msgstr "NIC:"
 msgid "NICs:"
 msgstr "NICs:"
 
-#: lxc/network.go:1058 lxc/operation.go:154 lxc/project.go:523
-#: lxc/project.go:528 lxc/project.go:533 lxc/project.go:538 lxc/project.go:543
-#: lxc/project.go:548 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
+#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:524
+#: lxc/project.go:529 lxc/project.go:534 lxc/project.go:539 lxc/project.go:544
+#: lxc/project.go:549 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
 msgid "NO"
 msgstr "NO"
 
@@ -4837,7 +4837,7 @@ msgstr "インスタンスもしくはカスタムボリュームのみをサポ
 msgid "Only managed networks can be modified"
 msgstr "管理対象のネットワークのみ変更できます"
 
-#: lxc/operation.go:86
+#: lxc/operation.go:87
 #, c-format
 msgid "Operation %s deleted"
 msgstr "バックグラウンド操作 %s を削除しました"
@@ -4884,11 +4884,11 @@ msgstr "PORTS"
 msgid "PROCESSES"
 msgstr "PROCESSES"
 
-#: lxc/list.go:576 lxc/project.go:567
+#: lxc/list.go:576 lxc/project.go:568
 msgid "PROFILES"
 msgstr "PROFILES"
 
-#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:212
+#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:213
 msgid "PROJECT"
 msgstr "PROJECT"
 
@@ -4950,26 +4950,26 @@ msgstr "ポートタイプ: %s"
 msgid "Ports:"
 msgstr "ポート:"
 
-#: lxc/file.go:1102
+#: lxc/file.go:1103
 msgid "Press ctrl+c to finish"
 msgstr "終了するには ctrl+c を押してください"
 
-#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:860
+#: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
-#: lxc/project.go:363 lxc/storage.go:360 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1151
+#: lxc/project.go:364 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1151
 #: lxc/storage_volume.go:1183
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 "再度エディタを開くためには Enter キーを、変更を取り消すには ctrl+c を入力しま"
 "す"
 
-#: lxc/monitor.go:48
+#: lxc/monitor.go:49
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr "Pretty レンダリング（--format=pretty の短縮系）"
 
@@ -5055,17 +5055,17 @@ msgstr "プロファイル:"
 msgid "Profiles: "
 msgstr "プロファイル: "
 
-#: lxc/project.go:172
+#: lxc/project.go:173
 #, c-format
 msgid "Project %s created"
 msgstr "プロジェクト %s を作成しました"
 
-#: lxc/project.go:236
+#: lxc/project.go:237
 #, c-format
 msgid "Project %s deleted"
 msgstr "プロジェクト %s を削除しました"
 
-#: lxc/project.go:637
+#: lxc/project.go:638
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr "プロジェクト名 %s を %s に変更しました"
@@ -5189,20 +5189,20 @@ msgstr "インスタンスをイメージとして出力します"
 msgid "Publishing instance: %s"
 msgstr "インスタンスの出力中: %s"
 
-#: lxc/file.go:241 lxc/file.go:242
+#: lxc/file.go:242 lxc/file.go:243
 msgid "Pull files from instances"
 msgstr "インスタンスからファイルを取得します"
 
-#: lxc/file.go:416 lxc/file.go:767
+#: lxc/file.go:417 lxc/file.go:768
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr "ファイル %s を %s から取得します: %%s"
 
-#: lxc/file.go:466 lxc/file.go:467
+#: lxc/file.go:467 lxc/file.go:468
 msgid "Push files into instances"
 msgstr "インスタンス内にファイルをコピーします"
 
-#: lxc/file.go:701 lxc/file.go:867
+#: lxc/file.go:702 lxc/file.go:868
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr "ファイル %s をコンテナ %s 内にコピーします: %%s"
@@ -5215,11 +5215,11 @@ msgstr "query のパスは / で始める必要があります"
 msgid "Query virtual machine images"
 msgstr "仮想マシンイメージを対象にします"
 
-#: lxc/project.go:983
+#: lxc/project.go:984
 msgid "RESOURCE"
 msgstr "RESOURCE"
 
-#: lxc/storage_bucket.go:833
+#: lxc/storage_bucket.go:834
 msgid "ROLE"
 msgstr "ROLE"
 
@@ -5232,17 +5232,17 @@ msgstr "ROLES"
 msgid "Read-Only: %v"
 msgstr "読み取り専用: %v"
 
-#: lxc/rebuild.go:31
+#: lxc/rebuild.go:32
 #, fuzzy
 msgid "Rebuild as an empty instance"
 msgstr "空のインスタンスを作成"
 
-#: lxc/rebuild.go:26
+#: lxc/rebuild.go:27
 #, fuzzy
 msgid "Rebuild instances"
 msgstr "インスタンスを一覧表示します"
 
-#: lxc/file.go:249 lxc/file.go:473
+#: lxc/file.go:250 lxc/file.go:474
 msgid "Recursively transfer files"
 msgstr "再帰的にファイルを転送します"
 
@@ -5269,7 +5269,7 @@ msgstr "イメージの更新中: %s"
 msgid "Remote %s already exists"
 msgstr "リモート %s は既に存在します"
 
-#: lxc/project.go:882 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
+#: lxc/project.go:883 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
 #: lxc/remote.go:994
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -5321,7 +5321,7 @@ msgstr "%s を消去しますか (yes/no): "
 msgid "Remove a cluster member from a cluster group"
 msgstr "クラスタグループからメンバを削除します"
 
-#: lxc/auth.go:1164 lxc/auth.go:1165
+#: lxc/auth.go:1165 lxc/auth.go:1166
 #, fuzzy
 msgid "Remove a group from an identity"
 msgstr "ACL からルールを削除します"
@@ -5358,7 +5358,7 @@ msgstr "ロードバランサーからバックエンドを削除します"
 msgid "Remove entries from a network zone record"
 msgstr "ネットワークゾーンレコードからエントリを削除します"
 
-#: lxc/auth.go:1927 lxc/auth.go:1928
+#: lxc/auth.go:1928 lxc/auth.go:1929
 #, fuzzy
 msgid "Remove identities from groups"
 msgstr "グループからメンバーを削除します"
@@ -5371,7 +5371,7 @@ msgstr "インスタンスのデバイスを削除します"
 msgid "Remove member from group"
 msgstr "グループからメンバーを削除します"
 
-#: lxc/auth.go:574 lxc/auth.go:575
+#: lxc/auth.go:575 lxc/auth.go:576
 #, fuzzy
 msgid "Remove permissions from groups"
 msgstr "グループからメンバーを削除します"
@@ -5417,12 +5417,12 @@ msgstr "クラスタメンバの名前を変更します"
 msgid "Rename aliases"
 msgstr "エイリアスの名前を変更します"
 
-#: lxc/auth.go:391 lxc/auth.go:392
+#: lxc/auth.go:392 lxc/auth.go:393
 #, fuzzy
 msgid "Rename groups"
 msgstr "リモートサーバ名を変更します"
 
-#: lxc/auth.go:1751 lxc/auth.go:1752
+#: lxc/auth.go:1752 lxc/auth.go:1753
 #, fuzzy
 msgid "Rename identity provider groups"
 msgstr "クラスタグループの名前を変更します"
@@ -5443,7 +5443,7 @@ msgstr "ネットワーク名を変更します"
 msgid "Rename profiles"
 msgstr "プロファイル名を変更します"
 
-#: lxc/project.go:589 lxc/project.go:590
+#: lxc/project.go:590 lxc/project.go:591
 msgid "Rename projects"
 msgstr "プロジェクト名を変更します"
 
@@ -5549,7 +5549,7 @@ msgstr "証明書追加トークンを失効（Revoke）させます"
 msgid "Revoke cluster member join token"
 msgstr "クラスターメンバーに join するためのトークンを失効（Revoke）させます"
 
-#: lxc/storage_bucket.go:862
+#: lxc/storage_bucket.go:863
 msgid "Role (admin or read-only)"
 msgstr "ロール（admin または read-only）"
 
@@ -5566,7 +5566,7 @@ msgstr "すべてのインスタンスに対してコマンドを実行します
 msgid "Run against all projects"
 msgstr "すべてのインスタンスに対してコマンドを実行します"
 
-#: lxc/warning.go:213
+#: lxc/warning.go:214
 msgid "SEVERITY"
 msgstr "SEVERITY"
 
@@ -5586,12 +5586,12 @@ msgstr "SOURCE"
 msgid "SR-IOV information:"
 msgstr "SR-IOV 情報:"
 
-#: lxc/file.go:1230
+#: lxc/file.go:1231
 #, c-format
 msgid "SSH client connected %q"
 msgstr "SSH クライアントが %q に接続されました"
 
-#: lxc/file.go:1231
+#: lxc/file.go:1232
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr "SSH クライアントが切断されました %q"
@@ -5605,11 +5605,11 @@ msgstr "STATE"
 msgid "STATIC"
 msgstr "STATIC"
 
-#: lxc/operation.go:173 lxc/warning.go:214
+#: lxc/operation.go:174 lxc/warning.go:215
 msgid "STATUS"
 msgstr "STATUS"
 
-#: lxc/project.go:569
+#: lxc/project.go:570
 msgid "STORAGE BUCKETS"
 msgstr "STORAGE BUCKETS"
 
@@ -5617,7 +5617,7 @@ msgstr "STORAGE BUCKETS"
 msgid "STORAGE POOL"
 msgstr "STORAGE POOL"
 
-#: lxc/project.go:568
+#: lxc/project.go:569
 msgid "STORAGE VOLUMES"
 msgstr "STORAGE VOLUMES"
 
@@ -5625,11 +5625,11 @@ msgstr "STORAGE VOLUMES"
 msgid "STP"
 msgstr "STP"
 
-#: lxc/storage_bucket.go:864
+#: lxc/storage_bucket.go:865
 msgid "Secret key (auto-generated if empty)"
 msgstr "秘密鍵（空白の場合自動生成）"
 
-#: lxc/storage_bucket.go:942
+#: lxc/storage_bucket.go:943
 #, c-format
 msgid "Secret key: %s"
 msgstr "秘密鍵: %s"
@@ -5669,7 +5669,7 @@ msgstr "インスタンスからファイルをマウントします"
 msgid "Set a cluster member's configuration keys"
 msgstr "クラスターメンバーの設定を行います"
 
-#: lxc/file.go:995
+#: lxc/file.go:996
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr "SSH SFTP リスナーを使う際の認証ユーザーを設定する"
 
@@ -5847,11 +5847,11 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 
-#: lxc/project.go:654
+#: lxc/project.go:655
 msgid "Set project configuration keys"
 msgstr "プロジェクトの設定項目を設定します"
 
-#: lxc/project.go:655
+#: lxc/project.go:656
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5864,11 +5864,11 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc project set [<remote>:]<project> <key> <value>"
 
-#: lxc/storage_bucket.go:534
+#: lxc/storage_bucket.go:535
 msgid "Set storage bucket configuration keys"
 msgstr "ストレージバケットの設定項目を設定します"
 
-#: lxc/storage_bucket.go:535
+#: lxc/storage_bucket.go:536
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -5920,15 +5920,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr "リモートの URL を設定します"
 
-#: lxc/file.go:476
+#: lxc/file.go:477
 msgid "Set the file's gid on push"
 msgstr "プッシュ時にファイルのgidを設定します"
 
-#: lxc/file.go:477
+#: lxc/file.go:478
 msgid "Set the file's perms on push"
 msgstr "プッシュ時にファイルのパーミションを設定します"
 
-#: lxc/file.go:475
+#: lxc/file.go:476
 msgid "Set the file's uid on push"
 msgstr "プッシュ時にファイルのuidを設定します"
 
@@ -5974,11 +5974,11 @@ msgstr "ネットワークゾーンレコードエントリを削除します"
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 msgid "Set the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:542
+#: lxc/storage_bucket.go:543
 #, fuzzy
 msgid "Set the key as a storage bucket property"
 msgstr "ストレージバケットに対する鍵を作成します"
@@ -5997,7 +5997,7 @@ msgstr "新しいストレージボリュームをプロファイルに追加し
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:993
+#: lxc/file.go:994
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 "マウントの代わりに address:port で SSH SFTP リスナーをセットアップします"
@@ -6010,7 +6010,7 @@ msgstr "デバッグメッセージをすべて表示します"
 msgid "Show all information messages"
 msgstr "詳細な情報を出力します"
 
-#: lxc/auth.go:1800 lxc/auth.go:1801
+#: lxc/auth.go:1801 lxc/auth.go:1802
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -6026,11 +6026,11 @@ msgstr "インスタンスのファイルテンプレートの内容を表示し
 msgid "Show details of a cluster member"
 msgstr "クラスタメンバの詳細を表示します"
 
-#: lxc/operation.go:192 lxc/operation.go:193
+#: lxc/operation.go:193 lxc/operation.go:194
 msgid "Show details on a background operation"
 msgstr "バックグラウンド操作の詳細を表示します"
 
-#: lxc/monitor.go:49
+#: lxc/monitor.go:50
 msgid "Show events from all projects"
 msgstr "すべてのプロジェクトのイベントを表示します"
 
@@ -6038,12 +6038,12 @@ msgstr "すべてのプロジェクトのイベントを表示します"
 msgid "Show full device configuration"
 msgstr "デバイスの設定をすべて表示します"
 
-#: lxc/auth.go:440 lxc/auth.go:441
+#: lxc/auth.go:441 lxc/auth.go:442
 #, fuzzy
 msgid "Show group configurations"
 msgstr "信頼済みクライアントの設定を表示します"
 
-#: lxc/auth.go:832
+#: lxc/auth.go:833
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -6125,15 +6125,15 @@ msgstr "ネットワークゾーンレコードの設定を表示します"
 msgid "Show profile configurations"
 msgstr "プロファイルの設定を表示します"
 
-#: lxc/project.go:786 lxc/project.go:787
+#: lxc/project.go:787 lxc/project.go:788
 msgid "Show project options"
 msgstr "プロジェクトの設定を表示します"
 
-#: lxc/storage_bucket.go:628 lxc/storage_bucket.go:629
+#: lxc/storage_bucket.go:629 lxc/storage_bucket.go:630
 msgid "Show storage bucket configurations"
 msgstr "ストレージバケットの設定を表示する"
 
-#: lxc/storage_bucket.go:1156 lxc/storage_bucket.go:1157
+#: lxc/storage_bucket.go:1157 lxc/storage_bucket.go:1158
 msgid "Show storage bucket key configurations"
 msgstr "ストレージバケットの鍵の設定を表示する"
 
@@ -6149,7 +6149,7 @@ msgstr "ストレージボリュームの設定を表示する"
 msgid "Show storage volume state information"
 msgstr "ストレージボリュームの状態を表示します"
 
-#: lxc/auth.go:895
+#: lxc/auth.go:896
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -6199,7 +6199,7 @@ msgstr "イメージについての情報を表示します"
 msgid "Show useful information about storage pools"
 msgstr "ストレージプールの情報を表示します"
 
-#: lxc/warning.go:302 lxc/warning.go:303
+#: lxc/warning.go:303 lxc/warning.go:304
 msgid "Show warning"
 msgstr "警告を表示します"
 
@@ -6283,22 +6283,22 @@ msgstr "インスタンスの停止に失敗しました！"
 msgid "Stopping the instance failed: %s"
 msgstr "インスタンスの停止に失敗しました: %s"
 
-#: lxc/storage_bucket.go:166
+#: lxc/storage_bucket.go:167
 #, c-format
 msgid "Storage bucket %s created"
 msgstr "ストレージバケット %s を作成しました"
 
-#: lxc/storage_bucket.go:233
+#: lxc/storage_bucket.go:234
 #, c-format
 msgid "Storage bucket %s deleted"
 msgstr "ストレージバケット %s を削除しました"
 
-#: lxc/storage_bucket.go:940
+#: lxc/storage_bucket.go:941
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr "ストレージバケットの鍵 %s を作成しました"
 
-#: lxc/storage_bucket.go:1006
+#: lxc/storage_bucket.go:1007
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr "ストレージバケットの鍵 %s を削除しました"
@@ -6367,7 +6367,7 @@ msgstr "Swap (現在値)"
 msgid "Swap (peak)"
 msgstr "Swap (ピーク)"
 
-#: lxc/project.go:847 lxc/project.go:848
+#: lxc/project.go:848 lxc/project.go:849
 msgid "Switch the current project"
 msgstr "現在のプロジェクトを切り替えます"
 
@@ -6383,10 +6383,10 @@ msgstr "TARGET"
 msgid "TOKEN"
 msgstr "TOKEN"
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1139
+#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1139
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
-#: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:171
-#: lxc/storage_volume.go:1730 lxc/warning.go:215
+#: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
+#: lxc/storage_volume.go:1730 lxc/warning.go:216
 msgid "TYPE"
 msgstr "TYPE"
 
@@ -6394,11 +6394,11 @@ msgstr "TYPE"
 msgid "Taken at"
 msgstr "取得日時"
 
-#: lxc/file.go:1032
+#: lxc/file.go:1033
 msgid "Target path and --listen flag cannot be used together"
 msgstr "ターゲットのパスと --listen オプションは同時に指定できません"
 
-#: lxc/file.go:1026
+#: lxc/file.go:1027
 msgid "Target path must be a directory"
 msgstr "ターゲットのパスはディレクトリでなければなりません"
 
@@ -6532,12 +6532,12 @@ msgstr "設定 %q はクラスタメンバー %q には存在しません"
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
 
-#: lxc/project.go:446
+#: lxc/project.go:447
 #, fuzzy, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
 
-#: lxc/storage_bucket.go:431
+#: lxc/storage_bucket.go:432
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage bucket %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
@@ -6745,7 +6745,7 @@ msgstr "タイプ: %s"
 msgid "Type: %s (ephemeral)"
 msgstr "タイプ: %s (ephemeral)"
 
-#: lxc/project.go:961
+#: lxc/project.go:962
 msgid "UNLIMITED"
 msgstr "UNLIMITED"
 
@@ -6757,17 +6757,17 @@ msgstr "UPLOAD DATE"
 msgid "URL"
 msgstr "URL"
 
-#: lxc/project.go:985 lxc/storage_volume.go:1735
+#: lxc/project.go:986 lxc/storage_volume.go:1735
 msgid "USAGE"
 msgstr "USAGE"
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:573
+#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:574
 #: lxc/storage.go:724 lxc/storage_volume.go:1734
 msgid "USED BY"
 msgstr "USED BY"
 
-#: lxc/warning.go:216
+#: lxc/warning.go:217
 msgid "UUID"
 msgstr "UUID"
 
@@ -6776,7 +6776,7 @@ msgstr "UUID"
 msgid "UUID: %v"
 msgstr "UUID: %v"
 
-#: lxc/file.go:197
+#: lxc/file.go:198
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr "テンポラリファイルを作成できません: %v"
@@ -6790,13 +6790,13 @@ msgstr "リモートサーバーが利用できません"
 msgid "Unknown certificate type %q"
 msgstr "未知の証明書タイプ %q"
 
-#: lxc/file.go:1253
+#: lxc/file.go:1254
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr "クライアント %q の未知のチャンネルタイプ: %s"
 
 #: lxc/image.go:1153 lxc/list.go:631 lxc/storage_volume.go:1772
-#: lxc/warning.go:241
+#: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr "未知のカラム名の短縮形です '%c' ('%s' 中)"
@@ -6806,7 +6806,7 @@ msgstr "未知のカラム名の短縮形です '%c' ('%s' 中)"
 msgid "Unknown console type %q"
 msgstr "未知のコンソールタイプ %q"
 
-#: lxc/file.go:807
+#: lxc/file.go:808
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr "未知のファイルタイプ '%s'"
@@ -6890,11 +6890,11 @@ msgstr "ネットワークゾーンレコードの設定を削除します"
 msgid "Unset profile configuration keys"
 msgstr "プロファイルの設定を削除します"
 
-#: lxc/project.go:742 lxc/project.go:743
+#: lxc/project.go:743 lxc/project.go:744
 msgid "Unset project configuration keys"
 msgstr "プロジェクトの設定を削除します"
 
-#: lxc/storage_bucket.go:697 lxc/storage_bucket.go:698
+#: lxc/storage_bucket.go:698 lxc/storage_bucket.go:699
 msgid "Unset storage bucket configuration keys"
 msgstr "ストレージバケットの設定を削除します"
 
@@ -6948,11 +6948,11 @@ msgstr "ネットワークゾーンレコードエントリを削除します"
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:747
+#: lxc/project.go:748
 msgid "Unset the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:701
+#: lxc/storage_bucket.go:702
 #, fuzzy
 msgid "Unset the key as a storage bucket property"
 msgstr "ストレージバケットに対する鍵を作成します"
@@ -7038,7 +7038,7 @@ msgstr "コマンドを実行する際のユーザ ID (UID) (デフォルト 0)"
 msgid "User aborted delete operation"
 msgstr "ユーザが削除操作を中断しました"
 
-#: lxc/file.go:71
+#: lxc/file.go:72
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -7077,11 +7077,11 @@ msgstr "ベンダ: %v (%v)"
 msgid "Verb: %s (%s)"
 msgstr "Verb: %s (%s)"
 
-#: lxc/auth.go:831
+#: lxc/auth.go:832
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:894
+#: lxc/auth.go:895
 #, fuzzy
 msgid "View the current identity"
 msgstr "現在のプロジェクトを切り替えます"
@@ -7115,15 +7115,15 @@ msgstr ""
 msgid "Whether or not to snapshot the instance's running state"
 msgstr "インスタンスの稼動状態のスナップショットを取得するかどうか"
 
-#: lxc/rebuild.go:27
+#: lxc/rebuild.go:28
 msgid ""
 "Wipe the instance root disk and re-initialize. The original image is used to "
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:156 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
+#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:526
+#: lxc/project.go:531 lxc/project.go:536 lxc/project.go:541 lxc/project.go:546
+#: lxc/project.go:551 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
 msgid "YES"
 msgstr "YES"
 
@@ -7144,7 +7144,7 @@ msgstr "コピー元のインスタンス名を指定してください"
 msgid "You must specify a source instance name"
 msgstr "コピー元のインスタンス名を指定してください"
 
-#: lxc/rebuild.go:119
+#: lxc/rebuild.go:120
 #, fuzzy
 msgid "You need to specify an image name or use --empty"
 msgstr ""
@@ -7158,12 +7158,12 @@ msgstr "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 
-#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1689
+#: lxc/auth.go:330 lxc/auth.go:763 lxc/auth.go:894 lxc/auth.go:1690
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
-#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
+#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
-#: lxc/operation.go:103 lxc/profile.go:700 lxc/project.go:467
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:68
+#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:468
+#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr "[<remote>:]"
 
@@ -7191,7 +7191,7 @@ msgstr "[<remote>:] [<filter>...]"
 msgid "[<remote>:] [<filters>...]"
 msgstr "[<remote>:] [<filters>...]"
 
-#: lxc/auth.go:1254
+#: lxc/auth.go:1255
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -7252,11 +7252,11 @@ msgstr "[<remote>:]<alias> <fingerprint>"
 msgid "[<remote>:]<alias> <new-name>"
 msgstr "[<remote>:]<alias> <new-name>"
 
-#: lxc/auth.go:830
+#: lxc/auth.go:831
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1926
+#: lxc/auth.go:1106 lxc/auth.go:1164 lxc/auth.go:1927
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -7264,13 +7264,13 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr "[<remote>:]<fingerprint>"
 
-#: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:954 lxc/auth.go:1470 lxc/cluster_group.go:168
+#: lxc/auth.go:97 lxc/auth.go:150 lxc/auth.go:200 lxc/auth.go:440
+#: lxc/auth.go:955 lxc/auth.go:1471 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr "[<remote>:]<group>"
 
-#: lxc/auth.go:514 lxc/auth.go:572
+#: lxc/auth.go:515 lxc/auth.go:573
 #, fuzzy
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
@@ -7281,22 +7281,22 @@ msgstr "[<remote>:]<pool> <volume> <key>=<value>..."
 msgid "[<remote>:]<group> <new-name>"
 msgstr "[<remote>:]<group> <new-name>"
 
-#: lxc/auth.go:389
+#: lxc/auth.go:390
 #, fuzzy
 msgid "[<remote>:]<group> <new_name>"
 msgstr "[<remote>:]<group> <new-name>"
 
-#: lxc/auth.go:1521 lxc/auth.go:1571 lxc/auth.go:1799
+#: lxc/auth.go:1522 lxc/auth.go:1572 lxc/auth.go:1800
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group>"
 msgstr "[<remote>:]<group>"
 
-#: lxc/auth.go:1873
+#: lxc/auth.go:1874
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr "[<remote>:]<member> <group>"
 
-#: lxc/auth.go:1749
+#: lxc/auth.go:1750
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr "[<remote>:]<group> <new-name>"
@@ -7317,7 +7317,7 @@ msgstr "[<remote>:]<image> <key> <value>"
 msgid "[<remote>:]<image> <remote>:"
 msgstr "[<remote>:]<image> <remote>:"
 
-#: lxc/rebuild.go:25
+#: lxc/rebuild.go:26
 #, fuzzy
 msgid "[<remote>:]<image> [<remote>:]<instance>"
 msgstr "[<remote>:]<image> [<remote>:][<name>]"
@@ -7403,21 +7403,21 @@ msgstr "[<remote>:]<instance> [flags] [--] <command line>"
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 
-#: lxc/file.go:170
+#: lxc/file.go:171
 msgid "[<remote>:]<instance>/<path>"
 msgstr "[<remote>:]<instance>/<path>"
 
-#: lxc/file.go:120
+#: lxc/file.go:121
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 
-#: lxc/file.go:240
+#: lxc/file.go:241
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 
-#: lxc/file.go:984
+#: lxc/file.go:985
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr "[<remote>:]<instance>[/<path>] [<target path>]"
 
@@ -7579,12 +7579,12 @@ msgstr "[<remote>:]<network> <listen_address> [key=value...]"
 msgid "[<remote>:]<network> [key=value...]"
 msgstr "[<remote>:]<network> [key=value...]"
 
-#: lxc/operation.go:53 lxc/operation.go:191
+#: lxc/operation.go:54 lxc/operation.go:192
 msgid "[<remote>:]<operation>"
 msgstr "[<remote>:]<operation>"
 
 #: lxc/storage.go:200 lxc/storage.go:259 lxc/storage.go:473 lxc/storage.go:844
-#: lxc/storage_bucket.go:454
+#: lxc/storage_bucket.go:455
 msgid "[<remote>:]<pool>"
 msgstr "[<remote>:]<pool>"
 
@@ -7592,22 +7592,22 @@ msgstr "[<remote>:]<pool>"
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr "[<remote>:]<pool> <backup file> [<volume name>]"
 
-#: lxc/storage_bucket.go:185 lxc/storage_bucket.go:247
-#: lxc/storage_bucket.go:627 lxc/storage_bucket.go:769
+#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:248
+#: lxc/storage_bucket.go:628 lxc/storage_bucket.go:770
 msgid "[<remote>:]<pool> <bucket>"
 msgstr "[<remote>:]<pool> <bucket>"
 
-#: lxc/storage_bucket.go:380 lxc/storage_bucket.go:696
-#: lxc/storage_bucket.go:850 lxc/storage_bucket.go:956
-#: lxc/storage_bucket.go:1020 lxc/storage_bucket.go:1155
+#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:697
+#: lxc/storage_bucket.go:851 lxc/storage_bucket.go:957
+#: lxc/storage_bucket.go:1021 lxc/storage_bucket.go:1156
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr "[<remote>:]<pool> <bucket> <key>"
 
-#: lxc/storage_bucket.go:533
+#: lxc/storage_bucket.go:534
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr "[<remote>:]<pool> <bucket> <key>=<value>..."
 
-#: lxc/storage_bucket.go:81
+#: lxc/storage_bucket.go:82
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr "[<remote>:]<pool> <bucket> [key=value...]"
 
@@ -7729,20 +7729,20 @@ msgstr "[<remote>:]<profile> <new-name>"
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr "[<remote>:]<profile> [<remote>:]<profile>"
 
-#: lxc/project.go:91 lxc/project.go:186 lxc/project.go:258 lxc/project.go:785
-#: lxc/project.go:846 lxc/project.go:913
+#: lxc/project.go:92 lxc/project.go:187 lxc/project.go:259 lxc/project.go:786
+#: lxc/project.go:847 lxc/project.go:914
 msgid "[<remote>:]<project>"
 msgstr "[<remote>:]<project>"
 
-#: lxc/project.go:394 lxc/project.go:741
+#: lxc/project.go:395 lxc/project.go:742
 msgid "[<remote>:]<project> <key>"
 msgstr "[<remote>:]<project> <key>"
 
-#: lxc/project.go:653
+#: lxc/project.go:654
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr "[<remote>:]<project> <key>=<value>..."
 
-#: lxc/project.go:587
+#: lxc/project.go:588
 msgid "[<remote>:]<project> <new-name>"
 msgstr "[<remote>:]<project> <new-name>"
 
@@ -7751,7 +7751,7 @@ msgstr "[<remote>:]<project> <new-name>"
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 
-#: lxc/warning.go:259 lxc/warning.go:301 lxc/warning.go:354
+#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
 msgid "[<remote>:]<warning-uuid>"
 msgstr "[<remote>:]<warning-uuid>"
 
@@ -7808,7 +7808,7 @@ msgstr "[<remote>] <IP|FQDN|URL|token>"
 msgid "[[<remote>:]<member>]"
 msgstr "[[<remote>:]<member>]"
 
-#: lxc/project.go:555 lxc/remote.go:739
+#: lxc/project.go:556 lxc/remote.go:739
 msgid "current"
 msgstr "現在値"
 
@@ -7861,7 +7861,7 @@ msgstr ""
 "lxc alias rename list my-list\n"
 "    エイリアス名 \"list\" を \"my-list\" に変更します。"
 
-#: lxc/auth.go:203
+#: lxc/auth.go:204
 #, fuzzy
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
@@ -7870,7 +7870,7 @@ msgstr ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    profile.yaml の内容でプロファイルを更新します"
 
-#: lxc/auth.go:958
+#: lxc/auth.go:959
 #, fuzzy
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
@@ -7880,7 +7880,7 @@ msgstr ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    profile.yaml の内容でプロファイルを更新します"
 
-#: lxc/auth.go:1575
+#: lxc/auth.go:1576
 #, fuzzy
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
@@ -7997,7 +7997,7 @@ msgstr ""
 "lxc export u1 backup0.tar.gz\n"
 "    u1 インスタンスのバックアップ tarball をダウンロードします。"
 
-#: lxc/file.go:988
+#: lxc/file.go:989
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -8006,7 +8006,7 @@ msgstr ""
 "   インスタンス foo の /root をローカルの fooroot ディレクトリにマウントしま"
 "す。"
 
-#: lxc/file.go:244
+#: lxc/file.go:245
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
@@ -8016,7 +8016,7 @@ msgstr ""
 "   インスタンスの /etc/hosts ファイルを取得し、カレントディレクトリにコピーし"
 "ます。"
 
-#: lxc/file.go:469
+#: lxc/file.go:470
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -8139,7 +8139,7 @@ msgstr ""
 "lxc list -c ns,user.comment:comment\n"
 "  実行状態とユーザコメントとともにインスタンスを一覧表示します。"
 
-#: lxc/monitor.go:37
+#: lxc/monitor.go:38
 msgid ""
 "lxc monitor --type=logging\n"
 "    Only show log messages.\n"
@@ -8259,7 +8259,7 @@ msgstr ""
 "lxc init ubuntu:22.04 u1 < config.yaml\n"
 "    config.yaml の設定を使ってインスタンスを作成します"
 
-#: lxc/operation.go:195
+#: lxc/operation.go:196
 msgid ""
 "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Show details on that operation UUID"
@@ -8328,7 +8328,7 @@ msgstr ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    profile.yaml の内容でプロファイルを更新します"
 
-#: lxc/project.go:95
+#: lxc/project.go:96
 #, fuzzy
 msgid ""
 "lxc project create p1\n"
@@ -8341,7 +8341,7 @@ msgstr ""
 "lxc init ubuntu:22.04 u1 < config.yaml\n"
 "    config.yaml の設定を使ってインスタンスを作成します"
 
-#: lxc/project.go:262
+#: lxc/project.go:263
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -8386,7 +8386,7 @@ msgstr ""
 "lxc restore u1 snap0\n"
 "    スナップショットからリストアします。"
 
-#: lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:85
 msgid ""
 "lxc storage bucket create p1 b01\n"
 "\tCreate a new storage bucket name b01 in storage pool p1\n"
@@ -8396,7 +8396,7 @@ msgid ""
 "of config.yaml"
 msgstr ""
 
-#: lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:251
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
@@ -8404,7 +8404,7 @@ msgstr ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    bucket.yaml の内容でストレージバケットを更新します。"
 
-#: lxc/storage_bucket.go:1023
+#: lxc/storage_bucket.go:1024
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
@@ -8412,7 +8412,7 @@ msgstr ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    key.yaml の内容でストレージバケットの鍵を更新します。"
 
-#: lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:854
 msgid ""
 "lxc storage bucket key create p1 b01 k1\n"
 "\tCreate a key called k1 for the bucket b01 in the pool p1.\n"
@@ -8422,7 +8422,7 @@ msgid ""
 "of config.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1158
+#: lxc/storage_bucket.go:1159
 msgid ""
 "lxc storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
@@ -8432,7 +8432,7 @@ msgstr ""
 "    \"default\" プール内の \"data\" という名前のバケットに対する \"foo\" とい"
 "う名前のバケットの鍵のプロパティを表示します。"
 
-#: lxc/storage_bucket.go:630
+#: lxc/storage_bucket.go:631
 msgid ""
 "lxc storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
@@ -8518,16 +8518,16 @@ msgstr "`lxc profile` コマンドを使ってください"
 msgid "space used"
 msgstr "使用量"
 
-#: lxc/file.go:1142
+#: lxc/file.go:1143
 msgid "sshfs has stopped"
 msgstr "sshfs が停止しました"
 
-#: lxc/file.go:1101
+#: lxc/file.go:1102
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr "sshfs で %q を %q にマウントします"
 
-#: lxc/file.go:1054
+#: lxc/file.go:1055
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 "sshfs が見つかりません。--listen オプションを使って SSH SFTP モードを試してみ"

--- a/po/ka.po
+++ b/po/ka.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-04 08:52-0600\n"
+"POT-Creation-Date: 2024-09-05 08:44-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: lxc/storage_bucket.go:260 lxc/storage_bucket.go:1033
+#: lxc/storage_bucket.go:261 lxc/storage_bucket.go:1034
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -130,7 +130,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:213
+#: lxc/auth.go:214
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -157,7 +157,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:968
+#: lxc/auth.go:969
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -178,7 +178,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1585
+#: lxc/auth.go:1586
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -388,7 +388,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:280
+#: lxc/project.go:281
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -430,12 +430,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:935
+#: lxc/file.go:936
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:825
+#: lxc/file.go:826
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -471,7 +471,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:142 lxc/rebuild.go:64
+#: lxc/init.go:142 lxc/rebuild.go:65
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -524,7 +524,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:465
+#: lxc/file.go:466
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -557,7 +557,7 @@ msgstr ""
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:813
+#: lxc/auth.go:814
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -565,11 +565,11 @@ msgstr ""
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/storage_bucket.go:863
+#: lxc/storage_bucket.go:864
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:941
+#: lxc/storage_bucket.go:942
 #, c-format
 msgid "Access key: %s"
 msgstr ""
@@ -578,7 +578,7 @@ msgstr ""
 msgid "Access the expanded configuration"
 msgstr ""
 
-#: lxc/warning.go:261 lxc/warning.go:262
+#: lxc/warning.go:262 lxc/warning.go:263
 msgid "Acknowledge warning"
 msgstr ""
 
@@ -595,11 +595,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1106 lxc/auth.go:1107
+#: lxc/auth.go:1107 lxc/auth.go:1108
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1874 lxc/auth.go:1875
+#: lxc/auth.go:1875 lxc/auth.go:1876
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -668,7 +668,7 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:515 lxc/auth.go:516
+#: lxc/auth.go:516 lxc/auth.go:517
 msgid "Add permissions to groups"
 msgstr ""
 
@@ -697,7 +697,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:169
+#: lxc/storage_bucket.go:170
 #, c-format
 msgid "Admin access key: %s"
 msgstr ""
@@ -707,7 +707,7 @@ msgstr ""
 msgid "Admin password (or token) for %s:"
 msgstr ""
 
-#: lxc/storage_bucket.go:170
+#: lxc/storage_bucket.go:171
 #, c-format
 msgid "Admin secret key: %s"
 msgstr ""
@@ -766,7 +766,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:342 lxc/rebuild.go:130
+#: lxc/init.go:342 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -866,12 +866,12 @@ msgstr ""
 
 #: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:318
 #: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
-#: lxc/network_zone.go:366 lxc/network_zone.go:1053 lxc/storage_bucket.go:141
+#: lxc/network_zone.go:366 lxc/network_zone.go:1053 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:159
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:160
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Bytes sent"
 msgstr ""
 
-#: lxc/operation.go:174
+#: lxc/operation.go:175
 msgid "CANCELABLE"
 msgstr ""
 
@@ -923,7 +923,7 @@ msgstr ""
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: lxc/warning.go:209
+#: lxc/warning.go:210
 msgid "COUNT"
 msgstr ""
 
@@ -949,7 +949,7 @@ msgstr ""
 msgid "CPUs (%s):"
 msgstr ""
 
-#: lxc/operation.go:175
+#: lxc/operation.go:176
 msgid "CREATED"
 msgstr ""
 
@@ -979,7 +979,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:340
+#: lxc/file.go:341
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1004,11 +1004,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:224
+#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:546
+#: lxc/file.go:547
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1017,7 +1017,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:160
+#: lxc/rebuild.go:161
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1140,13 +1140,13 @@ msgstr ""
 #: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
 #: lxc/network_load_balancer.go:1051 lxc/network_load_balancer.go:1125
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
-#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:90
-#: lxc/storage_bucket.go:190 lxc/storage_bucket.go:253
-#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:541
-#: lxc/storage_bucket.go:634 lxc/storage_bucket.go:700
-#: lxc/storage_bucket.go:775 lxc/storage_bucket.go:861
-#: lxc/storage_bucket.go:961 lxc/storage_bucket.go:1026
-#: lxc/storage_bucket.go:1162 lxc/storage_volume.go:394
+#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
+#: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
+#: lxc/storage_bucket.go:385 lxc/storage_bucket.go:542
+#: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
+#: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
+#: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
 #: lxc/storage_volume.go:612 lxc/storage_volume.go:717
 #: lxc/storage_volume.go:1005 lxc/storage_volume.go:1231
 #: lxc/storage_volume.go:1360 lxc/storage_volume.go:1848
@@ -1170,7 +1170,7 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1113 lxc/list.go:132 lxc/storage_volume.go:1589
-#: lxc/warning.go:92
+#: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
@@ -1198,7 +1198,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:100
+#: lxc/project.go:101
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1212,8 +1212,8 @@ msgstr ""
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
-#: lxc/project.go:362 lxc/storage.go:359 lxc/storage_bucket.go:348
-#: lxc/storage_bucket.go:1125 lxc/storage_volume.go:1150
+#: lxc/project.go:363 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1150
 #: lxc/storage_volume.go:1182
 #, c-format
 msgid "Config parsing error: %s"
@@ -1340,12 +1340,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:300 lxc/auth.go:1660
+#: lxc/auth.go:301 lxc/auth.go:1661
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1054
+#: lxc/auth.go:1055
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1394,15 +1394,15 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:248 lxc/file.go:474
+#: lxc/file.go:249 lxc/file.go:475
 msgid "Create any directories necessary"
 msgstr ""
 
-#: lxc/auth.go:97 lxc/auth.go:98
+#: lxc/auth.go:98 lxc/auth.go:99
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1471 lxc/auth.go:1472
+#: lxc/auth.go:1472 lxc/auth.go:1473
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1422,11 +1422,11 @@ msgstr ""
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_bucket.go:851 lxc/storage_bucket.go:852
+#: lxc/storage_bucket.go:852 lxc/storage_bucket.go:853
 msgid "Create key for a storage bucket"
 msgstr ""
 
-#: lxc/storage_bucket.go:82 lxc/storage_bucket.go:83
+#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
 msgid "Create new custom storage buckets"
 msgstr ""
 
@@ -1470,7 +1470,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:92 lxc/project.go:93
+#: lxc/project.go:93 lxc/project.go:94
 msgid "Create projects"
 msgstr ""
 
@@ -1505,13 +1505,13 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:376 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1135 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
-#: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:172
-#: lxc/profile.go:756 lxc/project.go:572 lxc/storage.go:723
-#: lxc/storage_bucket.go:512 lxc/storage_bucket.go:832
+#: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
+#: lxc/profile.go:756 lxc/project.go:573 lxc/storage.go:723
+#: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1732
 msgid "DESCRIPTION"
 msgstr ""
@@ -1536,7 +1536,7 @@ msgstr ""
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
-#: lxc/operation.go:55 lxc/operation.go:56
+#: lxc/operation.go:56 lxc/operation.go:57
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
@@ -1544,19 +1544,19 @@ msgstr ""
 msgid "Delete a cluster group"
 msgstr ""
 
-#: lxc/warning.go:360
+#: lxc/warning.go:361
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:122 lxc/file.go:123
+#: lxc/file.go:123 lxc/file.go:124
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/auth.go:151 lxc/auth.go:152
+#: lxc/auth.go:152 lxc/auth.go:153
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1523 lxc/auth.go:1524
+#: lxc/auth.go:1524 lxc/auth.go:1525
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1576,7 +1576,7 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/storage_bucket.go:957 lxc/storage_bucket.go:958
+#: lxc/storage_bucket.go:958 lxc/storage_bucket.go:959
 msgid "Delete key from a storage bucket"
 msgstr ""
 
@@ -1612,11 +1612,11 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:188 lxc/project.go:189
+#: lxc/project.go:189 lxc/project.go:190
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:187 lxc/storage_bucket.go:188
+#: lxc/storage_bucket.go:188 lxc/storage_bucket.go:189
 msgid "Delete storage buckets"
 msgstr ""
 
@@ -1628,20 +1628,20 @@ msgstr ""
 msgid "Delete storage volumes"
 msgstr ""
 
-#: lxc/warning.go:356 lxc/warning.go:357
+#: lxc/warning.go:357 lxc/warning.go:358
 msgid "Delete warning"
 msgstr ""
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:30 lxc/auth.go:59 lxc/auth.go:98
-#: lxc/auth.go:152 lxc/auth.go:201 lxc/auth.go:332 lxc/auth.go:392
-#: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
-#: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
-#: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
-#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1434 lxc/auth.go:1472
-#: lxc/auth.go:1524 lxc/auth.go:1573 lxc/auth.go:1692 lxc/auth.go:1752
-#: lxc/auth.go:1801 lxc/auth.go:1852 lxc/auth.go:1875 lxc/auth.go:1928
+#: lxc/alias.go:214 lxc/auth.go:31 lxc/auth.go:60 lxc/auth.go:99
+#: lxc/auth.go:153 lxc/auth.go:202 lxc/auth.go:333 lxc/auth.go:393
+#: lxc/auth.go:442 lxc/auth.go:494 lxc/auth.go:517 lxc/auth.go:576
+#: lxc/auth.go:732 lxc/auth.go:766 lxc/auth.go:833 lxc/auth.go:896
+#: lxc/auth.go:957 lxc/auth.go:1085 lxc/auth.go:1108 lxc/auth.go:1166
+#: lxc/auth.go:1235 lxc/auth.go:1257 lxc/auth.go:1435 lxc/auth.go:1473
+#: lxc/auth.go:1525 lxc/auth.go:1574 lxc/auth.go:1693 lxc/auth.go:1753
+#: lxc/auth.go:1802 lxc/auth.go:1853 lxc/auth.go:1876 lxc/auth.go:1929
 #: lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215 lxc/cluster.go:272
 #: lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:484 lxc/cluster.go:528
 #: lxc/cluster.go:586 lxc/cluster.go:677 lxc/cluster.go:770 lxc/cluster.go:893
@@ -1665,15 +1665,15 @@ msgstr ""
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:83 lxc/file.go:123 lxc/file.go:172
-#: lxc/file.go:242 lxc/file.go:467 lxc/file.go:986 lxc/image.go:38
+#: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
+#: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
 #: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
 #: lxc/image.go:697 lxc/image.go:946 lxc/image.go:1088 lxc/image.go:1415
 #: lxc/image.go:1506 lxc/image.go:1572 lxc/image.go:1636 lxc/image.go:1699
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:38 lxc/network.go:33
+#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33
 #: lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405
 #: lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793
 #: lxc/network.go:874 lxc/network.go:1005 lxc/network.go:1106
@@ -1707,27 +1707,27 @@ msgstr ""
 #: lxc/network_zone.go:909 lxc/network_zone.go:985 lxc/network_zone.go:1083
 #: lxc/network_zone.go:1172 lxc/network_zone.go:1219 lxc/network_zone.go:1349
 #: lxc/network_zone.go:1410 lxc/network_zone.go:1425 lxc/network_zone.go:1483
-#: lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:106
-#: lxc/operation.go:193 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
+#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
+#: lxc/operation.go:194 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
 #: lxc/profile.go:271 lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493
 #: lxc/profile.go:629 lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860
-#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:29
-#: lxc/project.go:93 lxc/project.go:189 lxc/project.go:260 lxc/project.go:396
-#: lxc/project.go:470 lxc/project.go:590 lxc/project.go:655 lxc/project.go:743
-#: lxc/project.go:787 lxc/project.go:848 lxc/project.go:915 lxc/publish.go:34
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:35 lxc/remote.go:91
+#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:30
+#: lxc/project.go:94 lxc/project.go:190 lxc/project.go:261 lxc/project.go:397
+#: lxc/project.go:471 lxc/project.go:591 lxc/project.go:656 lxc/project.go:744
+#: lxc/project.go:788 lxc/project.go:849 lxc/project.go:916 lxc/publish.go:34
+#: lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91
 #: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853
 #: lxc/remote.go:917 lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24
 #: lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203
 #: lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655
 #: lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940
-#: lxc/storage_bucket.go:29 lxc/storage_bucket.go:83 lxc/storage_bucket.go:188
-#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:382
-#: lxc/storage_bucket.go:458 lxc/storage_bucket.go:535
-#: lxc/storage_bucket.go:629 lxc/storage_bucket.go:698
-#: lxc/storage_bucket.go:732 lxc/storage_bucket.go:773
-#: lxc/storage_bucket.go:852 lxc/storage_bucket.go:958
-#: lxc/storage_bucket.go:1022 lxc/storage_bucket.go:1157
+#: lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189
+#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:383
+#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:536
+#: lxc/storage_bucket.go:630 lxc/storage_bucket.go:699
+#: lxc/storage_bucket.go:733 lxc/storage_bucket.go:774
+#: lxc/storage_bucket.go:853 lxc/storage_bucket.go:959
+#: lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158
 #: lxc/storage_volume.go:58 lxc/storage_volume.go:169 lxc/storage_volume.go:283
 #: lxc/storage_volume.go:390 lxc/storage_volume.go:605
 #: lxc/storage_volume.go:714 lxc/storage_volume.go:801
@@ -1738,8 +1738,8 @@ msgstr ""
 #: lxc/storage_volume.go:2064 lxc/storage_volume.go:2222
 #: lxc/storage_volume.go:2343 lxc/storage_volume.go:2405
 #: lxc/storage_volume.go:2541 lxc/storage_volume.go:2624
-#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:29
-#: lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
+#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:30
+#: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
@@ -1826,7 +1826,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:994
+#: lxc/file.go:995
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1892,7 +1892,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:74
+#: lxc/file.go:75
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1902,7 +1902,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:955 lxc/auth.go:956
+#: lxc/auth.go:956 lxc/auth.go:957
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1910,15 +1910,15 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:171 lxc/file.go:172
+#: lxc/file.go:172 lxc/file.go:173
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/auth.go:200 lxc/auth.go:201
+#: lxc/auth.go:201 lxc/auth.go:202
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1572 lxc/auth.go:1573
+#: lxc/auth.go:1573 lxc/auth.go:1574
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -1974,15 +1974,15 @@ msgstr ""
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:259 lxc/project.go:260
+#: lxc/project.go:260 lxc/project.go:261
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:248 lxc/storage_bucket.go:249
+#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:250
 msgid "Edit storage bucket configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:1021 lxc/storage_bucket.go:1022
+#: lxc/storage_bucket.go:1022 lxc/storage_bucket.go:1023
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
@@ -1999,7 +1999,7 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1147 lxc/list.go:622 lxc/storage_volume.go:1766
-#: lxc/warning.go:235
+#: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2054,7 +2054,7 @@ msgstr ""
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
-#: lxc/project.go:718 lxc/storage.go:812 lxc/storage_bucket.go:602
+#: lxc/project.go:719 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2155 lxc/storage_volume.go:2193
 #, c-format
 msgid "Error setting properties: %v"
@@ -2068,8 +2068,8 @@ msgstr ""
 #: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
-#: lxc/profile.go:981 lxc/project.go:712 lxc/storage.go:806
-#: lxc/storage_bucket.go:596 lxc/storage_volume.go:2149
+#: lxc/profile.go:981 lxc/project.go:713 lxc/storage.go:806
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2149
 #: lxc/storage_volume.go:2187
 #, c-format
 msgid "Error unsetting property: %v"
@@ -2089,7 +2089,7 @@ msgstr ""
 msgid "Evacuating cluster member: %s"
 msgstr ""
 
-#: lxc/monitor.go:50
+#: lxc/monitor.go:51
 msgid "Event type to listen for"
 msgstr ""
 
@@ -2176,16 +2176,16 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/warning.go:210
+#: lxc/warning.go:211
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1237
+#: lxc/file.go:1238
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1260
+#: lxc/file.go:1261
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2200,12 +2200,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1287
+#: lxc/file.go:1288
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1072
+#: lxc/file.go:1073
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2235,7 +2235,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1193
+#: lxc/file.go:1194
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2250,7 +2250,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1198
+#: lxc/file.go:1199
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2260,12 +2260,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1098
+#: lxc/file.go:1099
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1225
+#: lxc/file.go:1226
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2304,7 +2304,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1210
+#: lxc/file.go:1211
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2319,7 +2319,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:820
+#: lxc/file.go:821
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2334,7 +2334,7 @@ msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
 #: lxc/network.go:1044 lxc/network_acl.go:133 lxc/network_zone.go:124
-#: lxc/operation.go:136
+#: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
 
@@ -2399,21 +2399,21 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
+#: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:770 lxc/auth.go:1697
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1114 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:57
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
-#: lxc/operation.go:108 lxc/profile.go:707 lxc/project.go:472
-#: lxc/project.go:917 lxc/remote.go:690 lxc/storage.go:657
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:774
-#: lxc/storage_volume.go:1608 lxc/warning.go:93
+#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:473
+#: lxc/project.go:918 lxc/remote.go:690 lxc/storage.go:657
+#: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
+#: lxc/storage_volume.go:1608 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
-#: lxc/monitor.go:52
+#: lxc/monitor.go:53
 msgid "Format (json|pretty|yaml)"
 msgstr ""
 
@@ -2457,7 +2457,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:817 lxc/auth.go:1736
+#: lxc/auth.go:818 lxc/auth.go:1737
 msgid "GROUPS"
 msgstr ""
 
@@ -2473,7 +2473,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:914 lxc/project.go:915
+#: lxc/project.go:915 lxc/project.go:916
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2521,11 +2521,11 @@ msgstr ""
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:400
+#: lxc/project.go:401
 msgid "Get the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:385
+#: lxc/storage_bucket.go:386
 msgid "Get the key as a storage bucket property"
 msgstr ""
 
@@ -2585,11 +2585,11 @@ msgstr ""
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:395 lxc/project.go:396
+#: lxc/project.go:396 lxc/project.go:397
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:382
+#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:383
 msgid "Get values for storage bucket configuration keys"
 msgstr ""
 
@@ -2606,17 +2606,17 @@ msgstr ""
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: lxc/auth.go:136
+#: lxc/auth.go:137
 #, c-format
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:186
+#: lxc/auth.go:187
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:426 lxc/auth.go:1786
+#: lxc/auth.go:427 lxc/auth.go:1787
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2641,27 +2641,27 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1310
+#: lxc/file.go:1311
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1299
+#: lxc/file.go:1300
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1122
+#: lxc/file.go:1123
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1132
+#: lxc/file.go:1133
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:966 lxc/operation.go:170
+#: lxc/network.go:966 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2675,11 +2675,11 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:816
+#: lxc/auth.go:817
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:566
+#: lxc/project.go:567
 msgid "IMAGES"
 msgstr ""
 
@@ -2707,17 +2707,17 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1508
+#: lxc/auth.go:1509
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1558
+#: lxc/auth.go:1559
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
 
-#: lxc/rebuild.go:32
+#: lxc/rebuild.go:33
 msgid "If an instance is running, stop it and then rebuild it"
 msgstr ""
 
@@ -2838,7 +2838,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1233 lxc/auth.go:1234
+#: lxc/auth.go:1234 lxc/auth.go:1235
 msgid "Inspect permissions"
 msgstr ""
 
@@ -2846,11 +2846,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1124
+#: lxc/file.go:1125
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1301
+#: lxc/file.go:1302
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2868,7 +2868,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1044
+#: lxc/file.go:1045
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2877,7 +2877,7 @@ msgstr ""
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/rebuild.go:74
+#: lxc/rebuild.go:75
 #, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
@@ -2910,7 +2910,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/monitor.go:70
+#: lxc/monitor.go:71
 #, c-format
 msgid "Invalid format: %s"
 msgstr ""
@@ -2920,7 +2920,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1039
+#: lxc/file.go:1040
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2962,7 +2962,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:147
+#: lxc/file.go:148
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2978,12 +2978,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:313
+#: lxc/file.go:314
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:495
+#: lxc/file.go:496
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2997,7 +2997,7 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/warning.go:212
 msgid "LAST SEEN"
 msgstr ""
 
@@ -3005,7 +3005,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:984
+#: lxc/project.go:985
 msgid "LIMIT"
 msgstr ""
 
@@ -3014,8 +3014,8 @@ msgid "LISTEN ADDRESS"
 msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
-#: lxc/network_load_balancer.go:165 lxc/operation.go:177
-#: lxc/storage_bucket.go:516 lxc/storage_volume.go:1739 lxc/warning.go:220
+#: lxc/network_load_balancer.go:165 lxc/operation.go:178
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1739 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3089,7 +3089,7 @@ msgstr ""
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/warning.go:94
+#: lxc/warning.go:95
 msgid "List all warnings"
 msgstr ""
 
@@ -3133,19 +3133,19 @@ msgstr ""
 msgid "List available storage pools"
 msgstr ""
 
-#: lxc/operation.go:105 lxc/operation.go:106
+#: lxc/operation.go:106 lxc/operation.go:107
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:331 lxc/auth.go:332
+#: lxc/auth.go:332 lxc/auth.go:333
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:764 lxc/auth.go:765
+#: lxc/auth.go:765 lxc/auth.go:766
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1691 lxc/auth.go:1692
+#: lxc/auth.go:1692 lxc/auth.go:1693
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3294,11 +3294,11 @@ msgstr ""
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/operation.go:109
+#: lxc/operation.go:110
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1255 lxc/auth.go:1256
+#: lxc/auth.go:1256 lxc/auth.go:1257
 msgid "List permissions"
 msgstr ""
 
@@ -3306,15 +3306,15 @@ msgstr ""
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:469 lxc/project.go:470
+#: lxc/project.go:470 lxc/project.go:471
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:771 lxc/storage_bucket.go:773
+#: lxc/storage_bucket.go:772 lxc/storage_bucket.go:774
 msgid "List storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:456 lxc/storage_bucket.go:458
+#: lxc/storage_bucket.go:457 lxc/storage_bucket.go:459
 msgid "List storage buckets"
 msgstr ""
 
@@ -3350,11 +3350,11 @@ msgstr ""
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/warning.go:70
+#: lxc/warning.go:71
 msgid "List warnings"
 msgstr ""
 
-#: lxc/warning.go:71
+#: lxc/warning.go:72
 msgid ""
 "List warnings\n"
 "\n"
@@ -3377,7 +3377,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/operation.go:23 lxc/operation.go:24
+#: lxc/operation.go:24 lxc/operation.go:25
 msgid "List, show and delete background operations"
 msgstr ""
 
@@ -3386,7 +3386,7 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/monitor.go:79
+#: lxc/monitor.go:80
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
@@ -3490,23 +3490,23 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:82 lxc/file.go:83
+#: lxc/file.go:83 lxc/file.go:84
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1433 lxc/auth.go:1434
+#: lxc/auth.go:59 lxc/auth.go:60 lxc/auth.go:1434 lxc/auth.go:1435
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1083 lxc/auth.go:1084
+#: lxc/auth.go:1084 lxc/auth.go:1085
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:730 lxc/auth.go:731
+#: lxc/auth.go:731 lxc/auth.go:732
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1851 lxc/auth.go:1852
+#: lxc/auth.go:1852 lxc/auth.go:1853
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3597,7 +3597,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:492 lxc/auth.go:493
+#: lxc/auth.go:493 lxc/auth.go:494
 msgid "Manage permissions"
 msgstr ""
 
@@ -3605,23 +3605,23 @@ msgstr ""
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:28 lxc/project.go:29
+#: lxc/project.go:29 lxc/project.go:30
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:731
+#: lxc/storage_bucket.go:732
 msgid "Manage storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:732
+#: lxc/storage_bucket.go:733
 msgid "Manage storage bucket keys."
 msgstr ""
 
-#: lxc/storage_bucket.go:28
+#: lxc/storage_bucket.go:29
 msgid "Manage storage buckets"
 msgstr ""
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:30
 msgid "Manage storage buckets."
 msgstr ""
 
@@ -3649,11 +3649,11 @@ msgstr ""
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/auth.go:29 lxc/auth.go:30
+#: lxc/auth.go:30 lxc/auth.go:31
 msgid "Manage user authorization"
 msgstr ""
 
-#: lxc/warning.go:28 lxc/warning.go:29
+#: lxc/warning.go:29 lxc/warning.go:30
 msgid "Manage warnings"
 msgstr ""
 
@@ -3717,17 +3717,17 @@ msgstr ""
 msgid "Migration operation failure: %w"
 msgstr ""
 
-#: lxc/monitor.go:51
+#: lxc/monitor.go:52
 msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: lxc/storage_bucket.go:116 lxc/storage_bucket.go:216
-#: lxc/storage_bucket.go:292 lxc/storage_bucket.go:411
-#: lxc/storage_bucket.go:568 lxc/storage_bucket.go:660
-#: lxc/storage_bucket.go:802 lxc/storage_bucket.go:889
-#: lxc/storage_bucket.go:986 lxc/storage_bucket.go:1065
-#: lxc/storage_bucket.go:1188
+#: lxc/storage_bucket.go:117 lxc/storage_bucket.go:217
+#: lxc/storage_bucket.go:293 lxc/storage_bucket.go:412
+#: lxc/storage_bucket.go:569 lxc/storage_bucket.go:661
+#: lxc/storage_bucket.go:803 lxc/storage_bucket.go:890
+#: lxc/storage_bucket.go:987 lxc/storage_bucket.go:1066
+#: lxc/storage_bucket.go:1189
 msgid "Missing bucket name"
 msgstr ""
 
@@ -3746,20 +3746,20 @@ msgstr ""
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1825
+#: lxc/auth.go:123 lxc/auth.go:177 lxc/auth.go:255 lxc/auth.go:417
+#: lxc/auth.go:466 lxc/auth.go:541 lxc/auth.go:600 lxc/auth.go:1826
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:862 lxc/auth.go:1003 lxc/auth.go:1131 lxc/auth.go:1189
+#: lxc/auth.go:863 lxc/auth.go:1004 lxc/auth.go:1132 lxc/auth.go:1190
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1495 lxc/auth.go:1548 lxc/auth.go:1614 lxc/auth.go:1776
+#: lxc/auth.go:1496 lxc/auth.go:1549 lxc/auth.go:1615 lxc/auth.go:1777
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1899 lxc/auth.go:1952
+#: lxc/auth.go:1900 lxc/auth.go:1953
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -3767,12 +3767,12 @@ msgstr ""
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
 #: lxc/config_template.go:377 lxc/profile.go:141 lxc/profile.go:222
-#: lxc/profile.go:808 lxc/rebuild.go:60
+#: lxc/profile.go:808 lxc/rebuild.go:61
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/storage_bucket.go:893 lxc/storage_bucket.go:990
-#: lxc/storage_bucket.go:1069 lxc/storage_bucket.go:1192
+#: lxc/storage_bucket.go:894 lxc/storage_bucket.go:991
+#: lxc/storage_bucket.go:1070 lxc/storage_bucket.go:1193
 msgid "Missing key name"
 msgstr ""
 
@@ -3837,13 +3837,13 @@ msgid "Missing peer name"
 msgstr ""
 
 #: lxc/storage.go:235 lxc/storage.go:313 lxc/storage.go:431 lxc/storage.go:509
-#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:112
-#: lxc/storage_bucket.go:212 lxc/storage_bucket.go:288
-#: lxc/storage_bucket.go:407 lxc/storage_bucket.go:482
-#: lxc/storage_bucket.go:564 lxc/storage_bucket.go:656
-#: lxc/storage_bucket.go:798 lxc/storage_bucket.go:885
-#: lxc/storage_bucket.go:982 lxc/storage_bucket.go:1061
-#: lxc/storage_bucket.go:1184 lxc/storage_volume.go:209
+#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:113
+#: lxc/storage_bucket.go:213 lxc/storage_bucket.go:289
+#: lxc/storage_bucket.go:408 lxc/storage_bucket.go:483
+#: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
+#: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
+#: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
 #: lxc/storage_volume.go:323 lxc/storage_volume.go:643
 #: lxc/storage_volume.go:750 lxc/storage_volume.go:841
 #: lxc/storage_volume.go:939 lxc/storage_volume.go:1053
@@ -3858,9 +3858,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:404 lxc/project.go:146 lxc/project.go:226 lxc/project.go:316
-#: lxc/project.go:433 lxc/project.go:622 lxc/project.go:691 lxc/project.go:819
-#: lxc/project.go:948
+#: lxc/profile.go:404 lxc/project.go:147 lxc/project.go:227 lxc/project.go:317
+#: lxc/project.go:434 lxc/project.go:623 lxc/project.go:692 lxc/project.go:820
+#: lxc/project.go:949
 msgid "Missing project name"
 msgstr ""
 
@@ -3876,7 +3876,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:598
+#: lxc/file.go:599
 msgid "Missing target directory"
 msgstr ""
 
@@ -3898,11 +3898,11 @@ msgstr ""
 msgid "Model: %v"
 msgstr ""
 
-#: lxc/monitor.go:32
+#: lxc/monitor.go:33
 msgid "Monitor a local or remote LXD server"
 msgstr ""
 
-#: lxc/monitor.go:33
+#: lxc/monitor.go:34
 msgid ""
 "Monitor a local or remote LXD server\n"
 "\n"
@@ -3914,11 +3914,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:285
+#: lxc/file.go:286
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:985 lxc/file.go:986
+#: lxc/file.go:986 lxc/file.go:987
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3980,13 +3980,13 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:192
+#: lxc/auth.go:376 lxc/auth.go:816 lxc/auth.go:1736 lxc/cluster.go:192
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
-#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:565
-#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:511
-#: lxc/storage_bucket.go:831 lxc/storage_volume.go:1731
+#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:566
+#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1731
 msgid "NAME"
 msgstr ""
 
@@ -3994,11 +3994,11 @@ msgstr ""
 msgid "NAT"
 msgstr ""
 
-#: lxc/project.go:571
+#: lxc/project.go:572
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:570
+#: lxc/project.go:571
 msgid "NETWORKS"
 msgstr ""
 
@@ -4010,9 +4010,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/operation.go:154 lxc/project.go:523
-#: lxc/project.go:528 lxc/project.go:533 lxc/project.go:538 lxc/project.go:543
-#: lxc/project.go:548 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
+#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:524
+#: lxc/project.go:529 lxc/project.go:534 lxc/project.go:539 lxc/project.go:544
+#: lxc/project.go:549 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
 msgid "NO"
 msgstr ""
 
@@ -4257,7 +4257,7 @@ msgstr ""
 msgid "Only managed networks can be modified"
 msgstr ""
 
-#: lxc/operation.go:86
+#: lxc/operation.go:87
 #, c-format
 msgid "Operation %s deleted"
 msgstr ""
@@ -4304,11 +4304,11 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:567
+#: lxc/list.go:576 lxc/project.go:568
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:212
+#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4370,24 +4370,24 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1102
+#: lxc/file.go:1103
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:860
+#: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
-#: lxc/project.go:363 lxc/storage.go:360 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1151
+#: lxc/project.go:364 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1151
 #: lxc/storage_volume.go:1183
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
-#: lxc/monitor.go:48
+#: lxc/monitor.go:49
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
@@ -4473,17 +4473,17 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:172
+#: lxc/project.go:173
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:236
+#: lxc/project.go:237
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:637
+#: lxc/project.go:638
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -4604,20 +4604,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:241 lxc/file.go:242
+#: lxc/file.go:242 lxc/file.go:243
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:416 lxc/file.go:767
+#: lxc/file.go:417 lxc/file.go:768
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:466 lxc/file.go:467
+#: lxc/file.go:467 lxc/file.go:468
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:701 lxc/file.go:867
+#: lxc/file.go:702 lxc/file.go:868
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4630,11 +4630,11 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:983
+#: lxc/project.go:984
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/storage_bucket.go:833
+#: lxc/storage_bucket.go:834
 msgid "ROLE"
 msgstr ""
 
@@ -4647,15 +4647,15 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/rebuild.go:31
+#: lxc/rebuild.go:32
 msgid "Rebuild as an empty instance"
 msgstr ""
 
-#: lxc/rebuild.go:26
+#: lxc/rebuild.go:27
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:249 lxc/file.go:473
+#: lxc/file.go:250 lxc/file.go:474
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4682,7 +4682,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:882 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
+#: lxc/project.go:883 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
 #: lxc/remote.go:994
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4733,7 +4733,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1164 lxc/auth.go:1165
+#: lxc/auth.go:1165 lxc/auth.go:1166
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4769,7 +4769,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1927 lxc/auth.go:1928
+#: lxc/auth.go:1928 lxc/auth.go:1929
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4781,7 +4781,7 @@ msgstr ""
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:574 lxc/auth.go:575
+#: lxc/auth.go:575 lxc/auth.go:576
 msgid "Remove permissions from groups"
 msgstr ""
 
@@ -4826,11 +4826,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:391 lxc/auth.go:392
+#: lxc/auth.go:392 lxc/auth.go:393
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1751 lxc/auth.go:1752
+#: lxc/auth.go:1752 lxc/auth.go:1753
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -4850,7 +4850,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:589 lxc/project.go:590
+#: lxc/project.go:590 lxc/project.go:591
 msgid "Rename projects"
 msgstr ""
 
@@ -4948,7 +4948,7 @@ msgstr ""
 msgid "Revoke cluster member join token"
 msgstr ""
 
-#: lxc/storage_bucket.go:862
+#: lxc/storage_bucket.go:863
 msgid "Role (admin or read-only)"
 msgstr ""
 
@@ -4964,7 +4964,7 @@ msgstr ""
 msgid "Run against all projects"
 msgstr ""
 
-#: lxc/warning.go:213
+#: lxc/warning.go:214
 msgid "SEVERITY"
 msgstr ""
 
@@ -4984,12 +4984,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1231
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1231
+#: lxc/file.go:1232
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5003,11 +5003,11 @@ msgstr ""
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:173 lxc/warning.go:214
+#: lxc/operation.go:174 lxc/warning.go:215
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:569
+#: lxc/project.go:570
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5015,7 +5015,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:569
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -5023,11 +5023,11 @@ msgstr ""
 msgid "STP"
 msgstr ""
 
-#: lxc/storage_bucket.go:864
+#: lxc/storage_bucket.go:865
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:942
+#: lxc/storage_bucket.go:943
 #, c-format
 msgid "Secret key: %s"
 msgstr ""
@@ -5065,7 +5065,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:995
+#: lxc/file.go:996
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5203,11 +5203,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:654
+#: lxc/project.go:655
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:655
+#: lxc/project.go:656
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5216,11 +5216,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage_bucket.go:534
+#: lxc/storage_bucket.go:535
 msgid "Set storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:535
+#: lxc/storage_bucket.go:536
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -5259,15 +5259,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:476
+#: lxc/file.go:477
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:477
+#: lxc/file.go:478
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:475
+#: lxc/file.go:476
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5307,11 +5307,11 @@ msgstr ""
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 msgid "Set the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:542
+#: lxc/storage_bucket.go:543
 msgid "Set the key as a storage bucket property"
 msgstr ""
 
@@ -5327,7 +5327,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:993
+#: lxc/file.go:994
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5339,7 +5339,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1800 lxc/auth.go:1801
+#: lxc/auth.go:1801 lxc/auth.go:1802
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5355,11 +5355,11 @@ msgstr ""
 msgid "Show details of a cluster member"
 msgstr ""
 
-#: lxc/operation.go:192 lxc/operation.go:193
+#: lxc/operation.go:193 lxc/operation.go:194
 msgid "Show details on a background operation"
 msgstr ""
 
-#: lxc/monitor.go:49
+#: lxc/monitor.go:50
 msgid "Show events from all projects"
 msgstr ""
 
@@ -5367,11 +5367,11 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:440 lxc/auth.go:441
+#: lxc/auth.go:441 lxc/auth.go:442
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:832
+#: lxc/auth.go:833
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5452,15 +5452,15 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:786 lxc/project.go:787
+#: lxc/project.go:787 lxc/project.go:788
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage_bucket.go:628 lxc/storage_bucket.go:629
+#: lxc/storage_bucket.go:629 lxc/storage_bucket.go:630
 msgid "Show storage bucket configurations"
 msgstr ""
 
-#: lxc/storage_bucket.go:1156 lxc/storage_bucket.go:1157
+#: lxc/storage_bucket.go:1157 lxc/storage_bucket.go:1158
 msgid "Show storage bucket key configurations"
 msgstr ""
 
@@ -5476,7 +5476,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:895
+#: lxc/auth.go:896
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5526,7 +5526,7 @@ msgstr ""
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: lxc/warning.go:302 lxc/warning.go:303
+#: lxc/warning.go:303 lxc/warning.go:304
 msgid "Show warning"
 msgstr ""
 
@@ -5610,22 +5610,22 @@ msgstr ""
 msgid "Stopping the instance failed: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:166
+#: lxc/storage_bucket.go:167
 #, c-format
 msgid "Storage bucket %s created"
 msgstr ""
 
-#: lxc/storage_bucket.go:233
+#: lxc/storage_bucket.go:234
 #, c-format
 msgid "Storage bucket %s deleted"
 msgstr ""
 
-#: lxc/storage_bucket.go:940
+#: lxc/storage_bucket.go:941
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr ""
 
-#: lxc/storage_bucket.go:1006
+#: lxc/storage_bucket.go:1007
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr ""
@@ -5694,7 +5694,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:847 lxc/project.go:848
+#: lxc/project.go:848 lxc/project.go:849
 msgid "Switch the current project"
 msgstr ""
 
@@ -5710,10 +5710,10 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1139
+#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1139
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
-#: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:171
-#: lxc/storage_volume.go:1730 lxc/warning.go:215
+#: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
+#: lxc/storage_volume.go:1730 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
@@ -5721,11 +5721,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1032
+#: lxc/file.go:1033
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1026
+#: lxc/file.go:1027
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5853,12 +5853,12 @@ msgstr ""
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:446
+#: lxc/project.go:447
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
 
-#: lxc/storage_bucket.go:431
+#: lxc/storage_bucket.go:432
 #, c-format
 msgid "The property %q does not exist on the storage bucket %q: %v"
 msgstr ""
@@ -6043,7 +6043,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:961
+#: lxc/project.go:962
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6055,17 +6055,17 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:985 lxc/storage_volume.go:1735
+#: lxc/project.go:986 lxc/storage_volume.go:1735
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:573
+#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:574
 #: lxc/storage.go:724 lxc/storage_volume.go:1734
 msgid "USED BY"
 msgstr ""
 
-#: lxc/warning.go:216
+#: lxc/warning.go:217
 msgid "UUID"
 msgstr ""
 
@@ -6074,7 +6074,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:197
+#: lxc/file.go:198
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6088,13 +6088,13 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1253
+#: lxc/file.go:1254
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1153 lxc/list.go:631 lxc/storage_volume.go:1772
-#: lxc/warning.go:241
+#: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6104,7 +6104,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:807
+#: lxc/file.go:808
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6187,11 +6187,11 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:742 lxc/project.go:743
+#: lxc/project.go:743 lxc/project.go:744
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:697 lxc/storage_bucket.go:698
+#: lxc/storage_bucket.go:698 lxc/storage_bucket.go:699
 msgid "Unset storage bucket configuration keys"
 msgstr ""
 
@@ -6239,11 +6239,11 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:747
+#: lxc/project.go:748
 msgid "Unset the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:701
+#: lxc/storage_bucket.go:702
 msgid "Unset the key as a storage bucket property"
 msgstr ""
 
@@ -6322,7 +6322,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:71
+#: lxc/file.go:72
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6359,11 +6359,11 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:831
+#: lxc/auth.go:832
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:894
+#: lxc/auth.go:895
 msgid "View the current identity"
 msgstr ""
 
@@ -6394,15 +6394,15 @@ msgstr ""
 msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
-#: lxc/rebuild.go:27
+#: lxc/rebuild.go:28
 msgid ""
 "Wipe the instance root disk and re-initialize. The original image is used to "
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:156 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
+#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:526
+#: lxc/project.go:531 lxc/project.go:536 lxc/project.go:541 lxc/project.go:546
+#: lxc/project.go:551 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
 msgid "YES"
 msgstr ""
 
@@ -6422,7 +6422,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/rebuild.go:119
+#: lxc/rebuild.go:120
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
@@ -6434,12 +6434,12 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1689
+#: lxc/auth.go:330 lxc/auth.go:763 lxc/auth.go:894 lxc/auth.go:1690
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
-#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
+#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
-#: lxc/operation.go:103 lxc/profile.go:700 lxc/project.go:467
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:68
+#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:468
+#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6467,7 +6467,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1254
+#: lxc/auth.go:1255
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6528,11 +6528,11 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:830
+#: lxc/auth.go:831
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1926
+#: lxc/auth.go:1106 lxc/auth.go:1164 lxc/auth.go:1927
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6540,13 +6540,13 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:954 lxc/auth.go:1470 lxc/cluster_group.go:168
+#: lxc/auth.go:97 lxc/auth.go:150 lxc/auth.go:200 lxc/auth.go:440
+#: lxc/auth.go:955 lxc/auth.go:1471 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:514 lxc/auth.go:572
+#: lxc/auth.go:515 lxc/auth.go:573
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
@@ -6556,19 +6556,19 @@ msgstr ""
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:389
+#: lxc/auth.go:390
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1521 lxc/auth.go:1571 lxc/auth.go:1799
+#: lxc/auth.go:1522 lxc/auth.go:1572 lxc/auth.go:1800
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1873
+#: lxc/auth.go:1874
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1749
+#: lxc/auth.go:1750
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -6588,7 +6588,7 @@ msgstr ""
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
-#: lxc/rebuild.go:25
+#: lxc/rebuild.go:26
 msgid "[<remote>:]<image> [<remote>:]<instance>"
 msgstr ""
 
@@ -6671,20 +6671,20 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:170
+#: lxc/file.go:171
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:120
+#: lxc/file.go:121
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:240
+#: lxc/file.go:241
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:984
+#: lxc/file.go:985
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6835,12 +6835,12 @@ msgstr ""
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
-#: lxc/operation.go:53 lxc/operation.go:191
+#: lxc/operation.go:54 lxc/operation.go:192
 msgid "[<remote>:]<operation>"
 msgstr ""
 
 #: lxc/storage.go:200 lxc/storage.go:259 lxc/storage.go:473 lxc/storage.go:844
-#: lxc/storage_bucket.go:454
+#: lxc/storage_bucket.go:455
 msgid "[<remote>:]<pool>"
 msgstr ""
 
@@ -6848,22 +6848,22 @@ msgstr ""
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
-#: lxc/storage_bucket.go:185 lxc/storage_bucket.go:247
-#: lxc/storage_bucket.go:627 lxc/storage_bucket.go:769
+#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:248
+#: lxc/storage_bucket.go:628 lxc/storage_bucket.go:770
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
 
-#: lxc/storage_bucket.go:380 lxc/storage_bucket.go:696
-#: lxc/storage_bucket.go:850 lxc/storage_bucket.go:956
-#: lxc/storage_bucket.go:1020 lxc/storage_bucket.go:1155
+#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:697
+#: lxc/storage_bucket.go:851 lxc/storage_bucket.go:957
+#: lxc/storage_bucket.go:1021 lxc/storage_bucket.go:1156
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
 
-#: lxc/storage_bucket.go:533
+#: lxc/storage_bucket.go:534
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_bucket.go:81
+#: lxc/storage_bucket.go:82
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
 
@@ -6978,20 +6978,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:91 lxc/project.go:186 lxc/project.go:258 lxc/project.go:785
-#: lxc/project.go:846 lxc/project.go:913
+#: lxc/project.go:92 lxc/project.go:187 lxc/project.go:259 lxc/project.go:786
+#: lxc/project.go:847 lxc/project.go:914
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:394 lxc/project.go:741
+#: lxc/project.go:395 lxc/project.go:742
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:653
+#: lxc/project.go:654
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:587
+#: lxc/project.go:588
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -6999,7 +6999,7 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:259 lxc/warning.go:301 lxc/warning.go:354
+#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
@@ -7055,7 +7055,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:555 lxc/remote.go:739
+#: lxc/project.go:556 lxc/remote.go:739
 msgid "current"
 msgstr ""
 
@@ -7102,20 +7102,20 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/auth.go:203
+#: lxc/auth.go:204
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:958
+#: lxc/auth.go:959
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1575
+#: lxc/auth.go:1576
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7193,20 +7193,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:988
+#: lxc/file.go:989
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:244
+#: lxc/file.go:245
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:470
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7288,7 +7288,7 @@ msgid ""
 "  List instances with their running state and user comment."
 msgstr ""
 
-#: lxc/monitor.go:37
+#: lxc/monitor.go:38
 msgid ""
 "lxc monitor --type=logging\n"
 "    Only show log messages.\n"
@@ -7364,7 +7364,7 @@ msgid ""
 "    Create record r1 for zone z1 with configuration from config.yaml"
 msgstr ""
 
-#: lxc/operation.go:195
+#: lxc/operation.go:196
 msgid ""
 "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Show details on that operation UUID"
@@ -7407,7 +7407,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:95
+#: lxc/project.go:96
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7415,7 +7415,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:262
+#: lxc/project.go:263
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7446,7 +7446,7 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:85
 msgid ""
 "lxc storage bucket create p1 b01\n"
 "\tCreate a new storage bucket name b01 in storage pool p1\n"
@@ -7456,19 +7456,19 @@ msgid ""
 "of config.yaml"
 msgstr ""
 
-#: lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:251
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1023
+#: lxc/storage_bucket.go:1024
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:854
 msgid ""
 "lxc storage bucket key create p1 b01 k1\n"
 "\tCreate a key called k1 for the bucket b01 in the pool p1.\n"
@@ -7478,14 +7478,14 @@ msgid ""
 "of config.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1158
+#: lxc/storage_bucket.go:1159
 msgid ""
 "lxc storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_bucket.go:630
+#: lxc/storage_bucket.go:631
 msgid ""
 "lxc storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
@@ -7555,16 +7555,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1142
+#: lxc/file.go:1143
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1101
+#: lxc/file.go:1102
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1054
+#: lxc/file.go:1055
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-04 08:52-0600\n"
+"POT-Creation-Date: 2024-09-05 08:44-0400\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Korean <https://hosted.weblate.org/projects/linux-containers/"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: lxc/storage_bucket.go:260 lxc/storage_bucket.go:1033
+#: lxc/storage_bucket.go:261 lxc/storage_bucket.go:1034
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -133,7 +133,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:213
+#: lxc/auth.go:214
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -160,7 +160,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:968
+#: lxc/auth.go:969
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -181,7 +181,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1585
+#: lxc/auth.go:1586
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -391,7 +391,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:280
+#: lxc/project.go:281
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -433,12 +433,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:935
+#: lxc/file.go:936
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:825
+#: lxc/file.go:826
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -474,7 +474,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:142 lxc/rebuild.go:64
+#: lxc/init.go:142 lxc/rebuild.go:65
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -527,7 +527,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:465
+#: lxc/file.go:466
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -560,7 +560,7 @@ msgstr ""
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:813
+#: lxc/auth.go:814
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -568,11 +568,11 @@ msgstr ""
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/storage_bucket.go:863
+#: lxc/storage_bucket.go:864
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:941
+#: lxc/storage_bucket.go:942
 #, c-format
 msgid "Access key: %s"
 msgstr ""
@@ -581,7 +581,7 @@ msgstr ""
 msgid "Access the expanded configuration"
 msgstr ""
 
-#: lxc/warning.go:261 lxc/warning.go:262
+#: lxc/warning.go:262 lxc/warning.go:263
 msgid "Acknowledge warning"
 msgstr ""
 
@@ -598,11 +598,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1106 lxc/auth.go:1107
+#: lxc/auth.go:1107 lxc/auth.go:1108
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1874 lxc/auth.go:1875
+#: lxc/auth.go:1875 lxc/auth.go:1876
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -671,7 +671,7 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:515 lxc/auth.go:516
+#: lxc/auth.go:516 lxc/auth.go:517
 msgid "Add permissions to groups"
 msgstr ""
 
@@ -700,7 +700,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:169
+#: lxc/storage_bucket.go:170
 #, c-format
 msgid "Admin access key: %s"
 msgstr ""
@@ -710,7 +710,7 @@ msgstr ""
 msgid "Admin password (or token) for %s:"
 msgstr ""
 
-#: lxc/storage_bucket.go:170
+#: lxc/storage_bucket.go:171
 #, c-format
 msgid "Admin secret key: %s"
 msgstr ""
@@ -769,7 +769,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:342 lxc/rebuild.go:130
+#: lxc/init.go:342 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -869,12 +869,12 @@ msgstr ""
 
 #: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:318
 #: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
-#: lxc/network_zone.go:366 lxc/network_zone.go:1053 lxc/storage_bucket.go:141
+#: lxc/network_zone.go:366 lxc/network_zone.go:1053 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:159
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:160
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -914,7 +914,7 @@ msgstr ""
 msgid "Bytes sent"
 msgstr ""
 
-#: lxc/operation.go:174
+#: lxc/operation.go:175
 msgid "CANCELABLE"
 msgstr ""
 
@@ -926,7 +926,7 @@ msgstr ""
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: lxc/warning.go:209
+#: lxc/warning.go:210
 msgid "COUNT"
 msgstr ""
 
@@ -952,7 +952,7 @@ msgstr ""
 msgid "CPUs (%s):"
 msgstr ""
 
-#: lxc/operation.go:175
+#: lxc/operation.go:176
 msgid "CREATED"
 msgstr ""
 
@@ -982,7 +982,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:340
+#: lxc/file.go:341
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1007,11 +1007,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:224
+#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:546
+#: lxc/file.go:547
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1020,7 +1020,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:160
+#: lxc/rebuild.go:161
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1143,13 +1143,13 @@ msgstr ""
 #: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
 #: lxc/network_load_balancer.go:1051 lxc/network_load_balancer.go:1125
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
-#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:90
-#: lxc/storage_bucket.go:190 lxc/storage_bucket.go:253
-#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:541
-#: lxc/storage_bucket.go:634 lxc/storage_bucket.go:700
-#: lxc/storage_bucket.go:775 lxc/storage_bucket.go:861
-#: lxc/storage_bucket.go:961 lxc/storage_bucket.go:1026
-#: lxc/storage_bucket.go:1162 lxc/storage_volume.go:394
+#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
+#: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
+#: lxc/storage_bucket.go:385 lxc/storage_bucket.go:542
+#: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
+#: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
+#: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
 #: lxc/storage_volume.go:612 lxc/storage_volume.go:717
 #: lxc/storage_volume.go:1005 lxc/storage_volume.go:1231
 #: lxc/storage_volume.go:1360 lxc/storage_volume.go:1848
@@ -1173,7 +1173,7 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1113 lxc/list.go:132 lxc/storage_volume.go:1589
-#: lxc/warning.go:92
+#: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
@@ -1201,7 +1201,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:100
+#: lxc/project.go:101
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1215,8 +1215,8 @@ msgstr ""
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
-#: lxc/project.go:362 lxc/storage.go:359 lxc/storage_bucket.go:348
-#: lxc/storage_bucket.go:1125 lxc/storage_volume.go:1150
+#: lxc/project.go:363 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1150
 #: lxc/storage_volume.go:1182
 #, c-format
 msgid "Config parsing error: %s"
@@ -1343,12 +1343,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:300 lxc/auth.go:1660
+#: lxc/auth.go:301 lxc/auth.go:1661
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1054
+#: lxc/auth.go:1055
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1397,15 +1397,15 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:248 lxc/file.go:474
+#: lxc/file.go:249 lxc/file.go:475
 msgid "Create any directories necessary"
 msgstr ""
 
-#: lxc/auth.go:97 lxc/auth.go:98
+#: lxc/auth.go:98 lxc/auth.go:99
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1471 lxc/auth.go:1472
+#: lxc/auth.go:1472 lxc/auth.go:1473
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1425,11 +1425,11 @@ msgstr ""
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_bucket.go:851 lxc/storage_bucket.go:852
+#: lxc/storage_bucket.go:852 lxc/storage_bucket.go:853
 msgid "Create key for a storage bucket"
 msgstr ""
 
-#: lxc/storage_bucket.go:82 lxc/storage_bucket.go:83
+#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
 msgid "Create new custom storage buckets"
 msgstr ""
 
@@ -1473,7 +1473,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:92 lxc/project.go:93
+#: lxc/project.go:93 lxc/project.go:94
 msgid "Create projects"
 msgstr ""
 
@@ -1508,13 +1508,13 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:376 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1135 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
-#: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:172
-#: lxc/profile.go:756 lxc/project.go:572 lxc/storage.go:723
-#: lxc/storage_bucket.go:512 lxc/storage_bucket.go:832
+#: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
+#: lxc/profile.go:756 lxc/project.go:573 lxc/storage.go:723
+#: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1732
 msgid "DESCRIPTION"
 msgstr ""
@@ -1539,7 +1539,7 @@ msgstr ""
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
-#: lxc/operation.go:55 lxc/operation.go:56
+#: lxc/operation.go:56 lxc/operation.go:57
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
@@ -1547,19 +1547,19 @@ msgstr ""
 msgid "Delete a cluster group"
 msgstr ""
 
-#: lxc/warning.go:360
+#: lxc/warning.go:361
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:122 lxc/file.go:123
+#: lxc/file.go:123 lxc/file.go:124
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/auth.go:151 lxc/auth.go:152
+#: lxc/auth.go:152 lxc/auth.go:153
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1523 lxc/auth.go:1524
+#: lxc/auth.go:1524 lxc/auth.go:1525
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1579,7 +1579,7 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/storage_bucket.go:957 lxc/storage_bucket.go:958
+#: lxc/storage_bucket.go:958 lxc/storage_bucket.go:959
 msgid "Delete key from a storage bucket"
 msgstr ""
 
@@ -1615,11 +1615,11 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:188 lxc/project.go:189
+#: lxc/project.go:189 lxc/project.go:190
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:187 lxc/storage_bucket.go:188
+#: lxc/storage_bucket.go:188 lxc/storage_bucket.go:189
 msgid "Delete storage buckets"
 msgstr ""
 
@@ -1631,20 +1631,20 @@ msgstr ""
 msgid "Delete storage volumes"
 msgstr ""
 
-#: lxc/warning.go:356 lxc/warning.go:357
+#: lxc/warning.go:357 lxc/warning.go:358
 msgid "Delete warning"
 msgstr ""
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:30 lxc/auth.go:59 lxc/auth.go:98
-#: lxc/auth.go:152 lxc/auth.go:201 lxc/auth.go:332 lxc/auth.go:392
-#: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
-#: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
-#: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
-#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1434 lxc/auth.go:1472
-#: lxc/auth.go:1524 lxc/auth.go:1573 lxc/auth.go:1692 lxc/auth.go:1752
-#: lxc/auth.go:1801 lxc/auth.go:1852 lxc/auth.go:1875 lxc/auth.go:1928
+#: lxc/alias.go:214 lxc/auth.go:31 lxc/auth.go:60 lxc/auth.go:99
+#: lxc/auth.go:153 lxc/auth.go:202 lxc/auth.go:333 lxc/auth.go:393
+#: lxc/auth.go:442 lxc/auth.go:494 lxc/auth.go:517 lxc/auth.go:576
+#: lxc/auth.go:732 lxc/auth.go:766 lxc/auth.go:833 lxc/auth.go:896
+#: lxc/auth.go:957 lxc/auth.go:1085 lxc/auth.go:1108 lxc/auth.go:1166
+#: lxc/auth.go:1235 lxc/auth.go:1257 lxc/auth.go:1435 lxc/auth.go:1473
+#: lxc/auth.go:1525 lxc/auth.go:1574 lxc/auth.go:1693 lxc/auth.go:1753
+#: lxc/auth.go:1802 lxc/auth.go:1853 lxc/auth.go:1876 lxc/auth.go:1929
 #: lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215 lxc/cluster.go:272
 #: lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:484 lxc/cluster.go:528
 #: lxc/cluster.go:586 lxc/cluster.go:677 lxc/cluster.go:770 lxc/cluster.go:893
@@ -1668,15 +1668,15 @@ msgstr ""
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:83 lxc/file.go:123 lxc/file.go:172
-#: lxc/file.go:242 lxc/file.go:467 lxc/file.go:986 lxc/image.go:38
+#: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
+#: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
 #: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
 #: lxc/image.go:697 lxc/image.go:946 lxc/image.go:1088 lxc/image.go:1415
 #: lxc/image.go:1506 lxc/image.go:1572 lxc/image.go:1636 lxc/image.go:1699
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:38 lxc/network.go:33
+#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33
 #: lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405
 #: lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793
 #: lxc/network.go:874 lxc/network.go:1005 lxc/network.go:1106
@@ -1710,27 +1710,27 @@ msgstr ""
 #: lxc/network_zone.go:909 lxc/network_zone.go:985 lxc/network_zone.go:1083
 #: lxc/network_zone.go:1172 lxc/network_zone.go:1219 lxc/network_zone.go:1349
 #: lxc/network_zone.go:1410 lxc/network_zone.go:1425 lxc/network_zone.go:1483
-#: lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:106
-#: lxc/operation.go:193 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
+#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
+#: lxc/operation.go:194 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
 #: lxc/profile.go:271 lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493
 #: lxc/profile.go:629 lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860
-#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:29
-#: lxc/project.go:93 lxc/project.go:189 lxc/project.go:260 lxc/project.go:396
-#: lxc/project.go:470 lxc/project.go:590 lxc/project.go:655 lxc/project.go:743
-#: lxc/project.go:787 lxc/project.go:848 lxc/project.go:915 lxc/publish.go:34
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:35 lxc/remote.go:91
+#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:30
+#: lxc/project.go:94 lxc/project.go:190 lxc/project.go:261 lxc/project.go:397
+#: lxc/project.go:471 lxc/project.go:591 lxc/project.go:656 lxc/project.go:744
+#: lxc/project.go:788 lxc/project.go:849 lxc/project.go:916 lxc/publish.go:34
+#: lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91
 #: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853
 #: lxc/remote.go:917 lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24
 #: lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203
 #: lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655
 #: lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940
-#: lxc/storage_bucket.go:29 lxc/storage_bucket.go:83 lxc/storage_bucket.go:188
-#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:382
-#: lxc/storage_bucket.go:458 lxc/storage_bucket.go:535
-#: lxc/storage_bucket.go:629 lxc/storage_bucket.go:698
-#: lxc/storage_bucket.go:732 lxc/storage_bucket.go:773
-#: lxc/storage_bucket.go:852 lxc/storage_bucket.go:958
-#: lxc/storage_bucket.go:1022 lxc/storage_bucket.go:1157
+#: lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189
+#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:383
+#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:536
+#: lxc/storage_bucket.go:630 lxc/storage_bucket.go:699
+#: lxc/storage_bucket.go:733 lxc/storage_bucket.go:774
+#: lxc/storage_bucket.go:853 lxc/storage_bucket.go:959
+#: lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158
 #: lxc/storage_volume.go:58 lxc/storage_volume.go:169 lxc/storage_volume.go:283
 #: lxc/storage_volume.go:390 lxc/storage_volume.go:605
 #: lxc/storage_volume.go:714 lxc/storage_volume.go:801
@@ -1741,8 +1741,8 @@ msgstr ""
 #: lxc/storage_volume.go:2064 lxc/storage_volume.go:2222
 #: lxc/storage_volume.go:2343 lxc/storage_volume.go:2405
 #: lxc/storage_volume.go:2541 lxc/storage_volume.go:2624
-#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:29
-#: lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
+#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:30
+#: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
@@ -1829,7 +1829,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:994
+#: lxc/file.go:995
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1895,7 +1895,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:74
+#: lxc/file.go:75
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1905,7 +1905,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:955 lxc/auth.go:956
+#: lxc/auth.go:956 lxc/auth.go:957
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1913,15 +1913,15 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:171 lxc/file.go:172
+#: lxc/file.go:172 lxc/file.go:173
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/auth.go:200 lxc/auth.go:201
+#: lxc/auth.go:201 lxc/auth.go:202
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1572 lxc/auth.go:1573
+#: lxc/auth.go:1573 lxc/auth.go:1574
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -1977,15 +1977,15 @@ msgstr ""
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:259 lxc/project.go:260
+#: lxc/project.go:260 lxc/project.go:261
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:248 lxc/storage_bucket.go:249
+#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:250
 msgid "Edit storage bucket configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:1021 lxc/storage_bucket.go:1022
+#: lxc/storage_bucket.go:1022 lxc/storage_bucket.go:1023
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
@@ -2002,7 +2002,7 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1147 lxc/list.go:622 lxc/storage_volume.go:1766
-#: lxc/warning.go:235
+#: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2057,7 +2057,7 @@ msgstr ""
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
-#: lxc/project.go:718 lxc/storage.go:812 lxc/storage_bucket.go:602
+#: lxc/project.go:719 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2155 lxc/storage_volume.go:2193
 #, c-format
 msgid "Error setting properties: %v"
@@ -2071,8 +2071,8 @@ msgstr ""
 #: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
-#: lxc/profile.go:981 lxc/project.go:712 lxc/storage.go:806
-#: lxc/storage_bucket.go:596 lxc/storage_volume.go:2149
+#: lxc/profile.go:981 lxc/project.go:713 lxc/storage.go:806
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2149
 #: lxc/storage_volume.go:2187
 #, c-format
 msgid "Error unsetting property: %v"
@@ -2092,7 +2092,7 @@ msgstr ""
 msgid "Evacuating cluster member: %s"
 msgstr ""
 
-#: lxc/monitor.go:50
+#: lxc/monitor.go:51
 msgid "Event type to listen for"
 msgstr ""
 
@@ -2179,16 +2179,16 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/warning.go:210
+#: lxc/warning.go:211
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1237
+#: lxc/file.go:1238
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1260
+#: lxc/file.go:1261
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2203,12 +2203,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1287
+#: lxc/file.go:1288
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1072
+#: lxc/file.go:1073
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2238,7 +2238,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1193
+#: lxc/file.go:1194
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2253,7 +2253,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1198
+#: lxc/file.go:1199
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2263,12 +2263,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1098
+#: lxc/file.go:1099
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1225
+#: lxc/file.go:1226
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2307,7 +2307,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1210
+#: lxc/file.go:1211
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2322,7 +2322,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:820
+#: lxc/file.go:821
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2337,7 +2337,7 @@ msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
 #: lxc/network.go:1044 lxc/network_acl.go:133 lxc/network_zone.go:124
-#: lxc/operation.go:136
+#: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
 
@@ -2402,21 +2402,21 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
+#: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:770 lxc/auth.go:1697
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1114 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:57
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
-#: lxc/operation.go:108 lxc/profile.go:707 lxc/project.go:472
-#: lxc/project.go:917 lxc/remote.go:690 lxc/storage.go:657
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:774
-#: lxc/storage_volume.go:1608 lxc/warning.go:93
+#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:473
+#: lxc/project.go:918 lxc/remote.go:690 lxc/storage.go:657
+#: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
+#: lxc/storage_volume.go:1608 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
-#: lxc/monitor.go:52
+#: lxc/monitor.go:53
 msgid "Format (json|pretty|yaml)"
 msgstr ""
 
@@ -2460,7 +2460,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:817 lxc/auth.go:1736
+#: lxc/auth.go:818 lxc/auth.go:1737
 msgid "GROUPS"
 msgstr ""
 
@@ -2476,7 +2476,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:914 lxc/project.go:915
+#: lxc/project.go:915 lxc/project.go:916
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2524,11 +2524,11 @@ msgstr ""
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:400
+#: lxc/project.go:401
 msgid "Get the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:385
+#: lxc/storage_bucket.go:386
 msgid "Get the key as a storage bucket property"
 msgstr ""
 
@@ -2588,11 +2588,11 @@ msgstr ""
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:395 lxc/project.go:396
+#: lxc/project.go:396 lxc/project.go:397
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:382
+#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:383
 msgid "Get values for storage bucket configuration keys"
 msgstr ""
 
@@ -2609,17 +2609,17 @@ msgstr ""
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: lxc/auth.go:136
+#: lxc/auth.go:137
 #, c-format
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:186
+#: lxc/auth.go:187
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:426 lxc/auth.go:1786
+#: lxc/auth.go:427 lxc/auth.go:1787
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2644,27 +2644,27 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1310
+#: lxc/file.go:1311
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1299
+#: lxc/file.go:1300
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1122
+#: lxc/file.go:1123
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1132
+#: lxc/file.go:1133
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:966 lxc/operation.go:170
+#: lxc/network.go:966 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2678,11 +2678,11 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:816
+#: lxc/auth.go:817
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:566
+#: lxc/project.go:567
 msgid "IMAGES"
 msgstr ""
 
@@ -2710,17 +2710,17 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1508
+#: lxc/auth.go:1509
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1558
+#: lxc/auth.go:1559
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
 
-#: lxc/rebuild.go:32
+#: lxc/rebuild.go:33
 msgid "If an instance is running, stop it and then rebuild it"
 msgstr ""
 
@@ -2841,7 +2841,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1233 lxc/auth.go:1234
+#: lxc/auth.go:1234 lxc/auth.go:1235
 msgid "Inspect permissions"
 msgstr ""
 
@@ -2849,11 +2849,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1124
+#: lxc/file.go:1125
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1301
+#: lxc/file.go:1302
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2871,7 +2871,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1044
+#: lxc/file.go:1045
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2880,7 +2880,7 @@ msgstr ""
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/rebuild.go:74
+#: lxc/rebuild.go:75
 #, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
@@ -2913,7 +2913,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/monitor.go:70
+#: lxc/monitor.go:71
 #, c-format
 msgid "Invalid format: %s"
 msgstr ""
@@ -2923,7 +2923,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1039
+#: lxc/file.go:1040
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2965,7 +2965,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:147
+#: lxc/file.go:148
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2981,12 +2981,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:313
+#: lxc/file.go:314
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:495
+#: lxc/file.go:496
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3000,7 +3000,7 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/warning.go:212
 msgid "LAST SEEN"
 msgstr ""
 
@@ -3008,7 +3008,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:984
+#: lxc/project.go:985
 msgid "LIMIT"
 msgstr ""
 
@@ -3017,8 +3017,8 @@ msgid "LISTEN ADDRESS"
 msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
-#: lxc/network_load_balancer.go:165 lxc/operation.go:177
-#: lxc/storage_bucket.go:516 lxc/storage_volume.go:1739 lxc/warning.go:220
+#: lxc/network_load_balancer.go:165 lxc/operation.go:178
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1739 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3092,7 +3092,7 @@ msgstr ""
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/warning.go:94
+#: lxc/warning.go:95
 msgid "List all warnings"
 msgstr ""
 
@@ -3136,19 +3136,19 @@ msgstr ""
 msgid "List available storage pools"
 msgstr ""
 
-#: lxc/operation.go:105 lxc/operation.go:106
+#: lxc/operation.go:106 lxc/operation.go:107
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:331 lxc/auth.go:332
+#: lxc/auth.go:332 lxc/auth.go:333
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:764 lxc/auth.go:765
+#: lxc/auth.go:765 lxc/auth.go:766
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1691 lxc/auth.go:1692
+#: lxc/auth.go:1692 lxc/auth.go:1693
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3297,11 +3297,11 @@ msgstr ""
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/operation.go:109
+#: lxc/operation.go:110
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1255 lxc/auth.go:1256
+#: lxc/auth.go:1256 lxc/auth.go:1257
 msgid "List permissions"
 msgstr ""
 
@@ -3309,15 +3309,15 @@ msgstr ""
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:469 lxc/project.go:470
+#: lxc/project.go:470 lxc/project.go:471
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:771 lxc/storage_bucket.go:773
+#: lxc/storage_bucket.go:772 lxc/storage_bucket.go:774
 msgid "List storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:456 lxc/storage_bucket.go:458
+#: lxc/storage_bucket.go:457 lxc/storage_bucket.go:459
 msgid "List storage buckets"
 msgstr ""
 
@@ -3353,11 +3353,11 @@ msgstr ""
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/warning.go:70
+#: lxc/warning.go:71
 msgid "List warnings"
 msgstr ""
 
-#: lxc/warning.go:71
+#: lxc/warning.go:72
 msgid ""
 "List warnings\n"
 "\n"
@@ -3380,7 +3380,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/operation.go:23 lxc/operation.go:24
+#: lxc/operation.go:24 lxc/operation.go:25
 msgid "List, show and delete background operations"
 msgstr ""
 
@@ -3389,7 +3389,7 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/monitor.go:79
+#: lxc/monitor.go:80
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
@@ -3493,23 +3493,23 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:82 lxc/file.go:83
+#: lxc/file.go:83 lxc/file.go:84
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1433 lxc/auth.go:1434
+#: lxc/auth.go:59 lxc/auth.go:60 lxc/auth.go:1434 lxc/auth.go:1435
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1083 lxc/auth.go:1084
+#: lxc/auth.go:1084 lxc/auth.go:1085
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:730 lxc/auth.go:731
+#: lxc/auth.go:731 lxc/auth.go:732
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1851 lxc/auth.go:1852
+#: lxc/auth.go:1852 lxc/auth.go:1853
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3600,7 +3600,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:492 lxc/auth.go:493
+#: lxc/auth.go:493 lxc/auth.go:494
 msgid "Manage permissions"
 msgstr ""
 
@@ -3608,23 +3608,23 @@ msgstr ""
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:28 lxc/project.go:29
+#: lxc/project.go:29 lxc/project.go:30
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:731
+#: lxc/storage_bucket.go:732
 msgid "Manage storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:732
+#: lxc/storage_bucket.go:733
 msgid "Manage storage bucket keys."
 msgstr ""
 
-#: lxc/storage_bucket.go:28
+#: lxc/storage_bucket.go:29
 msgid "Manage storage buckets"
 msgstr ""
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:30
 msgid "Manage storage buckets."
 msgstr ""
 
@@ -3652,11 +3652,11 @@ msgstr ""
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/auth.go:29 lxc/auth.go:30
+#: lxc/auth.go:30 lxc/auth.go:31
 msgid "Manage user authorization"
 msgstr ""
 
-#: lxc/warning.go:28 lxc/warning.go:29
+#: lxc/warning.go:29 lxc/warning.go:30
 msgid "Manage warnings"
 msgstr ""
 
@@ -3720,17 +3720,17 @@ msgstr ""
 msgid "Migration operation failure: %w"
 msgstr ""
 
-#: lxc/monitor.go:51
+#: lxc/monitor.go:52
 msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: lxc/storage_bucket.go:116 lxc/storage_bucket.go:216
-#: lxc/storage_bucket.go:292 lxc/storage_bucket.go:411
-#: lxc/storage_bucket.go:568 lxc/storage_bucket.go:660
-#: lxc/storage_bucket.go:802 lxc/storage_bucket.go:889
-#: lxc/storage_bucket.go:986 lxc/storage_bucket.go:1065
-#: lxc/storage_bucket.go:1188
+#: lxc/storage_bucket.go:117 lxc/storage_bucket.go:217
+#: lxc/storage_bucket.go:293 lxc/storage_bucket.go:412
+#: lxc/storage_bucket.go:569 lxc/storage_bucket.go:661
+#: lxc/storage_bucket.go:803 lxc/storage_bucket.go:890
+#: lxc/storage_bucket.go:987 lxc/storage_bucket.go:1066
+#: lxc/storage_bucket.go:1189
 msgid "Missing bucket name"
 msgstr ""
 
@@ -3749,20 +3749,20 @@ msgstr ""
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1825
+#: lxc/auth.go:123 lxc/auth.go:177 lxc/auth.go:255 lxc/auth.go:417
+#: lxc/auth.go:466 lxc/auth.go:541 lxc/auth.go:600 lxc/auth.go:1826
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:862 lxc/auth.go:1003 lxc/auth.go:1131 lxc/auth.go:1189
+#: lxc/auth.go:863 lxc/auth.go:1004 lxc/auth.go:1132 lxc/auth.go:1190
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1495 lxc/auth.go:1548 lxc/auth.go:1614 lxc/auth.go:1776
+#: lxc/auth.go:1496 lxc/auth.go:1549 lxc/auth.go:1615 lxc/auth.go:1777
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1899 lxc/auth.go:1952
+#: lxc/auth.go:1900 lxc/auth.go:1953
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -3770,12 +3770,12 @@ msgstr ""
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
 #: lxc/config_template.go:377 lxc/profile.go:141 lxc/profile.go:222
-#: lxc/profile.go:808 lxc/rebuild.go:60
+#: lxc/profile.go:808 lxc/rebuild.go:61
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/storage_bucket.go:893 lxc/storage_bucket.go:990
-#: lxc/storage_bucket.go:1069 lxc/storage_bucket.go:1192
+#: lxc/storage_bucket.go:894 lxc/storage_bucket.go:991
+#: lxc/storage_bucket.go:1070 lxc/storage_bucket.go:1193
 msgid "Missing key name"
 msgstr ""
 
@@ -3840,13 +3840,13 @@ msgid "Missing peer name"
 msgstr ""
 
 #: lxc/storage.go:235 lxc/storage.go:313 lxc/storage.go:431 lxc/storage.go:509
-#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:112
-#: lxc/storage_bucket.go:212 lxc/storage_bucket.go:288
-#: lxc/storage_bucket.go:407 lxc/storage_bucket.go:482
-#: lxc/storage_bucket.go:564 lxc/storage_bucket.go:656
-#: lxc/storage_bucket.go:798 lxc/storage_bucket.go:885
-#: lxc/storage_bucket.go:982 lxc/storage_bucket.go:1061
-#: lxc/storage_bucket.go:1184 lxc/storage_volume.go:209
+#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:113
+#: lxc/storage_bucket.go:213 lxc/storage_bucket.go:289
+#: lxc/storage_bucket.go:408 lxc/storage_bucket.go:483
+#: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
+#: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
+#: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
 #: lxc/storage_volume.go:323 lxc/storage_volume.go:643
 #: lxc/storage_volume.go:750 lxc/storage_volume.go:841
 #: lxc/storage_volume.go:939 lxc/storage_volume.go:1053
@@ -3861,9 +3861,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:404 lxc/project.go:146 lxc/project.go:226 lxc/project.go:316
-#: lxc/project.go:433 lxc/project.go:622 lxc/project.go:691 lxc/project.go:819
-#: lxc/project.go:948
+#: lxc/profile.go:404 lxc/project.go:147 lxc/project.go:227 lxc/project.go:317
+#: lxc/project.go:434 lxc/project.go:623 lxc/project.go:692 lxc/project.go:820
+#: lxc/project.go:949
 msgid "Missing project name"
 msgstr ""
 
@@ -3879,7 +3879,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:598
+#: lxc/file.go:599
 msgid "Missing target directory"
 msgstr ""
 
@@ -3901,11 +3901,11 @@ msgstr ""
 msgid "Model: %v"
 msgstr ""
 
-#: lxc/monitor.go:32
+#: lxc/monitor.go:33
 msgid "Monitor a local or remote LXD server"
 msgstr ""
 
-#: lxc/monitor.go:33
+#: lxc/monitor.go:34
 msgid ""
 "Monitor a local or remote LXD server\n"
 "\n"
@@ -3917,11 +3917,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:285
+#: lxc/file.go:286
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:985 lxc/file.go:986
+#: lxc/file.go:986 lxc/file.go:987
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3983,13 +3983,13 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:192
+#: lxc/auth.go:376 lxc/auth.go:816 lxc/auth.go:1736 lxc/cluster.go:192
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
-#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:565
-#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:511
-#: lxc/storage_bucket.go:831 lxc/storage_volume.go:1731
+#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:566
+#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1731
 msgid "NAME"
 msgstr ""
 
@@ -3997,11 +3997,11 @@ msgstr ""
 msgid "NAT"
 msgstr ""
 
-#: lxc/project.go:571
+#: lxc/project.go:572
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:570
+#: lxc/project.go:571
 msgid "NETWORKS"
 msgstr ""
 
@@ -4013,9 +4013,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/operation.go:154 lxc/project.go:523
-#: lxc/project.go:528 lxc/project.go:533 lxc/project.go:538 lxc/project.go:543
-#: lxc/project.go:548 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
+#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:524
+#: lxc/project.go:529 lxc/project.go:534 lxc/project.go:539 lxc/project.go:544
+#: lxc/project.go:549 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
 msgid "NO"
 msgstr ""
 
@@ -4260,7 +4260,7 @@ msgstr ""
 msgid "Only managed networks can be modified"
 msgstr ""
 
-#: lxc/operation.go:86
+#: lxc/operation.go:87
 #, c-format
 msgid "Operation %s deleted"
 msgstr ""
@@ -4307,11 +4307,11 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:567
+#: lxc/list.go:576 lxc/project.go:568
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:212
+#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4373,24 +4373,24 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1102
+#: lxc/file.go:1103
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:860
+#: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
-#: lxc/project.go:363 lxc/storage.go:360 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1151
+#: lxc/project.go:364 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1151
 #: lxc/storage_volume.go:1183
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
-#: lxc/monitor.go:48
+#: lxc/monitor.go:49
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
@@ -4476,17 +4476,17 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:172
+#: lxc/project.go:173
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:236
+#: lxc/project.go:237
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:637
+#: lxc/project.go:638
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -4607,20 +4607,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:241 lxc/file.go:242
+#: lxc/file.go:242 lxc/file.go:243
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:416 lxc/file.go:767
+#: lxc/file.go:417 lxc/file.go:768
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:466 lxc/file.go:467
+#: lxc/file.go:467 lxc/file.go:468
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:701 lxc/file.go:867
+#: lxc/file.go:702 lxc/file.go:868
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4633,11 +4633,11 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:983
+#: lxc/project.go:984
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/storage_bucket.go:833
+#: lxc/storage_bucket.go:834
 msgid "ROLE"
 msgstr ""
 
@@ -4650,15 +4650,15 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/rebuild.go:31
+#: lxc/rebuild.go:32
 msgid "Rebuild as an empty instance"
 msgstr ""
 
-#: lxc/rebuild.go:26
+#: lxc/rebuild.go:27
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:249 lxc/file.go:473
+#: lxc/file.go:250 lxc/file.go:474
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4685,7 +4685,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:882 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
+#: lxc/project.go:883 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
 #: lxc/remote.go:994
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4736,7 +4736,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1164 lxc/auth.go:1165
+#: lxc/auth.go:1165 lxc/auth.go:1166
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4772,7 +4772,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1927 lxc/auth.go:1928
+#: lxc/auth.go:1928 lxc/auth.go:1929
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4784,7 +4784,7 @@ msgstr ""
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:574 lxc/auth.go:575
+#: lxc/auth.go:575 lxc/auth.go:576
 msgid "Remove permissions from groups"
 msgstr ""
 
@@ -4829,11 +4829,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:391 lxc/auth.go:392
+#: lxc/auth.go:392 lxc/auth.go:393
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1751 lxc/auth.go:1752
+#: lxc/auth.go:1752 lxc/auth.go:1753
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -4853,7 +4853,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:589 lxc/project.go:590
+#: lxc/project.go:590 lxc/project.go:591
 msgid "Rename projects"
 msgstr ""
 
@@ -4951,7 +4951,7 @@ msgstr ""
 msgid "Revoke cluster member join token"
 msgstr ""
 
-#: lxc/storage_bucket.go:862
+#: lxc/storage_bucket.go:863
 msgid "Role (admin or read-only)"
 msgstr ""
 
@@ -4967,7 +4967,7 @@ msgstr ""
 msgid "Run against all projects"
 msgstr ""
 
-#: lxc/warning.go:213
+#: lxc/warning.go:214
 msgid "SEVERITY"
 msgstr ""
 
@@ -4987,12 +4987,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1231
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1231
+#: lxc/file.go:1232
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5006,11 +5006,11 @@ msgstr ""
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:173 lxc/warning.go:214
+#: lxc/operation.go:174 lxc/warning.go:215
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:569
+#: lxc/project.go:570
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5018,7 +5018,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:569
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -5026,11 +5026,11 @@ msgstr ""
 msgid "STP"
 msgstr ""
 
-#: lxc/storage_bucket.go:864
+#: lxc/storage_bucket.go:865
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:942
+#: lxc/storage_bucket.go:943
 #, c-format
 msgid "Secret key: %s"
 msgstr ""
@@ -5068,7 +5068,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:995
+#: lxc/file.go:996
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5206,11 +5206,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:654
+#: lxc/project.go:655
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:655
+#: lxc/project.go:656
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5219,11 +5219,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage_bucket.go:534
+#: lxc/storage_bucket.go:535
 msgid "Set storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:535
+#: lxc/storage_bucket.go:536
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -5262,15 +5262,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:476
+#: lxc/file.go:477
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:477
+#: lxc/file.go:478
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:475
+#: lxc/file.go:476
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5310,11 +5310,11 @@ msgstr ""
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 msgid "Set the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:542
+#: lxc/storage_bucket.go:543
 msgid "Set the key as a storage bucket property"
 msgstr ""
 
@@ -5330,7 +5330,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:993
+#: lxc/file.go:994
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5342,7 +5342,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1800 lxc/auth.go:1801
+#: lxc/auth.go:1801 lxc/auth.go:1802
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5358,11 +5358,11 @@ msgstr ""
 msgid "Show details of a cluster member"
 msgstr ""
 
-#: lxc/operation.go:192 lxc/operation.go:193
+#: lxc/operation.go:193 lxc/operation.go:194
 msgid "Show details on a background operation"
 msgstr ""
 
-#: lxc/monitor.go:49
+#: lxc/monitor.go:50
 msgid "Show events from all projects"
 msgstr ""
 
@@ -5370,11 +5370,11 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:440 lxc/auth.go:441
+#: lxc/auth.go:441 lxc/auth.go:442
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:832
+#: lxc/auth.go:833
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5455,15 +5455,15 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:786 lxc/project.go:787
+#: lxc/project.go:787 lxc/project.go:788
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage_bucket.go:628 lxc/storage_bucket.go:629
+#: lxc/storage_bucket.go:629 lxc/storage_bucket.go:630
 msgid "Show storage bucket configurations"
 msgstr ""
 
-#: lxc/storage_bucket.go:1156 lxc/storage_bucket.go:1157
+#: lxc/storage_bucket.go:1157 lxc/storage_bucket.go:1158
 msgid "Show storage bucket key configurations"
 msgstr ""
 
@@ -5479,7 +5479,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:895
+#: lxc/auth.go:896
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5529,7 +5529,7 @@ msgstr ""
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: lxc/warning.go:302 lxc/warning.go:303
+#: lxc/warning.go:303 lxc/warning.go:304
 msgid "Show warning"
 msgstr ""
 
@@ -5613,22 +5613,22 @@ msgstr ""
 msgid "Stopping the instance failed: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:166
+#: lxc/storage_bucket.go:167
 #, c-format
 msgid "Storage bucket %s created"
 msgstr ""
 
-#: lxc/storage_bucket.go:233
+#: lxc/storage_bucket.go:234
 #, c-format
 msgid "Storage bucket %s deleted"
 msgstr ""
 
-#: lxc/storage_bucket.go:940
+#: lxc/storage_bucket.go:941
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr ""
 
-#: lxc/storage_bucket.go:1006
+#: lxc/storage_bucket.go:1007
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr ""
@@ -5697,7 +5697,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:847 lxc/project.go:848
+#: lxc/project.go:848 lxc/project.go:849
 msgid "Switch the current project"
 msgstr ""
 
@@ -5713,10 +5713,10 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1139
+#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1139
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
-#: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:171
-#: lxc/storage_volume.go:1730 lxc/warning.go:215
+#: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
+#: lxc/storage_volume.go:1730 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
@@ -5724,11 +5724,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1032
+#: lxc/file.go:1033
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1026
+#: lxc/file.go:1027
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5856,12 +5856,12 @@ msgstr ""
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:446
+#: lxc/project.go:447
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
 
-#: lxc/storage_bucket.go:431
+#: lxc/storage_bucket.go:432
 #, c-format
 msgid "The property %q does not exist on the storage bucket %q: %v"
 msgstr ""
@@ -6046,7 +6046,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:961
+#: lxc/project.go:962
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6058,17 +6058,17 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:985 lxc/storage_volume.go:1735
+#: lxc/project.go:986 lxc/storage_volume.go:1735
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:573
+#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:574
 #: lxc/storage.go:724 lxc/storage_volume.go:1734
 msgid "USED BY"
 msgstr ""
 
-#: lxc/warning.go:216
+#: lxc/warning.go:217
 msgid "UUID"
 msgstr ""
 
@@ -6077,7 +6077,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:197
+#: lxc/file.go:198
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6091,13 +6091,13 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1253
+#: lxc/file.go:1254
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1153 lxc/list.go:631 lxc/storage_volume.go:1772
-#: lxc/warning.go:241
+#: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6107,7 +6107,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:807
+#: lxc/file.go:808
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6190,11 +6190,11 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:742 lxc/project.go:743
+#: lxc/project.go:743 lxc/project.go:744
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:697 lxc/storage_bucket.go:698
+#: lxc/storage_bucket.go:698 lxc/storage_bucket.go:699
 msgid "Unset storage bucket configuration keys"
 msgstr ""
 
@@ -6242,11 +6242,11 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:747
+#: lxc/project.go:748
 msgid "Unset the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:701
+#: lxc/storage_bucket.go:702
 msgid "Unset the key as a storage bucket property"
 msgstr ""
 
@@ -6325,7 +6325,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:71
+#: lxc/file.go:72
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6362,11 +6362,11 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:831
+#: lxc/auth.go:832
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:894
+#: lxc/auth.go:895
 msgid "View the current identity"
 msgstr ""
 
@@ -6397,15 +6397,15 @@ msgstr ""
 msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
-#: lxc/rebuild.go:27
+#: lxc/rebuild.go:28
 msgid ""
 "Wipe the instance root disk and re-initialize. The original image is used to "
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:156 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
+#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:526
+#: lxc/project.go:531 lxc/project.go:536 lxc/project.go:541 lxc/project.go:546
+#: lxc/project.go:551 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
 msgid "YES"
 msgstr ""
 
@@ -6425,7 +6425,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/rebuild.go:119
+#: lxc/rebuild.go:120
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
@@ -6437,12 +6437,12 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1689
+#: lxc/auth.go:330 lxc/auth.go:763 lxc/auth.go:894 lxc/auth.go:1690
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
-#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
+#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
-#: lxc/operation.go:103 lxc/profile.go:700 lxc/project.go:467
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:68
+#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:468
+#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6470,7 +6470,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1254
+#: lxc/auth.go:1255
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6531,11 +6531,11 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:830
+#: lxc/auth.go:831
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1926
+#: lxc/auth.go:1106 lxc/auth.go:1164 lxc/auth.go:1927
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6543,13 +6543,13 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:954 lxc/auth.go:1470 lxc/cluster_group.go:168
+#: lxc/auth.go:97 lxc/auth.go:150 lxc/auth.go:200 lxc/auth.go:440
+#: lxc/auth.go:955 lxc/auth.go:1471 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:514 lxc/auth.go:572
+#: lxc/auth.go:515 lxc/auth.go:573
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
@@ -6559,19 +6559,19 @@ msgstr ""
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:389
+#: lxc/auth.go:390
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1521 lxc/auth.go:1571 lxc/auth.go:1799
+#: lxc/auth.go:1522 lxc/auth.go:1572 lxc/auth.go:1800
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1873
+#: lxc/auth.go:1874
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1749
+#: lxc/auth.go:1750
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -6591,7 +6591,7 @@ msgstr ""
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
-#: lxc/rebuild.go:25
+#: lxc/rebuild.go:26
 msgid "[<remote>:]<image> [<remote>:]<instance>"
 msgstr ""
 
@@ -6674,20 +6674,20 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:170
+#: lxc/file.go:171
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:120
+#: lxc/file.go:121
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:240
+#: lxc/file.go:241
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:984
+#: lxc/file.go:985
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6838,12 +6838,12 @@ msgstr ""
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
-#: lxc/operation.go:53 lxc/operation.go:191
+#: lxc/operation.go:54 lxc/operation.go:192
 msgid "[<remote>:]<operation>"
 msgstr ""
 
 #: lxc/storage.go:200 lxc/storage.go:259 lxc/storage.go:473 lxc/storage.go:844
-#: lxc/storage_bucket.go:454
+#: lxc/storage_bucket.go:455
 msgid "[<remote>:]<pool>"
 msgstr ""
 
@@ -6851,22 +6851,22 @@ msgstr ""
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
-#: lxc/storage_bucket.go:185 lxc/storage_bucket.go:247
-#: lxc/storage_bucket.go:627 lxc/storage_bucket.go:769
+#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:248
+#: lxc/storage_bucket.go:628 lxc/storage_bucket.go:770
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
 
-#: lxc/storage_bucket.go:380 lxc/storage_bucket.go:696
-#: lxc/storage_bucket.go:850 lxc/storage_bucket.go:956
-#: lxc/storage_bucket.go:1020 lxc/storage_bucket.go:1155
+#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:697
+#: lxc/storage_bucket.go:851 lxc/storage_bucket.go:957
+#: lxc/storage_bucket.go:1021 lxc/storage_bucket.go:1156
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
 
-#: lxc/storage_bucket.go:533
+#: lxc/storage_bucket.go:534
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_bucket.go:81
+#: lxc/storage_bucket.go:82
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
 
@@ -6981,20 +6981,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:91 lxc/project.go:186 lxc/project.go:258 lxc/project.go:785
-#: lxc/project.go:846 lxc/project.go:913
+#: lxc/project.go:92 lxc/project.go:187 lxc/project.go:259 lxc/project.go:786
+#: lxc/project.go:847 lxc/project.go:914
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:394 lxc/project.go:741
+#: lxc/project.go:395 lxc/project.go:742
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:653
+#: lxc/project.go:654
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:587
+#: lxc/project.go:588
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7002,7 +7002,7 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:259 lxc/warning.go:301 lxc/warning.go:354
+#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
@@ -7058,7 +7058,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:555 lxc/remote.go:739
+#: lxc/project.go:556 lxc/remote.go:739
 msgid "current"
 msgstr ""
 
@@ -7105,20 +7105,20 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/auth.go:203
+#: lxc/auth.go:204
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:958
+#: lxc/auth.go:959
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1575
+#: lxc/auth.go:1576
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7196,20 +7196,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:988
+#: lxc/file.go:989
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:244
+#: lxc/file.go:245
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:470
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7291,7 +7291,7 @@ msgid ""
 "  List instances with their running state and user comment."
 msgstr ""
 
-#: lxc/monitor.go:37
+#: lxc/monitor.go:38
 msgid ""
 "lxc monitor --type=logging\n"
 "    Only show log messages.\n"
@@ -7367,7 +7367,7 @@ msgid ""
 "    Create record r1 for zone z1 with configuration from config.yaml"
 msgstr ""
 
-#: lxc/operation.go:195
+#: lxc/operation.go:196
 msgid ""
 "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Show details on that operation UUID"
@@ -7410,7 +7410,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:95
+#: lxc/project.go:96
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7418,7 +7418,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:262
+#: lxc/project.go:263
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7449,7 +7449,7 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:85
 msgid ""
 "lxc storage bucket create p1 b01\n"
 "\tCreate a new storage bucket name b01 in storage pool p1\n"
@@ -7459,19 +7459,19 @@ msgid ""
 "of config.yaml"
 msgstr ""
 
-#: lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:251
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1023
+#: lxc/storage_bucket.go:1024
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:854
 msgid ""
 "lxc storage bucket key create p1 b01 k1\n"
 "\tCreate a key called k1 for the bucket b01 in the pool p1.\n"
@@ -7481,14 +7481,14 @@ msgid ""
 "of config.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1158
+#: lxc/storage_bucket.go:1159
 msgid ""
 "lxc storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_bucket.go:630
+#: lxc/storage_bucket.go:631
 msgid ""
 "lxc storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
@@ -7558,16 +7558,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1142
+#: lxc/file.go:1143
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1101
+#: lxc/file.go:1102
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1054
+#: lxc/file.go:1055
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-        "POT-Creation-Date: 2024-09-04 08:52-0600\n"
+        "POT-Creation-Date: 2024-09-05 08:44-0400\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,7 +16,7 @@ msgstr  "Project-Id-Version: lxd\n"
         "Content-Type: text/plain; charset=CHARSET\n"
         "Content-Transfer-Encoding: 8bit\n"
 
-#: lxc/storage_bucket.go:260 lxc/storage_bucket.go:1033
+#: lxc/storage_bucket.go:261 lxc/storage_bucket.go:1034
 msgid   "### This is a YAML representation of a storage bucket.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -122,7 +122,7 @@ msgid   "### This is a YAML representation of the configuration.\n"
         "### Note that the name is shown but cannot be changed"
 msgstr  ""
 
-#: lxc/auth.go:213
+#: lxc/auth.go:214
 msgid   "### This is a YAML representation of the group.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -147,7 +147,7 @@ msgid   "### This is a YAML representation of the group.\n"
         "### Note that all group information is shown but only the description and permissions can be modified"
 msgstr  ""
 
-#: lxc/auth.go:968
+#: lxc/auth.go:969
 msgid   "### This is a YAML representation of the group.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -166,7 +166,7 @@ msgid   "### This is a YAML representation of the group.\n"
         "### Note that all identity information is shown but only the projects and groups can be modified"
 msgstr  ""
 
-#: lxc/auth.go:1585
+#: lxc/auth.go:1586
 msgid   "### This is a YAML representation of the identity provider group.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -361,7 +361,7 @@ msgid   "### This is a YAML representation of the profile.\n"
         "### Note that the name is shown but cannot be changed"
 msgstr  ""
 
-#: lxc/project.go:280
+#: lxc/project.go:281
 msgid   "### This is a YAML representation of the project.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -401,12 +401,12 @@ msgstr  ""
 msgid   "%s (%s) (%d available)"
 msgstr  ""
 
-#: lxc/file.go:935
+#: lxc/file.go:936
 #, c-format
 msgid   "%s is not a directory"
 msgstr  ""
 
-#: lxc/file.go:825
+#: lxc/file.go:826
 #, c-format
 msgid   "'%s' isn't a supported file type"
 msgstr  ""
@@ -442,7 +442,7 @@ msgstr  ""
 msgid   "--console only works with a single instance"
 msgstr  ""
 
-#: lxc/init.go:142 lxc/rebuild.go:64
+#: lxc/init.go:142 lxc/rebuild.go:65
 msgid   "--empty cannot be combined with an image name"
 msgstr  ""
 
@@ -494,7 +494,7 @@ msgstr  ""
 msgid   "<remote> <new-name>"
 msgstr  ""
 
-#: lxc/file.go:465
+#: lxc/file.go:466
 msgid   "<source path>... [<remote>:]<instance>/<path>"
 msgstr  ""
 
@@ -526,7 +526,7 @@ msgstr  ""
 msgid   "AUTH TYPE"
 msgstr  ""
 
-#: lxc/auth.go:813
+#: lxc/auth.go:814
 msgid   "AUTHENTICATION METHOD"
 msgstr  ""
 
@@ -534,11 +534,11 @@ msgstr  ""
 msgid   "Accept certificate"
 msgstr  ""
 
-#: lxc/storage_bucket.go:863
+#: lxc/storage_bucket.go:864
 msgid   "Access key (auto-generated if empty)"
 msgstr  ""
 
-#: lxc/storage_bucket.go:941
+#: lxc/storage_bucket.go:942
 #, c-format
 msgid   "Access key: %s"
 msgstr  ""
@@ -547,7 +547,7 @@ msgstr  ""
 msgid   "Access the expanded configuration"
 msgstr  ""
 
-#: lxc/warning.go:261 lxc/warning.go:262
+#: lxc/warning.go:262 lxc/warning.go:263
 msgid   "Acknowledge warning"
 msgstr  ""
 
@@ -564,11 +564,11 @@ msgstr  ""
 msgid   "Add a cluster member to a cluster group"
 msgstr  ""
 
-#: lxc/auth.go:1106 lxc/auth.go:1107
+#: lxc/auth.go:1107 lxc/auth.go:1108
 msgid   "Add a group to an identity"
 msgstr  ""
 
-#: lxc/auth.go:1874 lxc/auth.go:1875
+#: lxc/auth.go:1875 lxc/auth.go:1876
 msgid   "Add a group to an identity provider group"
 msgstr  ""
 
@@ -630,7 +630,7 @@ msgid   "Add new trusted client\n"
         "restricted to one or more projects.\n"
 msgstr  ""
 
-#: lxc/auth.go:515 lxc/auth.go:516
+#: lxc/auth.go:516 lxc/auth.go:517
 msgid   "Add permissions to groups"
 msgstr  ""
 
@@ -659,7 +659,7 @@ msgstr  ""
 msgid   "Address: %s"
 msgstr  ""
 
-#: lxc/storage_bucket.go:169
+#: lxc/storage_bucket.go:170
 #, c-format
 msgid   "Admin access key: %s"
 msgstr  ""
@@ -669,7 +669,7 @@ msgstr  ""
 msgid   "Admin password (or token) for %s:"
 msgstr  ""
 
-#: lxc/storage_bucket.go:170
+#: lxc/storage_bucket.go:171
 #, c-format
 msgid   "Admin secret key: %s"
 msgstr  ""
@@ -728,7 +728,7 @@ msgstr  ""
 msgid   "As neither could be found, the raw SPICE socket can be found at:"
 msgstr  ""
 
-#: lxc/init.go:342 lxc/rebuild.go:130
+#: lxc/init.go:342 lxc/rebuild.go:131
 msgid   "Asked for a VM but image is of type container"
 msgstr  ""
 
@@ -825,12 +825,12 @@ msgstr  ""
 msgid   "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr  ""
 
-#: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:318 lxc/network_load_balancer.go:321 lxc/network_peer.go:309 lxc/network_zone.go:366 lxc/network_zone.go:1053 lxc/storage_bucket.go:141
+#: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:318 lxc/network_load_balancer.go:321 lxc/network_peer.go:309 lxc/network_zone.go:366 lxc/network_zone.go:1053 lxc/storage_bucket.go:142
 #, c-format
 msgid   "Bad key/value pair: %s"
 msgstr  ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:159
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:160
 #, c-format
 msgid   "Bad key=value pair: %q"
 msgstr  ""
@@ -870,7 +870,7 @@ msgstr  ""
 msgid   "Bytes sent"
 msgstr  ""
 
-#: lxc/operation.go:174
+#: lxc/operation.go:175
 msgid   "CANCELABLE"
 msgstr  ""
 
@@ -882,7 +882,7 @@ msgstr  ""
 msgid   "CONTENT-TYPE"
 msgstr  ""
 
-#: lxc/warning.go:209
+#: lxc/warning.go:210
 msgid   "COUNT"
 msgstr  ""
 
@@ -908,7 +908,7 @@ msgstr  ""
 msgid   "CPUs (%s):"
 msgstr  ""
 
-#: lxc/operation.go:175
+#: lxc/operation.go:176
 msgid   "CREATED"
 msgstr  ""
 
@@ -938,7 +938,7 @@ msgstr  ""
 msgid   "Can't provide a name for the target image"
 msgstr  ""
 
-#: lxc/file.go:340
+#: lxc/file.go:341
 msgid   "Can't pull a directory without --recursive"
 msgstr  ""
 
@@ -963,11 +963,11 @@ msgstr  ""
 msgid   "Can't specify a different remote for rename"
 msgstr  ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:224
+#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:225
 msgid   "Can't specify column L when not clustered"
 msgstr  ""
 
-#: lxc/file.go:546
+#: lxc/file.go:547
 msgid   "Can't supply uid/gid/mode in recursive mode"
 msgstr  ""
 
@@ -976,7 +976,7 @@ msgstr  ""
 msgid   "Can't unset key '%s', it's not currently set"
 msgstr  ""
 
-#: lxc/rebuild.go:160
+#: lxc/rebuild.go:161
 msgid   "Can't use an image with --empty"
 msgstr  ""
 
@@ -1084,7 +1084,7 @@ msgstr  ""
 msgid   "Cluster member %s removed from group %s"
 msgstr  ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:550 lxc/config.go:768 lxc/config.go:899 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65 lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877 lxc/network.go:1251 lxc/network.go:1344 lxc/network.go:1416 lxc/network_forward.go:182 lxc/network_forward.go:264 lxc/network_forward.go:497 lxc/network_forward.go:649 lxc/network_forward.go:803 lxc/network_forward.go:892 lxc/network_forward.go:974 lxc/network_load_balancer.go:184 lxc/network_load_balancer.go:266 lxc/network_load_balancer.go:484 lxc/network_load_balancer.go:619 lxc/network_load_balancer.go:774 lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938 lxc/network_load_balancer.go:1051 lxc/network_load_balancer.go:1125 lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748 lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:90 lxc/storage_bucket.go:190 lxc/storage_bucket.go:253 lxc/storage_bucket.go:384 lxc/storage_bucket.go:541 lxc/storage_bucket.go:634 lxc/storage_bucket.go:700 lxc/storage_bucket.go:775 lxc/storage_bucket.go:861 lxc/storage_bucket.go:961 lxc/storage_bucket.go:1026 lxc/storage_bucket.go:1162 lxc/storage_volume.go:394 lxc/storage_volume.go:612 lxc/storage_volume.go:717 lxc/storage_volume.go:1005 lxc/storage_volume.go:1231 lxc/storage_volume.go:1360 lxc/storage_volume.go:1848 lxc/storage_volume.go:1940 lxc/storage_volume.go:2079 lxc/storage_volume.go:2239 lxc/storage_volume.go:2355 lxc/storage_volume.go:2416 lxc/storage_volume.go:2543 lxc/storage_volume.go:2631 lxc/storage_volume.go:2795
+#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:550 lxc/config.go:768 lxc/config.go:899 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65 lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877 lxc/network.go:1251 lxc/network.go:1344 lxc/network.go:1416 lxc/network_forward.go:182 lxc/network_forward.go:264 lxc/network_forward.go:497 lxc/network_forward.go:649 lxc/network_forward.go:803 lxc/network_forward.go:892 lxc/network_forward.go:974 lxc/network_load_balancer.go:184 lxc/network_load_balancer.go:266 lxc/network_load_balancer.go:484 lxc/network_load_balancer.go:619 lxc/network_load_balancer.go:774 lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938 lxc/network_load_balancer.go:1051 lxc/network_load_balancer.go:1125 lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748 lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91 lxc/storage_bucket.go:191 lxc/storage_bucket.go:254 lxc/storage_bucket.go:385 lxc/storage_bucket.go:542 lxc/storage_bucket.go:635 lxc/storage_bucket.go:701 lxc/storage_bucket.go:776 lxc/storage_bucket.go:862 lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027 lxc/storage_bucket.go:1163 lxc/storage_volume.go:394 lxc/storage_volume.go:612 lxc/storage_volume.go:717 lxc/storage_volume.go:1005 lxc/storage_volume.go:1231 lxc/storage_volume.go:1360 lxc/storage_volume.go:1848 lxc/storage_volume.go:1940 lxc/storage_volume.go:2079 lxc/storage_volume.go:2239 lxc/storage_volume.go:2355 lxc/storage_volume.go:2416 lxc/storage_volume.go:2543 lxc/storage_volume.go:2631 lxc/storage_volume.go:2795
 msgid   "Cluster member name"
 msgstr  ""
 
@@ -1100,7 +1100,7 @@ msgstr  ""
 msgid   "Clustering enabled"
 msgstr  ""
 
-#: lxc/image.go:1113 lxc/list.go:132 lxc/storage_volume.go:1589 lxc/warning.go:92
+#: lxc/image.go:1113 lxc/list.go:132 lxc/storage_volume.go:1589 lxc/warning.go:93
 msgid   "Columns"
 msgstr  ""
 
@@ -1127,7 +1127,7 @@ msgstr  ""
 msgid   "Config key/value to apply to the new instance"
 msgstr  ""
 
-#: lxc/project.go:100
+#: lxc/project.go:101
 msgid   "Config key/value to apply to the new project"
 msgstr  ""
 
@@ -1135,7 +1135,7 @@ msgstr  ""
 msgid   "Config key/value to apply to the target instance"
 msgstr  ""
 
-#: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281 lxc/config.go:356 lxc/config.go:1327 lxc/config_metadata.go:156 lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759 lxc/network_acl.go:698 lxc/network_forward.go:767 lxc/network_load_balancer.go:738 lxc/network_peer.go:698 lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595 lxc/project.go:362 lxc/storage.go:359 lxc/storage_bucket.go:348 lxc/storage_bucket.go:1125 lxc/storage_volume.go:1150 lxc/storage_volume.go:1182
+#: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281 lxc/config.go:356 lxc/config.go:1327 lxc/config_metadata.go:156 lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759 lxc/network_acl.go:698 lxc/network_forward.go:767 lxc/network_load_balancer.go:738 lxc/network_peer.go:698 lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595 lxc/project.go:363 lxc/storage.go:359 lxc/storage_bucket.go:349 lxc/storage_bucket.go:1126 lxc/storage_volume.go:1150 lxc/storage_volume.go:1182
 #, c-format
 msgid   "Config parsing error: %s"
 msgstr  ""
@@ -1254,12 +1254,12 @@ msgstr  ""
 msgid   "Could not find certificate key file path: %s"
 msgstr  ""
 
-#: lxc/auth.go:300 lxc/auth.go:1660
+#: lxc/auth.go:301 lxc/auth.go:1661
 #, c-format
 msgid   "Could not parse group: %s"
 msgstr  ""
 
-#: lxc/auth.go:1054
+#: lxc/auth.go:1055
 #, c-format
 msgid   "Could not parse identity: %s"
 msgstr  ""
@@ -1308,15 +1308,15 @@ msgstr  ""
 msgid   "Create and start instances from images"
 msgstr  ""
 
-#: lxc/file.go:248 lxc/file.go:474
+#: lxc/file.go:249 lxc/file.go:475
 msgid   "Create any directories necessary"
 msgstr  ""
 
-#: lxc/auth.go:97 lxc/auth.go:98
+#: lxc/auth.go:98 lxc/auth.go:99
 msgid   "Create groups"
 msgstr  ""
 
-#: lxc/auth.go:1471 lxc/auth.go:1472
+#: lxc/auth.go:1472 lxc/auth.go:1473
 msgid   "Create identity provider groups"
 msgstr  ""
 
@@ -1335,11 +1335,11 @@ msgstr  ""
 msgid   "Create instances from images"
 msgstr  ""
 
-#: lxc/storage_bucket.go:851 lxc/storage_bucket.go:852
+#: lxc/storage_bucket.go:852 lxc/storage_bucket.go:853
 msgid   "Create key for a storage bucket"
 msgstr  ""
 
-#: lxc/storage_bucket.go:82 lxc/storage_bucket.go:83
+#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
 msgid   "Create new custom storage buckets"
 msgstr  ""
 
@@ -1383,7 +1383,7 @@ msgstr  ""
 msgid   "Create profiles"
 msgstr  ""
 
-#: lxc/project.go:92 lxc/project.go:93
+#: lxc/project.go:93 lxc/project.go:94
 msgid   "Create projects"
 msgstr  ""
 
@@ -1418,7 +1418,7 @@ msgstr  ""
 msgid   "DEFAULT TARGET ADDRESS"
 msgstr  ""
 
-#: lxc/auth.go:376 lxc/cluster.go:197 lxc/cluster_group.go:504 lxc/image.go:1135 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086 lxc/network_acl.go:157 lxc/network_forward.go:157 lxc/network_load_balancer.go:160 lxc/network_peer.go:149 lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:172 lxc/profile.go:756 lxc/project.go:572 lxc/storage.go:723 lxc/storage_bucket.go:512 lxc/storage_bucket.go:832 lxc/storage_volume.go:1732
+#: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504 lxc/image.go:1135 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086 lxc/network_acl.go:157 lxc/network_forward.go:157 lxc/network_load_balancer.go:160 lxc/network_peer.go:149 lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173 lxc/profile.go:756 lxc/project.go:573 lxc/storage.go:723 lxc/storage_bucket.go:513 lxc/storage_bucket.go:833 lxc/storage_volume.go:1732
 msgid   "DESCRIPTION"
 msgstr  ""
 
@@ -1442,7 +1442,7 @@ msgstr  ""
 msgid   "Define a compression algorithm: for backup or none"
 msgstr  ""
 
-#: lxc/operation.go:55 lxc/operation.go:56
+#: lxc/operation.go:56 lxc/operation.go:57
 msgid   "Delete a background operation (will attempt to cancel)"
 msgstr  ""
 
@@ -1450,19 +1450,19 @@ msgstr  ""
 msgid   "Delete a cluster group"
 msgstr  ""
 
-#: lxc/warning.go:360
+#: lxc/warning.go:361
 msgid   "Delete all warnings"
 msgstr  ""
 
-#: lxc/file.go:122 lxc/file.go:123
+#: lxc/file.go:123 lxc/file.go:124
 msgid   "Delete files in instances"
 msgstr  ""
 
-#: lxc/auth.go:151 lxc/auth.go:152
+#: lxc/auth.go:152 lxc/auth.go:153
 msgid   "Delete groups"
 msgstr  ""
 
-#: lxc/auth.go:1523 lxc/auth.go:1524
+#: lxc/auth.go:1524 lxc/auth.go:1525
 msgid   "Delete identity provider groups"
 msgstr  ""
 
@@ -1482,7 +1482,7 @@ msgstr  ""
 msgid   "Delete instances and snapshots"
 msgstr  ""
 
-#: lxc/storage_bucket.go:957 lxc/storage_bucket.go:958
+#: lxc/storage_bucket.go:958 lxc/storage_bucket.go:959
 msgid   "Delete key from a storage bucket"
 msgstr  ""
 
@@ -1518,11 +1518,11 @@ msgstr  ""
 msgid   "Delete profiles"
 msgstr  ""
 
-#: lxc/project.go:188 lxc/project.go:189
+#: lxc/project.go:189 lxc/project.go:190
 msgid   "Delete projects"
 msgstr  ""
 
-#: lxc/storage_bucket.go:187 lxc/storage_bucket.go:188
+#: lxc/storage_bucket.go:188 lxc/storage_bucket.go:189
 msgid   "Delete storage buckets"
 msgstr  ""
 
@@ -1534,11 +1534,11 @@ msgstr  ""
 msgid   "Delete storage volumes"
 msgstr  ""
 
-#: lxc/warning.go:356 lxc/warning.go:357
+#: lxc/warning.go:357 lxc/warning.go:358
 msgid   "Delete warning"
 msgstr  ""
 
-#: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159 lxc/alias.go:214 lxc/auth.go:30 lxc/auth.go:59 lxc/auth.go:98 lxc/auth.go:152 lxc/auth.go:201 lxc/auth.go:332 lxc/auth.go:392 lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575 lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895 lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165 lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1434 lxc/auth.go:1472 lxc/auth.go:1524 lxc/auth.go:1573 lxc/auth.go:1692 lxc/auth.go:1752 lxc/auth.go:1801 lxc/auth.go:1852 lxc/auth.go:1875 lxc/auth.go:1928 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677 lxc/cluster.go:770 lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087 lxc/cluster.go:1175 lxc/cluster.go:1299 lxc/cluster.go:1329 lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170 lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440 lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663 lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51 lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:538 lxc/config.go:764 lxc/config.go:896 lxc/config.go:943 lxc/config.go:983 lxc/config.go:1038 lxc/config.go:1129 lxc/config.go:1160 lxc/config.go:1214 lxc/config_device.go:25 lxc/config_device.go:79 lxc/config_device.go:221 lxc/config_device.go:318 lxc/config_device.go:401 lxc/config_device.go:503 lxc/config_device.go:619 lxc/config_device.go:626 lxc/config_device.go:759 lxc/config_device.go:844 lxc/config_metadata.go:28 lxc/config_metadata.go:56 lxc/config_metadata.go:189 lxc/config_template.go:28 lxc/config_template.go:68 lxc/config_template.go:119 lxc/config_template.go:173 lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34 lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651 lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41 lxc/export.go:32 lxc/file.go:83 lxc/file.go:123 lxc/file.go:172 lxc/file.go:242 lxc/file.go:467 lxc/file.go:986 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:946 lxc/image.go:1088 lxc/image.go:1415 lxc/image.go:1506 lxc/image.go:1572 lxc/image.go:1636 lxc/image.go:1699 lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1005 lxc/network.go:1106 lxc/network.go:1185 lxc/network.go:1245 lxc/network.go:1341 lxc/network.go:1413 lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731 lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:51 lxc/network_forward.go:33 lxc/network_forward.go:90 lxc/network_forward.go:179 lxc/network_forward.go:256 lxc/network_forward.go:404 lxc/network_forward.go:489 lxc/network_forward.go:599 lxc/network_forward.go:646 lxc/network_forward.go:800 lxc/network_forward.go:874 lxc/network_forward.go:889 lxc/network_forward.go:970 lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476 lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935 lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1121 lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236 lxc/network_peer.go:360 lxc/network_peer.go:445 lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:165 lxc/network_zone.go:228 lxc/network_zone.go:301 lxc/network_zone.go:396 lxc/network_zone.go:484 lxc/network_zone.go:527 lxc/network_zone.go:654 lxc/network_zone.go:710 lxc/network_zone.go:767 lxc/network_zone.go:845 lxc/network_zone.go:909 lxc/network_zone.go:985 lxc/network_zone.go:1083 lxc/network_zone.go:1172 lxc/network_zone.go:1219 lxc/network_zone.go:1349 lxc/network_zone.go:1410 lxc/network_zone.go:1425 lxc/network_zone.go:1483 lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:106 lxc/operation.go:193 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180 lxc/profile.go:271 lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493 lxc/profile.go:629 lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860 lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:29 lxc/project.go:93 lxc/project.go:189 lxc/project.go:260 lxc/project.go:396 lxc/project.go:470 lxc/project.go:590 lxc/project.go:655 lxc/project.go:743 lxc/project.go:787 lxc/project.go:848 lxc/project.go:915 lxc/publish.go:34 lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853 lxc/remote.go:917 lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:29 lxc/storage_bucket.go:83 lxc/storage_bucket.go:188 lxc/storage_bucket.go:249 lxc/storage_bucket.go:382 lxc/storage_bucket.go:458 lxc/storage_bucket.go:535 lxc/storage_bucket.go:629 lxc/storage_bucket.go:698 lxc/storage_bucket.go:732 lxc/storage_bucket.go:773 lxc/storage_bucket.go:852 lxc/storage_bucket.go:958 lxc/storage_bucket.go:1022 lxc/storage_bucket.go:1157 lxc/storage_volume.go:58 lxc/storage_volume.go:169 lxc/storage_volume.go:283 lxc/storage_volume.go:390 lxc/storage_volume.go:605 lxc/storage_volume.go:714 lxc/storage_volume.go:801 lxc/storage_volume.go:899 lxc/storage_volume.go:996 lxc/storage_volume.go:1217 lxc/storage_volume.go:1348 lxc/storage_volume.go:1507 lxc/storage_volume.go:1591 lxc/storage_volume.go:1844 lxc/storage_volume.go:1937 lxc/storage_volume.go:2064 lxc/storage_volume.go:2222 lxc/storage_volume.go:2343 lxc/storage_volume.go:2405 lxc/storage_volume.go:2541 lxc/storage_volume.go:2624 lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:29 lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
+#: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159 lxc/alias.go:214 lxc/auth.go:31 lxc/auth.go:60 lxc/auth.go:99 lxc/auth.go:153 lxc/auth.go:202 lxc/auth.go:333 lxc/auth.go:393 lxc/auth.go:442 lxc/auth.go:494 lxc/auth.go:517 lxc/auth.go:576 lxc/auth.go:732 lxc/auth.go:766 lxc/auth.go:833 lxc/auth.go:896 lxc/auth.go:957 lxc/auth.go:1085 lxc/auth.go:1108 lxc/auth.go:1166 lxc/auth.go:1235 lxc/auth.go:1257 lxc/auth.go:1435 lxc/auth.go:1473 lxc/auth.go:1525 lxc/auth.go:1574 lxc/auth.go:1693 lxc/auth.go:1753 lxc/auth.go:1802 lxc/auth.go:1853 lxc/auth.go:1876 lxc/auth.go:1929 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677 lxc/cluster.go:770 lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087 lxc/cluster.go:1175 lxc/cluster.go:1299 lxc/cluster.go:1329 lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170 lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440 lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663 lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51 lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:538 lxc/config.go:764 lxc/config.go:896 lxc/config.go:943 lxc/config.go:983 lxc/config.go:1038 lxc/config.go:1129 lxc/config.go:1160 lxc/config.go:1214 lxc/config_device.go:25 lxc/config_device.go:79 lxc/config_device.go:221 lxc/config_device.go:318 lxc/config_device.go:401 lxc/config_device.go:503 lxc/config_device.go:619 lxc/config_device.go:626 lxc/config_device.go:759 lxc/config_device.go:844 lxc/config_metadata.go:28 lxc/config_metadata.go:56 lxc/config_metadata.go:189 lxc/config_template.go:28 lxc/config_template.go:68 lxc/config_template.go:119 lxc/config_template.go:173 lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34 lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651 lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41 lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173 lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:946 lxc/image.go:1088 lxc/image.go:1415 lxc/image.go:1506 lxc/image.go:1572 lxc/image.go:1636 lxc/image.go:1699 lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1005 lxc/network.go:1106 lxc/network.go:1185 lxc/network.go:1245 lxc/network.go:1341 lxc/network.go:1413 lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731 lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:51 lxc/network_forward.go:33 lxc/network_forward.go:90 lxc/network_forward.go:179 lxc/network_forward.go:256 lxc/network_forward.go:404 lxc/network_forward.go:489 lxc/network_forward.go:599 lxc/network_forward.go:646 lxc/network_forward.go:800 lxc/network_forward.go:874 lxc/network_forward.go:889 lxc/network_forward.go:970 lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476 lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935 lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1121 lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236 lxc/network_peer.go:360 lxc/network_peer.go:445 lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:165 lxc/network_zone.go:228 lxc/network_zone.go:301 lxc/network_zone.go:396 lxc/network_zone.go:484 lxc/network_zone.go:527 lxc/network_zone.go:654 lxc/network_zone.go:710 lxc/network_zone.go:767 lxc/network_zone.go:845 lxc/network_zone.go:909 lxc/network_zone.go:985 lxc/network_zone.go:1083 lxc/network_zone.go:1172 lxc/network_zone.go:1219 lxc/network_zone.go:1349 lxc/network_zone.go:1410 lxc/network_zone.go:1425 lxc/network_zone.go:1483 lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180 lxc/profile.go:271 lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493 lxc/profile.go:629 lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860 lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:30 lxc/project.go:94 lxc/project.go:190 lxc/project.go:261 lxc/project.go:397 lxc/project.go:471 lxc/project.go:591 lxc/project.go:656 lxc/project.go:744 lxc/project.go:788 lxc/project.go:849 lxc/project.go:916 lxc/publish.go:34 lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853 lxc/remote.go:917 lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250 lxc/storage_bucket.go:383 lxc/storage_bucket.go:459 lxc/storage_bucket.go:536 lxc/storage_bucket.go:630 lxc/storage_bucket.go:699 lxc/storage_bucket.go:733 lxc/storage_bucket.go:774 lxc/storage_bucket.go:853 lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158 lxc/storage_volume.go:58 lxc/storage_volume.go:169 lxc/storage_volume.go:283 lxc/storage_volume.go:390 lxc/storage_volume.go:605 lxc/storage_volume.go:714 lxc/storage_volume.go:801 lxc/storage_volume.go:899 lxc/storage_volume.go:996 lxc/storage_volume.go:1217 lxc/storage_volume.go:1348 lxc/storage_volume.go:1507 lxc/storage_volume.go:1591 lxc/storage_volume.go:1844 lxc/storage_volume.go:1937 lxc/storage_volume.go:2064 lxc/storage_volume.go:2222 lxc/storage_volume.go:2343 lxc/storage_volume.go:2405 lxc/storage_volume.go:2541 lxc/storage_volume.go:2624 lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid   "Description"
 msgstr  ""
 
@@ -1620,7 +1620,7 @@ msgstr  ""
 msgid   "Directory to run the command in (default /root)"
 msgstr  ""
 
-#: lxc/file.go:994
+#: lxc/file.go:995
 msgid   "Disable authentication when using SSH SFTP listener"
 msgstr  ""
 
@@ -1686,7 +1686,7 @@ msgstr  ""
 msgid   "EXPIRY DATE"
 msgstr  ""
 
-#: lxc/file.go:74
+#: lxc/file.go:75
 msgid   "Early server side processing of file transfer requests cannot be canceled (interrupt two more times to force)"
 msgstr  ""
 
@@ -1694,7 +1694,7 @@ msgstr  ""
 msgid   "Edit a cluster group"
 msgstr  ""
 
-#: lxc/auth.go:955 lxc/auth.go:956
+#: lxc/auth.go:956 lxc/auth.go:957
 msgid   "Edit an identity as YAML"
 msgstr  ""
 
@@ -1702,15 +1702,15 @@ msgstr  ""
 msgid   "Edit cluster member configurations as YAML"
 msgstr  ""
 
-#: lxc/file.go:171 lxc/file.go:172
+#: lxc/file.go:172 lxc/file.go:173
 msgid   "Edit files in instances"
 msgstr  ""
 
-#: lxc/auth.go:200 lxc/auth.go:201
+#: lxc/auth.go:201 lxc/auth.go:202
 msgid   "Edit groups as YAML"
 msgstr  ""
 
-#: lxc/auth.go:1572 lxc/auth.go:1573
+#: lxc/auth.go:1573 lxc/auth.go:1574
 msgid   "Edit identity provider groups as YAML"
 msgstr  ""
 
@@ -1766,15 +1766,15 @@ msgstr  ""
 msgid   "Edit profile configurations as YAML"
 msgstr  ""
 
-#: lxc/project.go:259 lxc/project.go:260
+#: lxc/project.go:260 lxc/project.go:261
 msgid   "Edit project configurations as YAML"
 msgstr  ""
 
-#: lxc/storage_bucket.go:248 lxc/storage_bucket.go:249
+#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:250
 msgid   "Edit storage bucket configurations as YAML"
 msgstr  ""
 
-#: lxc/storage_bucket.go:1021 lxc/storage_bucket.go:1022
+#: lxc/storage_bucket.go:1022 lxc/storage_bucket.go:1023
 msgid   "Edit storage bucket key as YAML"
 msgstr  ""
 
@@ -1790,7 +1790,7 @@ msgstr  ""
 msgid   "Edit trust configurations as YAML"
 msgstr  ""
 
-#: lxc/image.go:1147 lxc/list.go:622 lxc/storage_volume.go:1766 lxc/warning.go:235
+#: lxc/image.go:1147 lxc/list.go:622 lxc/storage_volume.go:1766 lxc/warning.go:236
 #, c-format
 msgid   "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr  ""
@@ -1837,7 +1837,7 @@ msgstr  ""
 msgid   "Error retrieving aliases: %w"
 msgstr  ""
 
-#: lxc/cluster.go:459 lxc/config.go:654 lxc/config.go:686 lxc/network.go:1319 lxc/network_acl.go:524 lxc/network_forward.go:572 lxc/network_load_balancer.go:559 lxc/network_peer.go:522 lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987 lxc/project.go:718 lxc/storage.go:812 lxc/storage_bucket.go:602 lxc/storage_volume.go:2155 lxc/storage_volume.go:2193
+#: lxc/cluster.go:459 lxc/config.go:654 lxc/config.go:686 lxc/network.go:1319 lxc/network_acl.go:524 lxc/network_forward.go:572 lxc/network_load_balancer.go:559 lxc/network_peer.go:522 lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987 lxc/project.go:719 lxc/storage.go:812 lxc/storage_bucket.go:603 lxc/storage_volume.go:2155 lxc/storage_volume.go:2193
 #, c-format
 msgid   "Error setting properties: %v"
 msgstr  ""
@@ -1847,7 +1847,7 @@ msgstr  ""
 msgid   "Error unsetting properties: %v"
 msgstr  ""
 
-#: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518 lxc/network_forward.go:566 lxc/network_load_balancer.go:553 lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141 lxc/profile.go:981 lxc/project.go:712 lxc/storage.go:806 lxc/storage_bucket.go:596 lxc/storage_volume.go:2149 lxc/storage_volume.go:2187
+#: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518 lxc/network_forward.go:566 lxc/network_load_balancer.go:553 lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141 lxc/profile.go:981 lxc/project.go:713 lxc/storage.go:806 lxc/storage_bucket.go:597 lxc/storage_volume.go:2149 lxc/storage_volume.go:2187
 #, c-format
 msgid   "Error unsetting property: %v"
 msgstr  ""
@@ -1866,7 +1866,7 @@ msgstr  ""
 msgid   "Evacuating cluster member: %s"
 msgstr  ""
 
-#: lxc/monitor.go:50
+#: lxc/monitor.go:51
 msgid   "Event type to listen for"
 msgstr  ""
 
@@ -1948,16 +1948,16 @@ msgstr  ""
 msgid   "FINGERPRINT"
 msgstr  ""
 
-#: lxc/warning.go:210
+#: lxc/warning.go:211
 msgid   "FIRST SEEN"
 msgstr  ""
 
-#: lxc/file.go:1237
+#: lxc/file.go:1238
 #, c-format
 msgid   "Failed SSH handshake with client %q: %v"
 msgstr  ""
 
-#: lxc/file.go:1260
+#: lxc/file.go:1261
 #, c-format
 msgid   "Failed accepting channel client %q: %v"
 msgstr  ""
@@ -1972,12 +1972,12 @@ msgstr  ""
 msgid   "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr  ""
 
-#: lxc/file.go:1287
+#: lxc/file.go:1288
 #, c-format
 msgid   "Failed connecting to instance SFTP for client %q: %v"
 msgstr  ""
 
-#: lxc/file.go:1072
+#: lxc/file.go:1073
 #, c-format
 msgid   "Failed connecting to instance SFTP: %w"
 msgstr  ""
@@ -2007,7 +2007,7 @@ msgstr  ""
 msgid   "Failed fetching fingerprint %q: %w"
 msgstr  ""
 
-#: lxc/file.go:1193
+#: lxc/file.go:1194
 #, c-format
 msgid   "Failed generating SSH host key: %w"
 msgstr  ""
@@ -2022,7 +2022,7 @@ msgstr  ""
 msgid   "Failed loading profile %q: %w"
 msgstr  ""
 
-#: lxc/file.go:1198
+#: lxc/file.go:1199
 #, c-format
 msgid   "Failed parsing SSH host key: %w"
 msgstr  ""
@@ -2032,12 +2032,12 @@ msgstr  ""
 msgid   "Failed starting command: %w"
 msgstr  ""
 
-#: lxc/file.go:1098
+#: lxc/file.go:1099
 #, c-format
 msgid   "Failed starting sshfs: %w"
 msgstr  ""
 
-#: lxc/file.go:1225
+#: lxc/file.go:1226
 #, c-format
 msgid   "Failed to accept incoming connection: %w"
 msgstr  ""
@@ -2076,7 +2076,7 @@ msgstr  ""
 msgid   "Failed to find project: %w"
 msgstr  ""
 
-#: lxc/file.go:1210
+#: lxc/file.go:1211
 #, c-format
 msgid   "Failed to listen for connection: %w"
 msgstr  ""
@@ -2091,7 +2091,7 @@ msgstr  ""
 msgid   "Failed to remove alias %s: %w"
 msgstr  ""
 
-#: lxc/file.go:820
+#: lxc/file.go:821
 #, c-format
 msgid   "Failed to walk path for %s: %s"
 msgstr  ""
@@ -2105,7 +2105,7 @@ msgstr  ""
 msgid   "Fast mode (same as --columns=nsacPt)"
 msgstr  ""
 
-#: lxc/network.go:1044 lxc/network_acl.go:133 lxc/network_zone.go:124 lxc/operation.go:136
+#: lxc/network.go:1044 lxc/network_acl.go:133 lxc/network_zone.go:124 lxc/operation.go:137
 msgid   "Filtering isn't supported yet"
 msgstr  ""
 
@@ -2165,11 +2165,11 @@ msgid   "Forcefully removing a server from the cluster should only be done as a 
         "Are you really sure you want to force removing %s? (yes/no): "
 msgstr  ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696 lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442 lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434 lxc/image.go:1114 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009 lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:57 lxc/network_forward.go:93 lxc/network_load_balancer.go:97 lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770 lxc/operation.go:108 lxc/profile.go:707 lxc/project.go:472 lxc/project.go:917 lxc/remote.go:690 lxc/storage.go:657 lxc/storage_bucket.go:459 lxc/storage_bucket.go:774 lxc/storage_volume.go:1608 lxc/warning.go:93
+#: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:770 lxc/auth.go:1697 lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442 lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434 lxc/image.go:1114 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009 lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:57 lxc/network_forward.go:93 lxc/network_load_balancer.go:97 lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770 lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:473 lxc/project.go:918 lxc/remote.go:690 lxc/storage.go:657 lxc/storage_bucket.go:460 lxc/storage_bucket.go:775 lxc/storage_volume.go:1608 lxc/warning.go:94
 msgid   "Format (csv|json|table|yaml|compact)"
 msgstr  ""
 
-#: lxc/monitor.go:52
+#: lxc/monitor.go:53
 msgid   "Format (json|pretty|yaml)"
 msgstr  ""
 
@@ -2213,7 +2213,7 @@ msgstr  ""
 msgid   "GPUs:"
 msgstr  ""
 
-#: lxc/auth.go:817 lxc/auth.go:1736
+#: lxc/auth.go:818 lxc/auth.go:1737
 msgid   "GROUPS"
 msgstr  ""
 
@@ -2229,7 +2229,7 @@ msgstr  ""
 msgid   "Get UEFI variables for instance"
 msgstr  ""
 
-#: lxc/project.go:914 lxc/project.go:915
+#: lxc/project.go:915 lxc/project.go:916
 msgid   "Get a summary of resource allocations"
 msgstr  ""
 
@@ -2277,11 +2277,11 @@ msgstr  ""
 msgid   "Get the key as a profile property"
 msgstr  ""
 
-#: lxc/project.go:400
+#: lxc/project.go:401
 msgid   "Get the key as a project property"
 msgstr  ""
 
-#: lxc/storage_bucket.go:385
+#: lxc/storage_bucket.go:386
 msgid   "Get the key as a storage bucket property"
 msgstr  ""
 
@@ -2341,11 +2341,11 @@ msgstr  ""
 msgid   "Get values for profile configuration keys"
 msgstr  ""
 
-#: lxc/project.go:395 lxc/project.go:396
+#: lxc/project.go:396 lxc/project.go:397
 msgid   "Get values for project configuration keys"
 msgstr  ""
 
-#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:382
+#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:383
 msgid   "Get values for storage bucket configuration keys"
 msgstr  ""
 
@@ -2362,17 +2362,17 @@ msgstr  ""
 msgid   "Given target %q does not match source volume location %q"
 msgstr  ""
 
-#: lxc/auth.go:136
+#: lxc/auth.go:137
 #, c-format
 msgid   "Group %s created"
 msgstr  ""
 
-#: lxc/auth.go:186
+#: lxc/auth.go:187
 #, c-format
 msgid   "Group %s deleted"
 msgstr  ""
 
-#: lxc/auth.go:426 lxc/auth.go:1786
+#: lxc/auth.go:427 lxc/auth.go:1787
 #, c-format
 msgid   "Group %s renamed to %s"
 msgstr  ""
@@ -2397,27 +2397,27 @@ msgstr  ""
 msgid   "Hugepages:\n"
 msgstr  ""
 
-#: lxc/file.go:1310
+#: lxc/file.go:1311
 #, c-format
 msgid   "I/O copy from SSH to instance failed: %v"
 msgstr  ""
 
-#: lxc/file.go:1299
+#: lxc/file.go:1300
 #, c-format
 msgid   "I/O copy from instance to SSH failed: %v"
 msgstr  ""
 
-#: lxc/file.go:1122
+#: lxc/file.go:1123
 #, c-format
 msgid   "I/O copy from instance to sshfs failed: %v"
 msgstr  ""
 
-#: lxc/file.go:1132
+#: lxc/file.go:1133
 #, c-format
 msgid   "I/O copy from sshfs to instance failed: %v"
 msgstr  ""
 
-#: lxc/network.go:966 lxc/operation.go:170
+#: lxc/network.go:966 lxc/operation.go:171
 msgid   "ID"
 msgstr  ""
 
@@ -2431,11 +2431,11 @@ msgstr  ""
 msgid   "ID: %s"
 msgstr  ""
 
-#: lxc/auth.go:816
+#: lxc/auth.go:817
 msgid   "IDENTIFIER"
 msgstr  ""
 
-#: lxc/project.go:566
+#: lxc/project.go:567
 msgid   "IMAGES"
 msgstr  ""
 
@@ -2463,17 +2463,17 @@ msgstr  ""
 msgid   "ISSUE DATE"
 msgstr  ""
 
-#: lxc/auth.go:1508
+#: lxc/auth.go:1509
 #, c-format
 msgid   "Identity provider group %s created"
 msgstr  ""
 
-#: lxc/auth.go:1558
+#: lxc/auth.go:1559
 #, c-format
 msgid   "Identity provider group %s deleted"
 msgstr  ""
 
-#: lxc/rebuild.go:32
+#: lxc/rebuild.go:33
 msgid   "If an instance is running, stop it and then rebuild it"
 msgstr  ""
 
@@ -2591,7 +2591,7 @@ msgstr  ""
 msgid   "Input data"
 msgstr  ""
 
-#: lxc/auth.go:1233 lxc/auth.go:1234
+#: lxc/auth.go:1234 lxc/auth.go:1235
 msgid   "Inspect permissions"
 msgstr  ""
 
@@ -2599,11 +2599,11 @@ msgstr  ""
 msgid   "Instance Only"
 msgstr  ""
 
-#: lxc/file.go:1124
+#: lxc/file.go:1125
 msgid   "Instance disconnected"
 msgstr  ""
 
-#: lxc/file.go:1301
+#: lxc/file.go:1302
 #, c-format
 msgid   "Instance disconnected for client %q"
 msgstr  ""
@@ -2621,7 +2621,7 @@ msgstr  ""
 msgid   "Instance name must be specified"
 msgstr  ""
 
-#: lxc/file.go:1044
+#: lxc/file.go:1045
 msgid   "Instance path cannot be used in SSH SFTP listener mode"
 msgstr  ""
 
@@ -2630,7 +2630,7 @@ msgstr  ""
 msgid   "Instance published with fingerprint: %s"
 msgstr  ""
 
-#: lxc/rebuild.go:74
+#: lxc/rebuild.go:75
 #, c-format
 msgid   "Instance snapshots cannot be rebuilt: %s"
 msgstr  ""
@@ -2663,7 +2663,7 @@ msgstr  ""
 msgid   "Invalid config key column format (too many fields): '%s'"
 msgstr  ""
 
-#: lxc/monitor.go:70
+#: lxc/monitor.go:71
 #, c-format
 msgid   "Invalid format: %s"
 msgstr  ""
@@ -2673,7 +2673,7 @@ msgstr  ""
 msgid   "Invalid instance name: %s"
 msgstr  ""
 
-#: lxc/file.go:1039
+#: lxc/file.go:1040
 #, c-format
 msgid   "Invalid instance path: %q"
 msgstr  ""
@@ -2714,7 +2714,7 @@ msgstr  ""
 msgid   "Invalid number of arguments"
 msgstr  ""
 
-#: lxc/file.go:147
+#: lxc/file.go:148
 #, c-format
 msgid   "Invalid path %s"
 msgstr  ""
@@ -2728,12 +2728,12 @@ msgstr  ""
 msgid   "Invalid snapshot name"
 msgstr  ""
 
-#: lxc/file.go:313
+#: lxc/file.go:314
 #, c-format
 msgid   "Invalid source %s"
 msgstr  ""
 
-#: lxc/file.go:495
+#: lxc/file.go:496
 #, c-format
 msgid   "Invalid target %s"
 msgstr  ""
@@ -2747,7 +2747,7 @@ msgstr  ""
 msgid   "Keep the image up to date after initial copy"
 msgstr  ""
 
-#: lxc/warning.go:211
+#: lxc/warning.go:212
 msgid   "LAST SEEN"
 msgstr  ""
 
@@ -2755,7 +2755,7 @@ msgstr  ""
 msgid   "LAST USED AT"
 msgstr  ""
 
-#: lxc/project.go:984
+#: lxc/project.go:985
 msgid   "LIMIT"
 msgstr  ""
 
@@ -2763,7 +2763,7 @@ msgstr  ""
 msgid   "LISTEN ADDRESS"
 msgstr  ""
 
-#: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163 lxc/network_load_balancer.go:165 lxc/operation.go:177 lxc/storage_bucket.go:516 lxc/storage_volume.go:1739 lxc/warning.go:220
+#: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163 lxc/network_load_balancer.go:165 lxc/operation.go:178 lxc/storage_bucket.go:517 lxc/storage_volume.go:1739 lxc/warning.go:221
 msgid   "LOCATION"
 msgstr  ""
 
@@ -2836,7 +2836,7 @@ msgstr  ""
 msgid   "List all the cluster members"
 msgstr  ""
 
-#: lxc/warning.go:94
+#: lxc/warning.go:95
 msgid   "List all warnings"
 msgstr  ""
 
@@ -2880,19 +2880,19 @@ msgstr  ""
 msgid   "List available storage pools"
 msgstr  ""
 
-#: lxc/operation.go:105 lxc/operation.go:106
+#: lxc/operation.go:106 lxc/operation.go:107
 msgid   "List background operations"
 msgstr  ""
 
-#: lxc/auth.go:331 lxc/auth.go:332
+#: lxc/auth.go:332 lxc/auth.go:333
 msgid   "List groups"
 msgstr  ""
 
-#: lxc/auth.go:764 lxc/auth.go:765
+#: lxc/auth.go:765 lxc/auth.go:766
 msgid   "List identities"
 msgstr  ""
 
-#: lxc/auth.go:1691 lxc/auth.go:1692
+#: lxc/auth.go:1692 lxc/auth.go:1693
 msgid   "List identity provider groups"
 msgstr  ""
 
@@ -3031,11 +3031,11 @@ msgstr  ""
 msgid   "List of projects to restrict the certificate to"
 msgstr  ""
 
-#: lxc/operation.go:109
+#: lxc/operation.go:110
 msgid   "List operations from all projects"
 msgstr  ""
 
-#: lxc/auth.go:1255 lxc/auth.go:1256
+#: lxc/auth.go:1256 lxc/auth.go:1257
 msgid   "List permissions"
 msgstr  ""
 
@@ -3043,15 +3043,15 @@ msgstr  ""
 msgid   "List profiles"
 msgstr  ""
 
-#: lxc/project.go:469 lxc/project.go:470
+#: lxc/project.go:470 lxc/project.go:471
 msgid   "List projects"
 msgstr  ""
 
-#: lxc/storage_bucket.go:771 lxc/storage_bucket.go:773
+#: lxc/storage_bucket.go:772 lxc/storage_bucket.go:774
 msgid   "List storage bucket keys"
 msgstr  ""
 
-#: lxc/storage_bucket.go:456 lxc/storage_bucket.go:458
+#: lxc/storage_bucket.go:457 lxc/storage_bucket.go:459
 msgid   "List storage buckets"
 msgstr  ""
 
@@ -3086,11 +3086,11 @@ msgstr  ""
 msgid   "List trusted clients"
 msgstr  ""
 
-#: lxc/warning.go:70
+#: lxc/warning.go:71
 msgid   "List warnings"
 msgstr  ""
 
-#: lxc/warning.go:71
+#: lxc/warning.go:72
 msgid   "List warnings\n"
         "\n"
         "The -c option takes a (optionally comma-separated) list of arguments\n"
@@ -3112,7 +3112,7 @@ msgid   "List warnings\n"
         "    t - Type"
 msgstr  ""
 
-#: lxc/operation.go:23 lxc/operation.go:24
+#: lxc/operation.go:24 lxc/operation.go:25
 msgid   "List, show and delete background operations"
 msgstr  ""
 
@@ -3121,7 +3121,7 @@ msgstr  ""
 msgid   "Location: %s"
 msgstr  ""
 
-#: lxc/monitor.go:79
+#: lxc/monitor.go:80
 msgid   "Log level filtering can only be used with pretty formatting"
 msgstr  ""
 
@@ -3225,23 +3225,23 @@ msgstr  ""
 msgid   "Manage devices"
 msgstr  ""
 
-#: lxc/file.go:82 lxc/file.go:83
+#: lxc/file.go:83 lxc/file.go:84
 msgid   "Manage files in instances"
 msgstr  ""
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1433 lxc/auth.go:1434
+#: lxc/auth.go:59 lxc/auth.go:60 lxc/auth.go:1434 lxc/auth.go:1435
 msgid   "Manage groups"
 msgstr  ""
 
-#: lxc/auth.go:1083 lxc/auth.go:1084
+#: lxc/auth.go:1084 lxc/auth.go:1085
 msgid   "Manage groups for the identity"
 msgstr  ""
 
-#: lxc/auth.go:730 lxc/auth.go:731
+#: lxc/auth.go:731 lxc/auth.go:732
 msgid   "Manage identities"
 msgstr  ""
 
-#: lxc/auth.go:1851 lxc/auth.go:1852
+#: lxc/auth.go:1852 lxc/auth.go:1853
 msgid   "Manage identity provider group mappings"
 msgstr  ""
 
@@ -3331,7 +3331,7 @@ msgstr  ""
 msgid   "Manage network zones"
 msgstr  ""
 
-#: lxc/auth.go:492 lxc/auth.go:493
+#: lxc/auth.go:493 lxc/auth.go:494
 msgid   "Manage permissions"
 msgstr  ""
 
@@ -3339,23 +3339,23 @@ msgstr  ""
 msgid   "Manage profiles"
 msgstr  ""
 
-#: lxc/project.go:28 lxc/project.go:29
+#: lxc/project.go:29 lxc/project.go:30
 msgid   "Manage projects"
 msgstr  ""
 
-#: lxc/storage_bucket.go:731
+#: lxc/storage_bucket.go:732
 msgid   "Manage storage bucket keys"
 msgstr  ""
 
-#: lxc/storage_bucket.go:732
+#: lxc/storage_bucket.go:733
 msgid   "Manage storage bucket keys."
 msgstr  ""
 
-#: lxc/storage_bucket.go:28
+#: lxc/storage_bucket.go:29
 msgid   "Manage storage buckets"
 msgstr  ""
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:30
 msgid   "Manage storage buckets."
 msgstr  ""
 
@@ -3381,11 +3381,11 @@ msgstr  ""
 msgid   "Manage trusted clients"
 msgstr  ""
 
-#: lxc/auth.go:29 lxc/auth.go:30
+#: lxc/auth.go:30 lxc/auth.go:31
 msgid   "Manage user authorization"
 msgstr  ""
 
-#: lxc/warning.go:28 lxc/warning.go:29
+#: lxc/warning.go:29 lxc/warning.go:30
 msgid   "Manage warnings"
 msgstr  ""
 
@@ -3449,11 +3449,11 @@ msgstr  ""
 msgid   "Migration operation failure: %w"
 msgstr  ""
 
-#: lxc/monitor.go:51
+#: lxc/monitor.go:52
 msgid   "Minimum level for log messages (only available when using pretty format)"
 msgstr  ""
 
-#: lxc/storage_bucket.go:116 lxc/storage_bucket.go:216 lxc/storage_bucket.go:292 lxc/storage_bucket.go:411 lxc/storage_bucket.go:568 lxc/storage_bucket.go:660 lxc/storage_bucket.go:802 lxc/storage_bucket.go:889 lxc/storage_bucket.go:986 lxc/storage_bucket.go:1065 lxc/storage_bucket.go:1188
+#: lxc/storage_bucket.go:117 lxc/storage_bucket.go:217 lxc/storage_bucket.go:293 lxc/storage_bucket.go:412 lxc/storage_bucket.go:569 lxc/storage_bucket.go:661 lxc/storage_bucket.go:803 lxc/storage_bucket.go:890 lxc/storage_bucket.go:987 lxc/storage_bucket.go:1066 lxc/storage_bucket.go:1189
 msgid   "Missing bucket name"
 msgstr  ""
 
@@ -3469,27 +3469,27 @@ msgstr  ""
 msgid   "Missing cluster member name"
 msgstr  ""
 
-#: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416 lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1825
+#: lxc/auth.go:123 lxc/auth.go:177 lxc/auth.go:255 lxc/auth.go:417 lxc/auth.go:466 lxc/auth.go:541 lxc/auth.go:600 lxc/auth.go:1826
 msgid   "Missing group name"
 msgstr  ""
 
-#: lxc/auth.go:862 lxc/auth.go:1003 lxc/auth.go:1131 lxc/auth.go:1189
+#: lxc/auth.go:863 lxc/auth.go:1004 lxc/auth.go:1132 lxc/auth.go:1190
 msgid   "Missing identity argument"
 msgstr  ""
 
-#: lxc/auth.go:1495 lxc/auth.go:1548 lxc/auth.go:1614 lxc/auth.go:1776
+#: lxc/auth.go:1496 lxc/auth.go:1549 lxc/auth.go:1615 lxc/auth.go:1777
 msgid   "Missing identity provider group name"
 msgstr  ""
 
-#: lxc/auth.go:1899 lxc/auth.go:1952
+#: lxc/auth.go:1900 lxc/auth.go:1953
 msgid   "Missing identity provider group name argument"
 msgstr  ""
 
-#: lxc/config_metadata.go:112 lxc/config_metadata.go:221 lxc/config_template.go:100 lxc/config_template.go:155 lxc/config_template.go:209 lxc/config_template.go:306 lxc/config_template.go:377 lxc/profile.go:141 lxc/profile.go:222 lxc/profile.go:808 lxc/rebuild.go:60
+#: lxc/config_metadata.go:112 lxc/config_metadata.go:221 lxc/config_template.go:100 lxc/config_template.go:155 lxc/config_template.go:209 lxc/config_template.go:306 lxc/config_template.go:377 lxc/profile.go:141 lxc/profile.go:222 lxc/profile.go:808 lxc/rebuild.go:61
 msgid   "Missing instance name"
 msgstr  ""
 
-#: lxc/storage_bucket.go:893 lxc/storage_bucket.go:990 lxc/storage_bucket.go:1069 lxc/storage_bucket.go:1192
+#: lxc/storage_bucket.go:894 lxc/storage_bucket.go:991 lxc/storage_bucket.go:1070 lxc/storage_bucket.go:1193
 msgid   "Missing key name"
 msgstr  ""
 
@@ -3521,7 +3521,7 @@ msgstr  ""
 msgid   "Missing peer name"
 msgstr  ""
 
-#: lxc/storage.go:235 lxc/storage.go:313 lxc/storage.go:431 lxc/storage.go:509 lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:112 lxc/storage_bucket.go:212 lxc/storage_bucket.go:288 lxc/storage_bucket.go:407 lxc/storage_bucket.go:482 lxc/storage_bucket.go:564 lxc/storage_bucket.go:656 lxc/storage_bucket.go:798 lxc/storage_bucket.go:885 lxc/storage_bucket.go:982 lxc/storage_bucket.go:1061 lxc/storage_bucket.go:1184 lxc/storage_volume.go:209 lxc/storage_volume.go:323 lxc/storage_volume.go:643 lxc/storage_volume.go:750 lxc/storage_volume.go:841 lxc/storage_volume.go:939 lxc/storage_volume.go:1053 lxc/storage_volume.go:1270 lxc/storage_volume.go:1974 lxc/storage_volume.go:2115 lxc/storage_volume.go:2273 lxc/storage_volume.go:2464 lxc/storage_volume.go:2581
+#: lxc/storage.go:235 lxc/storage.go:313 lxc/storage.go:431 lxc/storage.go:509 lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:113 lxc/storage_bucket.go:213 lxc/storage_bucket.go:289 lxc/storage_bucket.go:408 lxc/storage_bucket.go:483 lxc/storage_bucket.go:565 lxc/storage_bucket.go:657 lxc/storage_bucket.go:799 lxc/storage_bucket.go:886 lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062 lxc/storage_bucket.go:1185 lxc/storage_volume.go:209 lxc/storage_volume.go:323 lxc/storage_volume.go:643 lxc/storage_volume.go:750 lxc/storage_volume.go:841 lxc/storage_volume.go:939 lxc/storage_volume.go:1053 lxc/storage_volume.go:1270 lxc/storage_volume.go:1974 lxc/storage_volume.go:2115 lxc/storage_volume.go:2273 lxc/storage_volume.go:2464 lxc/storage_volume.go:2581
 msgid   "Missing pool name"
 msgstr  ""
 
@@ -3529,7 +3529,7 @@ msgstr  ""
 msgid   "Missing profile name"
 msgstr  ""
 
-#: lxc/profile.go:404 lxc/project.go:146 lxc/project.go:226 lxc/project.go:316 lxc/project.go:433 lxc/project.go:622 lxc/project.go:691 lxc/project.go:819 lxc/project.go:948
+#: lxc/profile.go:404 lxc/project.go:147 lxc/project.go:227 lxc/project.go:317 lxc/project.go:434 lxc/project.go:623 lxc/project.go:692 lxc/project.go:820 lxc/project.go:949
 msgid   "Missing project name"
 msgstr  ""
 
@@ -3545,7 +3545,7 @@ msgstr  ""
 msgid   "Missing storage pool name"
 msgstr  ""
 
-#: lxc/file.go:598
+#: lxc/file.go:599
 msgid   "Missing target directory"
 msgstr  ""
 
@@ -3567,11 +3567,11 @@ msgstr  ""
 msgid   "Model: %v"
 msgstr  ""
 
-#: lxc/monitor.go:32
+#: lxc/monitor.go:33
 msgid   "Monitor a local or remote LXD server"
 msgstr  ""
 
-#: lxc/monitor.go:33
+#: lxc/monitor.go:34
 msgid   "Monitor a local or remote LXD server\n"
         "\n"
         "By default the monitor will listen to all message types."
@@ -3581,11 +3581,11 @@ msgstr  ""
 msgid   "More than one device matches, specify the device name"
 msgstr  ""
 
-#: lxc/file.go:285
+#: lxc/file.go:286
 msgid   "More than one file to download, but target is not a directory"
 msgstr  ""
 
-#: lxc/file.go:985 lxc/file.go:986
+#: lxc/file.go:986 lxc/file.go:987
 msgid   "Mount files from instances"
 msgstr  ""
 
@@ -3642,7 +3642,7 @@ msgstr  ""
 msgid   "Must supply instance name for: "
 msgstr  ""
 
-#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:192 lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081 lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147 lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:565 lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:511 lxc/storage_bucket.go:831 lxc/storage_volume.go:1731
+#: lxc/auth.go:376 lxc/auth.go:816 lxc/auth.go:1736 lxc/cluster.go:192 lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081 lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147 lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:566 lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:512 lxc/storage_bucket.go:832 lxc/storage_volume.go:1731
 msgid   "NAME"
 msgstr  ""
 
@@ -3650,11 +3650,11 @@ msgstr  ""
 msgid   "NAT"
 msgstr  ""
 
-#: lxc/project.go:571
+#: lxc/project.go:572
 msgid   "NETWORK ZONES"
 msgstr  ""
 
-#: lxc/project.go:570
+#: lxc/project.go:571
 msgid   "NETWORKS"
 msgstr  ""
 
@@ -3666,7 +3666,7 @@ msgstr  ""
 msgid   "NICs:"
 msgstr  ""
 
-#: lxc/network.go:1058 lxc/operation.go:154 lxc/project.go:523 lxc/project.go:528 lxc/project.go:533 lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
+#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:524 lxc/project.go:529 lxc/project.go:534 lxc/project.go:539 lxc/project.go:544 lxc/project.go:549 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
 msgid   "NO"
 msgstr  ""
 
@@ -3909,7 +3909,7 @@ msgstr  ""
 msgid   "Only managed networks can be modified"
 msgstr  ""
 
-#: lxc/operation.go:86
+#: lxc/operation.go:87
 #, c-format
 msgid   "Operation %s deleted"
 msgstr  ""
@@ -3956,11 +3956,11 @@ msgstr  ""
 msgid   "PROCESSES"
 msgstr  ""
 
-#: lxc/list.go:576 lxc/project.go:567
+#: lxc/list.go:576 lxc/project.go:568
 msgid   "PROFILES"
 msgstr  ""
 
-#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:212
+#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:213
 msgid   "PROJECT"
 msgstr  ""
 
@@ -4022,15 +4022,15 @@ msgstr  ""
 msgid   "Ports:"
 msgstr  ""
 
-#: lxc/file.go:1102
+#: lxc/file.go:1103
 msgid   "Press ctrl+c to finish"
 msgstr  ""
 
-#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:860 lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357 lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239 lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760 lxc/network_acl.go:699 lxc/network_forward.go:768 lxc/network_load_balancer.go:739 lxc/network_peer.go:699 lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596 lxc/project.go:363 lxc/storage.go:360 lxc/storage_bucket.go:349 lxc/storage_bucket.go:1126 lxc/storage_volume.go:1151 lxc/storage_volume.go:1183
+#: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860 lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357 lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239 lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760 lxc/network_acl.go:699 lxc/network_forward.go:768 lxc/network_load_balancer.go:739 lxc/network_peer.go:699 lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596 lxc/project.go:364 lxc/storage.go:360 lxc/storage_bucket.go:350 lxc/storage_bucket.go:1127 lxc/storage_volume.go:1151 lxc/storage_volume.go:1183
 msgid   "Press enter to open the editor again or ctrl+c to abort change"
 msgstr  ""
 
-#: lxc/monitor.go:48
+#: lxc/monitor.go:49
 msgid   "Pretty rendering (short for --format=pretty)"
 msgstr  ""
 
@@ -4116,17 +4116,17 @@ msgstr  ""
 msgid   "Profiles: "
 msgstr  ""
 
-#: lxc/project.go:172
+#: lxc/project.go:173
 #, c-format
 msgid   "Project %s created"
 msgstr  ""
 
-#: lxc/project.go:236
+#: lxc/project.go:237
 #, c-format
 msgid   "Project %s deleted"
 msgstr  ""
 
-#: lxc/project.go:637
+#: lxc/project.go:638
 #, c-format
 msgid   "Project %s renamed to %s"
 msgstr  ""
@@ -4231,20 +4231,20 @@ msgstr  ""
 msgid   "Publishing instance: %s"
 msgstr  ""
 
-#: lxc/file.go:241 lxc/file.go:242
+#: lxc/file.go:242 lxc/file.go:243
 msgid   "Pull files from instances"
 msgstr  ""
 
-#: lxc/file.go:416 lxc/file.go:767
+#: lxc/file.go:417 lxc/file.go:768
 #, c-format
 msgid   "Pulling %s from %s: %%s"
 msgstr  ""
 
-#: lxc/file.go:466 lxc/file.go:467
+#: lxc/file.go:467 lxc/file.go:468
 msgid   "Push files into instances"
 msgstr  ""
 
-#: lxc/file.go:701 lxc/file.go:867
+#: lxc/file.go:702 lxc/file.go:868
 #, c-format
 msgid   "Pushing %s to %s: %%s"
 msgstr  ""
@@ -4257,11 +4257,11 @@ msgstr  ""
 msgid   "Query virtual machine images"
 msgstr  ""
 
-#: lxc/project.go:983
+#: lxc/project.go:984
 msgid   "RESOURCE"
 msgstr  ""
 
-#: lxc/storage_bucket.go:833
+#: lxc/storage_bucket.go:834
 msgid   "ROLE"
 msgstr  ""
 
@@ -4274,15 +4274,15 @@ msgstr  ""
 msgid   "Read-Only: %v"
 msgstr  ""
 
-#: lxc/rebuild.go:31
+#: lxc/rebuild.go:32
 msgid   "Rebuild as an empty instance"
 msgstr  ""
 
-#: lxc/rebuild.go:26
+#: lxc/rebuild.go:27
 msgid   "Rebuild instances"
 msgstr  ""
 
-#: lxc/file.go:249 lxc/file.go:473
+#: lxc/file.go:250 lxc/file.go:474
 msgid   "Recursively transfer files"
 msgstr  ""
 
@@ -4309,7 +4309,7 @@ msgstr  ""
 msgid   "Remote %s already exists"
 msgstr  ""
 
-#: lxc/project.go:882 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946 lxc/remote.go:994
+#: lxc/project.go:883 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946 lxc/remote.go:994
 #, c-format
 msgid   "Remote %s doesn't exist"
 msgstr  ""
@@ -4359,7 +4359,7 @@ msgstr  ""
 msgid   "Remove a cluster member from a cluster group"
 msgstr  ""
 
-#: lxc/auth.go:1164 lxc/auth.go:1165
+#: lxc/auth.go:1165 lxc/auth.go:1166
 msgid   "Remove a group from an identity"
 msgstr  ""
 
@@ -4395,7 +4395,7 @@ msgstr  ""
 msgid   "Remove entries from a network zone record"
 msgstr  ""
 
-#: lxc/auth.go:1927 lxc/auth.go:1928
+#: lxc/auth.go:1928 lxc/auth.go:1929
 msgid   "Remove identities from groups"
 msgstr  ""
 
@@ -4407,7 +4407,7 @@ msgstr  ""
 msgid   "Remove member from group"
 msgstr  ""
 
-#: lxc/auth.go:574 lxc/auth.go:575
+#: lxc/auth.go:575 lxc/auth.go:576
 msgid   "Remove permissions from groups"
 msgstr  ""
 
@@ -4451,11 +4451,11 @@ msgstr  ""
 msgid   "Rename aliases"
 msgstr  ""
 
-#: lxc/auth.go:391 lxc/auth.go:392
+#: lxc/auth.go:392 lxc/auth.go:393
 msgid   "Rename groups"
 msgstr  ""
 
-#: lxc/auth.go:1751 lxc/auth.go:1752
+#: lxc/auth.go:1752 lxc/auth.go:1753
 msgid   "Rename identity provider groups"
 msgstr  ""
 
@@ -4475,7 +4475,7 @@ msgstr  ""
 msgid   "Rename profiles"
 msgstr  ""
 
-#: lxc/project.go:589 lxc/project.go:590
+#: lxc/project.go:590 lxc/project.go:591
 msgid   "Rename projects"
 msgstr  ""
 
@@ -4571,7 +4571,7 @@ msgstr  ""
 msgid   "Revoke cluster member join token"
 msgstr  ""
 
-#: lxc/storage_bucket.go:862
+#: lxc/storage_bucket.go:863
 msgid   "Role (admin or read-only)"
 msgstr  ""
 
@@ -4587,7 +4587,7 @@ msgstr  ""
 msgid   "Run against all projects"
 msgstr  ""
 
-#: lxc/warning.go:213
+#: lxc/warning.go:214
 msgid   "SEVERITY"
 msgstr  ""
 
@@ -4607,12 +4607,12 @@ msgstr  ""
 msgid   "SR-IOV information:"
 msgstr  ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1231
 #, c-format
 msgid   "SSH client connected %q"
 msgstr  ""
 
-#: lxc/file.go:1231
+#: lxc/file.go:1232
 #, c-format
 msgid   "SSH client disconnected %q"
 msgstr  ""
@@ -4625,11 +4625,11 @@ msgstr  ""
 msgid   "STATIC"
 msgstr  ""
 
-#: lxc/operation.go:173 lxc/warning.go:214
+#: lxc/operation.go:174 lxc/warning.go:215
 msgid   "STATUS"
 msgstr  ""
 
-#: lxc/project.go:569
+#: lxc/project.go:570
 msgid   "STORAGE BUCKETS"
 msgstr  ""
 
@@ -4637,7 +4637,7 @@ msgstr  ""
 msgid   "STORAGE POOL"
 msgstr  ""
 
-#: lxc/project.go:568
+#: lxc/project.go:569
 msgid   "STORAGE VOLUMES"
 msgstr  ""
 
@@ -4645,11 +4645,11 @@ msgstr  ""
 msgid   "STP"
 msgstr  ""
 
-#: lxc/storage_bucket.go:864
+#: lxc/storage_bucket.go:865
 msgid   "Secret key (auto-generated if empty)"
 msgstr  ""
 
-#: lxc/storage_bucket.go:942
+#: lxc/storage_bucket.go:943
 #, c-format
 msgid   "Secret key: %s"
 msgstr  ""
@@ -4687,7 +4687,7 @@ msgstr  ""
 msgid   "Set a cluster member's configuration keys"
 msgstr  ""
 
-#: lxc/file.go:995
+#: lxc/file.go:996
 msgid   "Set authentication user when using SSH SFTP listener"
 msgstr  ""
 
@@ -4805,22 +4805,22 @@ msgid   "Set profile configuration keys\n"
         "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr  ""
 
-#: lxc/project.go:654
+#: lxc/project.go:655
 msgid   "Set project configuration keys"
 msgstr  ""
 
-#: lxc/project.go:655
+#: lxc/project.go:656
 msgid   "Set project configuration keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
         "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr  ""
 
-#: lxc/storage_bucket.go:534
+#: lxc/storage_bucket.go:535
 msgid   "Set storage bucket configuration keys"
 msgstr  ""
 
-#: lxc/storage_bucket.go:535
+#: lxc/storage_bucket.go:536
 msgid   "Set storage bucket configuration keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
@@ -4853,15 +4853,15 @@ msgstr  ""
 msgid   "Set the URL for the remote"
 msgstr  ""
 
-#: lxc/file.go:476
+#: lxc/file.go:477
 msgid   "Set the file's gid on push"
 msgstr  ""
 
-#: lxc/file.go:477
+#: lxc/file.go:478
 msgid   "Set the file's perms on push"
 msgstr  ""
 
-#: lxc/file.go:475
+#: lxc/file.go:476
 msgid   "Set the file's uid on push"
 msgstr  ""
 
@@ -4901,11 +4901,11 @@ msgstr  ""
 msgid   "Set the key as a profile property"
 msgstr  ""
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 msgid   "Set the key as a project property"
 msgstr  ""
 
-#: lxc/storage_bucket.go:542
+#: lxc/storage_bucket.go:543
 msgid   "Set the key as a storage bucket property"
 msgstr  ""
 
@@ -4921,7 +4921,7 @@ msgstr  ""
 msgid   "Set the key as an instance property"
 msgstr  ""
 
-#: lxc/file.go:993
+#: lxc/file.go:994
 msgid   "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr  ""
 
@@ -4933,7 +4933,7 @@ msgstr  ""
 msgid   "Show all information messages"
 msgstr  ""
 
-#: lxc/auth.go:1800 lxc/auth.go:1801
+#: lxc/auth.go:1801 lxc/auth.go:1802
 msgid   "Show an identity provider group"
 msgstr  ""
 
@@ -4949,11 +4949,11 @@ msgstr  ""
 msgid   "Show details of a cluster member"
 msgstr  ""
 
-#: lxc/operation.go:192 lxc/operation.go:193
+#: lxc/operation.go:193 lxc/operation.go:194
 msgid   "Show details on a background operation"
 msgstr  ""
 
-#: lxc/monitor.go:49
+#: lxc/monitor.go:50
 msgid   "Show events from all projects"
 msgstr  ""
 
@@ -4961,11 +4961,11 @@ msgstr  ""
 msgid   "Show full device configuration"
 msgstr  ""
 
-#: lxc/auth.go:440 lxc/auth.go:441
+#: lxc/auth.go:441 lxc/auth.go:442
 msgid   "Show group configurations"
 msgstr  ""
 
-#: lxc/auth.go:832
+#: lxc/auth.go:833
 msgid   "Show identity configurations\n"
         "\n"
         "The argument must be a concatenation of the authentication method and either the\n"
@@ -5042,15 +5042,15 @@ msgstr  ""
 msgid   "Show profile configurations"
 msgstr  ""
 
-#: lxc/project.go:786 lxc/project.go:787
+#: lxc/project.go:787 lxc/project.go:788
 msgid   "Show project options"
 msgstr  ""
 
-#: lxc/storage_bucket.go:628 lxc/storage_bucket.go:629
+#: lxc/storage_bucket.go:629 lxc/storage_bucket.go:630
 msgid   "Show storage bucket configurations"
 msgstr  ""
 
-#: lxc/storage_bucket.go:1156 lxc/storage_bucket.go:1157
+#: lxc/storage_bucket.go:1157 lxc/storage_bucket.go:1158
 msgid   "Show storage bucket key configurations"
 msgstr  ""
 
@@ -5066,7 +5066,7 @@ msgstr  ""
 msgid   "Show storage volume state information"
 msgstr  ""
 
-#: lxc/auth.go:895
+#: lxc/auth.go:896
 msgid   "Show the current identity\n"
         "\n"
         "This command will display permissions for the current user.\n"
@@ -5114,7 +5114,7 @@ msgstr  ""
 msgid   "Show useful information about storage pools"
 msgstr  ""
 
-#: lxc/warning.go:302 lxc/warning.go:303
+#: lxc/warning.go:303 lxc/warning.go:304
 msgid   "Show warning"
 msgstr  ""
 
@@ -5198,22 +5198,22 @@ msgstr  ""
 msgid   "Stopping the instance failed: %s"
 msgstr  ""
 
-#: lxc/storage_bucket.go:166
+#: lxc/storage_bucket.go:167
 #, c-format
 msgid   "Storage bucket %s created"
 msgstr  ""
 
-#: lxc/storage_bucket.go:233
+#: lxc/storage_bucket.go:234
 #, c-format
 msgid   "Storage bucket %s deleted"
 msgstr  ""
 
-#: lxc/storage_bucket.go:940
+#: lxc/storage_bucket.go:941
 #, c-format
 msgid   "Storage bucket key %s added"
 msgstr  ""
 
-#: lxc/storage_bucket.go:1006
+#: lxc/storage_bucket.go:1007
 #, c-format
 msgid   "Storage bucket key %s removed"
 msgstr  ""
@@ -5282,7 +5282,7 @@ msgstr  ""
 msgid   "Swap (peak)"
 msgstr  ""
 
-#: lxc/project.go:847 lxc/project.go:848
+#: lxc/project.go:848 lxc/project.go:849
 msgid   "Switch the current project"
 msgstr  ""
 
@@ -5298,7 +5298,7 @@ msgstr  ""
 msgid   "TOKEN"
 msgstr  ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1139 lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082 lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:171 lxc/storage_volume.go:1730 lxc/warning.go:215
+#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1139 lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082 lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172 lxc/storage_volume.go:1730 lxc/warning.go:216
 msgid   "TYPE"
 msgstr  ""
 
@@ -5306,11 +5306,11 @@ msgstr  ""
 msgid   "Taken at"
 msgstr  ""
 
-#: lxc/file.go:1032
+#: lxc/file.go:1033
 msgid   "Target path and --listen flag cannot be used together"
 msgstr  ""
 
-#: lxc/file.go:1026
+#: lxc/file.go:1027
 msgid   "Target path must be a directory"
 msgstr  ""
 
@@ -5436,12 +5436,12 @@ msgstr  ""
 msgid   "The property %q does not exist on the profile %q: %v"
 msgstr  ""
 
-#: lxc/project.go:446
+#: lxc/project.go:447
 #, c-format
 msgid   "The property %q does not exist on the project %q: %v"
 msgstr  ""
 
-#: lxc/storage_bucket.go:431
+#: lxc/storage_bucket.go:432
 #, c-format
 msgid   "The property %q does not exist on the storage bucket %q: %v"
 msgstr  ""
@@ -5615,7 +5615,7 @@ msgstr  ""
 msgid   "Type: %s (ephemeral)"
 msgstr  ""
 
-#: lxc/project.go:961
+#: lxc/project.go:962
 msgid   "UNLIMITED"
 msgstr  ""
 
@@ -5627,15 +5627,15 @@ msgstr  ""
 msgid   "URL"
 msgstr  ""
 
-#: lxc/project.go:985 lxc/storage_volume.go:1735
+#: lxc/project.go:986 lxc/storage_volume.go:1735
 msgid   "USAGE"
 msgstr  ""
 
-#: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24 lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:573 lxc/storage.go:724 lxc/storage_volume.go:1734
+#: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24 lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:574 lxc/storage.go:724 lxc/storage_volume.go:1734
 msgid   "USED BY"
 msgstr  ""
 
-#: lxc/warning.go:216
+#: lxc/warning.go:217
 msgid   "UUID"
 msgstr  ""
 
@@ -5644,7 +5644,7 @@ msgstr  ""
 msgid   "UUID: %v"
 msgstr  ""
 
-#: lxc/file.go:197
+#: lxc/file.go:198
 #, c-format
 msgid   "Unable to create a temporary file: %v"
 msgstr  ""
@@ -5658,12 +5658,12 @@ msgstr  ""
 msgid   "Unknown certificate type %q"
 msgstr  ""
 
-#: lxc/file.go:1253
+#: lxc/file.go:1254
 #, c-format
 msgid   "Unknown channel type for client %q: %s"
 msgstr  ""
 
-#: lxc/image.go:1153 lxc/list.go:631 lxc/storage_volume.go:1772 lxc/warning.go:241
+#: lxc/image.go:1153 lxc/list.go:631 lxc/storage_volume.go:1772 lxc/warning.go:242
 #, c-format
 msgid   "Unknown column shorthand char '%c' in '%s'"
 msgstr  ""
@@ -5673,7 +5673,7 @@ msgstr  ""
 msgid   "Unknown console type %q"
 msgstr  ""
 
-#: lxc/file.go:807
+#: lxc/file.go:808
 #, c-format
 msgid   "Unknown file type '%s'"
 msgstr  ""
@@ -5756,11 +5756,11 @@ msgstr  ""
 msgid   "Unset profile configuration keys"
 msgstr  ""
 
-#: lxc/project.go:742 lxc/project.go:743
+#: lxc/project.go:743 lxc/project.go:744
 msgid   "Unset project configuration keys"
 msgstr  ""
 
-#: lxc/storage_bucket.go:697 lxc/storage_bucket.go:698
+#: lxc/storage_bucket.go:698 lxc/storage_bucket.go:699
 msgid   "Unset storage bucket configuration keys"
 msgstr  ""
 
@@ -5808,11 +5808,11 @@ msgstr  ""
 msgid   "Unset the key as a profile property"
 msgstr  ""
 
-#: lxc/project.go:747
+#: lxc/project.go:748
 msgid   "Unset the key as a project property"
 msgstr  ""
 
-#: lxc/storage_bucket.go:701
+#: lxc/storage_bucket.go:702
 msgid   "Unset the key as a storage bucket property"
 msgstr  ""
 
@@ -5888,7 +5888,7 @@ msgstr  ""
 msgid   "User aborted delete operation"
 msgstr  ""
 
-#: lxc/file.go:71
+#: lxc/file.go:72
 msgid   "User signaled us three times, exiting. The remote operation will keep running"
 msgstr  ""
 
@@ -5924,11 +5924,11 @@ msgstr  ""
 msgid   "Verb: %s (%s)"
 msgstr  ""
 
-#: lxc/auth.go:831
+#: lxc/auth.go:832
 msgid   "View an identity"
 msgstr  ""
 
-#: lxc/auth.go:894
+#: lxc/auth.go:895
 msgid   "View the current identity"
 msgstr  ""
 
@@ -5957,11 +5957,11 @@ msgstr  ""
 msgid   "Whether or not to snapshot the instance's running state"
 msgstr  ""
 
-#: lxc/rebuild.go:27
+#: lxc/rebuild.go:28
 msgid   "Wipe the instance root disk and re-initialize. The original image is used to re-initialize the instance if a different image or --empty is not specified."
 msgstr  ""
 
-#: lxc/network.go:1060 lxc/operation.go:156 lxc/project.go:525 lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545 lxc/project.go:550 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
+#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:526 lxc/project.go:531 lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
 msgid   "YES"
 msgstr  ""
 
@@ -5981,7 +5981,7 @@ msgstr  ""
 msgid   "You must specify a source instance name"
 msgstr  ""
 
-#: lxc/rebuild.go:119
+#: lxc/rebuild.go:120
 msgid   "You need to specify an image name or use --empty"
 msgstr  ""
 
@@ -5993,7 +5993,7 @@ msgstr  ""
 msgid   "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr  ""
 
-#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1689 lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437 lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31 lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83 lxc/operation.go:103 lxc/profile.go:700 lxc/project.go:467 lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:68
+#: lxc/auth.go:330 lxc/auth.go:763 lxc/auth.go:894 lxc/auth.go:1690 lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437 lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32 lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83 lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:468 lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid   "[<remote>:]"
 msgstr  ""
 
@@ -6021,7 +6021,7 @@ msgstr  ""
 msgid   "[<remote>:] [<filters>...]"
 msgstr  ""
 
-#: lxc/auth.go:1254
+#: lxc/auth.go:1255
 msgid   "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr  ""
 
@@ -6081,11 +6081,11 @@ msgstr  ""
 msgid   "[<remote>:]<alias> <new-name>"
 msgstr  ""
 
-#: lxc/auth.go:830
+#: lxc/auth.go:831
 msgid   "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr  ""
 
-#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1926
+#: lxc/auth.go:1106 lxc/auth.go:1164 lxc/auth.go:1927
 msgid   "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr  ""
 
@@ -6093,11 +6093,11 @@ msgstr  ""
 msgid   "[<remote>:]<fingerprint>"
 msgstr  ""
 
-#: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439 lxc/auth.go:954 lxc/auth.go:1470 lxc/cluster_group.go:168 lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
+#: lxc/auth.go:97 lxc/auth.go:150 lxc/auth.go:200 lxc/auth.go:440 lxc/auth.go:955 lxc/auth.go:1471 lxc/cluster_group.go:168 lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid   "[<remote>:]<group>"
 msgstr  ""
 
-#: lxc/auth.go:514 lxc/auth.go:572
+#: lxc/auth.go:515 lxc/auth.go:573
 msgid   "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> [<key>=<value>...]"
 msgstr  ""
 
@@ -6105,19 +6105,19 @@ msgstr  ""
 msgid   "[<remote>:]<group> <new-name>"
 msgstr  ""
 
-#: lxc/auth.go:389
+#: lxc/auth.go:390
 msgid   "[<remote>:]<group> <new_name>"
 msgstr  ""
 
-#: lxc/auth.go:1521 lxc/auth.go:1571 lxc/auth.go:1799
+#: lxc/auth.go:1522 lxc/auth.go:1572 lxc/auth.go:1800
 msgid   "[<remote>:]<identity_provider_group>"
 msgstr  ""
 
-#: lxc/auth.go:1873
+#: lxc/auth.go:1874
 msgid   "[<remote>:]<identity_provider_group> <group>"
 msgstr  ""
 
-#: lxc/auth.go:1749
+#: lxc/auth.go:1750
 msgid   "[<remote>:]<identity_provider_group> <new_name>"
 msgstr  ""
 
@@ -6137,7 +6137,7 @@ msgstr  ""
 msgid   "[<remote>:]<image> <remote>:"
 msgstr  ""
 
-#: lxc/rebuild.go:25
+#: lxc/rebuild.go:26
 msgid   "[<remote>:]<image> [<remote>:]<instance>"
 msgstr  ""
 
@@ -6217,19 +6217,19 @@ msgstr  ""
 msgid   "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr  ""
 
-#: lxc/file.go:170
+#: lxc/file.go:171
 msgid   "[<remote>:]<instance>/<path>"
 msgstr  ""
 
-#: lxc/file.go:120
+#: lxc/file.go:121
 msgid   "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr  ""
 
-#: lxc/file.go:240
+#: lxc/file.go:241
 msgid   "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr  ""
 
-#: lxc/file.go:984
+#: lxc/file.go:985
 msgid   "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr  ""
 
@@ -6365,11 +6365,11 @@ msgstr  ""
 msgid   "[<remote>:]<network> [key=value...]"
 msgstr  ""
 
-#: lxc/operation.go:53 lxc/operation.go:191
+#: lxc/operation.go:54 lxc/operation.go:192
 msgid   "[<remote>:]<operation>"
 msgstr  ""
 
-#: lxc/storage.go:200 lxc/storage.go:259 lxc/storage.go:473 lxc/storage.go:844 lxc/storage_bucket.go:454
+#: lxc/storage.go:200 lxc/storage.go:259 lxc/storage.go:473 lxc/storage.go:844 lxc/storage_bucket.go:455
 msgid   "[<remote>:]<pool>"
 msgstr  ""
 
@@ -6377,19 +6377,19 @@ msgstr  ""
 msgid   "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr  ""
 
-#: lxc/storage_bucket.go:185 lxc/storage_bucket.go:247 lxc/storage_bucket.go:627 lxc/storage_bucket.go:769
+#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:248 lxc/storage_bucket.go:628 lxc/storage_bucket.go:770
 msgid   "[<remote>:]<pool> <bucket>"
 msgstr  ""
 
-#: lxc/storage_bucket.go:380 lxc/storage_bucket.go:696 lxc/storage_bucket.go:850 lxc/storage_bucket.go:956 lxc/storage_bucket.go:1020 lxc/storage_bucket.go:1155
+#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:697 lxc/storage_bucket.go:851 lxc/storage_bucket.go:957 lxc/storage_bucket.go:1021 lxc/storage_bucket.go:1156
 msgid   "[<remote>:]<pool> <bucket> <key>"
 msgstr  ""
 
-#: lxc/storage_bucket.go:533
+#: lxc/storage_bucket.go:534
 msgid   "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr  ""
 
-#: lxc/storage_bucket.go:81
+#: lxc/storage_bucket.go:82
 msgid   "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr  ""
 
@@ -6501,19 +6501,19 @@ msgstr  ""
 msgid   "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr  ""
 
-#: lxc/project.go:91 lxc/project.go:186 lxc/project.go:258 lxc/project.go:785 lxc/project.go:846 lxc/project.go:913
+#: lxc/project.go:92 lxc/project.go:187 lxc/project.go:259 lxc/project.go:786 lxc/project.go:847 lxc/project.go:914
 msgid   "[<remote>:]<project>"
 msgstr  ""
 
-#: lxc/project.go:394 lxc/project.go:741
+#: lxc/project.go:395 lxc/project.go:742
 msgid   "[<remote>:]<project> <key>"
 msgstr  ""
 
-#: lxc/project.go:653
+#: lxc/project.go:654
 msgid   "[<remote>:]<project> <key>=<value>..."
 msgstr  ""
 
-#: lxc/project.go:587
+#: lxc/project.go:588
 msgid   "[<remote>:]<project> <new-name>"
 msgstr  ""
 
@@ -6521,7 +6521,7 @@ msgstr  ""
 msgid   "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr  ""
 
-#: lxc/warning.go:259 lxc/warning.go:301 lxc/warning.go:354
+#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
 msgid   "[<remote>:]<warning-uuid>"
 msgstr  ""
 
@@ -6577,7 +6577,7 @@ msgstr  ""
 msgid   "[[<remote>:]<member>]"
 msgstr  ""
 
-#: lxc/project.go:555 lxc/remote.go:739
+#: lxc/project.go:556 lxc/remote.go:739
 msgid   "current"
 msgstr  ""
 
@@ -6621,17 +6621,17 @@ msgid   "lxc alias rename list my-list\n"
         "    Rename existing alias \"list\" to \"my-list\"."
 msgstr  ""
 
-#: lxc/auth.go:203
+#: lxc/auth.go:204
 msgid   "lxc auth group edit <group> < group.yaml\n"
         "   Update a group using the content of group.yaml"
 msgstr  ""
 
-#: lxc/auth.go:958
+#: lxc/auth.go:959
 msgid   "lxc auth identity edit <authentication_method>/<name_or_identifier> < identity.yaml\n"
         "   Update an identity using the content of identity.yaml"
 msgstr  ""
 
-#: lxc/auth.go:1575
+#: lxc/auth.go:1576
 msgid   "lxc auth identity-provider-group edit <identity_provider_group> < identity-provider-group.yaml\n"
         "   Update an identity provider group using the content of identity-provider-group.yaml"
 msgstr  ""
@@ -6692,17 +6692,17 @@ msgid   "lxc export u1 backup0.tar.gz\n"
         "    Download a backup tarball of the u1 instance."
 msgstr  ""
 
-#: lxc/file.go:988
+#: lxc/file.go:989
 msgid   "lxc file mount foo/root fooroot\n"
         "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr  ""
 
-#: lxc/file.go:244
+#: lxc/file.go:245
 msgid   "lxc file pull foo/etc/hosts .\n"
         "   To pull /etc/hosts from the instance and write it to the current directory."
 msgstr  ""
 
-#: lxc/file.go:469
+#: lxc/file.go:470
 msgid   "lxc file push /etc/hosts foo/etc/hosts\n"
         "   To push /etc/hosts into the instance \"foo\"."
 msgstr  ""
@@ -6769,7 +6769,7 @@ msgid   "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0
         "  List instances with their running state and user comment."
 msgstr  ""
 
-#: lxc/monitor.go:37
+#: lxc/monitor.go:38
 msgid   "lxc monitor --type=logging\n"
         "    Only show log messages.\n"
         "\n"
@@ -6834,7 +6834,7 @@ msgid   "lxc network zone record create z1 r1\n"
         "    Create record r1 for zone z1 with configuration from config.yaml"
 msgstr  ""
 
-#: lxc/operation.go:195
+#: lxc/operation.go:196
 msgid   "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
         "    Show details on that operation UUID"
 msgstr  ""
@@ -6870,14 +6870,14 @@ msgid   "lxc profile edit <profile> < profile.yaml\n"
         "    Update a profile using the content of profile.yaml"
 msgstr  ""
 
-#: lxc/project.go:95
+#: lxc/project.go:96
 msgid   "lxc project create p1\n"
         "\n"
         "lxc project create p1 < config.yaml\n"
         "    Create a project with configuration from config.yaml"
 msgstr  ""
 
-#: lxc/project.go:262
+#: lxc/project.go:263
 msgid   "lxc project edit <project> < project.yaml\n"
         "    Update a project using the content of project.yaml"
 msgstr  ""
@@ -6903,7 +6903,7 @@ msgid   "lxc snapshot u1 snap0\n"
         "    Restore the snapshot."
 msgstr  ""
 
-#: lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:85
 msgid   "lxc storage bucket create p1 b01\n"
         "	Create a new storage bucket name b01 in storage pool p1\n"
         "\n"
@@ -6911,17 +6911,17 @@ msgid   "lxc storage bucket create p1 b01\n"
         "	Create a new storage bucket name b01 in storage pool p1 using the content of config.yaml"
 msgstr  ""
 
-#: lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:251
 msgid   "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
         "    Update a storage bucket using the content of bucket.yaml."
 msgstr  ""
 
-#: lxc/storage_bucket.go:1023
+#: lxc/storage_bucket.go:1024
 msgid   "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
         "    Update a storage bucket key using the content of key.yaml."
 msgstr  ""
 
-#: lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:854
 msgid   "lxc storage bucket key create p1 b01 k1\n"
         "	Create a key called k1 for the bucket b01 in the pool p1.\n"
         "\n"
@@ -6929,12 +6929,12 @@ msgid   "lxc storage bucket key create p1 b01 k1\n"
         "	Create a key called k1 for the bucket b01 in the pool p1 using the content of config.yaml."
 msgstr  ""
 
-#: lxc/storage_bucket.go:1158
+#: lxc/storage_bucket.go:1159
 msgid   "lxc storage bucket key show default data foo\n"
         "    Will show the properties of a bucket key called \"foo\" for a bucket called \"data\" in the \"default\" pool."
 msgstr  ""
 
-#: lxc/storage_bucket.go:630
+#: lxc/storage_bucket.go:631
 msgid   "lxc storage bucket show default data\n"
         "    Will show the properties of a bucket called \"data\" in the \"default\" pool."
 msgstr  ""
@@ -6996,16 +6996,16 @@ msgstr  ""
 msgid   "space used"
 msgstr  ""
 
-#: lxc/file.go:1142
+#: lxc/file.go:1143
 msgid   "sshfs has stopped"
 msgstr  ""
 
-#: lxc/file.go:1101
+#: lxc/file.go:1102
 #, c-format
 msgid   "sshfs mounting %q on %q"
 msgstr  ""
 
-#: lxc/file.go:1054
+#: lxc/file.go:1055
 msgid   "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr  ""
 

--- a/po/mr.po
+++ b/po/mr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-04 08:52-0600\n"
+"POT-Creation-Date: 2024-09-05 08:44-0400\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Marathi <https://hosted.weblate.org/projects/linux-containers/"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: lxc/storage_bucket.go:260 lxc/storage_bucket.go:1033
+#: lxc/storage_bucket.go:261 lxc/storage_bucket.go:1034
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -133,7 +133,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:213
+#: lxc/auth.go:214
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -160,7 +160,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:968
+#: lxc/auth.go:969
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -181,7 +181,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1585
+#: lxc/auth.go:1586
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -391,7 +391,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:280
+#: lxc/project.go:281
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -433,12 +433,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:935
+#: lxc/file.go:936
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:825
+#: lxc/file.go:826
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -474,7 +474,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:142 lxc/rebuild.go:64
+#: lxc/init.go:142 lxc/rebuild.go:65
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -527,7 +527,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:465
+#: lxc/file.go:466
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -560,7 +560,7 @@ msgstr ""
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:813
+#: lxc/auth.go:814
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -568,11 +568,11 @@ msgstr ""
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/storage_bucket.go:863
+#: lxc/storage_bucket.go:864
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:941
+#: lxc/storage_bucket.go:942
 #, c-format
 msgid "Access key: %s"
 msgstr ""
@@ -581,7 +581,7 @@ msgstr ""
 msgid "Access the expanded configuration"
 msgstr ""
 
-#: lxc/warning.go:261 lxc/warning.go:262
+#: lxc/warning.go:262 lxc/warning.go:263
 msgid "Acknowledge warning"
 msgstr ""
 
@@ -598,11 +598,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1106 lxc/auth.go:1107
+#: lxc/auth.go:1107 lxc/auth.go:1108
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1874 lxc/auth.go:1875
+#: lxc/auth.go:1875 lxc/auth.go:1876
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -671,7 +671,7 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:515 lxc/auth.go:516
+#: lxc/auth.go:516 lxc/auth.go:517
 msgid "Add permissions to groups"
 msgstr ""
 
@@ -700,7 +700,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:169
+#: lxc/storage_bucket.go:170
 #, c-format
 msgid "Admin access key: %s"
 msgstr ""
@@ -710,7 +710,7 @@ msgstr ""
 msgid "Admin password (or token) for %s:"
 msgstr ""
 
-#: lxc/storage_bucket.go:170
+#: lxc/storage_bucket.go:171
 #, c-format
 msgid "Admin secret key: %s"
 msgstr ""
@@ -769,7 +769,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:342 lxc/rebuild.go:130
+#: lxc/init.go:342 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -869,12 +869,12 @@ msgstr ""
 
 #: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:318
 #: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
-#: lxc/network_zone.go:366 lxc/network_zone.go:1053 lxc/storage_bucket.go:141
+#: lxc/network_zone.go:366 lxc/network_zone.go:1053 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:159
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:160
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -914,7 +914,7 @@ msgstr ""
 msgid "Bytes sent"
 msgstr ""
 
-#: lxc/operation.go:174
+#: lxc/operation.go:175
 msgid "CANCELABLE"
 msgstr ""
 
@@ -926,7 +926,7 @@ msgstr ""
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: lxc/warning.go:209
+#: lxc/warning.go:210
 msgid "COUNT"
 msgstr ""
 
@@ -952,7 +952,7 @@ msgstr ""
 msgid "CPUs (%s):"
 msgstr ""
 
-#: lxc/operation.go:175
+#: lxc/operation.go:176
 msgid "CREATED"
 msgstr ""
 
@@ -982,7 +982,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:340
+#: lxc/file.go:341
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1007,11 +1007,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:224
+#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:546
+#: lxc/file.go:547
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1020,7 +1020,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:160
+#: lxc/rebuild.go:161
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1143,13 +1143,13 @@ msgstr ""
 #: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
 #: lxc/network_load_balancer.go:1051 lxc/network_load_balancer.go:1125
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
-#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:90
-#: lxc/storage_bucket.go:190 lxc/storage_bucket.go:253
-#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:541
-#: lxc/storage_bucket.go:634 lxc/storage_bucket.go:700
-#: lxc/storage_bucket.go:775 lxc/storage_bucket.go:861
-#: lxc/storage_bucket.go:961 lxc/storage_bucket.go:1026
-#: lxc/storage_bucket.go:1162 lxc/storage_volume.go:394
+#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
+#: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
+#: lxc/storage_bucket.go:385 lxc/storage_bucket.go:542
+#: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
+#: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
+#: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
 #: lxc/storage_volume.go:612 lxc/storage_volume.go:717
 #: lxc/storage_volume.go:1005 lxc/storage_volume.go:1231
 #: lxc/storage_volume.go:1360 lxc/storage_volume.go:1848
@@ -1173,7 +1173,7 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1113 lxc/list.go:132 lxc/storage_volume.go:1589
-#: lxc/warning.go:92
+#: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
@@ -1201,7 +1201,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:100
+#: lxc/project.go:101
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1215,8 +1215,8 @@ msgstr ""
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
-#: lxc/project.go:362 lxc/storage.go:359 lxc/storage_bucket.go:348
-#: lxc/storage_bucket.go:1125 lxc/storage_volume.go:1150
+#: lxc/project.go:363 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1150
 #: lxc/storage_volume.go:1182
 #, c-format
 msgid "Config parsing error: %s"
@@ -1343,12 +1343,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:300 lxc/auth.go:1660
+#: lxc/auth.go:301 lxc/auth.go:1661
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1054
+#: lxc/auth.go:1055
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1397,15 +1397,15 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:248 lxc/file.go:474
+#: lxc/file.go:249 lxc/file.go:475
 msgid "Create any directories necessary"
 msgstr ""
 
-#: lxc/auth.go:97 lxc/auth.go:98
+#: lxc/auth.go:98 lxc/auth.go:99
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1471 lxc/auth.go:1472
+#: lxc/auth.go:1472 lxc/auth.go:1473
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1425,11 +1425,11 @@ msgstr ""
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_bucket.go:851 lxc/storage_bucket.go:852
+#: lxc/storage_bucket.go:852 lxc/storage_bucket.go:853
 msgid "Create key for a storage bucket"
 msgstr ""
 
-#: lxc/storage_bucket.go:82 lxc/storage_bucket.go:83
+#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
 msgid "Create new custom storage buckets"
 msgstr ""
 
@@ -1473,7 +1473,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:92 lxc/project.go:93
+#: lxc/project.go:93 lxc/project.go:94
 msgid "Create projects"
 msgstr ""
 
@@ -1508,13 +1508,13 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:376 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1135 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
-#: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:172
-#: lxc/profile.go:756 lxc/project.go:572 lxc/storage.go:723
-#: lxc/storage_bucket.go:512 lxc/storage_bucket.go:832
+#: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
+#: lxc/profile.go:756 lxc/project.go:573 lxc/storage.go:723
+#: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1732
 msgid "DESCRIPTION"
 msgstr ""
@@ -1539,7 +1539,7 @@ msgstr ""
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
-#: lxc/operation.go:55 lxc/operation.go:56
+#: lxc/operation.go:56 lxc/operation.go:57
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
@@ -1547,19 +1547,19 @@ msgstr ""
 msgid "Delete a cluster group"
 msgstr ""
 
-#: lxc/warning.go:360
+#: lxc/warning.go:361
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:122 lxc/file.go:123
+#: lxc/file.go:123 lxc/file.go:124
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/auth.go:151 lxc/auth.go:152
+#: lxc/auth.go:152 lxc/auth.go:153
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1523 lxc/auth.go:1524
+#: lxc/auth.go:1524 lxc/auth.go:1525
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1579,7 +1579,7 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/storage_bucket.go:957 lxc/storage_bucket.go:958
+#: lxc/storage_bucket.go:958 lxc/storage_bucket.go:959
 msgid "Delete key from a storage bucket"
 msgstr ""
 
@@ -1615,11 +1615,11 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:188 lxc/project.go:189
+#: lxc/project.go:189 lxc/project.go:190
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:187 lxc/storage_bucket.go:188
+#: lxc/storage_bucket.go:188 lxc/storage_bucket.go:189
 msgid "Delete storage buckets"
 msgstr ""
 
@@ -1631,20 +1631,20 @@ msgstr ""
 msgid "Delete storage volumes"
 msgstr ""
 
-#: lxc/warning.go:356 lxc/warning.go:357
+#: lxc/warning.go:357 lxc/warning.go:358
 msgid "Delete warning"
 msgstr ""
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:30 lxc/auth.go:59 lxc/auth.go:98
-#: lxc/auth.go:152 lxc/auth.go:201 lxc/auth.go:332 lxc/auth.go:392
-#: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
-#: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
-#: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
-#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1434 lxc/auth.go:1472
-#: lxc/auth.go:1524 lxc/auth.go:1573 lxc/auth.go:1692 lxc/auth.go:1752
-#: lxc/auth.go:1801 lxc/auth.go:1852 lxc/auth.go:1875 lxc/auth.go:1928
+#: lxc/alias.go:214 lxc/auth.go:31 lxc/auth.go:60 lxc/auth.go:99
+#: lxc/auth.go:153 lxc/auth.go:202 lxc/auth.go:333 lxc/auth.go:393
+#: lxc/auth.go:442 lxc/auth.go:494 lxc/auth.go:517 lxc/auth.go:576
+#: lxc/auth.go:732 lxc/auth.go:766 lxc/auth.go:833 lxc/auth.go:896
+#: lxc/auth.go:957 lxc/auth.go:1085 lxc/auth.go:1108 lxc/auth.go:1166
+#: lxc/auth.go:1235 lxc/auth.go:1257 lxc/auth.go:1435 lxc/auth.go:1473
+#: lxc/auth.go:1525 lxc/auth.go:1574 lxc/auth.go:1693 lxc/auth.go:1753
+#: lxc/auth.go:1802 lxc/auth.go:1853 lxc/auth.go:1876 lxc/auth.go:1929
 #: lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215 lxc/cluster.go:272
 #: lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:484 lxc/cluster.go:528
 #: lxc/cluster.go:586 lxc/cluster.go:677 lxc/cluster.go:770 lxc/cluster.go:893
@@ -1668,15 +1668,15 @@ msgstr ""
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:83 lxc/file.go:123 lxc/file.go:172
-#: lxc/file.go:242 lxc/file.go:467 lxc/file.go:986 lxc/image.go:38
+#: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
+#: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
 #: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
 #: lxc/image.go:697 lxc/image.go:946 lxc/image.go:1088 lxc/image.go:1415
 #: lxc/image.go:1506 lxc/image.go:1572 lxc/image.go:1636 lxc/image.go:1699
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:38 lxc/network.go:33
+#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33
 #: lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405
 #: lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793
 #: lxc/network.go:874 lxc/network.go:1005 lxc/network.go:1106
@@ -1710,27 +1710,27 @@ msgstr ""
 #: lxc/network_zone.go:909 lxc/network_zone.go:985 lxc/network_zone.go:1083
 #: lxc/network_zone.go:1172 lxc/network_zone.go:1219 lxc/network_zone.go:1349
 #: lxc/network_zone.go:1410 lxc/network_zone.go:1425 lxc/network_zone.go:1483
-#: lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:106
-#: lxc/operation.go:193 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
+#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
+#: lxc/operation.go:194 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
 #: lxc/profile.go:271 lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493
 #: lxc/profile.go:629 lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860
-#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:29
-#: lxc/project.go:93 lxc/project.go:189 lxc/project.go:260 lxc/project.go:396
-#: lxc/project.go:470 lxc/project.go:590 lxc/project.go:655 lxc/project.go:743
-#: lxc/project.go:787 lxc/project.go:848 lxc/project.go:915 lxc/publish.go:34
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:35 lxc/remote.go:91
+#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:30
+#: lxc/project.go:94 lxc/project.go:190 lxc/project.go:261 lxc/project.go:397
+#: lxc/project.go:471 lxc/project.go:591 lxc/project.go:656 lxc/project.go:744
+#: lxc/project.go:788 lxc/project.go:849 lxc/project.go:916 lxc/publish.go:34
+#: lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91
 #: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853
 #: lxc/remote.go:917 lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24
 #: lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203
 #: lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655
 #: lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940
-#: lxc/storage_bucket.go:29 lxc/storage_bucket.go:83 lxc/storage_bucket.go:188
-#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:382
-#: lxc/storage_bucket.go:458 lxc/storage_bucket.go:535
-#: lxc/storage_bucket.go:629 lxc/storage_bucket.go:698
-#: lxc/storage_bucket.go:732 lxc/storage_bucket.go:773
-#: lxc/storage_bucket.go:852 lxc/storage_bucket.go:958
-#: lxc/storage_bucket.go:1022 lxc/storage_bucket.go:1157
+#: lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189
+#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:383
+#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:536
+#: lxc/storage_bucket.go:630 lxc/storage_bucket.go:699
+#: lxc/storage_bucket.go:733 lxc/storage_bucket.go:774
+#: lxc/storage_bucket.go:853 lxc/storage_bucket.go:959
+#: lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158
 #: lxc/storage_volume.go:58 lxc/storage_volume.go:169 lxc/storage_volume.go:283
 #: lxc/storage_volume.go:390 lxc/storage_volume.go:605
 #: lxc/storage_volume.go:714 lxc/storage_volume.go:801
@@ -1741,8 +1741,8 @@ msgstr ""
 #: lxc/storage_volume.go:2064 lxc/storage_volume.go:2222
 #: lxc/storage_volume.go:2343 lxc/storage_volume.go:2405
 #: lxc/storage_volume.go:2541 lxc/storage_volume.go:2624
-#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:29
-#: lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
+#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:30
+#: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
@@ -1829,7 +1829,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:994
+#: lxc/file.go:995
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1895,7 +1895,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:74
+#: lxc/file.go:75
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1905,7 +1905,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:955 lxc/auth.go:956
+#: lxc/auth.go:956 lxc/auth.go:957
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1913,15 +1913,15 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:171 lxc/file.go:172
+#: lxc/file.go:172 lxc/file.go:173
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/auth.go:200 lxc/auth.go:201
+#: lxc/auth.go:201 lxc/auth.go:202
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1572 lxc/auth.go:1573
+#: lxc/auth.go:1573 lxc/auth.go:1574
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -1977,15 +1977,15 @@ msgstr ""
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:259 lxc/project.go:260
+#: lxc/project.go:260 lxc/project.go:261
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:248 lxc/storage_bucket.go:249
+#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:250
 msgid "Edit storage bucket configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:1021 lxc/storage_bucket.go:1022
+#: lxc/storage_bucket.go:1022 lxc/storage_bucket.go:1023
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
@@ -2002,7 +2002,7 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1147 lxc/list.go:622 lxc/storage_volume.go:1766
-#: lxc/warning.go:235
+#: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2057,7 +2057,7 @@ msgstr ""
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
-#: lxc/project.go:718 lxc/storage.go:812 lxc/storage_bucket.go:602
+#: lxc/project.go:719 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2155 lxc/storage_volume.go:2193
 #, c-format
 msgid "Error setting properties: %v"
@@ -2071,8 +2071,8 @@ msgstr ""
 #: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
-#: lxc/profile.go:981 lxc/project.go:712 lxc/storage.go:806
-#: lxc/storage_bucket.go:596 lxc/storage_volume.go:2149
+#: lxc/profile.go:981 lxc/project.go:713 lxc/storage.go:806
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2149
 #: lxc/storage_volume.go:2187
 #, c-format
 msgid "Error unsetting property: %v"
@@ -2092,7 +2092,7 @@ msgstr ""
 msgid "Evacuating cluster member: %s"
 msgstr ""
 
-#: lxc/monitor.go:50
+#: lxc/monitor.go:51
 msgid "Event type to listen for"
 msgstr ""
 
@@ -2179,16 +2179,16 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/warning.go:210
+#: lxc/warning.go:211
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1237
+#: lxc/file.go:1238
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1260
+#: lxc/file.go:1261
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2203,12 +2203,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1287
+#: lxc/file.go:1288
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1072
+#: lxc/file.go:1073
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2238,7 +2238,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1193
+#: lxc/file.go:1194
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2253,7 +2253,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1198
+#: lxc/file.go:1199
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2263,12 +2263,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1098
+#: lxc/file.go:1099
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1225
+#: lxc/file.go:1226
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2307,7 +2307,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1210
+#: lxc/file.go:1211
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2322,7 +2322,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:820
+#: lxc/file.go:821
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2337,7 +2337,7 @@ msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
 #: lxc/network.go:1044 lxc/network_acl.go:133 lxc/network_zone.go:124
-#: lxc/operation.go:136
+#: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
 
@@ -2402,21 +2402,21 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
+#: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:770 lxc/auth.go:1697
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1114 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:57
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
-#: lxc/operation.go:108 lxc/profile.go:707 lxc/project.go:472
-#: lxc/project.go:917 lxc/remote.go:690 lxc/storage.go:657
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:774
-#: lxc/storage_volume.go:1608 lxc/warning.go:93
+#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:473
+#: lxc/project.go:918 lxc/remote.go:690 lxc/storage.go:657
+#: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
+#: lxc/storage_volume.go:1608 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
-#: lxc/monitor.go:52
+#: lxc/monitor.go:53
 msgid "Format (json|pretty|yaml)"
 msgstr ""
 
@@ -2460,7 +2460,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:817 lxc/auth.go:1736
+#: lxc/auth.go:818 lxc/auth.go:1737
 msgid "GROUPS"
 msgstr ""
 
@@ -2476,7 +2476,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:914 lxc/project.go:915
+#: lxc/project.go:915 lxc/project.go:916
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2524,11 +2524,11 @@ msgstr ""
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:400
+#: lxc/project.go:401
 msgid "Get the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:385
+#: lxc/storage_bucket.go:386
 msgid "Get the key as a storage bucket property"
 msgstr ""
 
@@ -2588,11 +2588,11 @@ msgstr ""
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:395 lxc/project.go:396
+#: lxc/project.go:396 lxc/project.go:397
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:382
+#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:383
 msgid "Get values for storage bucket configuration keys"
 msgstr ""
 
@@ -2609,17 +2609,17 @@ msgstr ""
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: lxc/auth.go:136
+#: lxc/auth.go:137
 #, c-format
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:186
+#: lxc/auth.go:187
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:426 lxc/auth.go:1786
+#: lxc/auth.go:427 lxc/auth.go:1787
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2644,27 +2644,27 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1310
+#: lxc/file.go:1311
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1299
+#: lxc/file.go:1300
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1122
+#: lxc/file.go:1123
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1132
+#: lxc/file.go:1133
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:966 lxc/operation.go:170
+#: lxc/network.go:966 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2678,11 +2678,11 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:816
+#: lxc/auth.go:817
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:566
+#: lxc/project.go:567
 msgid "IMAGES"
 msgstr ""
 
@@ -2710,17 +2710,17 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1508
+#: lxc/auth.go:1509
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1558
+#: lxc/auth.go:1559
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
 
-#: lxc/rebuild.go:32
+#: lxc/rebuild.go:33
 msgid "If an instance is running, stop it and then rebuild it"
 msgstr ""
 
@@ -2841,7 +2841,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1233 lxc/auth.go:1234
+#: lxc/auth.go:1234 lxc/auth.go:1235
 msgid "Inspect permissions"
 msgstr ""
 
@@ -2849,11 +2849,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1124
+#: lxc/file.go:1125
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1301
+#: lxc/file.go:1302
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2871,7 +2871,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1044
+#: lxc/file.go:1045
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2880,7 +2880,7 @@ msgstr ""
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/rebuild.go:74
+#: lxc/rebuild.go:75
 #, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
@@ -2913,7 +2913,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/monitor.go:70
+#: lxc/monitor.go:71
 #, c-format
 msgid "Invalid format: %s"
 msgstr ""
@@ -2923,7 +2923,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1039
+#: lxc/file.go:1040
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2965,7 +2965,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:147
+#: lxc/file.go:148
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2981,12 +2981,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:313
+#: lxc/file.go:314
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:495
+#: lxc/file.go:496
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3000,7 +3000,7 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/warning.go:212
 msgid "LAST SEEN"
 msgstr ""
 
@@ -3008,7 +3008,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:984
+#: lxc/project.go:985
 msgid "LIMIT"
 msgstr ""
 
@@ -3017,8 +3017,8 @@ msgid "LISTEN ADDRESS"
 msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
-#: lxc/network_load_balancer.go:165 lxc/operation.go:177
-#: lxc/storage_bucket.go:516 lxc/storage_volume.go:1739 lxc/warning.go:220
+#: lxc/network_load_balancer.go:165 lxc/operation.go:178
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1739 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3092,7 +3092,7 @@ msgstr ""
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/warning.go:94
+#: lxc/warning.go:95
 msgid "List all warnings"
 msgstr ""
 
@@ -3136,19 +3136,19 @@ msgstr ""
 msgid "List available storage pools"
 msgstr ""
 
-#: lxc/operation.go:105 lxc/operation.go:106
+#: lxc/operation.go:106 lxc/operation.go:107
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:331 lxc/auth.go:332
+#: lxc/auth.go:332 lxc/auth.go:333
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:764 lxc/auth.go:765
+#: lxc/auth.go:765 lxc/auth.go:766
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1691 lxc/auth.go:1692
+#: lxc/auth.go:1692 lxc/auth.go:1693
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3297,11 +3297,11 @@ msgstr ""
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/operation.go:109
+#: lxc/operation.go:110
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1255 lxc/auth.go:1256
+#: lxc/auth.go:1256 lxc/auth.go:1257
 msgid "List permissions"
 msgstr ""
 
@@ -3309,15 +3309,15 @@ msgstr ""
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:469 lxc/project.go:470
+#: lxc/project.go:470 lxc/project.go:471
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:771 lxc/storage_bucket.go:773
+#: lxc/storage_bucket.go:772 lxc/storage_bucket.go:774
 msgid "List storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:456 lxc/storage_bucket.go:458
+#: lxc/storage_bucket.go:457 lxc/storage_bucket.go:459
 msgid "List storage buckets"
 msgstr ""
 
@@ -3353,11 +3353,11 @@ msgstr ""
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/warning.go:70
+#: lxc/warning.go:71
 msgid "List warnings"
 msgstr ""
 
-#: lxc/warning.go:71
+#: lxc/warning.go:72
 msgid ""
 "List warnings\n"
 "\n"
@@ -3380,7 +3380,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/operation.go:23 lxc/operation.go:24
+#: lxc/operation.go:24 lxc/operation.go:25
 msgid "List, show and delete background operations"
 msgstr ""
 
@@ -3389,7 +3389,7 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/monitor.go:79
+#: lxc/monitor.go:80
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
@@ -3493,23 +3493,23 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:82 lxc/file.go:83
+#: lxc/file.go:83 lxc/file.go:84
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1433 lxc/auth.go:1434
+#: lxc/auth.go:59 lxc/auth.go:60 lxc/auth.go:1434 lxc/auth.go:1435
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1083 lxc/auth.go:1084
+#: lxc/auth.go:1084 lxc/auth.go:1085
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:730 lxc/auth.go:731
+#: lxc/auth.go:731 lxc/auth.go:732
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1851 lxc/auth.go:1852
+#: lxc/auth.go:1852 lxc/auth.go:1853
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3600,7 +3600,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:492 lxc/auth.go:493
+#: lxc/auth.go:493 lxc/auth.go:494
 msgid "Manage permissions"
 msgstr ""
 
@@ -3608,23 +3608,23 @@ msgstr ""
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:28 lxc/project.go:29
+#: lxc/project.go:29 lxc/project.go:30
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:731
+#: lxc/storage_bucket.go:732
 msgid "Manage storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:732
+#: lxc/storage_bucket.go:733
 msgid "Manage storage bucket keys."
 msgstr ""
 
-#: lxc/storage_bucket.go:28
+#: lxc/storage_bucket.go:29
 msgid "Manage storage buckets"
 msgstr ""
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:30
 msgid "Manage storage buckets."
 msgstr ""
 
@@ -3652,11 +3652,11 @@ msgstr ""
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/auth.go:29 lxc/auth.go:30
+#: lxc/auth.go:30 lxc/auth.go:31
 msgid "Manage user authorization"
 msgstr ""
 
-#: lxc/warning.go:28 lxc/warning.go:29
+#: lxc/warning.go:29 lxc/warning.go:30
 msgid "Manage warnings"
 msgstr ""
 
@@ -3720,17 +3720,17 @@ msgstr ""
 msgid "Migration operation failure: %w"
 msgstr ""
 
-#: lxc/monitor.go:51
+#: lxc/monitor.go:52
 msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: lxc/storage_bucket.go:116 lxc/storage_bucket.go:216
-#: lxc/storage_bucket.go:292 lxc/storage_bucket.go:411
-#: lxc/storage_bucket.go:568 lxc/storage_bucket.go:660
-#: lxc/storage_bucket.go:802 lxc/storage_bucket.go:889
-#: lxc/storage_bucket.go:986 lxc/storage_bucket.go:1065
-#: lxc/storage_bucket.go:1188
+#: lxc/storage_bucket.go:117 lxc/storage_bucket.go:217
+#: lxc/storage_bucket.go:293 lxc/storage_bucket.go:412
+#: lxc/storage_bucket.go:569 lxc/storage_bucket.go:661
+#: lxc/storage_bucket.go:803 lxc/storage_bucket.go:890
+#: lxc/storage_bucket.go:987 lxc/storage_bucket.go:1066
+#: lxc/storage_bucket.go:1189
 msgid "Missing bucket name"
 msgstr ""
 
@@ -3749,20 +3749,20 @@ msgstr ""
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1825
+#: lxc/auth.go:123 lxc/auth.go:177 lxc/auth.go:255 lxc/auth.go:417
+#: lxc/auth.go:466 lxc/auth.go:541 lxc/auth.go:600 lxc/auth.go:1826
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:862 lxc/auth.go:1003 lxc/auth.go:1131 lxc/auth.go:1189
+#: lxc/auth.go:863 lxc/auth.go:1004 lxc/auth.go:1132 lxc/auth.go:1190
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1495 lxc/auth.go:1548 lxc/auth.go:1614 lxc/auth.go:1776
+#: lxc/auth.go:1496 lxc/auth.go:1549 lxc/auth.go:1615 lxc/auth.go:1777
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1899 lxc/auth.go:1952
+#: lxc/auth.go:1900 lxc/auth.go:1953
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -3770,12 +3770,12 @@ msgstr ""
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
 #: lxc/config_template.go:377 lxc/profile.go:141 lxc/profile.go:222
-#: lxc/profile.go:808 lxc/rebuild.go:60
+#: lxc/profile.go:808 lxc/rebuild.go:61
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/storage_bucket.go:893 lxc/storage_bucket.go:990
-#: lxc/storage_bucket.go:1069 lxc/storage_bucket.go:1192
+#: lxc/storage_bucket.go:894 lxc/storage_bucket.go:991
+#: lxc/storage_bucket.go:1070 lxc/storage_bucket.go:1193
 msgid "Missing key name"
 msgstr ""
 
@@ -3840,13 +3840,13 @@ msgid "Missing peer name"
 msgstr ""
 
 #: lxc/storage.go:235 lxc/storage.go:313 lxc/storage.go:431 lxc/storage.go:509
-#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:112
-#: lxc/storage_bucket.go:212 lxc/storage_bucket.go:288
-#: lxc/storage_bucket.go:407 lxc/storage_bucket.go:482
-#: lxc/storage_bucket.go:564 lxc/storage_bucket.go:656
-#: lxc/storage_bucket.go:798 lxc/storage_bucket.go:885
-#: lxc/storage_bucket.go:982 lxc/storage_bucket.go:1061
-#: lxc/storage_bucket.go:1184 lxc/storage_volume.go:209
+#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:113
+#: lxc/storage_bucket.go:213 lxc/storage_bucket.go:289
+#: lxc/storage_bucket.go:408 lxc/storage_bucket.go:483
+#: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
+#: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
+#: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
 #: lxc/storage_volume.go:323 lxc/storage_volume.go:643
 #: lxc/storage_volume.go:750 lxc/storage_volume.go:841
 #: lxc/storage_volume.go:939 lxc/storage_volume.go:1053
@@ -3861,9 +3861,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:404 lxc/project.go:146 lxc/project.go:226 lxc/project.go:316
-#: lxc/project.go:433 lxc/project.go:622 lxc/project.go:691 lxc/project.go:819
-#: lxc/project.go:948
+#: lxc/profile.go:404 lxc/project.go:147 lxc/project.go:227 lxc/project.go:317
+#: lxc/project.go:434 lxc/project.go:623 lxc/project.go:692 lxc/project.go:820
+#: lxc/project.go:949
 msgid "Missing project name"
 msgstr ""
 
@@ -3879,7 +3879,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:598
+#: lxc/file.go:599
 msgid "Missing target directory"
 msgstr ""
 
@@ -3901,11 +3901,11 @@ msgstr ""
 msgid "Model: %v"
 msgstr ""
 
-#: lxc/monitor.go:32
+#: lxc/monitor.go:33
 msgid "Monitor a local or remote LXD server"
 msgstr ""
 
-#: lxc/monitor.go:33
+#: lxc/monitor.go:34
 msgid ""
 "Monitor a local or remote LXD server\n"
 "\n"
@@ -3917,11 +3917,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:285
+#: lxc/file.go:286
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:985 lxc/file.go:986
+#: lxc/file.go:986 lxc/file.go:987
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3983,13 +3983,13 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:192
+#: lxc/auth.go:376 lxc/auth.go:816 lxc/auth.go:1736 lxc/cluster.go:192
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
-#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:565
-#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:511
-#: lxc/storage_bucket.go:831 lxc/storage_volume.go:1731
+#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:566
+#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1731
 msgid "NAME"
 msgstr ""
 
@@ -3997,11 +3997,11 @@ msgstr ""
 msgid "NAT"
 msgstr ""
 
-#: lxc/project.go:571
+#: lxc/project.go:572
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:570
+#: lxc/project.go:571
 msgid "NETWORKS"
 msgstr ""
 
@@ -4013,9 +4013,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/operation.go:154 lxc/project.go:523
-#: lxc/project.go:528 lxc/project.go:533 lxc/project.go:538 lxc/project.go:543
-#: lxc/project.go:548 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
+#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:524
+#: lxc/project.go:529 lxc/project.go:534 lxc/project.go:539 lxc/project.go:544
+#: lxc/project.go:549 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
 msgid "NO"
 msgstr ""
 
@@ -4260,7 +4260,7 @@ msgstr ""
 msgid "Only managed networks can be modified"
 msgstr ""
 
-#: lxc/operation.go:86
+#: lxc/operation.go:87
 #, c-format
 msgid "Operation %s deleted"
 msgstr ""
@@ -4307,11 +4307,11 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:567
+#: lxc/list.go:576 lxc/project.go:568
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:212
+#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4373,24 +4373,24 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1102
+#: lxc/file.go:1103
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:860
+#: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
-#: lxc/project.go:363 lxc/storage.go:360 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1151
+#: lxc/project.go:364 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1151
 #: lxc/storage_volume.go:1183
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
-#: lxc/monitor.go:48
+#: lxc/monitor.go:49
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
@@ -4476,17 +4476,17 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:172
+#: lxc/project.go:173
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:236
+#: lxc/project.go:237
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:637
+#: lxc/project.go:638
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -4607,20 +4607,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:241 lxc/file.go:242
+#: lxc/file.go:242 lxc/file.go:243
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:416 lxc/file.go:767
+#: lxc/file.go:417 lxc/file.go:768
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:466 lxc/file.go:467
+#: lxc/file.go:467 lxc/file.go:468
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:701 lxc/file.go:867
+#: lxc/file.go:702 lxc/file.go:868
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4633,11 +4633,11 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:983
+#: lxc/project.go:984
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/storage_bucket.go:833
+#: lxc/storage_bucket.go:834
 msgid "ROLE"
 msgstr ""
 
@@ -4650,15 +4650,15 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/rebuild.go:31
+#: lxc/rebuild.go:32
 msgid "Rebuild as an empty instance"
 msgstr ""
 
-#: lxc/rebuild.go:26
+#: lxc/rebuild.go:27
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:249 lxc/file.go:473
+#: lxc/file.go:250 lxc/file.go:474
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4685,7 +4685,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:882 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
+#: lxc/project.go:883 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
 #: lxc/remote.go:994
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4736,7 +4736,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1164 lxc/auth.go:1165
+#: lxc/auth.go:1165 lxc/auth.go:1166
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4772,7 +4772,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1927 lxc/auth.go:1928
+#: lxc/auth.go:1928 lxc/auth.go:1929
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4784,7 +4784,7 @@ msgstr ""
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:574 lxc/auth.go:575
+#: lxc/auth.go:575 lxc/auth.go:576
 msgid "Remove permissions from groups"
 msgstr ""
 
@@ -4829,11 +4829,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:391 lxc/auth.go:392
+#: lxc/auth.go:392 lxc/auth.go:393
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1751 lxc/auth.go:1752
+#: lxc/auth.go:1752 lxc/auth.go:1753
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -4853,7 +4853,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:589 lxc/project.go:590
+#: lxc/project.go:590 lxc/project.go:591
 msgid "Rename projects"
 msgstr ""
 
@@ -4951,7 +4951,7 @@ msgstr ""
 msgid "Revoke cluster member join token"
 msgstr ""
 
-#: lxc/storage_bucket.go:862
+#: lxc/storage_bucket.go:863
 msgid "Role (admin or read-only)"
 msgstr ""
 
@@ -4967,7 +4967,7 @@ msgstr ""
 msgid "Run against all projects"
 msgstr ""
 
-#: lxc/warning.go:213
+#: lxc/warning.go:214
 msgid "SEVERITY"
 msgstr ""
 
@@ -4987,12 +4987,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1231
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1231
+#: lxc/file.go:1232
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5006,11 +5006,11 @@ msgstr ""
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:173 lxc/warning.go:214
+#: lxc/operation.go:174 lxc/warning.go:215
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:569
+#: lxc/project.go:570
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5018,7 +5018,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:569
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -5026,11 +5026,11 @@ msgstr ""
 msgid "STP"
 msgstr ""
 
-#: lxc/storage_bucket.go:864
+#: lxc/storage_bucket.go:865
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:942
+#: lxc/storage_bucket.go:943
 #, c-format
 msgid "Secret key: %s"
 msgstr ""
@@ -5068,7 +5068,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:995
+#: lxc/file.go:996
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5206,11 +5206,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:654
+#: lxc/project.go:655
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:655
+#: lxc/project.go:656
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5219,11 +5219,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage_bucket.go:534
+#: lxc/storage_bucket.go:535
 msgid "Set storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:535
+#: lxc/storage_bucket.go:536
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -5262,15 +5262,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:476
+#: lxc/file.go:477
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:477
+#: lxc/file.go:478
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:475
+#: lxc/file.go:476
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5310,11 +5310,11 @@ msgstr ""
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 msgid "Set the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:542
+#: lxc/storage_bucket.go:543
 msgid "Set the key as a storage bucket property"
 msgstr ""
 
@@ -5330,7 +5330,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:993
+#: lxc/file.go:994
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5342,7 +5342,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1800 lxc/auth.go:1801
+#: lxc/auth.go:1801 lxc/auth.go:1802
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5358,11 +5358,11 @@ msgstr ""
 msgid "Show details of a cluster member"
 msgstr ""
 
-#: lxc/operation.go:192 lxc/operation.go:193
+#: lxc/operation.go:193 lxc/operation.go:194
 msgid "Show details on a background operation"
 msgstr ""
 
-#: lxc/monitor.go:49
+#: lxc/monitor.go:50
 msgid "Show events from all projects"
 msgstr ""
 
@@ -5370,11 +5370,11 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:440 lxc/auth.go:441
+#: lxc/auth.go:441 lxc/auth.go:442
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:832
+#: lxc/auth.go:833
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5455,15 +5455,15 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:786 lxc/project.go:787
+#: lxc/project.go:787 lxc/project.go:788
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage_bucket.go:628 lxc/storage_bucket.go:629
+#: lxc/storage_bucket.go:629 lxc/storage_bucket.go:630
 msgid "Show storage bucket configurations"
 msgstr ""
 
-#: lxc/storage_bucket.go:1156 lxc/storage_bucket.go:1157
+#: lxc/storage_bucket.go:1157 lxc/storage_bucket.go:1158
 msgid "Show storage bucket key configurations"
 msgstr ""
 
@@ -5479,7 +5479,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:895
+#: lxc/auth.go:896
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5529,7 +5529,7 @@ msgstr ""
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: lxc/warning.go:302 lxc/warning.go:303
+#: lxc/warning.go:303 lxc/warning.go:304
 msgid "Show warning"
 msgstr ""
 
@@ -5613,22 +5613,22 @@ msgstr ""
 msgid "Stopping the instance failed: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:166
+#: lxc/storage_bucket.go:167
 #, c-format
 msgid "Storage bucket %s created"
 msgstr ""
 
-#: lxc/storage_bucket.go:233
+#: lxc/storage_bucket.go:234
 #, c-format
 msgid "Storage bucket %s deleted"
 msgstr ""
 
-#: lxc/storage_bucket.go:940
+#: lxc/storage_bucket.go:941
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr ""
 
-#: lxc/storage_bucket.go:1006
+#: lxc/storage_bucket.go:1007
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr ""
@@ -5697,7 +5697,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:847 lxc/project.go:848
+#: lxc/project.go:848 lxc/project.go:849
 msgid "Switch the current project"
 msgstr ""
 
@@ -5713,10 +5713,10 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1139
+#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1139
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
-#: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:171
-#: lxc/storage_volume.go:1730 lxc/warning.go:215
+#: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
+#: lxc/storage_volume.go:1730 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
@@ -5724,11 +5724,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1032
+#: lxc/file.go:1033
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1026
+#: lxc/file.go:1027
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5856,12 +5856,12 @@ msgstr ""
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:446
+#: lxc/project.go:447
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
 
-#: lxc/storage_bucket.go:431
+#: lxc/storage_bucket.go:432
 #, c-format
 msgid "The property %q does not exist on the storage bucket %q: %v"
 msgstr ""
@@ -6046,7 +6046,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:961
+#: lxc/project.go:962
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6058,17 +6058,17 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:985 lxc/storage_volume.go:1735
+#: lxc/project.go:986 lxc/storage_volume.go:1735
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:573
+#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:574
 #: lxc/storage.go:724 lxc/storage_volume.go:1734
 msgid "USED BY"
 msgstr ""
 
-#: lxc/warning.go:216
+#: lxc/warning.go:217
 msgid "UUID"
 msgstr ""
 
@@ -6077,7 +6077,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:197
+#: lxc/file.go:198
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6091,13 +6091,13 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1253
+#: lxc/file.go:1254
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1153 lxc/list.go:631 lxc/storage_volume.go:1772
-#: lxc/warning.go:241
+#: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6107,7 +6107,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:807
+#: lxc/file.go:808
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6190,11 +6190,11 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:742 lxc/project.go:743
+#: lxc/project.go:743 lxc/project.go:744
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:697 lxc/storage_bucket.go:698
+#: lxc/storage_bucket.go:698 lxc/storage_bucket.go:699
 msgid "Unset storage bucket configuration keys"
 msgstr ""
 
@@ -6242,11 +6242,11 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:747
+#: lxc/project.go:748
 msgid "Unset the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:701
+#: lxc/storage_bucket.go:702
 msgid "Unset the key as a storage bucket property"
 msgstr ""
 
@@ -6325,7 +6325,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:71
+#: lxc/file.go:72
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6362,11 +6362,11 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:831
+#: lxc/auth.go:832
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:894
+#: lxc/auth.go:895
 msgid "View the current identity"
 msgstr ""
 
@@ -6397,15 +6397,15 @@ msgstr ""
 msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
-#: lxc/rebuild.go:27
+#: lxc/rebuild.go:28
 msgid ""
 "Wipe the instance root disk and re-initialize. The original image is used to "
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:156 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
+#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:526
+#: lxc/project.go:531 lxc/project.go:536 lxc/project.go:541 lxc/project.go:546
+#: lxc/project.go:551 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
 msgid "YES"
 msgstr ""
 
@@ -6425,7 +6425,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/rebuild.go:119
+#: lxc/rebuild.go:120
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
@@ -6437,12 +6437,12 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1689
+#: lxc/auth.go:330 lxc/auth.go:763 lxc/auth.go:894 lxc/auth.go:1690
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
-#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
+#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
-#: lxc/operation.go:103 lxc/profile.go:700 lxc/project.go:467
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:68
+#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:468
+#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6470,7 +6470,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1254
+#: lxc/auth.go:1255
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6531,11 +6531,11 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:830
+#: lxc/auth.go:831
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1926
+#: lxc/auth.go:1106 lxc/auth.go:1164 lxc/auth.go:1927
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6543,13 +6543,13 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:954 lxc/auth.go:1470 lxc/cluster_group.go:168
+#: lxc/auth.go:97 lxc/auth.go:150 lxc/auth.go:200 lxc/auth.go:440
+#: lxc/auth.go:955 lxc/auth.go:1471 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:514 lxc/auth.go:572
+#: lxc/auth.go:515 lxc/auth.go:573
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
@@ -6559,19 +6559,19 @@ msgstr ""
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:389
+#: lxc/auth.go:390
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1521 lxc/auth.go:1571 lxc/auth.go:1799
+#: lxc/auth.go:1522 lxc/auth.go:1572 lxc/auth.go:1800
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1873
+#: lxc/auth.go:1874
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1749
+#: lxc/auth.go:1750
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -6591,7 +6591,7 @@ msgstr ""
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
-#: lxc/rebuild.go:25
+#: lxc/rebuild.go:26
 msgid "[<remote>:]<image> [<remote>:]<instance>"
 msgstr ""
 
@@ -6674,20 +6674,20 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:170
+#: lxc/file.go:171
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:120
+#: lxc/file.go:121
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:240
+#: lxc/file.go:241
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:984
+#: lxc/file.go:985
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6838,12 +6838,12 @@ msgstr ""
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
-#: lxc/operation.go:53 lxc/operation.go:191
+#: lxc/operation.go:54 lxc/operation.go:192
 msgid "[<remote>:]<operation>"
 msgstr ""
 
 #: lxc/storage.go:200 lxc/storage.go:259 lxc/storage.go:473 lxc/storage.go:844
-#: lxc/storage_bucket.go:454
+#: lxc/storage_bucket.go:455
 msgid "[<remote>:]<pool>"
 msgstr ""
 
@@ -6851,22 +6851,22 @@ msgstr ""
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
-#: lxc/storage_bucket.go:185 lxc/storage_bucket.go:247
-#: lxc/storage_bucket.go:627 lxc/storage_bucket.go:769
+#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:248
+#: lxc/storage_bucket.go:628 lxc/storage_bucket.go:770
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
 
-#: lxc/storage_bucket.go:380 lxc/storage_bucket.go:696
-#: lxc/storage_bucket.go:850 lxc/storage_bucket.go:956
-#: lxc/storage_bucket.go:1020 lxc/storage_bucket.go:1155
+#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:697
+#: lxc/storage_bucket.go:851 lxc/storage_bucket.go:957
+#: lxc/storage_bucket.go:1021 lxc/storage_bucket.go:1156
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
 
-#: lxc/storage_bucket.go:533
+#: lxc/storage_bucket.go:534
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_bucket.go:81
+#: lxc/storage_bucket.go:82
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
 
@@ -6981,20 +6981,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:91 lxc/project.go:186 lxc/project.go:258 lxc/project.go:785
-#: lxc/project.go:846 lxc/project.go:913
+#: lxc/project.go:92 lxc/project.go:187 lxc/project.go:259 lxc/project.go:786
+#: lxc/project.go:847 lxc/project.go:914
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:394 lxc/project.go:741
+#: lxc/project.go:395 lxc/project.go:742
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:653
+#: lxc/project.go:654
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:587
+#: lxc/project.go:588
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7002,7 +7002,7 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:259 lxc/warning.go:301 lxc/warning.go:354
+#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
@@ -7058,7 +7058,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:555 lxc/remote.go:739
+#: lxc/project.go:556 lxc/remote.go:739
 msgid "current"
 msgstr ""
 
@@ -7105,20 +7105,20 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/auth.go:203
+#: lxc/auth.go:204
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:958
+#: lxc/auth.go:959
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1575
+#: lxc/auth.go:1576
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7196,20 +7196,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:988
+#: lxc/file.go:989
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:244
+#: lxc/file.go:245
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:470
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7291,7 +7291,7 @@ msgid ""
 "  List instances with their running state and user comment."
 msgstr ""
 
-#: lxc/monitor.go:37
+#: lxc/monitor.go:38
 msgid ""
 "lxc monitor --type=logging\n"
 "    Only show log messages.\n"
@@ -7367,7 +7367,7 @@ msgid ""
 "    Create record r1 for zone z1 with configuration from config.yaml"
 msgstr ""
 
-#: lxc/operation.go:195
+#: lxc/operation.go:196
 msgid ""
 "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Show details on that operation UUID"
@@ -7410,7 +7410,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:95
+#: lxc/project.go:96
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7418,7 +7418,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:262
+#: lxc/project.go:263
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7449,7 +7449,7 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:85
 msgid ""
 "lxc storage bucket create p1 b01\n"
 "\tCreate a new storage bucket name b01 in storage pool p1\n"
@@ -7459,19 +7459,19 @@ msgid ""
 "of config.yaml"
 msgstr ""
 
-#: lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:251
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1023
+#: lxc/storage_bucket.go:1024
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:854
 msgid ""
 "lxc storage bucket key create p1 b01 k1\n"
 "\tCreate a key called k1 for the bucket b01 in the pool p1.\n"
@@ -7481,14 +7481,14 @@ msgid ""
 "of config.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1158
+#: lxc/storage_bucket.go:1159
 msgid ""
 "lxc storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_bucket.go:630
+#: lxc/storage_bucket.go:631
 msgid ""
 "lxc storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
@@ -7558,16 +7558,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1142
+#: lxc/file.go:1143
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1101
+#: lxc/file.go:1102
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1054
+#: lxc/file.go:1055
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-04 08:52-0600\n"
+"POT-Creation-Date: 2024-09-05 08:44-0400\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Norwegian Bokmål <https://hosted.weblate.org/projects/linux-"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: lxc/storage_bucket.go:260 lxc/storage_bucket.go:1033
+#: lxc/storage_bucket.go:261 lxc/storage_bucket.go:1034
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -133,7 +133,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:213
+#: lxc/auth.go:214
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -160,7 +160,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:968
+#: lxc/auth.go:969
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -181,7 +181,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1585
+#: lxc/auth.go:1586
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -391,7 +391,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:280
+#: lxc/project.go:281
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -433,12 +433,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:935
+#: lxc/file.go:936
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:825
+#: lxc/file.go:826
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -474,7 +474,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:142 lxc/rebuild.go:64
+#: lxc/init.go:142 lxc/rebuild.go:65
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -527,7 +527,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:465
+#: lxc/file.go:466
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -560,7 +560,7 @@ msgstr ""
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:813
+#: lxc/auth.go:814
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -568,11 +568,11 @@ msgstr ""
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/storage_bucket.go:863
+#: lxc/storage_bucket.go:864
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:941
+#: lxc/storage_bucket.go:942
 #, c-format
 msgid "Access key: %s"
 msgstr ""
@@ -581,7 +581,7 @@ msgstr ""
 msgid "Access the expanded configuration"
 msgstr ""
 
-#: lxc/warning.go:261 lxc/warning.go:262
+#: lxc/warning.go:262 lxc/warning.go:263
 msgid "Acknowledge warning"
 msgstr ""
 
@@ -598,11 +598,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1106 lxc/auth.go:1107
+#: lxc/auth.go:1107 lxc/auth.go:1108
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1874 lxc/auth.go:1875
+#: lxc/auth.go:1875 lxc/auth.go:1876
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -671,7 +671,7 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:515 lxc/auth.go:516
+#: lxc/auth.go:516 lxc/auth.go:517
 msgid "Add permissions to groups"
 msgstr ""
 
@@ -700,7 +700,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:169
+#: lxc/storage_bucket.go:170
 #, c-format
 msgid "Admin access key: %s"
 msgstr ""
@@ -710,7 +710,7 @@ msgstr ""
 msgid "Admin password (or token) for %s:"
 msgstr ""
 
-#: lxc/storage_bucket.go:170
+#: lxc/storage_bucket.go:171
 #, c-format
 msgid "Admin secret key: %s"
 msgstr ""
@@ -769,7 +769,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:342 lxc/rebuild.go:130
+#: lxc/init.go:342 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -869,12 +869,12 @@ msgstr ""
 
 #: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:318
 #: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
-#: lxc/network_zone.go:366 lxc/network_zone.go:1053 lxc/storage_bucket.go:141
+#: lxc/network_zone.go:366 lxc/network_zone.go:1053 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:159
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:160
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -914,7 +914,7 @@ msgstr ""
 msgid "Bytes sent"
 msgstr ""
 
-#: lxc/operation.go:174
+#: lxc/operation.go:175
 msgid "CANCELABLE"
 msgstr ""
 
@@ -926,7 +926,7 @@ msgstr ""
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: lxc/warning.go:209
+#: lxc/warning.go:210
 msgid "COUNT"
 msgstr ""
 
@@ -952,7 +952,7 @@ msgstr ""
 msgid "CPUs (%s):"
 msgstr ""
 
-#: lxc/operation.go:175
+#: lxc/operation.go:176
 msgid "CREATED"
 msgstr ""
 
@@ -982,7 +982,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:340
+#: lxc/file.go:341
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1007,11 +1007,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:224
+#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:546
+#: lxc/file.go:547
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1020,7 +1020,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:160
+#: lxc/rebuild.go:161
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1143,13 +1143,13 @@ msgstr ""
 #: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
 #: lxc/network_load_balancer.go:1051 lxc/network_load_balancer.go:1125
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
-#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:90
-#: lxc/storage_bucket.go:190 lxc/storage_bucket.go:253
-#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:541
-#: lxc/storage_bucket.go:634 lxc/storage_bucket.go:700
-#: lxc/storage_bucket.go:775 lxc/storage_bucket.go:861
-#: lxc/storage_bucket.go:961 lxc/storage_bucket.go:1026
-#: lxc/storage_bucket.go:1162 lxc/storage_volume.go:394
+#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
+#: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
+#: lxc/storage_bucket.go:385 lxc/storage_bucket.go:542
+#: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
+#: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
+#: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
 #: lxc/storage_volume.go:612 lxc/storage_volume.go:717
 #: lxc/storage_volume.go:1005 lxc/storage_volume.go:1231
 #: lxc/storage_volume.go:1360 lxc/storage_volume.go:1848
@@ -1173,7 +1173,7 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1113 lxc/list.go:132 lxc/storage_volume.go:1589
-#: lxc/warning.go:92
+#: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
@@ -1201,7 +1201,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:100
+#: lxc/project.go:101
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1215,8 +1215,8 @@ msgstr ""
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
-#: lxc/project.go:362 lxc/storage.go:359 lxc/storage_bucket.go:348
-#: lxc/storage_bucket.go:1125 lxc/storage_volume.go:1150
+#: lxc/project.go:363 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1150
 #: lxc/storage_volume.go:1182
 #, c-format
 msgid "Config parsing error: %s"
@@ -1343,12 +1343,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:300 lxc/auth.go:1660
+#: lxc/auth.go:301 lxc/auth.go:1661
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1054
+#: lxc/auth.go:1055
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1397,15 +1397,15 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:248 lxc/file.go:474
+#: lxc/file.go:249 lxc/file.go:475
 msgid "Create any directories necessary"
 msgstr ""
 
-#: lxc/auth.go:97 lxc/auth.go:98
+#: lxc/auth.go:98 lxc/auth.go:99
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1471 lxc/auth.go:1472
+#: lxc/auth.go:1472 lxc/auth.go:1473
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1425,11 +1425,11 @@ msgstr ""
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_bucket.go:851 lxc/storage_bucket.go:852
+#: lxc/storage_bucket.go:852 lxc/storage_bucket.go:853
 msgid "Create key for a storage bucket"
 msgstr ""
 
-#: lxc/storage_bucket.go:82 lxc/storage_bucket.go:83
+#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
 msgid "Create new custom storage buckets"
 msgstr ""
 
@@ -1473,7 +1473,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:92 lxc/project.go:93
+#: lxc/project.go:93 lxc/project.go:94
 msgid "Create projects"
 msgstr ""
 
@@ -1508,13 +1508,13 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:376 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1135 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
-#: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:172
-#: lxc/profile.go:756 lxc/project.go:572 lxc/storage.go:723
-#: lxc/storage_bucket.go:512 lxc/storage_bucket.go:832
+#: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
+#: lxc/profile.go:756 lxc/project.go:573 lxc/storage.go:723
+#: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1732
 msgid "DESCRIPTION"
 msgstr ""
@@ -1539,7 +1539,7 @@ msgstr ""
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
-#: lxc/operation.go:55 lxc/operation.go:56
+#: lxc/operation.go:56 lxc/operation.go:57
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
@@ -1547,19 +1547,19 @@ msgstr ""
 msgid "Delete a cluster group"
 msgstr ""
 
-#: lxc/warning.go:360
+#: lxc/warning.go:361
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:122 lxc/file.go:123
+#: lxc/file.go:123 lxc/file.go:124
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/auth.go:151 lxc/auth.go:152
+#: lxc/auth.go:152 lxc/auth.go:153
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1523 lxc/auth.go:1524
+#: lxc/auth.go:1524 lxc/auth.go:1525
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1579,7 +1579,7 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/storage_bucket.go:957 lxc/storage_bucket.go:958
+#: lxc/storage_bucket.go:958 lxc/storage_bucket.go:959
 msgid "Delete key from a storage bucket"
 msgstr ""
 
@@ -1615,11 +1615,11 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:188 lxc/project.go:189
+#: lxc/project.go:189 lxc/project.go:190
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:187 lxc/storage_bucket.go:188
+#: lxc/storage_bucket.go:188 lxc/storage_bucket.go:189
 msgid "Delete storage buckets"
 msgstr ""
 
@@ -1631,20 +1631,20 @@ msgstr ""
 msgid "Delete storage volumes"
 msgstr ""
 
-#: lxc/warning.go:356 lxc/warning.go:357
+#: lxc/warning.go:357 lxc/warning.go:358
 msgid "Delete warning"
 msgstr ""
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:30 lxc/auth.go:59 lxc/auth.go:98
-#: lxc/auth.go:152 lxc/auth.go:201 lxc/auth.go:332 lxc/auth.go:392
-#: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
-#: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
-#: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
-#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1434 lxc/auth.go:1472
-#: lxc/auth.go:1524 lxc/auth.go:1573 lxc/auth.go:1692 lxc/auth.go:1752
-#: lxc/auth.go:1801 lxc/auth.go:1852 lxc/auth.go:1875 lxc/auth.go:1928
+#: lxc/alias.go:214 lxc/auth.go:31 lxc/auth.go:60 lxc/auth.go:99
+#: lxc/auth.go:153 lxc/auth.go:202 lxc/auth.go:333 lxc/auth.go:393
+#: lxc/auth.go:442 lxc/auth.go:494 lxc/auth.go:517 lxc/auth.go:576
+#: lxc/auth.go:732 lxc/auth.go:766 lxc/auth.go:833 lxc/auth.go:896
+#: lxc/auth.go:957 lxc/auth.go:1085 lxc/auth.go:1108 lxc/auth.go:1166
+#: lxc/auth.go:1235 lxc/auth.go:1257 lxc/auth.go:1435 lxc/auth.go:1473
+#: lxc/auth.go:1525 lxc/auth.go:1574 lxc/auth.go:1693 lxc/auth.go:1753
+#: lxc/auth.go:1802 lxc/auth.go:1853 lxc/auth.go:1876 lxc/auth.go:1929
 #: lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215 lxc/cluster.go:272
 #: lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:484 lxc/cluster.go:528
 #: lxc/cluster.go:586 lxc/cluster.go:677 lxc/cluster.go:770 lxc/cluster.go:893
@@ -1668,15 +1668,15 @@ msgstr ""
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:83 lxc/file.go:123 lxc/file.go:172
-#: lxc/file.go:242 lxc/file.go:467 lxc/file.go:986 lxc/image.go:38
+#: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
+#: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
 #: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
 #: lxc/image.go:697 lxc/image.go:946 lxc/image.go:1088 lxc/image.go:1415
 #: lxc/image.go:1506 lxc/image.go:1572 lxc/image.go:1636 lxc/image.go:1699
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:38 lxc/network.go:33
+#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33
 #: lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405
 #: lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793
 #: lxc/network.go:874 lxc/network.go:1005 lxc/network.go:1106
@@ -1710,27 +1710,27 @@ msgstr ""
 #: lxc/network_zone.go:909 lxc/network_zone.go:985 lxc/network_zone.go:1083
 #: lxc/network_zone.go:1172 lxc/network_zone.go:1219 lxc/network_zone.go:1349
 #: lxc/network_zone.go:1410 lxc/network_zone.go:1425 lxc/network_zone.go:1483
-#: lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:106
-#: lxc/operation.go:193 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
+#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
+#: lxc/operation.go:194 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
 #: lxc/profile.go:271 lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493
 #: lxc/profile.go:629 lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860
-#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:29
-#: lxc/project.go:93 lxc/project.go:189 lxc/project.go:260 lxc/project.go:396
-#: lxc/project.go:470 lxc/project.go:590 lxc/project.go:655 lxc/project.go:743
-#: lxc/project.go:787 lxc/project.go:848 lxc/project.go:915 lxc/publish.go:34
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:35 lxc/remote.go:91
+#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:30
+#: lxc/project.go:94 lxc/project.go:190 lxc/project.go:261 lxc/project.go:397
+#: lxc/project.go:471 lxc/project.go:591 lxc/project.go:656 lxc/project.go:744
+#: lxc/project.go:788 lxc/project.go:849 lxc/project.go:916 lxc/publish.go:34
+#: lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91
 #: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853
 #: lxc/remote.go:917 lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24
 #: lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203
 #: lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655
 #: lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940
-#: lxc/storage_bucket.go:29 lxc/storage_bucket.go:83 lxc/storage_bucket.go:188
-#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:382
-#: lxc/storage_bucket.go:458 lxc/storage_bucket.go:535
-#: lxc/storage_bucket.go:629 lxc/storage_bucket.go:698
-#: lxc/storage_bucket.go:732 lxc/storage_bucket.go:773
-#: lxc/storage_bucket.go:852 lxc/storage_bucket.go:958
-#: lxc/storage_bucket.go:1022 lxc/storage_bucket.go:1157
+#: lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189
+#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:383
+#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:536
+#: lxc/storage_bucket.go:630 lxc/storage_bucket.go:699
+#: lxc/storage_bucket.go:733 lxc/storage_bucket.go:774
+#: lxc/storage_bucket.go:853 lxc/storage_bucket.go:959
+#: lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158
 #: lxc/storage_volume.go:58 lxc/storage_volume.go:169 lxc/storage_volume.go:283
 #: lxc/storage_volume.go:390 lxc/storage_volume.go:605
 #: lxc/storage_volume.go:714 lxc/storage_volume.go:801
@@ -1741,8 +1741,8 @@ msgstr ""
 #: lxc/storage_volume.go:2064 lxc/storage_volume.go:2222
 #: lxc/storage_volume.go:2343 lxc/storage_volume.go:2405
 #: lxc/storage_volume.go:2541 lxc/storage_volume.go:2624
-#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:29
-#: lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
+#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:30
+#: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
@@ -1829,7 +1829,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:994
+#: lxc/file.go:995
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1895,7 +1895,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:74
+#: lxc/file.go:75
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1905,7 +1905,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:955 lxc/auth.go:956
+#: lxc/auth.go:956 lxc/auth.go:957
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1913,15 +1913,15 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:171 lxc/file.go:172
+#: lxc/file.go:172 lxc/file.go:173
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/auth.go:200 lxc/auth.go:201
+#: lxc/auth.go:201 lxc/auth.go:202
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1572 lxc/auth.go:1573
+#: lxc/auth.go:1573 lxc/auth.go:1574
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -1977,15 +1977,15 @@ msgstr ""
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:259 lxc/project.go:260
+#: lxc/project.go:260 lxc/project.go:261
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:248 lxc/storage_bucket.go:249
+#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:250
 msgid "Edit storage bucket configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:1021 lxc/storage_bucket.go:1022
+#: lxc/storage_bucket.go:1022 lxc/storage_bucket.go:1023
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
@@ -2002,7 +2002,7 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1147 lxc/list.go:622 lxc/storage_volume.go:1766
-#: lxc/warning.go:235
+#: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2057,7 +2057,7 @@ msgstr ""
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
-#: lxc/project.go:718 lxc/storage.go:812 lxc/storage_bucket.go:602
+#: lxc/project.go:719 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2155 lxc/storage_volume.go:2193
 #, c-format
 msgid "Error setting properties: %v"
@@ -2071,8 +2071,8 @@ msgstr ""
 #: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
-#: lxc/profile.go:981 lxc/project.go:712 lxc/storage.go:806
-#: lxc/storage_bucket.go:596 lxc/storage_volume.go:2149
+#: lxc/profile.go:981 lxc/project.go:713 lxc/storage.go:806
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2149
 #: lxc/storage_volume.go:2187
 #, c-format
 msgid "Error unsetting property: %v"
@@ -2092,7 +2092,7 @@ msgstr ""
 msgid "Evacuating cluster member: %s"
 msgstr ""
 
-#: lxc/monitor.go:50
+#: lxc/monitor.go:51
 msgid "Event type to listen for"
 msgstr ""
 
@@ -2179,16 +2179,16 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/warning.go:210
+#: lxc/warning.go:211
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1237
+#: lxc/file.go:1238
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1260
+#: lxc/file.go:1261
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2203,12 +2203,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1287
+#: lxc/file.go:1288
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1072
+#: lxc/file.go:1073
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2238,7 +2238,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1193
+#: lxc/file.go:1194
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2253,7 +2253,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1198
+#: lxc/file.go:1199
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2263,12 +2263,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1098
+#: lxc/file.go:1099
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1225
+#: lxc/file.go:1226
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2307,7 +2307,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1210
+#: lxc/file.go:1211
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2322,7 +2322,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:820
+#: lxc/file.go:821
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2337,7 +2337,7 @@ msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
 #: lxc/network.go:1044 lxc/network_acl.go:133 lxc/network_zone.go:124
-#: lxc/operation.go:136
+#: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
 
@@ -2402,21 +2402,21 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
+#: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:770 lxc/auth.go:1697
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1114 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:57
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
-#: lxc/operation.go:108 lxc/profile.go:707 lxc/project.go:472
-#: lxc/project.go:917 lxc/remote.go:690 lxc/storage.go:657
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:774
-#: lxc/storage_volume.go:1608 lxc/warning.go:93
+#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:473
+#: lxc/project.go:918 lxc/remote.go:690 lxc/storage.go:657
+#: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
+#: lxc/storage_volume.go:1608 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
-#: lxc/monitor.go:52
+#: lxc/monitor.go:53
 msgid "Format (json|pretty|yaml)"
 msgstr ""
 
@@ -2460,7 +2460,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:817 lxc/auth.go:1736
+#: lxc/auth.go:818 lxc/auth.go:1737
 msgid "GROUPS"
 msgstr ""
 
@@ -2476,7 +2476,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:914 lxc/project.go:915
+#: lxc/project.go:915 lxc/project.go:916
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2524,11 +2524,11 @@ msgstr ""
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:400
+#: lxc/project.go:401
 msgid "Get the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:385
+#: lxc/storage_bucket.go:386
 msgid "Get the key as a storage bucket property"
 msgstr ""
 
@@ -2588,11 +2588,11 @@ msgstr ""
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:395 lxc/project.go:396
+#: lxc/project.go:396 lxc/project.go:397
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:382
+#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:383
 msgid "Get values for storage bucket configuration keys"
 msgstr ""
 
@@ -2609,17 +2609,17 @@ msgstr ""
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: lxc/auth.go:136
+#: lxc/auth.go:137
 #, c-format
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:186
+#: lxc/auth.go:187
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:426 lxc/auth.go:1786
+#: lxc/auth.go:427 lxc/auth.go:1787
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2644,27 +2644,27 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1310
+#: lxc/file.go:1311
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1299
+#: lxc/file.go:1300
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1122
+#: lxc/file.go:1123
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1132
+#: lxc/file.go:1133
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:966 lxc/operation.go:170
+#: lxc/network.go:966 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2678,11 +2678,11 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:816
+#: lxc/auth.go:817
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:566
+#: lxc/project.go:567
 msgid "IMAGES"
 msgstr ""
 
@@ -2710,17 +2710,17 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1508
+#: lxc/auth.go:1509
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1558
+#: lxc/auth.go:1559
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
 
-#: lxc/rebuild.go:32
+#: lxc/rebuild.go:33
 msgid "If an instance is running, stop it and then rebuild it"
 msgstr ""
 
@@ -2841,7 +2841,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1233 lxc/auth.go:1234
+#: lxc/auth.go:1234 lxc/auth.go:1235
 msgid "Inspect permissions"
 msgstr ""
 
@@ -2849,11 +2849,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1124
+#: lxc/file.go:1125
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1301
+#: lxc/file.go:1302
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2871,7 +2871,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1044
+#: lxc/file.go:1045
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2880,7 +2880,7 @@ msgstr ""
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/rebuild.go:74
+#: lxc/rebuild.go:75
 #, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
@@ -2913,7 +2913,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/monitor.go:70
+#: lxc/monitor.go:71
 #, c-format
 msgid "Invalid format: %s"
 msgstr ""
@@ -2923,7 +2923,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1039
+#: lxc/file.go:1040
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2965,7 +2965,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:147
+#: lxc/file.go:148
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2981,12 +2981,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:313
+#: lxc/file.go:314
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:495
+#: lxc/file.go:496
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3000,7 +3000,7 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/warning.go:212
 msgid "LAST SEEN"
 msgstr ""
 
@@ -3008,7 +3008,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:984
+#: lxc/project.go:985
 msgid "LIMIT"
 msgstr ""
 
@@ -3017,8 +3017,8 @@ msgid "LISTEN ADDRESS"
 msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
-#: lxc/network_load_balancer.go:165 lxc/operation.go:177
-#: lxc/storage_bucket.go:516 lxc/storage_volume.go:1739 lxc/warning.go:220
+#: lxc/network_load_balancer.go:165 lxc/operation.go:178
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1739 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3092,7 +3092,7 @@ msgstr ""
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/warning.go:94
+#: lxc/warning.go:95
 msgid "List all warnings"
 msgstr ""
 
@@ -3136,19 +3136,19 @@ msgstr ""
 msgid "List available storage pools"
 msgstr ""
 
-#: lxc/operation.go:105 lxc/operation.go:106
+#: lxc/operation.go:106 lxc/operation.go:107
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:331 lxc/auth.go:332
+#: lxc/auth.go:332 lxc/auth.go:333
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:764 lxc/auth.go:765
+#: lxc/auth.go:765 lxc/auth.go:766
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1691 lxc/auth.go:1692
+#: lxc/auth.go:1692 lxc/auth.go:1693
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3297,11 +3297,11 @@ msgstr ""
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/operation.go:109
+#: lxc/operation.go:110
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1255 lxc/auth.go:1256
+#: lxc/auth.go:1256 lxc/auth.go:1257
 msgid "List permissions"
 msgstr ""
 
@@ -3309,15 +3309,15 @@ msgstr ""
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:469 lxc/project.go:470
+#: lxc/project.go:470 lxc/project.go:471
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:771 lxc/storage_bucket.go:773
+#: lxc/storage_bucket.go:772 lxc/storage_bucket.go:774
 msgid "List storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:456 lxc/storage_bucket.go:458
+#: lxc/storage_bucket.go:457 lxc/storage_bucket.go:459
 msgid "List storage buckets"
 msgstr ""
 
@@ -3353,11 +3353,11 @@ msgstr ""
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/warning.go:70
+#: lxc/warning.go:71
 msgid "List warnings"
 msgstr ""
 
-#: lxc/warning.go:71
+#: lxc/warning.go:72
 msgid ""
 "List warnings\n"
 "\n"
@@ -3380,7 +3380,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/operation.go:23 lxc/operation.go:24
+#: lxc/operation.go:24 lxc/operation.go:25
 msgid "List, show and delete background operations"
 msgstr ""
 
@@ -3389,7 +3389,7 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/monitor.go:79
+#: lxc/monitor.go:80
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
@@ -3493,23 +3493,23 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:82 lxc/file.go:83
+#: lxc/file.go:83 lxc/file.go:84
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1433 lxc/auth.go:1434
+#: lxc/auth.go:59 lxc/auth.go:60 lxc/auth.go:1434 lxc/auth.go:1435
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1083 lxc/auth.go:1084
+#: lxc/auth.go:1084 lxc/auth.go:1085
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:730 lxc/auth.go:731
+#: lxc/auth.go:731 lxc/auth.go:732
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1851 lxc/auth.go:1852
+#: lxc/auth.go:1852 lxc/auth.go:1853
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3600,7 +3600,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:492 lxc/auth.go:493
+#: lxc/auth.go:493 lxc/auth.go:494
 msgid "Manage permissions"
 msgstr ""
 
@@ -3608,23 +3608,23 @@ msgstr ""
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:28 lxc/project.go:29
+#: lxc/project.go:29 lxc/project.go:30
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:731
+#: lxc/storage_bucket.go:732
 msgid "Manage storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:732
+#: lxc/storage_bucket.go:733
 msgid "Manage storage bucket keys."
 msgstr ""
 
-#: lxc/storage_bucket.go:28
+#: lxc/storage_bucket.go:29
 msgid "Manage storage buckets"
 msgstr ""
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:30
 msgid "Manage storage buckets."
 msgstr ""
 
@@ -3652,11 +3652,11 @@ msgstr ""
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/auth.go:29 lxc/auth.go:30
+#: lxc/auth.go:30 lxc/auth.go:31
 msgid "Manage user authorization"
 msgstr ""
 
-#: lxc/warning.go:28 lxc/warning.go:29
+#: lxc/warning.go:29 lxc/warning.go:30
 msgid "Manage warnings"
 msgstr ""
 
@@ -3720,17 +3720,17 @@ msgstr ""
 msgid "Migration operation failure: %w"
 msgstr ""
 
-#: lxc/monitor.go:51
+#: lxc/monitor.go:52
 msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: lxc/storage_bucket.go:116 lxc/storage_bucket.go:216
-#: lxc/storage_bucket.go:292 lxc/storage_bucket.go:411
-#: lxc/storage_bucket.go:568 lxc/storage_bucket.go:660
-#: lxc/storage_bucket.go:802 lxc/storage_bucket.go:889
-#: lxc/storage_bucket.go:986 lxc/storage_bucket.go:1065
-#: lxc/storage_bucket.go:1188
+#: lxc/storage_bucket.go:117 lxc/storage_bucket.go:217
+#: lxc/storage_bucket.go:293 lxc/storage_bucket.go:412
+#: lxc/storage_bucket.go:569 lxc/storage_bucket.go:661
+#: lxc/storage_bucket.go:803 lxc/storage_bucket.go:890
+#: lxc/storage_bucket.go:987 lxc/storage_bucket.go:1066
+#: lxc/storage_bucket.go:1189
 msgid "Missing bucket name"
 msgstr ""
 
@@ -3749,20 +3749,20 @@ msgstr ""
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1825
+#: lxc/auth.go:123 lxc/auth.go:177 lxc/auth.go:255 lxc/auth.go:417
+#: lxc/auth.go:466 lxc/auth.go:541 lxc/auth.go:600 lxc/auth.go:1826
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:862 lxc/auth.go:1003 lxc/auth.go:1131 lxc/auth.go:1189
+#: lxc/auth.go:863 lxc/auth.go:1004 lxc/auth.go:1132 lxc/auth.go:1190
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1495 lxc/auth.go:1548 lxc/auth.go:1614 lxc/auth.go:1776
+#: lxc/auth.go:1496 lxc/auth.go:1549 lxc/auth.go:1615 lxc/auth.go:1777
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1899 lxc/auth.go:1952
+#: lxc/auth.go:1900 lxc/auth.go:1953
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -3770,12 +3770,12 @@ msgstr ""
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
 #: lxc/config_template.go:377 lxc/profile.go:141 lxc/profile.go:222
-#: lxc/profile.go:808 lxc/rebuild.go:60
+#: lxc/profile.go:808 lxc/rebuild.go:61
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/storage_bucket.go:893 lxc/storage_bucket.go:990
-#: lxc/storage_bucket.go:1069 lxc/storage_bucket.go:1192
+#: lxc/storage_bucket.go:894 lxc/storage_bucket.go:991
+#: lxc/storage_bucket.go:1070 lxc/storage_bucket.go:1193
 msgid "Missing key name"
 msgstr ""
 
@@ -3840,13 +3840,13 @@ msgid "Missing peer name"
 msgstr ""
 
 #: lxc/storage.go:235 lxc/storage.go:313 lxc/storage.go:431 lxc/storage.go:509
-#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:112
-#: lxc/storage_bucket.go:212 lxc/storage_bucket.go:288
-#: lxc/storage_bucket.go:407 lxc/storage_bucket.go:482
-#: lxc/storage_bucket.go:564 lxc/storage_bucket.go:656
-#: lxc/storage_bucket.go:798 lxc/storage_bucket.go:885
-#: lxc/storage_bucket.go:982 lxc/storage_bucket.go:1061
-#: lxc/storage_bucket.go:1184 lxc/storage_volume.go:209
+#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:113
+#: lxc/storage_bucket.go:213 lxc/storage_bucket.go:289
+#: lxc/storage_bucket.go:408 lxc/storage_bucket.go:483
+#: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
+#: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
+#: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
 #: lxc/storage_volume.go:323 lxc/storage_volume.go:643
 #: lxc/storage_volume.go:750 lxc/storage_volume.go:841
 #: lxc/storage_volume.go:939 lxc/storage_volume.go:1053
@@ -3861,9 +3861,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:404 lxc/project.go:146 lxc/project.go:226 lxc/project.go:316
-#: lxc/project.go:433 lxc/project.go:622 lxc/project.go:691 lxc/project.go:819
-#: lxc/project.go:948
+#: lxc/profile.go:404 lxc/project.go:147 lxc/project.go:227 lxc/project.go:317
+#: lxc/project.go:434 lxc/project.go:623 lxc/project.go:692 lxc/project.go:820
+#: lxc/project.go:949
 msgid "Missing project name"
 msgstr ""
 
@@ -3879,7 +3879,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:598
+#: lxc/file.go:599
 msgid "Missing target directory"
 msgstr ""
 
@@ -3901,11 +3901,11 @@ msgstr ""
 msgid "Model: %v"
 msgstr ""
 
-#: lxc/monitor.go:32
+#: lxc/monitor.go:33
 msgid "Monitor a local or remote LXD server"
 msgstr ""
 
-#: lxc/monitor.go:33
+#: lxc/monitor.go:34
 msgid ""
 "Monitor a local or remote LXD server\n"
 "\n"
@@ -3917,11 +3917,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:285
+#: lxc/file.go:286
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:985 lxc/file.go:986
+#: lxc/file.go:986 lxc/file.go:987
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3983,13 +3983,13 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:192
+#: lxc/auth.go:376 lxc/auth.go:816 lxc/auth.go:1736 lxc/cluster.go:192
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
-#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:565
-#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:511
-#: lxc/storage_bucket.go:831 lxc/storage_volume.go:1731
+#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:566
+#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1731
 msgid "NAME"
 msgstr ""
 
@@ -3997,11 +3997,11 @@ msgstr ""
 msgid "NAT"
 msgstr ""
 
-#: lxc/project.go:571
+#: lxc/project.go:572
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:570
+#: lxc/project.go:571
 msgid "NETWORKS"
 msgstr ""
 
@@ -4013,9 +4013,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/operation.go:154 lxc/project.go:523
-#: lxc/project.go:528 lxc/project.go:533 lxc/project.go:538 lxc/project.go:543
-#: lxc/project.go:548 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
+#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:524
+#: lxc/project.go:529 lxc/project.go:534 lxc/project.go:539 lxc/project.go:544
+#: lxc/project.go:549 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
 msgid "NO"
 msgstr ""
 
@@ -4260,7 +4260,7 @@ msgstr ""
 msgid "Only managed networks can be modified"
 msgstr ""
 
-#: lxc/operation.go:86
+#: lxc/operation.go:87
 #, c-format
 msgid "Operation %s deleted"
 msgstr ""
@@ -4307,11 +4307,11 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:567
+#: lxc/list.go:576 lxc/project.go:568
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:212
+#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4373,24 +4373,24 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1102
+#: lxc/file.go:1103
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:860
+#: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
-#: lxc/project.go:363 lxc/storage.go:360 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1151
+#: lxc/project.go:364 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1151
 #: lxc/storage_volume.go:1183
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
-#: lxc/monitor.go:48
+#: lxc/monitor.go:49
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
@@ -4476,17 +4476,17 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:172
+#: lxc/project.go:173
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:236
+#: lxc/project.go:237
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:637
+#: lxc/project.go:638
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -4607,20 +4607,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:241 lxc/file.go:242
+#: lxc/file.go:242 lxc/file.go:243
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:416 lxc/file.go:767
+#: lxc/file.go:417 lxc/file.go:768
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:466 lxc/file.go:467
+#: lxc/file.go:467 lxc/file.go:468
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:701 lxc/file.go:867
+#: lxc/file.go:702 lxc/file.go:868
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4633,11 +4633,11 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:983
+#: lxc/project.go:984
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/storage_bucket.go:833
+#: lxc/storage_bucket.go:834
 msgid "ROLE"
 msgstr ""
 
@@ -4650,15 +4650,15 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/rebuild.go:31
+#: lxc/rebuild.go:32
 msgid "Rebuild as an empty instance"
 msgstr ""
 
-#: lxc/rebuild.go:26
+#: lxc/rebuild.go:27
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:249 lxc/file.go:473
+#: lxc/file.go:250 lxc/file.go:474
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4685,7 +4685,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:882 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
+#: lxc/project.go:883 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
 #: lxc/remote.go:994
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4736,7 +4736,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1164 lxc/auth.go:1165
+#: lxc/auth.go:1165 lxc/auth.go:1166
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4772,7 +4772,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1927 lxc/auth.go:1928
+#: lxc/auth.go:1928 lxc/auth.go:1929
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4784,7 +4784,7 @@ msgstr ""
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:574 lxc/auth.go:575
+#: lxc/auth.go:575 lxc/auth.go:576
 msgid "Remove permissions from groups"
 msgstr ""
 
@@ -4829,11 +4829,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:391 lxc/auth.go:392
+#: lxc/auth.go:392 lxc/auth.go:393
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1751 lxc/auth.go:1752
+#: lxc/auth.go:1752 lxc/auth.go:1753
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -4853,7 +4853,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:589 lxc/project.go:590
+#: lxc/project.go:590 lxc/project.go:591
 msgid "Rename projects"
 msgstr ""
 
@@ -4951,7 +4951,7 @@ msgstr ""
 msgid "Revoke cluster member join token"
 msgstr ""
 
-#: lxc/storage_bucket.go:862
+#: lxc/storage_bucket.go:863
 msgid "Role (admin or read-only)"
 msgstr ""
 
@@ -4967,7 +4967,7 @@ msgstr ""
 msgid "Run against all projects"
 msgstr ""
 
-#: lxc/warning.go:213
+#: lxc/warning.go:214
 msgid "SEVERITY"
 msgstr ""
 
@@ -4987,12 +4987,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1231
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1231
+#: lxc/file.go:1232
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5006,11 +5006,11 @@ msgstr ""
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:173 lxc/warning.go:214
+#: lxc/operation.go:174 lxc/warning.go:215
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:569
+#: lxc/project.go:570
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5018,7 +5018,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:569
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -5026,11 +5026,11 @@ msgstr ""
 msgid "STP"
 msgstr ""
 
-#: lxc/storage_bucket.go:864
+#: lxc/storage_bucket.go:865
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:942
+#: lxc/storage_bucket.go:943
 #, c-format
 msgid "Secret key: %s"
 msgstr ""
@@ -5068,7 +5068,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:995
+#: lxc/file.go:996
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5206,11 +5206,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:654
+#: lxc/project.go:655
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:655
+#: lxc/project.go:656
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5219,11 +5219,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage_bucket.go:534
+#: lxc/storage_bucket.go:535
 msgid "Set storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:535
+#: lxc/storage_bucket.go:536
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -5262,15 +5262,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:476
+#: lxc/file.go:477
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:477
+#: lxc/file.go:478
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:475
+#: lxc/file.go:476
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5310,11 +5310,11 @@ msgstr ""
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 msgid "Set the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:542
+#: lxc/storage_bucket.go:543
 msgid "Set the key as a storage bucket property"
 msgstr ""
 
@@ -5330,7 +5330,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:993
+#: lxc/file.go:994
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5342,7 +5342,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1800 lxc/auth.go:1801
+#: lxc/auth.go:1801 lxc/auth.go:1802
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5358,11 +5358,11 @@ msgstr ""
 msgid "Show details of a cluster member"
 msgstr ""
 
-#: lxc/operation.go:192 lxc/operation.go:193
+#: lxc/operation.go:193 lxc/operation.go:194
 msgid "Show details on a background operation"
 msgstr ""
 
-#: lxc/monitor.go:49
+#: lxc/monitor.go:50
 msgid "Show events from all projects"
 msgstr ""
 
@@ -5370,11 +5370,11 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:440 lxc/auth.go:441
+#: lxc/auth.go:441 lxc/auth.go:442
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:832
+#: lxc/auth.go:833
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5455,15 +5455,15 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:786 lxc/project.go:787
+#: lxc/project.go:787 lxc/project.go:788
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage_bucket.go:628 lxc/storage_bucket.go:629
+#: lxc/storage_bucket.go:629 lxc/storage_bucket.go:630
 msgid "Show storage bucket configurations"
 msgstr ""
 
-#: lxc/storage_bucket.go:1156 lxc/storage_bucket.go:1157
+#: lxc/storage_bucket.go:1157 lxc/storage_bucket.go:1158
 msgid "Show storage bucket key configurations"
 msgstr ""
 
@@ -5479,7 +5479,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:895
+#: lxc/auth.go:896
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5529,7 +5529,7 @@ msgstr ""
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: lxc/warning.go:302 lxc/warning.go:303
+#: lxc/warning.go:303 lxc/warning.go:304
 msgid "Show warning"
 msgstr ""
 
@@ -5613,22 +5613,22 @@ msgstr ""
 msgid "Stopping the instance failed: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:166
+#: lxc/storage_bucket.go:167
 #, c-format
 msgid "Storage bucket %s created"
 msgstr ""
 
-#: lxc/storage_bucket.go:233
+#: lxc/storage_bucket.go:234
 #, c-format
 msgid "Storage bucket %s deleted"
 msgstr ""
 
-#: lxc/storage_bucket.go:940
+#: lxc/storage_bucket.go:941
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr ""
 
-#: lxc/storage_bucket.go:1006
+#: lxc/storage_bucket.go:1007
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr ""
@@ -5697,7 +5697,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:847 lxc/project.go:848
+#: lxc/project.go:848 lxc/project.go:849
 msgid "Switch the current project"
 msgstr ""
 
@@ -5713,10 +5713,10 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1139
+#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1139
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
-#: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:171
-#: lxc/storage_volume.go:1730 lxc/warning.go:215
+#: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
+#: lxc/storage_volume.go:1730 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
@@ -5724,11 +5724,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1032
+#: lxc/file.go:1033
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1026
+#: lxc/file.go:1027
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5856,12 +5856,12 @@ msgstr ""
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:446
+#: lxc/project.go:447
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
 
-#: lxc/storage_bucket.go:431
+#: lxc/storage_bucket.go:432
 #, c-format
 msgid "The property %q does not exist on the storage bucket %q: %v"
 msgstr ""
@@ -6046,7 +6046,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:961
+#: lxc/project.go:962
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6058,17 +6058,17 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:985 lxc/storage_volume.go:1735
+#: lxc/project.go:986 lxc/storage_volume.go:1735
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:573
+#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:574
 #: lxc/storage.go:724 lxc/storage_volume.go:1734
 msgid "USED BY"
 msgstr ""
 
-#: lxc/warning.go:216
+#: lxc/warning.go:217
 msgid "UUID"
 msgstr ""
 
@@ -6077,7 +6077,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:197
+#: lxc/file.go:198
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6091,13 +6091,13 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1253
+#: lxc/file.go:1254
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1153 lxc/list.go:631 lxc/storage_volume.go:1772
-#: lxc/warning.go:241
+#: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6107,7 +6107,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:807
+#: lxc/file.go:808
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6190,11 +6190,11 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:742 lxc/project.go:743
+#: lxc/project.go:743 lxc/project.go:744
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:697 lxc/storage_bucket.go:698
+#: lxc/storage_bucket.go:698 lxc/storage_bucket.go:699
 msgid "Unset storage bucket configuration keys"
 msgstr ""
 
@@ -6242,11 +6242,11 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:747
+#: lxc/project.go:748
 msgid "Unset the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:701
+#: lxc/storage_bucket.go:702
 msgid "Unset the key as a storage bucket property"
 msgstr ""
 
@@ -6325,7 +6325,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:71
+#: lxc/file.go:72
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6362,11 +6362,11 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:831
+#: lxc/auth.go:832
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:894
+#: lxc/auth.go:895
 msgid "View the current identity"
 msgstr ""
 
@@ -6397,15 +6397,15 @@ msgstr ""
 msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
-#: lxc/rebuild.go:27
+#: lxc/rebuild.go:28
 msgid ""
 "Wipe the instance root disk and re-initialize. The original image is used to "
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:156 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
+#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:526
+#: lxc/project.go:531 lxc/project.go:536 lxc/project.go:541 lxc/project.go:546
+#: lxc/project.go:551 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
 msgid "YES"
 msgstr ""
 
@@ -6425,7 +6425,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/rebuild.go:119
+#: lxc/rebuild.go:120
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
@@ -6437,12 +6437,12 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1689
+#: lxc/auth.go:330 lxc/auth.go:763 lxc/auth.go:894 lxc/auth.go:1690
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
-#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
+#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
-#: lxc/operation.go:103 lxc/profile.go:700 lxc/project.go:467
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:68
+#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:468
+#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6470,7 +6470,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1254
+#: lxc/auth.go:1255
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6531,11 +6531,11 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:830
+#: lxc/auth.go:831
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1926
+#: lxc/auth.go:1106 lxc/auth.go:1164 lxc/auth.go:1927
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6543,13 +6543,13 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:954 lxc/auth.go:1470 lxc/cluster_group.go:168
+#: lxc/auth.go:97 lxc/auth.go:150 lxc/auth.go:200 lxc/auth.go:440
+#: lxc/auth.go:955 lxc/auth.go:1471 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:514 lxc/auth.go:572
+#: lxc/auth.go:515 lxc/auth.go:573
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
@@ -6559,19 +6559,19 @@ msgstr ""
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:389
+#: lxc/auth.go:390
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1521 lxc/auth.go:1571 lxc/auth.go:1799
+#: lxc/auth.go:1522 lxc/auth.go:1572 lxc/auth.go:1800
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1873
+#: lxc/auth.go:1874
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1749
+#: lxc/auth.go:1750
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -6591,7 +6591,7 @@ msgstr ""
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
-#: lxc/rebuild.go:25
+#: lxc/rebuild.go:26
 msgid "[<remote>:]<image> [<remote>:]<instance>"
 msgstr ""
 
@@ -6674,20 +6674,20 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:170
+#: lxc/file.go:171
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:120
+#: lxc/file.go:121
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:240
+#: lxc/file.go:241
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:984
+#: lxc/file.go:985
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6838,12 +6838,12 @@ msgstr ""
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
-#: lxc/operation.go:53 lxc/operation.go:191
+#: lxc/operation.go:54 lxc/operation.go:192
 msgid "[<remote>:]<operation>"
 msgstr ""
 
 #: lxc/storage.go:200 lxc/storage.go:259 lxc/storage.go:473 lxc/storage.go:844
-#: lxc/storage_bucket.go:454
+#: lxc/storage_bucket.go:455
 msgid "[<remote>:]<pool>"
 msgstr ""
 
@@ -6851,22 +6851,22 @@ msgstr ""
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
-#: lxc/storage_bucket.go:185 lxc/storage_bucket.go:247
-#: lxc/storage_bucket.go:627 lxc/storage_bucket.go:769
+#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:248
+#: lxc/storage_bucket.go:628 lxc/storage_bucket.go:770
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
 
-#: lxc/storage_bucket.go:380 lxc/storage_bucket.go:696
-#: lxc/storage_bucket.go:850 lxc/storage_bucket.go:956
-#: lxc/storage_bucket.go:1020 lxc/storage_bucket.go:1155
+#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:697
+#: lxc/storage_bucket.go:851 lxc/storage_bucket.go:957
+#: lxc/storage_bucket.go:1021 lxc/storage_bucket.go:1156
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
 
-#: lxc/storage_bucket.go:533
+#: lxc/storage_bucket.go:534
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_bucket.go:81
+#: lxc/storage_bucket.go:82
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
 
@@ -6981,20 +6981,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:91 lxc/project.go:186 lxc/project.go:258 lxc/project.go:785
-#: lxc/project.go:846 lxc/project.go:913
+#: lxc/project.go:92 lxc/project.go:187 lxc/project.go:259 lxc/project.go:786
+#: lxc/project.go:847 lxc/project.go:914
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:394 lxc/project.go:741
+#: lxc/project.go:395 lxc/project.go:742
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:653
+#: lxc/project.go:654
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:587
+#: lxc/project.go:588
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7002,7 +7002,7 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:259 lxc/warning.go:301 lxc/warning.go:354
+#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
@@ -7058,7 +7058,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:555 lxc/remote.go:739
+#: lxc/project.go:556 lxc/remote.go:739
 msgid "current"
 msgstr ""
 
@@ -7105,20 +7105,20 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/auth.go:203
+#: lxc/auth.go:204
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:958
+#: lxc/auth.go:959
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1575
+#: lxc/auth.go:1576
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7196,20 +7196,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:988
+#: lxc/file.go:989
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:244
+#: lxc/file.go:245
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:470
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7291,7 +7291,7 @@ msgid ""
 "  List instances with their running state and user comment."
 msgstr ""
 
-#: lxc/monitor.go:37
+#: lxc/monitor.go:38
 msgid ""
 "lxc monitor --type=logging\n"
 "    Only show log messages.\n"
@@ -7367,7 +7367,7 @@ msgid ""
 "    Create record r1 for zone z1 with configuration from config.yaml"
 msgstr ""
 
-#: lxc/operation.go:195
+#: lxc/operation.go:196
 msgid ""
 "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Show details on that operation UUID"
@@ -7410,7 +7410,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:95
+#: lxc/project.go:96
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7418,7 +7418,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:262
+#: lxc/project.go:263
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7449,7 +7449,7 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:85
 msgid ""
 "lxc storage bucket create p1 b01\n"
 "\tCreate a new storage bucket name b01 in storage pool p1\n"
@@ -7459,19 +7459,19 @@ msgid ""
 "of config.yaml"
 msgstr ""
 
-#: lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:251
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1023
+#: lxc/storage_bucket.go:1024
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:854
 msgid ""
 "lxc storage bucket key create p1 b01 k1\n"
 "\tCreate a key called k1 for the bucket b01 in the pool p1.\n"
@@ -7481,14 +7481,14 @@ msgid ""
 "of config.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1158
+#: lxc/storage_bucket.go:1159
 msgid ""
 "lxc storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_bucket.go:630
+#: lxc/storage_bucket.go:631
 msgid ""
 "lxc storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
@@ -7558,16 +7558,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1142
+#: lxc/file.go:1143
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1101
+#: lxc/file.go:1102
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1054
+#: lxc/file.go:1055
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-04 08:52-0600\n"
+"POT-Creation-Date: 2024-09-05 08:44-0400\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Heimen Stoffels <vistausss@fastmail.com>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/linux-containers/"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: lxc/storage_bucket.go:260 lxc/storage_bucket.go:1033
+#: lxc/storage_bucket.go:261 lxc/storage_bucket.go:1034
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
@@ -201,7 +201,7 @@ msgstr ""
 "###\n"
 "### NB: de naam is weergegeven, maar kan niet worden veranderd"
 
-#: lxc/auth.go:213
+#: lxc/auth.go:214
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -228,7 +228,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:968
+#: lxc/auth.go:969
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -249,7 +249,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1585
+#: lxc/auth.go:1586
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
@@ -601,7 +601,7 @@ msgstr ""
 "###\n"
 "### NB: de naam is weergegeven, maar kan niet worden veranderd"
 
-#: lxc/project.go:280
+#: lxc/project.go:281
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the project.\n"
@@ -657,12 +657,12 @@ msgstr "%s (en nog %d)"
 msgid "%s (%s) (%d available)"
 msgstr "%s (en nog %d)"
 
-#: lxc/file.go:935
+#: lxc/file.go:936
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:825
+#: lxc/file.go:826
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -698,7 +698,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:142 lxc/rebuild.go:64
+#: lxc/init.go:142 lxc/rebuild.go:65
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -751,7 +751,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:465
+#: lxc/file.go:466
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -784,7 +784,7 @@ msgstr "ARCHITECTUUR"
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:813
+#: lxc/auth.go:814
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -792,11 +792,11 @@ msgstr ""
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/storage_bucket.go:863
+#: lxc/storage_bucket.go:864
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:941
+#: lxc/storage_bucket.go:942
 #, c-format
 msgid "Access key: %s"
 msgstr ""
@@ -805,7 +805,7 @@ msgstr ""
 msgid "Access the expanded configuration"
 msgstr ""
 
-#: lxc/warning.go:261 lxc/warning.go:262
+#: lxc/warning.go:262 lxc/warning.go:263
 msgid "Acknowledge warning"
 msgstr ""
 
@@ -822,11 +822,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1106 lxc/auth.go:1107
+#: lxc/auth.go:1107 lxc/auth.go:1108
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1874 lxc/auth.go:1875
+#: lxc/auth.go:1875 lxc/auth.go:1876
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:515 lxc/auth.go:516
+#: lxc/auth.go:516 lxc/auth.go:517
 msgid "Add permissions to groups"
 msgstr ""
 
@@ -924,7 +924,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:169
+#: lxc/storage_bucket.go:170
 #, c-format
 msgid "Admin access key: %s"
 msgstr ""
@@ -934,7 +934,7 @@ msgstr ""
 msgid "Admin password (or token) for %s:"
 msgstr ""
 
-#: lxc/storage_bucket.go:170
+#: lxc/storage_bucket.go:171
 #, c-format
 msgid "Admin secret key: %s"
 msgstr ""
@@ -993,7 +993,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:342 lxc/rebuild.go:130
+#: lxc/init.go:342 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -1093,12 +1093,12 @@ msgstr ""
 
 #: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:318
 #: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
-#: lxc/network_zone.go:366 lxc/network_zone.go:1053 lxc/storage_bucket.go:141
+#: lxc/network_zone.go:366 lxc/network_zone.go:1053 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:159
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:160
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1138,7 +1138,7 @@ msgstr ""
 msgid "Bytes sent"
 msgstr ""
 
-#: lxc/operation.go:174
+#: lxc/operation.go:175
 msgid "CANCELABLE"
 msgstr ""
 
@@ -1150,7 +1150,7 @@ msgstr ""
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: lxc/warning.go:209
+#: lxc/warning.go:210
 msgid "COUNT"
 msgstr ""
 
@@ -1176,7 +1176,7 @@ msgstr ""
 msgid "CPUs (%s):"
 msgstr ""
 
-#: lxc/operation.go:175
+#: lxc/operation.go:176
 msgid "CREATED"
 msgstr ""
 
@@ -1206,7 +1206,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:340
+#: lxc/file.go:341
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1231,11 +1231,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:224
+#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:546
+#: lxc/file.go:547
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1244,7 +1244,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:160
+#: lxc/rebuild.go:161
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1367,13 +1367,13 @@ msgstr ""
 #: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
 #: lxc/network_load_balancer.go:1051 lxc/network_load_balancer.go:1125
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
-#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:90
-#: lxc/storage_bucket.go:190 lxc/storage_bucket.go:253
-#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:541
-#: lxc/storage_bucket.go:634 lxc/storage_bucket.go:700
-#: lxc/storage_bucket.go:775 lxc/storage_bucket.go:861
-#: lxc/storage_bucket.go:961 lxc/storage_bucket.go:1026
-#: lxc/storage_bucket.go:1162 lxc/storage_volume.go:394
+#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
+#: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
+#: lxc/storage_bucket.go:385 lxc/storage_bucket.go:542
+#: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
+#: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
+#: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
 #: lxc/storage_volume.go:612 lxc/storage_volume.go:717
 #: lxc/storage_volume.go:1005 lxc/storage_volume.go:1231
 #: lxc/storage_volume.go:1360 lxc/storage_volume.go:1848
@@ -1397,7 +1397,7 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1113 lxc/list.go:132 lxc/storage_volume.go:1589
-#: lxc/warning.go:92
+#: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:100
+#: lxc/project.go:101
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1439,8 +1439,8 @@ msgstr ""
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
-#: lxc/project.go:362 lxc/storage.go:359 lxc/storage_bucket.go:348
-#: lxc/storage_bucket.go:1125 lxc/storage_volume.go:1150
+#: lxc/project.go:363 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1150
 #: lxc/storage_volume.go:1182
 #, c-format
 msgid "Config parsing error: %s"
@@ -1567,12 +1567,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:300 lxc/auth.go:1660
+#: lxc/auth.go:301 lxc/auth.go:1661
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1054
+#: lxc/auth.go:1055
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1621,15 +1621,15 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:248 lxc/file.go:474
+#: lxc/file.go:249 lxc/file.go:475
 msgid "Create any directories necessary"
 msgstr ""
 
-#: lxc/auth.go:97 lxc/auth.go:98
+#: lxc/auth.go:98 lxc/auth.go:99
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1471 lxc/auth.go:1472
+#: lxc/auth.go:1472 lxc/auth.go:1473
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1649,11 +1649,11 @@ msgstr ""
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_bucket.go:851 lxc/storage_bucket.go:852
+#: lxc/storage_bucket.go:852 lxc/storage_bucket.go:853
 msgid "Create key for a storage bucket"
 msgstr ""
 
-#: lxc/storage_bucket.go:82 lxc/storage_bucket.go:83
+#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
 msgid "Create new custom storage buckets"
 msgstr ""
 
@@ -1697,7 +1697,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:92 lxc/project.go:93
+#: lxc/project.go:93 lxc/project.go:94
 msgid "Create projects"
 msgstr ""
 
@@ -1732,13 +1732,13 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:376 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1135 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
-#: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:172
-#: lxc/profile.go:756 lxc/project.go:572 lxc/storage.go:723
-#: lxc/storage_bucket.go:512 lxc/storage_bucket.go:832
+#: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
+#: lxc/profile.go:756 lxc/project.go:573 lxc/storage.go:723
+#: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1732
 msgid "DESCRIPTION"
 msgstr ""
@@ -1763,7 +1763,7 @@ msgstr ""
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
-#: lxc/operation.go:55 lxc/operation.go:56
+#: lxc/operation.go:56 lxc/operation.go:57
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
@@ -1771,19 +1771,19 @@ msgstr ""
 msgid "Delete a cluster group"
 msgstr ""
 
-#: lxc/warning.go:360
+#: lxc/warning.go:361
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:122 lxc/file.go:123
+#: lxc/file.go:123 lxc/file.go:124
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/auth.go:151 lxc/auth.go:152
+#: lxc/auth.go:152 lxc/auth.go:153
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1523 lxc/auth.go:1524
+#: lxc/auth.go:1524 lxc/auth.go:1525
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1803,7 +1803,7 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/storage_bucket.go:957 lxc/storage_bucket.go:958
+#: lxc/storage_bucket.go:958 lxc/storage_bucket.go:959
 msgid "Delete key from a storage bucket"
 msgstr ""
 
@@ -1839,11 +1839,11 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:188 lxc/project.go:189
+#: lxc/project.go:189 lxc/project.go:190
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:187 lxc/storage_bucket.go:188
+#: lxc/storage_bucket.go:188 lxc/storage_bucket.go:189
 msgid "Delete storage buckets"
 msgstr ""
 
@@ -1855,20 +1855,20 @@ msgstr ""
 msgid "Delete storage volumes"
 msgstr ""
 
-#: lxc/warning.go:356 lxc/warning.go:357
+#: lxc/warning.go:357 lxc/warning.go:358
 msgid "Delete warning"
 msgstr ""
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:30 lxc/auth.go:59 lxc/auth.go:98
-#: lxc/auth.go:152 lxc/auth.go:201 lxc/auth.go:332 lxc/auth.go:392
-#: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
-#: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
-#: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
-#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1434 lxc/auth.go:1472
-#: lxc/auth.go:1524 lxc/auth.go:1573 lxc/auth.go:1692 lxc/auth.go:1752
-#: lxc/auth.go:1801 lxc/auth.go:1852 lxc/auth.go:1875 lxc/auth.go:1928
+#: lxc/alias.go:214 lxc/auth.go:31 lxc/auth.go:60 lxc/auth.go:99
+#: lxc/auth.go:153 lxc/auth.go:202 lxc/auth.go:333 lxc/auth.go:393
+#: lxc/auth.go:442 lxc/auth.go:494 lxc/auth.go:517 lxc/auth.go:576
+#: lxc/auth.go:732 lxc/auth.go:766 lxc/auth.go:833 lxc/auth.go:896
+#: lxc/auth.go:957 lxc/auth.go:1085 lxc/auth.go:1108 lxc/auth.go:1166
+#: lxc/auth.go:1235 lxc/auth.go:1257 lxc/auth.go:1435 lxc/auth.go:1473
+#: lxc/auth.go:1525 lxc/auth.go:1574 lxc/auth.go:1693 lxc/auth.go:1753
+#: lxc/auth.go:1802 lxc/auth.go:1853 lxc/auth.go:1876 lxc/auth.go:1929
 #: lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215 lxc/cluster.go:272
 #: lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:484 lxc/cluster.go:528
 #: lxc/cluster.go:586 lxc/cluster.go:677 lxc/cluster.go:770 lxc/cluster.go:893
@@ -1892,15 +1892,15 @@ msgstr ""
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:83 lxc/file.go:123 lxc/file.go:172
-#: lxc/file.go:242 lxc/file.go:467 lxc/file.go:986 lxc/image.go:38
+#: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
+#: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
 #: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
 #: lxc/image.go:697 lxc/image.go:946 lxc/image.go:1088 lxc/image.go:1415
 #: lxc/image.go:1506 lxc/image.go:1572 lxc/image.go:1636 lxc/image.go:1699
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:38 lxc/network.go:33
+#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33
 #: lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405
 #: lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793
 #: lxc/network.go:874 lxc/network.go:1005 lxc/network.go:1106
@@ -1934,27 +1934,27 @@ msgstr ""
 #: lxc/network_zone.go:909 lxc/network_zone.go:985 lxc/network_zone.go:1083
 #: lxc/network_zone.go:1172 lxc/network_zone.go:1219 lxc/network_zone.go:1349
 #: lxc/network_zone.go:1410 lxc/network_zone.go:1425 lxc/network_zone.go:1483
-#: lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:106
-#: lxc/operation.go:193 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
+#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
+#: lxc/operation.go:194 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
 #: lxc/profile.go:271 lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493
 #: lxc/profile.go:629 lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860
-#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:29
-#: lxc/project.go:93 lxc/project.go:189 lxc/project.go:260 lxc/project.go:396
-#: lxc/project.go:470 lxc/project.go:590 lxc/project.go:655 lxc/project.go:743
-#: lxc/project.go:787 lxc/project.go:848 lxc/project.go:915 lxc/publish.go:34
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:35 lxc/remote.go:91
+#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:30
+#: lxc/project.go:94 lxc/project.go:190 lxc/project.go:261 lxc/project.go:397
+#: lxc/project.go:471 lxc/project.go:591 lxc/project.go:656 lxc/project.go:744
+#: lxc/project.go:788 lxc/project.go:849 lxc/project.go:916 lxc/publish.go:34
+#: lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91
 #: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853
 #: lxc/remote.go:917 lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24
 #: lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203
 #: lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655
 #: lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940
-#: lxc/storage_bucket.go:29 lxc/storage_bucket.go:83 lxc/storage_bucket.go:188
-#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:382
-#: lxc/storage_bucket.go:458 lxc/storage_bucket.go:535
-#: lxc/storage_bucket.go:629 lxc/storage_bucket.go:698
-#: lxc/storage_bucket.go:732 lxc/storage_bucket.go:773
-#: lxc/storage_bucket.go:852 lxc/storage_bucket.go:958
-#: lxc/storage_bucket.go:1022 lxc/storage_bucket.go:1157
+#: lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189
+#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:383
+#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:536
+#: lxc/storage_bucket.go:630 lxc/storage_bucket.go:699
+#: lxc/storage_bucket.go:733 lxc/storage_bucket.go:774
+#: lxc/storage_bucket.go:853 lxc/storage_bucket.go:959
+#: lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158
 #: lxc/storage_volume.go:58 lxc/storage_volume.go:169 lxc/storage_volume.go:283
 #: lxc/storage_volume.go:390 lxc/storage_volume.go:605
 #: lxc/storage_volume.go:714 lxc/storage_volume.go:801
@@ -1965,8 +1965,8 @@ msgstr ""
 #: lxc/storage_volume.go:2064 lxc/storage_volume.go:2222
 #: lxc/storage_volume.go:2343 lxc/storage_volume.go:2405
 #: lxc/storage_volume.go:2541 lxc/storage_volume.go:2624
-#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:29
-#: lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
+#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:30
+#: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
@@ -2053,7 +2053,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:994
+#: lxc/file.go:995
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2119,7 +2119,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:74
+#: lxc/file.go:75
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -2129,7 +2129,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:955 lxc/auth.go:956
+#: lxc/auth.go:956 lxc/auth.go:957
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -2137,15 +2137,15 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:171 lxc/file.go:172
+#: lxc/file.go:172 lxc/file.go:173
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/auth.go:200 lxc/auth.go:201
+#: lxc/auth.go:201 lxc/auth.go:202
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1572 lxc/auth.go:1573
+#: lxc/auth.go:1573 lxc/auth.go:1574
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2201,15 +2201,15 @@ msgstr ""
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:259 lxc/project.go:260
+#: lxc/project.go:260 lxc/project.go:261
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:248 lxc/storage_bucket.go:249
+#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:250
 msgid "Edit storage bucket configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:1021 lxc/storage_bucket.go:1022
+#: lxc/storage_bucket.go:1022 lxc/storage_bucket.go:1023
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
@@ -2226,7 +2226,7 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1147 lxc/list.go:622 lxc/storage_volume.go:1766
-#: lxc/warning.go:235
+#: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2281,7 +2281,7 @@ msgstr ""
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
-#: lxc/project.go:718 lxc/storage.go:812 lxc/storage_bucket.go:602
+#: lxc/project.go:719 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2155 lxc/storage_volume.go:2193
 #, c-format
 msgid "Error setting properties: %v"
@@ -2295,8 +2295,8 @@ msgstr ""
 #: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
-#: lxc/profile.go:981 lxc/project.go:712 lxc/storage.go:806
-#: lxc/storage_bucket.go:596 lxc/storage_volume.go:2149
+#: lxc/profile.go:981 lxc/project.go:713 lxc/storage.go:806
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2149
 #: lxc/storage_volume.go:2187
 #, c-format
 msgid "Error unsetting property: %v"
@@ -2316,7 +2316,7 @@ msgstr ""
 msgid "Evacuating cluster member: %s"
 msgstr ""
 
-#: lxc/monitor.go:50
+#: lxc/monitor.go:51
 msgid "Event type to listen for"
 msgstr ""
 
@@ -2403,16 +2403,16 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/warning.go:210
+#: lxc/warning.go:211
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1237
+#: lxc/file.go:1238
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1260
+#: lxc/file.go:1261
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2427,12 +2427,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1287
+#: lxc/file.go:1288
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1072
+#: lxc/file.go:1073
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2462,7 +2462,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1193
+#: lxc/file.go:1194
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2477,7 +2477,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1198
+#: lxc/file.go:1199
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2487,12 +2487,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1098
+#: lxc/file.go:1099
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1225
+#: lxc/file.go:1226
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2531,7 +2531,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1210
+#: lxc/file.go:1211
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2546,7 +2546,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:820
+#: lxc/file.go:821
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2561,7 +2561,7 @@ msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
 #: lxc/network.go:1044 lxc/network_acl.go:133 lxc/network_zone.go:124
-#: lxc/operation.go:136
+#: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
 
@@ -2626,21 +2626,21 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
+#: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:770 lxc/auth.go:1697
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1114 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:57
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
-#: lxc/operation.go:108 lxc/profile.go:707 lxc/project.go:472
-#: lxc/project.go:917 lxc/remote.go:690 lxc/storage.go:657
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:774
-#: lxc/storage_volume.go:1608 lxc/warning.go:93
+#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:473
+#: lxc/project.go:918 lxc/remote.go:690 lxc/storage.go:657
+#: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
+#: lxc/storage_volume.go:1608 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
-#: lxc/monitor.go:52
+#: lxc/monitor.go:53
 msgid "Format (json|pretty|yaml)"
 msgstr ""
 
@@ -2684,7 +2684,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:817 lxc/auth.go:1736
+#: lxc/auth.go:818 lxc/auth.go:1737
 msgid "GROUPS"
 msgstr ""
 
@@ -2700,7 +2700,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:914 lxc/project.go:915
+#: lxc/project.go:915 lxc/project.go:916
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2748,11 +2748,11 @@ msgstr ""
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:400
+#: lxc/project.go:401
 msgid "Get the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:385
+#: lxc/storage_bucket.go:386
 msgid "Get the key as a storage bucket property"
 msgstr ""
 
@@ -2812,11 +2812,11 @@ msgstr ""
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:395 lxc/project.go:396
+#: lxc/project.go:396 lxc/project.go:397
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:382
+#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:383
 msgid "Get values for storage bucket configuration keys"
 msgstr ""
 
@@ -2833,17 +2833,17 @@ msgstr ""
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: lxc/auth.go:136
+#: lxc/auth.go:137
 #, c-format
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:186
+#: lxc/auth.go:187
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:426 lxc/auth.go:1786
+#: lxc/auth.go:427 lxc/auth.go:1787
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2868,27 +2868,27 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1310
+#: lxc/file.go:1311
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1299
+#: lxc/file.go:1300
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1122
+#: lxc/file.go:1123
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1132
+#: lxc/file.go:1133
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:966 lxc/operation.go:170
+#: lxc/network.go:966 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2902,11 +2902,11 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:816
+#: lxc/auth.go:817
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:566
+#: lxc/project.go:567
 msgid "IMAGES"
 msgstr ""
 
@@ -2934,17 +2934,17 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1508
+#: lxc/auth.go:1509
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1558
+#: lxc/auth.go:1559
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
 
-#: lxc/rebuild.go:32
+#: lxc/rebuild.go:33
 msgid "If an instance is running, stop it and then rebuild it"
 msgstr ""
 
@@ -3065,7 +3065,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1233 lxc/auth.go:1234
+#: lxc/auth.go:1234 lxc/auth.go:1235
 msgid "Inspect permissions"
 msgstr ""
 
@@ -3073,11 +3073,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1124
+#: lxc/file.go:1125
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1301
+#: lxc/file.go:1302
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3095,7 +3095,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1044
+#: lxc/file.go:1045
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3104,7 +3104,7 @@ msgstr ""
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/rebuild.go:74
+#: lxc/rebuild.go:75
 #, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
@@ -3137,7 +3137,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/monitor.go:70
+#: lxc/monitor.go:71
 #, c-format
 msgid "Invalid format: %s"
 msgstr ""
@@ -3147,7 +3147,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1039
+#: lxc/file.go:1040
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3189,7 +3189,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:147
+#: lxc/file.go:148
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -3205,12 +3205,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:313
+#: lxc/file.go:314
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:495
+#: lxc/file.go:496
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3224,7 +3224,7 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/warning.go:212
 msgid "LAST SEEN"
 msgstr ""
 
@@ -3232,7 +3232,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:984
+#: lxc/project.go:985
 msgid "LIMIT"
 msgstr ""
 
@@ -3241,8 +3241,8 @@ msgid "LISTEN ADDRESS"
 msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
-#: lxc/network_load_balancer.go:165 lxc/operation.go:177
-#: lxc/storage_bucket.go:516 lxc/storage_volume.go:1739 lxc/warning.go:220
+#: lxc/network_load_balancer.go:165 lxc/operation.go:178
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1739 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3316,7 +3316,7 @@ msgstr ""
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/warning.go:94
+#: lxc/warning.go:95
 msgid "List all warnings"
 msgstr ""
 
@@ -3360,19 +3360,19 @@ msgstr ""
 msgid "List available storage pools"
 msgstr ""
 
-#: lxc/operation.go:105 lxc/operation.go:106
+#: lxc/operation.go:106 lxc/operation.go:107
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:331 lxc/auth.go:332
+#: lxc/auth.go:332 lxc/auth.go:333
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:764 lxc/auth.go:765
+#: lxc/auth.go:765 lxc/auth.go:766
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1691 lxc/auth.go:1692
+#: lxc/auth.go:1692 lxc/auth.go:1693
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3521,11 +3521,11 @@ msgstr ""
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/operation.go:109
+#: lxc/operation.go:110
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1255 lxc/auth.go:1256
+#: lxc/auth.go:1256 lxc/auth.go:1257
 msgid "List permissions"
 msgstr ""
 
@@ -3533,15 +3533,15 @@ msgstr ""
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:469 lxc/project.go:470
+#: lxc/project.go:470 lxc/project.go:471
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:771 lxc/storage_bucket.go:773
+#: lxc/storage_bucket.go:772 lxc/storage_bucket.go:774
 msgid "List storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:456 lxc/storage_bucket.go:458
+#: lxc/storage_bucket.go:457 lxc/storage_bucket.go:459
 msgid "List storage buckets"
 msgstr ""
 
@@ -3577,11 +3577,11 @@ msgstr ""
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/warning.go:70
+#: lxc/warning.go:71
 msgid "List warnings"
 msgstr ""
 
-#: lxc/warning.go:71
+#: lxc/warning.go:72
 msgid ""
 "List warnings\n"
 "\n"
@@ -3604,7 +3604,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/operation.go:23 lxc/operation.go:24
+#: lxc/operation.go:24 lxc/operation.go:25
 msgid "List, show and delete background operations"
 msgstr ""
 
@@ -3613,7 +3613,7 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/monitor.go:79
+#: lxc/monitor.go:80
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
@@ -3717,23 +3717,23 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:82 lxc/file.go:83
+#: lxc/file.go:83 lxc/file.go:84
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1433 lxc/auth.go:1434
+#: lxc/auth.go:59 lxc/auth.go:60 lxc/auth.go:1434 lxc/auth.go:1435
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1083 lxc/auth.go:1084
+#: lxc/auth.go:1084 lxc/auth.go:1085
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:730 lxc/auth.go:731
+#: lxc/auth.go:731 lxc/auth.go:732
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1851 lxc/auth.go:1852
+#: lxc/auth.go:1852 lxc/auth.go:1853
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3824,7 +3824,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:492 lxc/auth.go:493
+#: lxc/auth.go:493 lxc/auth.go:494
 msgid "Manage permissions"
 msgstr ""
 
@@ -3832,23 +3832,23 @@ msgstr ""
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:28 lxc/project.go:29
+#: lxc/project.go:29 lxc/project.go:30
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:731
+#: lxc/storage_bucket.go:732
 msgid "Manage storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:732
+#: lxc/storage_bucket.go:733
 msgid "Manage storage bucket keys."
 msgstr ""
 
-#: lxc/storage_bucket.go:28
+#: lxc/storage_bucket.go:29
 msgid "Manage storage buckets"
 msgstr ""
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:30
 msgid "Manage storage buckets."
 msgstr ""
 
@@ -3876,11 +3876,11 @@ msgstr ""
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/auth.go:29 lxc/auth.go:30
+#: lxc/auth.go:30 lxc/auth.go:31
 msgid "Manage user authorization"
 msgstr ""
 
-#: lxc/warning.go:28 lxc/warning.go:29
+#: lxc/warning.go:29 lxc/warning.go:30
 msgid "Manage warnings"
 msgstr ""
 
@@ -3944,17 +3944,17 @@ msgstr ""
 msgid "Migration operation failure: %w"
 msgstr ""
 
-#: lxc/monitor.go:51
+#: lxc/monitor.go:52
 msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: lxc/storage_bucket.go:116 lxc/storage_bucket.go:216
-#: lxc/storage_bucket.go:292 lxc/storage_bucket.go:411
-#: lxc/storage_bucket.go:568 lxc/storage_bucket.go:660
-#: lxc/storage_bucket.go:802 lxc/storage_bucket.go:889
-#: lxc/storage_bucket.go:986 lxc/storage_bucket.go:1065
-#: lxc/storage_bucket.go:1188
+#: lxc/storage_bucket.go:117 lxc/storage_bucket.go:217
+#: lxc/storage_bucket.go:293 lxc/storage_bucket.go:412
+#: lxc/storage_bucket.go:569 lxc/storage_bucket.go:661
+#: lxc/storage_bucket.go:803 lxc/storage_bucket.go:890
+#: lxc/storage_bucket.go:987 lxc/storage_bucket.go:1066
+#: lxc/storage_bucket.go:1189
 msgid "Missing bucket name"
 msgstr ""
 
@@ -3973,20 +3973,20 @@ msgstr ""
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1825
+#: lxc/auth.go:123 lxc/auth.go:177 lxc/auth.go:255 lxc/auth.go:417
+#: lxc/auth.go:466 lxc/auth.go:541 lxc/auth.go:600 lxc/auth.go:1826
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:862 lxc/auth.go:1003 lxc/auth.go:1131 lxc/auth.go:1189
+#: lxc/auth.go:863 lxc/auth.go:1004 lxc/auth.go:1132 lxc/auth.go:1190
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1495 lxc/auth.go:1548 lxc/auth.go:1614 lxc/auth.go:1776
+#: lxc/auth.go:1496 lxc/auth.go:1549 lxc/auth.go:1615 lxc/auth.go:1777
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1899 lxc/auth.go:1952
+#: lxc/auth.go:1900 lxc/auth.go:1953
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -3994,12 +3994,12 @@ msgstr ""
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
 #: lxc/config_template.go:377 lxc/profile.go:141 lxc/profile.go:222
-#: lxc/profile.go:808 lxc/rebuild.go:60
+#: lxc/profile.go:808 lxc/rebuild.go:61
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/storage_bucket.go:893 lxc/storage_bucket.go:990
-#: lxc/storage_bucket.go:1069 lxc/storage_bucket.go:1192
+#: lxc/storage_bucket.go:894 lxc/storage_bucket.go:991
+#: lxc/storage_bucket.go:1070 lxc/storage_bucket.go:1193
 msgid "Missing key name"
 msgstr ""
 
@@ -4064,13 +4064,13 @@ msgid "Missing peer name"
 msgstr ""
 
 #: lxc/storage.go:235 lxc/storage.go:313 lxc/storage.go:431 lxc/storage.go:509
-#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:112
-#: lxc/storage_bucket.go:212 lxc/storage_bucket.go:288
-#: lxc/storage_bucket.go:407 lxc/storage_bucket.go:482
-#: lxc/storage_bucket.go:564 lxc/storage_bucket.go:656
-#: lxc/storage_bucket.go:798 lxc/storage_bucket.go:885
-#: lxc/storage_bucket.go:982 lxc/storage_bucket.go:1061
-#: lxc/storage_bucket.go:1184 lxc/storage_volume.go:209
+#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:113
+#: lxc/storage_bucket.go:213 lxc/storage_bucket.go:289
+#: lxc/storage_bucket.go:408 lxc/storage_bucket.go:483
+#: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
+#: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
+#: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
 #: lxc/storage_volume.go:323 lxc/storage_volume.go:643
 #: lxc/storage_volume.go:750 lxc/storage_volume.go:841
 #: lxc/storage_volume.go:939 lxc/storage_volume.go:1053
@@ -4085,9 +4085,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:404 lxc/project.go:146 lxc/project.go:226 lxc/project.go:316
-#: lxc/project.go:433 lxc/project.go:622 lxc/project.go:691 lxc/project.go:819
-#: lxc/project.go:948
+#: lxc/profile.go:404 lxc/project.go:147 lxc/project.go:227 lxc/project.go:317
+#: lxc/project.go:434 lxc/project.go:623 lxc/project.go:692 lxc/project.go:820
+#: lxc/project.go:949
 msgid "Missing project name"
 msgstr ""
 
@@ -4103,7 +4103,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:598
+#: lxc/file.go:599
 msgid "Missing target directory"
 msgstr ""
 
@@ -4125,11 +4125,11 @@ msgstr ""
 msgid "Model: %v"
 msgstr ""
 
-#: lxc/monitor.go:32
+#: lxc/monitor.go:33
 msgid "Monitor a local or remote LXD server"
 msgstr ""
 
-#: lxc/monitor.go:33
+#: lxc/monitor.go:34
 msgid ""
 "Monitor a local or remote LXD server\n"
 "\n"
@@ -4141,11 +4141,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:285
+#: lxc/file.go:286
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:985 lxc/file.go:986
+#: lxc/file.go:986 lxc/file.go:987
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4207,13 +4207,13 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:192
+#: lxc/auth.go:376 lxc/auth.go:816 lxc/auth.go:1736 lxc/cluster.go:192
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
-#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:565
-#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:511
-#: lxc/storage_bucket.go:831 lxc/storage_volume.go:1731
+#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:566
+#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1731
 msgid "NAME"
 msgstr ""
 
@@ -4221,11 +4221,11 @@ msgstr ""
 msgid "NAT"
 msgstr ""
 
-#: lxc/project.go:571
+#: lxc/project.go:572
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:570
+#: lxc/project.go:571
 msgid "NETWORKS"
 msgstr ""
 
@@ -4237,9 +4237,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/operation.go:154 lxc/project.go:523
-#: lxc/project.go:528 lxc/project.go:533 lxc/project.go:538 lxc/project.go:543
-#: lxc/project.go:548 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
+#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:524
+#: lxc/project.go:529 lxc/project.go:534 lxc/project.go:539 lxc/project.go:544
+#: lxc/project.go:549 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
 msgid "NO"
 msgstr ""
 
@@ -4484,7 +4484,7 @@ msgstr ""
 msgid "Only managed networks can be modified"
 msgstr ""
 
-#: lxc/operation.go:86
+#: lxc/operation.go:87
 #, c-format
 msgid "Operation %s deleted"
 msgstr ""
@@ -4531,11 +4531,11 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:567
+#: lxc/list.go:576 lxc/project.go:568
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:212
+#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4597,24 +4597,24 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1102
+#: lxc/file.go:1103
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:860
+#: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
-#: lxc/project.go:363 lxc/storage.go:360 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1151
+#: lxc/project.go:364 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1151
 #: lxc/storage_volume.go:1183
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
-#: lxc/monitor.go:48
+#: lxc/monitor.go:49
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
@@ -4700,17 +4700,17 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:172
+#: lxc/project.go:173
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:236
+#: lxc/project.go:237
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:637
+#: lxc/project.go:638
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -4831,20 +4831,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:241 lxc/file.go:242
+#: lxc/file.go:242 lxc/file.go:243
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:416 lxc/file.go:767
+#: lxc/file.go:417 lxc/file.go:768
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:466 lxc/file.go:467
+#: lxc/file.go:467 lxc/file.go:468
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:701 lxc/file.go:867
+#: lxc/file.go:702 lxc/file.go:868
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4857,11 +4857,11 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:983
+#: lxc/project.go:984
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/storage_bucket.go:833
+#: lxc/storage_bucket.go:834
 msgid "ROLE"
 msgstr ""
 
@@ -4874,15 +4874,15 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/rebuild.go:31
+#: lxc/rebuild.go:32
 msgid "Rebuild as an empty instance"
 msgstr ""
 
-#: lxc/rebuild.go:26
+#: lxc/rebuild.go:27
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:249 lxc/file.go:473
+#: lxc/file.go:250 lxc/file.go:474
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4909,7 +4909,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:882 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
+#: lxc/project.go:883 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
 #: lxc/remote.go:994
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4960,7 +4960,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1164 lxc/auth.go:1165
+#: lxc/auth.go:1165 lxc/auth.go:1166
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4996,7 +4996,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1927 lxc/auth.go:1928
+#: lxc/auth.go:1928 lxc/auth.go:1929
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -5008,7 +5008,7 @@ msgstr ""
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:574 lxc/auth.go:575
+#: lxc/auth.go:575 lxc/auth.go:576
 msgid "Remove permissions from groups"
 msgstr ""
 
@@ -5053,11 +5053,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:391 lxc/auth.go:392
+#: lxc/auth.go:392 lxc/auth.go:393
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1751 lxc/auth.go:1752
+#: lxc/auth.go:1752 lxc/auth.go:1753
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5077,7 +5077,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:589 lxc/project.go:590
+#: lxc/project.go:590 lxc/project.go:591
 msgid "Rename projects"
 msgstr ""
 
@@ -5175,7 +5175,7 @@ msgstr ""
 msgid "Revoke cluster member join token"
 msgstr ""
 
-#: lxc/storage_bucket.go:862
+#: lxc/storage_bucket.go:863
 msgid "Role (admin or read-only)"
 msgstr ""
 
@@ -5191,7 +5191,7 @@ msgstr ""
 msgid "Run against all projects"
 msgstr ""
 
-#: lxc/warning.go:213
+#: lxc/warning.go:214
 msgid "SEVERITY"
 msgstr ""
 
@@ -5211,12 +5211,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1231
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1231
+#: lxc/file.go:1232
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5230,11 +5230,11 @@ msgstr ""
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:173 lxc/warning.go:214
+#: lxc/operation.go:174 lxc/warning.go:215
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:569
+#: lxc/project.go:570
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5242,7 +5242,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:569
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -5250,11 +5250,11 @@ msgstr ""
 msgid "STP"
 msgstr ""
 
-#: lxc/storage_bucket.go:864
+#: lxc/storage_bucket.go:865
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:942
+#: lxc/storage_bucket.go:943
 #, c-format
 msgid "Secret key: %s"
 msgstr ""
@@ -5292,7 +5292,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:995
+#: lxc/file.go:996
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5430,11 +5430,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:654
+#: lxc/project.go:655
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:655
+#: lxc/project.go:656
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5443,11 +5443,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage_bucket.go:534
+#: lxc/storage_bucket.go:535
 msgid "Set storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:535
+#: lxc/storage_bucket.go:536
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -5486,15 +5486,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:476
+#: lxc/file.go:477
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:477
+#: lxc/file.go:478
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:475
+#: lxc/file.go:476
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5534,11 +5534,11 @@ msgstr ""
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 msgid "Set the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:542
+#: lxc/storage_bucket.go:543
 msgid "Set the key as a storage bucket property"
 msgstr ""
 
@@ -5554,7 +5554,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:993
+#: lxc/file.go:994
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5566,7 +5566,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1800 lxc/auth.go:1801
+#: lxc/auth.go:1801 lxc/auth.go:1802
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5582,11 +5582,11 @@ msgstr ""
 msgid "Show details of a cluster member"
 msgstr ""
 
-#: lxc/operation.go:192 lxc/operation.go:193
+#: lxc/operation.go:193 lxc/operation.go:194
 msgid "Show details on a background operation"
 msgstr ""
 
-#: lxc/monitor.go:49
+#: lxc/monitor.go:50
 msgid "Show events from all projects"
 msgstr ""
 
@@ -5594,11 +5594,11 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:440 lxc/auth.go:441
+#: lxc/auth.go:441 lxc/auth.go:442
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:832
+#: lxc/auth.go:833
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5679,15 +5679,15 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:786 lxc/project.go:787
+#: lxc/project.go:787 lxc/project.go:788
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage_bucket.go:628 lxc/storage_bucket.go:629
+#: lxc/storage_bucket.go:629 lxc/storage_bucket.go:630
 msgid "Show storage bucket configurations"
 msgstr ""
 
-#: lxc/storage_bucket.go:1156 lxc/storage_bucket.go:1157
+#: lxc/storage_bucket.go:1157 lxc/storage_bucket.go:1158
 msgid "Show storage bucket key configurations"
 msgstr ""
 
@@ -5703,7 +5703,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:895
+#: lxc/auth.go:896
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5753,7 +5753,7 @@ msgstr ""
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: lxc/warning.go:302 lxc/warning.go:303
+#: lxc/warning.go:303 lxc/warning.go:304
 msgid "Show warning"
 msgstr ""
 
@@ -5837,22 +5837,22 @@ msgstr ""
 msgid "Stopping the instance failed: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:166
+#: lxc/storage_bucket.go:167
 #, c-format
 msgid "Storage bucket %s created"
 msgstr ""
 
-#: lxc/storage_bucket.go:233
+#: lxc/storage_bucket.go:234
 #, c-format
 msgid "Storage bucket %s deleted"
 msgstr ""
 
-#: lxc/storage_bucket.go:940
+#: lxc/storage_bucket.go:941
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr ""
 
-#: lxc/storage_bucket.go:1006
+#: lxc/storage_bucket.go:1007
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr ""
@@ -5921,7 +5921,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:847 lxc/project.go:848
+#: lxc/project.go:848 lxc/project.go:849
 msgid "Switch the current project"
 msgstr ""
 
@@ -5937,10 +5937,10 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1139
+#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1139
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
-#: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:171
-#: lxc/storage_volume.go:1730 lxc/warning.go:215
+#: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
+#: lxc/storage_volume.go:1730 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
@@ -5948,11 +5948,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1032
+#: lxc/file.go:1033
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1026
+#: lxc/file.go:1027
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -6080,12 +6080,12 @@ msgstr ""
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:446
+#: lxc/project.go:447
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
 
-#: lxc/storage_bucket.go:431
+#: lxc/storage_bucket.go:432
 #, c-format
 msgid "The property %q does not exist on the storage bucket %q: %v"
 msgstr ""
@@ -6270,7 +6270,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:961
+#: lxc/project.go:962
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6282,17 +6282,17 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:985 lxc/storage_volume.go:1735
+#: lxc/project.go:986 lxc/storage_volume.go:1735
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:573
+#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:574
 #: lxc/storage.go:724 lxc/storage_volume.go:1734
 msgid "USED BY"
 msgstr ""
 
-#: lxc/warning.go:216
+#: lxc/warning.go:217
 msgid "UUID"
 msgstr ""
 
@@ -6301,7 +6301,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:197
+#: lxc/file.go:198
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6315,13 +6315,13 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1253
+#: lxc/file.go:1254
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1153 lxc/list.go:631 lxc/storage_volume.go:1772
-#: lxc/warning.go:241
+#: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6331,7 +6331,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:807
+#: lxc/file.go:808
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6414,11 +6414,11 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:742 lxc/project.go:743
+#: lxc/project.go:743 lxc/project.go:744
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:697 lxc/storage_bucket.go:698
+#: lxc/storage_bucket.go:698 lxc/storage_bucket.go:699
 msgid "Unset storage bucket configuration keys"
 msgstr ""
 
@@ -6466,11 +6466,11 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:747
+#: lxc/project.go:748
 msgid "Unset the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:701
+#: lxc/storage_bucket.go:702
 msgid "Unset the key as a storage bucket property"
 msgstr ""
 
@@ -6549,7 +6549,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:71
+#: lxc/file.go:72
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6586,11 +6586,11 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:831
+#: lxc/auth.go:832
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:894
+#: lxc/auth.go:895
 msgid "View the current identity"
 msgstr ""
 
@@ -6621,15 +6621,15 @@ msgstr ""
 msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
-#: lxc/rebuild.go:27
+#: lxc/rebuild.go:28
 msgid ""
 "Wipe the instance root disk and re-initialize. The original image is used to "
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:156 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
+#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:526
+#: lxc/project.go:531 lxc/project.go:536 lxc/project.go:541 lxc/project.go:546
+#: lxc/project.go:551 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
 msgid "YES"
 msgstr ""
 
@@ -6649,7 +6649,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/rebuild.go:119
+#: lxc/rebuild.go:120
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
@@ -6661,12 +6661,12 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1689
+#: lxc/auth.go:330 lxc/auth.go:763 lxc/auth.go:894 lxc/auth.go:1690
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
-#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
+#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
-#: lxc/operation.go:103 lxc/profile.go:700 lxc/project.go:467
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:68
+#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:468
+#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6694,7 +6694,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1254
+#: lxc/auth.go:1255
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6755,11 +6755,11 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:830
+#: lxc/auth.go:831
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1926
+#: lxc/auth.go:1106 lxc/auth.go:1164 lxc/auth.go:1927
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6767,13 +6767,13 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:954 lxc/auth.go:1470 lxc/cluster_group.go:168
+#: lxc/auth.go:97 lxc/auth.go:150 lxc/auth.go:200 lxc/auth.go:440
+#: lxc/auth.go:955 lxc/auth.go:1471 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:514 lxc/auth.go:572
+#: lxc/auth.go:515 lxc/auth.go:573
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
@@ -6783,19 +6783,19 @@ msgstr ""
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:389
+#: lxc/auth.go:390
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1521 lxc/auth.go:1571 lxc/auth.go:1799
+#: lxc/auth.go:1522 lxc/auth.go:1572 lxc/auth.go:1800
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1873
+#: lxc/auth.go:1874
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1749
+#: lxc/auth.go:1750
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -6815,7 +6815,7 @@ msgstr ""
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
-#: lxc/rebuild.go:25
+#: lxc/rebuild.go:26
 msgid "[<remote>:]<image> [<remote>:]<instance>"
 msgstr ""
 
@@ -6898,20 +6898,20 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:170
+#: lxc/file.go:171
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:120
+#: lxc/file.go:121
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:240
+#: lxc/file.go:241
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:984
+#: lxc/file.go:985
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7062,12 +7062,12 @@ msgstr ""
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
-#: lxc/operation.go:53 lxc/operation.go:191
+#: lxc/operation.go:54 lxc/operation.go:192
 msgid "[<remote>:]<operation>"
 msgstr ""
 
 #: lxc/storage.go:200 lxc/storage.go:259 lxc/storage.go:473 lxc/storage.go:844
-#: lxc/storage_bucket.go:454
+#: lxc/storage_bucket.go:455
 msgid "[<remote>:]<pool>"
 msgstr ""
 
@@ -7075,22 +7075,22 @@ msgstr ""
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
-#: lxc/storage_bucket.go:185 lxc/storage_bucket.go:247
-#: lxc/storage_bucket.go:627 lxc/storage_bucket.go:769
+#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:248
+#: lxc/storage_bucket.go:628 lxc/storage_bucket.go:770
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
 
-#: lxc/storage_bucket.go:380 lxc/storage_bucket.go:696
-#: lxc/storage_bucket.go:850 lxc/storage_bucket.go:956
-#: lxc/storage_bucket.go:1020 lxc/storage_bucket.go:1155
+#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:697
+#: lxc/storage_bucket.go:851 lxc/storage_bucket.go:957
+#: lxc/storage_bucket.go:1021 lxc/storage_bucket.go:1156
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
 
-#: lxc/storage_bucket.go:533
+#: lxc/storage_bucket.go:534
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_bucket.go:81
+#: lxc/storage_bucket.go:82
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
 
@@ -7205,20 +7205,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:91 lxc/project.go:186 lxc/project.go:258 lxc/project.go:785
-#: lxc/project.go:846 lxc/project.go:913
+#: lxc/project.go:92 lxc/project.go:187 lxc/project.go:259 lxc/project.go:786
+#: lxc/project.go:847 lxc/project.go:914
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:394 lxc/project.go:741
+#: lxc/project.go:395 lxc/project.go:742
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:653
+#: lxc/project.go:654
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:587
+#: lxc/project.go:588
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7226,7 +7226,7 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:259 lxc/warning.go:301 lxc/warning.go:354
+#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
@@ -7282,7 +7282,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:555 lxc/remote.go:739
+#: lxc/project.go:556 lxc/remote.go:739
 msgid "current"
 msgstr ""
 
@@ -7329,20 +7329,20 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/auth.go:203
+#: lxc/auth.go:204
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:958
+#: lxc/auth.go:959
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1575
+#: lxc/auth.go:1576
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7420,20 +7420,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:988
+#: lxc/file.go:989
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:244
+#: lxc/file.go:245
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:470
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7515,7 +7515,7 @@ msgid ""
 "  List instances with their running state and user comment."
 msgstr ""
 
-#: lxc/monitor.go:37
+#: lxc/monitor.go:38
 msgid ""
 "lxc monitor --type=logging\n"
 "    Only show log messages.\n"
@@ -7591,7 +7591,7 @@ msgid ""
 "    Create record r1 for zone z1 with configuration from config.yaml"
 msgstr ""
 
-#: lxc/operation.go:195
+#: lxc/operation.go:196
 msgid ""
 "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Show details on that operation UUID"
@@ -7634,7 +7634,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:95
+#: lxc/project.go:96
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7642,7 +7642,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:262
+#: lxc/project.go:263
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7673,7 +7673,7 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:85
 msgid ""
 "lxc storage bucket create p1 b01\n"
 "\tCreate a new storage bucket name b01 in storage pool p1\n"
@@ -7683,19 +7683,19 @@ msgid ""
 "of config.yaml"
 msgstr ""
 
-#: lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:251
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1023
+#: lxc/storage_bucket.go:1024
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:854
 msgid ""
 "lxc storage bucket key create p1 b01 k1\n"
 "\tCreate a key called k1 for the bucket b01 in the pool p1.\n"
@@ -7705,14 +7705,14 @@ msgid ""
 "of config.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1158
+#: lxc/storage_bucket.go:1159
 msgid ""
 "lxc storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_bucket.go:630
+#: lxc/storage_bucket.go:631
 msgid ""
 "lxc storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
@@ -7782,16 +7782,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1142
+#: lxc/file.go:1143
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1101
+#: lxc/file.go:1102
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1054
+#: lxc/file.go:1055
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/pa.po
+++ b/po/pa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-04 08:52-0600\n"
+"POT-Creation-Date: 2024-09-05 08:44-0400\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Punjabi <https://hosted.weblate.org/projects/linux-containers/"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: lxc/storage_bucket.go:260 lxc/storage_bucket.go:1033
+#: lxc/storage_bucket.go:261 lxc/storage_bucket.go:1034
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -133,7 +133,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:213
+#: lxc/auth.go:214
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -160,7 +160,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:968
+#: lxc/auth.go:969
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -181,7 +181,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1585
+#: lxc/auth.go:1586
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -391,7 +391,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:280
+#: lxc/project.go:281
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -433,12 +433,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:935
+#: lxc/file.go:936
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:825
+#: lxc/file.go:826
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -474,7 +474,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:142 lxc/rebuild.go:64
+#: lxc/init.go:142 lxc/rebuild.go:65
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -527,7 +527,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:465
+#: lxc/file.go:466
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -560,7 +560,7 @@ msgstr ""
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:813
+#: lxc/auth.go:814
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -568,11 +568,11 @@ msgstr ""
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/storage_bucket.go:863
+#: lxc/storage_bucket.go:864
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:941
+#: lxc/storage_bucket.go:942
 #, c-format
 msgid "Access key: %s"
 msgstr ""
@@ -581,7 +581,7 @@ msgstr ""
 msgid "Access the expanded configuration"
 msgstr ""
 
-#: lxc/warning.go:261 lxc/warning.go:262
+#: lxc/warning.go:262 lxc/warning.go:263
 msgid "Acknowledge warning"
 msgstr ""
 
@@ -598,11 +598,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1106 lxc/auth.go:1107
+#: lxc/auth.go:1107 lxc/auth.go:1108
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1874 lxc/auth.go:1875
+#: lxc/auth.go:1875 lxc/auth.go:1876
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -671,7 +671,7 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:515 lxc/auth.go:516
+#: lxc/auth.go:516 lxc/auth.go:517
 msgid "Add permissions to groups"
 msgstr ""
 
@@ -700,7 +700,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:169
+#: lxc/storage_bucket.go:170
 #, c-format
 msgid "Admin access key: %s"
 msgstr ""
@@ -710,7 +710,7 @@ msgstr ""
 msgid "Admin password (or token) for %s:"
 msgstr ""
 
-#: lxc/storage_bucket.go:170
+#: lxc/storage_bucket.go:171
 #, c-format
 msgid "Admin secret key: %s"
 msgstr ""
@@ -769,7 +769,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:342 lxc/rebuild.go:130
+#: lxc/init.go:342 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -869,12 +869,12 @@ msgstr ""
 
 #: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:318
 #: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
-#: lxc/network_zone.go:366 lxc/network_zone.go:1053 lxc/storage_bucket.go:141
+#: lxc/network_zone.go:366 lxc/network_zone.go:1053 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:159
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:160
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -914,7 +914,7 @@ msgstr ""
 msgid "Bytes sent"
 msgstr ""
 
-#: lxc/operation.go:174
+#: lxc/operation.go:175
 msgid "CANCELABLE"
 msgstr ""
 
@@ -926,7 +926,7 @@ msgstr ""
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: lxc/warning.go:209
+#: lxc/warning.go:210
 msgid "COUNT"
 msgstr ""
 
@@ -952,7 +952,7 @@ msgstr ""
 msgid "CPUs (%s):"
 msgstr ""
 
-#: lxc/operation.go:175
+#: lxc/operation.go:176
 msgid "CREATED"
 msgstr ""
 
@@ -982,7 +982,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:340
+#: lxc/file.go:341
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1007,11 +1007,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:224
+#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:546
+#: lxc/file.go:547
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1020,7 +1020,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:160
+#: lxc/rebuild.go:161
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1143,13 +1143,13 @@ msgstr ""
 #: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
 #: lxc/network_load_balancer.go:1051 lxc/network_load_balancer.go:1125
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
-#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:90
-#: lxc/storage_bucket.go:190 lxc/storage_bucket.go:253
-#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:541
-#: lxc/storage_bucket.go:634 lxc/storage_bucket.go:700
-#: lxc/storage_bucket.go:775 lxc/storage_bucket.go:861
-#: lxc/storage_bucket.go:961 lxc/storage_bucket.go:1026
-#: lxc/storage_bucket.go:1162 lxc/storage_volume.go:394
+#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
+#: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
+#: lxc/storage_bucket.go:385 lxc/storage_bucket.go:542
+#: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
+#: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
+#: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
 #: lxc/storage_volume.go:612 lxc/storage_volume.go:717
 #: lxc/storage_volume.go:1005 lxc/storage_volume.go:1231
 #: lxc/storage_volume.go:1360 lxc/storage_volume.go:1848
@@ -1173,7 +1173,7 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1113 lxc/list.go:132 lxc/storage_volume.go:1589
-#: lxc/warning.go:92
+#: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
@@ -1201,7 +1201,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:100
+#: lxc/project.go:101
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1215,8 +1215,8 @@ msgstr ""
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
-#: lxc/project.go:362 lxc/storage.go:359 lxc/storage_bucket.go:348
-#: lxc/storage_bucket.go:1125 lxc/storage_volume.go:1150
+#: lxc/project.go:363 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1150
 #: lxc/storage_volume.go:1182
 #, c-format
 msgid "Config parsing error: %s"
@@ -1343,12 +1343,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:300 lxc/auth.go:1660
+#: lxc/auth.go:301 lxc/auth.go:1661
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1054
+#: lxc/auth.go:1055
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1397,15 +1397,15 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:248 lxc/file.go:474
+#: lxc/file.go:249 lxc/file.go:475
 msgid "Create any directories necessary"
 msgstr ""
 
-#: lxc/auth.go:97 lxc/auth.go:98
+#: lxc/auth.go:98 lxc/auth.go:99
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1471 lxc/auth.go:1472
+#: lxc/auth.go:1472 lxc/auth.go:1473
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1425,11 +1425,11 @@ msgstr ""
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_bucket.go:851 lxc/storage_bucket.go:852
+#: lxc/storage_bucket.go:852 lxc/storage_bucket.go:853
 msgid "Create key for a storage bucket"
 msgstr ""
 
-#: lxc/storage_bucket.go:82 lxc/storage_bucket.go:83
+#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
 msgid "Create new custom storage buckets"
 msgstr ""
 
@@ -1473,7 +1473,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:92 lxc/project.go:93
+#: lxc/project.go:93 lxc/project.go:94
 msgid "Create projects"
 msgstr ""
 
@@ -1508,13 +1508,13 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:376 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1135 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
-#: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:172
-#: lxc/profile.go:756 lxc/project.go:572 lxc/storage.go:723
-#: lxc/storage_bucket.go:512 lxc/storage_bucket.go:832
+#: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
+#: lxc/profile.go:756 lxc/project.go:573 lxc/storage.go:723
+#: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1732
 msgid "DESCRIPTION"
 msgstr ""
@@ -1539,7 +1539,7 @@ msgstr ""
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
-#: lxc/operation.go:55 lxc/operation.go:56
+#: lxc/operation.go:56 lxc/operation.go:57
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
@@ -1547,19 +1547,19 @@ msgstr ""
 msgid "Delete a cluster group"
 msgstr ""
 
-#: lxc/warning.go:360
+#: lxc/warning.go:361
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:122 lxc/file.go:123
+#: lxc/file.go:123 lxc/file.go:124
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/auth.go:151 lxc/auth.go:152
+#: lxc/auth.go:152 lxc/auth.go:153
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1523 lxc/auth.go:1524
+#: lxc/auth.go:1524 lxc/auth.go:1525
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1579,7 +1579,7 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/storage_bucket.go:957 lxc/storage_bucket.go:958
+#: lxc/storage_bucket.go:958 lxc/storage_bucket.go:959
 msgid "Delete key from a storage bucket"
 msgstr ""
 
@@ -1615,11 +1615,11 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:188 lxc/project.go:189
+#: lxc/project.go:189 lxc/project.go:190
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:187 lxc/storage_bucket.go:188
+#: lxc/storage_bucket.go:188 lxc/storage_bucket.go:189
 msgid "Delete storage buckets"
 msgstr ""
 
@@ -1631,20 +1631,20 @@ msgstr ""
 msgid "Delete storage volumes"
 msgstr ""
 
-#: lxc/warning.go:356 lxc/warning.go:357
+#: lxc/warning.go:357 lxc/warning.go:358
 msgid "Delete warning"
 msgstr ""
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:30 lxc/auth.go:59 lxc/auth.go:98
-#: lxc/auth.go:152 lxc/auth.go:201 lxc/auth.go:332 lxc/auth.go:392
-#: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
-#: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
-#: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
-#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1434 lxc/auth.go:1472
-#: lxc/auth.go:1524 lxc/auth.go:1573 lxc/auth.go:1692 lxc/auth.go:1752
-#: lxc/auth.go:1801 lxc/auth.go:1852 lxc/auth.go:1875 lxc/auth.go:1928
+#: lxc/alias.go:214 lxc/auth.go:31 lxc/auth.go:60 lxc/auth.go:99
+#: lxc/auth.go:153 lxc/auth.go:202 lxc/auth.go:333 lxc/auth.go:393
+#: lxc/auth.go:442 lxc/auth.go:494 lxc/auth.go:517 lxc/auth.go:576
+#: lxc/auth.go:732 lxc/auth.go:766 lxc/auth.go:833 lxc/auth.go:896
+#: lxc/auth.go:957 lxc/auth.go:1085 lxc/auth.go:1108 lxc/auth.go:1166
+#: lxc/auth.go:1235 lxc/auth.go:1257 lxc/auth.go:1435 lxc/auth.go:1473
+#: lxc/auth.go:1525 lxc/auth.go:1574 lxc/auth.go:1693 lxc/auth.go:1753
+#: lxc/auth.go:1802 lxc/auth.go:1853 lxc/auth.go:1876 lxc/auth.go:1929
 #: lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215 lxc/cluster.go:272
 #: lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:484 lxc/cluster.go:528
 #: lxc/cluster.go:586 lxc/cluster.go:677 lxc/cluster.go:770 lxc/cluster.go:893
@@ -1668,15 +1668,15 @@ msgstr ""
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:83 lxc/file.go:123 lxc/file.go:172
-#: lxc/file.go:242 lxc/file.go:467 lxc/file.go:986 lxc/image.go:38
+#: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
+#: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
 #: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
 #: lxc/image.go:697 lxc/image.go:946 lxc/image.go:1088 lxc/image.go:1415
 #: lxc/image.go:1506 lxc/image.go:1572 lxc/image.go:1636 lxc/image.go:1699
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:38 lxc/network.go:33
+#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33
 #: lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405
 #: lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793
 #: lxc/network.go:874 lxc/network.go:1005 lxc/network.go:1106
@@ -1710,27 +1710,27 @@ msgstr ""
 #: lxc/network_zone.go:909 lxc/network_zone.go:985 lxc/network_zone.go:1083
 #: lxc/network_zone.go:1172 lxc/network_zone.go:1219 lxc/network_zone.go:1349
 #: lxc/network_zone.go:1410 lxc/network_zone.go:1425 lxc/network_zone.go:1483
-#: lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:106
-#: lxc/operation.go:193 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
+#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
+#: lxc/operation.go:194 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
 #: lxc/profile.go:271 lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493
 #: lxc/profile.go:629 lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860
-#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:29
-#: lxc/project.go:93 lxc/project.go:189 lxc/project.go:260 lxc/project.go:396
-#: lxc/project.go:470 lxc/project.go:590 lxc/project.go:655 lxc/project.go:743
-#: lxc/project.go:787 lxc/project.go:848 lxc/project.go:915 lxc/publish.go:34
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:35 lxc/remote.go:91
+#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:30
+#: lxc/project.go:94 lxc/project.go:190 lxc/project.go:261 lxc/project.go:397
+#: lxc/project.go:471 lxc/project.go:591 lxc/project.go:656 lxc/project.go:744
+#: lxc/project.go:788 lxc/project.go:849 lxc/project.go:916 lxc/publish.go:34
+#: lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91
 #: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853
 #: lxc/remote.go:917 lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24
 #: lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203
 #: lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655
 #: lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940
-#: lxc/storage_bucket.go:29 lxc/storage_bucket.go:83 lxc/storage_bucket.go:188
-#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:382
-#: lxc/storage_bucket.go:458 lxc/storage_bucket.go:535
-#: lxc/storage_bucket.go:629 lxc/storage_bucket.go:698
-#: lxc/storage_bucket.go:732 lxc/storage_bucket.go:773
-#: lxc/storage_bucket.go:852 lxc/storage_bucket.go:958
-#: lxc/storage_bucket.go:1022 lxc/storage_bucket.go:1157
+#: lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189
+#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:383
+#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:536
+#: lxc/storage_bucket.go:630 lxc/storage_bucket.go:699
+#: lxc/storage_bucket.go:733 lxc/storage_bucket.go:774
+#: lxc/storage_bucket.go:853 lxc/storage_bucket.go:959
+#: lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158
 #: lxc/storage_volume.go:58 lxc/storage_volume.go:169 lxc/storage_volume.go:283
 #: lxc/storage_volume.go:390 lxc/storage_volume.go:605
 #: lxc/storage_volume.go:714 lxc/storage_volume.go:801
@@ -1741,8 +1741,8 @@ msgstr ""
 #: lxc/storage_volume.go:2064 lxc/storage_volume.go:2222
 #: lxc/storage_volume.go:2343 lxc/storage_volume.go:2405
 #: lxc/storage_volume.go:2541 lxc/storage_volume.go:2624
-#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:29
-#: lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
+#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:30
+#: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
@@ -1829,7 +1829,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:994
+#: lxc/file.go:995
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1895,7 +1895,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:74
+#: lxc/file.go:75
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1905,7 +1905,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:955 lxc/auth.go:956
+#: lxc/auth.go:956 lxc/auth.go:957
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1913,15 +1913,15 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:171 lxc/file.go:172
+#: lxc/file.go:172 lxc/file.go:173
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/auth.go:200 lxc/auth.go:201
+#: lxc/auth.go:201 lxc/auth.go:202
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1572 lxc/auth.go:1573
+#: lxc/auth.go:1573 lxc/auth.go:1574
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -1977,15 +1977,15 @@ msgstr ""
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:259 lxc/project.go:260
+#: lxc/project.go:260 lxc/project.go:261
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:248 lxc/storage_bucket.go:249
+#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:250
 msgid "Edit storage bucket configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:1021 lxc/storage_bucket.go:1022
+#: lxc/storage_bucket.go:1022 lxc/storage_bucket.go:1023
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
@@ -2002,7 +2002,7 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1147 lxc/list.go:622 lxc/storage_volume.go:1766
-#: lxc/warning.go:235
+#: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2057,7 +2057,7 @@ msgstr ""
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
-#: lxc/project.go:718 lxc/storage.go:812 lxc/storage_bucket.go:602
+#: lxc/project.go:719 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2155 lxc/storage_volume.go:2193
 #, c-format
 msgid "Error setting properties: %v"
@@ -2071,8 +2071,8 @@ msgstr ""
 #: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
-#: lxc/profile.go:981 lxc/project.go:712 lxc/storage.go:806
-#: lxc/storage_bucket.go:596 lxc/storage_volume.go:2149
+#: lxc/profile.go:981 lxc/project.go:713 lxc/storage.go:806
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2149
 #: lxc/storage_volume.go:2187
 #, c-format
 msgid "Error unsetting property: %v"
@@ -2092,7 +2092,7 @@ msgstr ""
 msgid "Evacuating cluster member: %s"
 msgstr ""
 
-#: lxc/monitor.go:50
+#: lxc/monitor.go:51
 msgid "Event type to listen for"
 msgstr ""
 
@@ -2179,16 +2179,16 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/warning.go:210
+#: lxc/warning.go:211
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1237
+#: lxc/file.go:1238
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1260
+#: lxc/file.go:1261
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2203,12 +2203,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1287
+#: lxc/file.go:1288
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1072
+#: lxc/file.go:1073
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2238,7 +2238,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1193
+#: lxc/file.go:1194
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2253,7 +2253,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1198
+#: lxc/file.go:1199
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2263,12 +2263,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1098
+#: lxc/file.go:1099
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1225
+#: lxc/file.go:1226
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2307,7 +2307,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1210
+#: lxc/file.go:1211
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2322,7 +2322,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:820
+#: lxc/file.go:821
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2337,7 +2337,7 @@ msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
 #: lxc/network.go:1044 lxc/network_acl.go:133 lxc/network_zone.go:124
-#: lxc/operation.go:136
+#: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
 
@@ -2402,21 +2402,21 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
+#: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:770 lxc/auth.go:1697
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1114 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:57
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
-#: lxc/operation.go:108 lxc/profile.go:707 lxc/project.go:472
-#: lxc/project.go:917 lxc/remote.go:690 lxc/storage.go:657
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:774
-#: lxc/storage_volume.go:1608 lxc/warning.go:93
+#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:473
+#: lxc/project.go:918 lxc/remote.go:690 lxc/storage.go:657
+#: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
+#: lxc/storage_volume.go:1608 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
-#: lxc/monitor.go:52
+#: lxc/monitor.go:53
 msgid "Format (json|pretty|yaml)"
 msgstr ""
 
@@ -2460,7 +2460,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:817 lxc/auth.go:1736
+#: lxc/auth.go:818 lxc/auth.go:1737
 msgid "GROUPS"
 msgstr ""
 
@@ -2476,7 +2476,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:914 lxc/project.go:915
+#: lxc/project.go:915 lxc/project.go:916
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2524,11 +2524,11 @@ msgstr ""
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:400
+#: lxc/project.go:401
 msgid "Get the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:385
+#: lxc/storage_bucket.go:386
 msgid "Get the key as a storage bucket property"
 msgstr ""
 
@@ -2588,11 +2588,11 @@ msgstr ""
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:395 lxc/project.go:396
+#: lxc/project.go:396 lxc/project.go:397
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:382
+#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:383
 msgid "Get values for storage bucket configuration keys"
 msgstr ""
 
@@ -2609,17 +2609,17 @@ msgstr ""
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: lxc/auth.go:136
+#: lxc/auth.go:137
 #, c-format
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:186
+#: lxc/auth.go:187
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:426 lxc/auth.go:1786
+#: lxc/auth.go:427 lxc/auth.go:1787
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2644,27 +2644,27 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1310
+#: lxc/file.go:1311
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1299
+#: lxc/file.go:1300
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1122
+#: lxc/file.go:1123
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1132
+#: lxc/file.go:1133
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:966 lxc/operation.go:170
+#: lxc/network.go:966 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2678,11 +2678,11 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:816
+#: lxc/auth.go:817
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:566
+#: lxc/project.go:567
 msgid "IMAGES"
 msgstr ""
 
@@ -2710,17 +2710,17 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1508
+#: lxc/auth.go:1509
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1558
+#: lxc/auth.go:1559
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
 
-#: lxc/rebuild.go:32
+#: lxc/rebuild.go:33
 msgid "If an instance is running, stop it and then rebuild it"
 msgstr ""
 
@@ -2841,7 +2841,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1233 lxc/auth.go:1234
+#: lxc/auth.go:1234 lxc/auth.go:1235
 msgid "Inspect permissions"
 msgstr ""
 
@@ -2849,11 +2849,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1124
+#: lxc/file.go:1125
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1301
+#: lxc/file.go:1302
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2871,7 +2871,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1044
+#: lxc/file.go:1045
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2880,7 +2880,7 @@ msgstr ""
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/rebuild.go:74
+#: lxc/rebuild.go:75
 #, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
@@ -2913,7 +2913,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/monitor.go:70
+#: lxc/monitor.go:71
 #, c-format
 msgid "Invalid format: %s"
 msgstr ""
@@ -2923,7 +2923,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1039
+#: lxc/file.go:1040
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2965,7 +2965,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:147
+#: lxc/file.go:148
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2981,12 +2981,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:313
+#: lxc/file.go:314
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:495
+#: lxc/file.go:496
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3000,7 +3000,7 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/warning.go:212
 msgid "LAST SEEN"
 msgstr ""
 
@@ -3008,7 +3008,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:984
+#: lxc/project.go:985
 msgid "LIMIT"
 msgstr ""
 
@@ -3017,8 +3017,8 @@ msgid "LISTEN ADDRESS"
 msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
-#: lxc/network_load_balancer.go:165 lxc/operation.go:177
-#: lxc/storage_bucket.go:516 lxc/storage_volume.go:1739 lxc/warning.go:220
+#: lxc/network_load_balancer.go:165 lxc/operation.go:178
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1739 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3092,7 +3092,7 @@ msgstr ""
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/warning.go:94
+#: lxc/warning.go:95
 msgid "List all warnings"
 msgstr ""
 
@@ -3136,19 +3136,19 @@ msgstr ""
 msgid "List available storage pools"
 msgstr ""
 
-#: lxc/operation.go:105 lxc/operation.go:106
+#: lxc/operation.go:106 lxc/operation.go:107
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:331 lxc/auth.go:332
+#: lxc/auth.go:332 lxc/auth.go:333
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:764 lxc/auth.go:765
+#: lxc/auth.go:765 lxc/auth.go:766
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1691 lxc/auth.go:1692
+#: lxc/auth.go:1692 lxc/auth.go:1693
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3297,11 +3297,11 @@ msgstr ""
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/operation.go:109
+#: lxc/operation.go:110
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1255 lxc/auth.go:1256
+#: lxc/auth.go:1256 lxc/auth.go:1257
 msgid "List permissions"
 msgstr ""
 
@@ -3309,15 +3309,15 @@ msgstr ""
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:469 lxc/project.go:470
+#: lxc/project.go:470 lxc/project.go:471
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:771 lxc/storage_bucket.go:773
+#: lxc/storage_bucket.go:772 lxc/storage_bucket.go:774
 msgid "List storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:456 lxc/storage_bucket.go:458
+#: lxc/storage_bucket.go:457 lxc/storage_bucket.go:459
 msgid "List storage buckets"
 msgstr ""
 
@@ -3353,11 +3353,11 @@ msgstr ""
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/warning.go:70
+#: lxc/warning.go:71
 msgid "List warnings"
 msgstr ""
 
-#: lxc/warning.go:71
+#: lxc/warning.go:72
 msgid ""
 "List warnings\n"
 "\n"
@@ -3380,7 +3380,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/operation.go:23 lxc/operation.go:24
+#: lxc/operation.go:24 lxc/operation.go:25
 msgid "List, show and delete background operations"
 msgstr ""
 
@@ -3389,7 +3389,7 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/monitor.go:79
+#: lxc/monitor.go:80
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
@@ -3493,23 +3493,23 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:82 lxc/file.go:83
+#: lxc/file.go:83 lxc/file.go:84
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1433 lxc/auth.go:1434
+#: lxc/auth.go:59 lxc/auth.go:60 lxc/auth.go:1434 lxc/auth.go:1435
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1083 lxc/auth.go:1084
+#: lxc/auth.go:1084 lxc/auth.go:1085
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:730 lxc/auth.go:731
+#: lxc/auth.go:731 lxc/auth.go:732
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1851 lxc/auth.go:1852
+#: lxc/auth.go:1852 lxc/auth.go:1853
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3600,7 +3600,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:492 lxc/auth.go:493
+#: lxc/auth.go:493 lxc/auth.go:494
 msgid "Manage permissions"
 msgstr ""
 
@@ -3608,23 +3608,23 @@ msgstr ""
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:28 lxc/project.go:29
+#: lxc/project.go:29 lxc/project.go:30
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:731
+#: lxc/storage_bucket.go:732
 msgid "Manage storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:732
+#: lxc/storage_bucket.go:733
 msgid "Manage storage bucket keys."
 msgstr ""
 
-#: lxc/storage_bucket.go:28
+#: lxc/storage_bucket.go:29
 msgid "Manage storage buckets"
 msgstr ""
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:30
 msgid "Manage storage buckets."
 msgstr ""
 
@@ -3652,11 +3652,11 @@ msgstr ""
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/auth.go:29 lxc/auth.go:30
+#: lxc/auth.go:30 lxc/auth.go:31
 msgid "Manage user authorization"
 msgstr ""
 
-#: lxc/warning.go:28 lxc/warning.go:29
+#: lxc/warning.go:29 lxc/warning.go:30
 msgid "Manage warnings"
 msgstr ""
 
@@ -3720,17 +3720,17 @@ msgstr ""
 msgid "Migration operation failure: %w"
 msgstr ""
 
-#: lxc/monitor.go:51
+#: lxc/monitor.go:52
 msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: lxc/storage_bucket.go:116 lxc/storage_bucket.go:216
-#: lxc/storage_bucket.go:292 lxc/storage_bucket.go:411
-#: lxc/storage_bucket.go:568 lxc/storage_bucket.go:660
-#: lxc/storage_bucket.go:802 lxc/storage_bucket.go:889
-#: lxc/storage_bucket.go:986 lxc/storage_bucket.go:1065
-#: lxc/storage_bucket.go:1188
+#: lxc/storage_bucket.go:117 lxc/storage_bucket.go:217
+#: lxc/storage_bucket.go:293 lxc/storage_bucket.go:412
+#: lxc/storage_bucket.go:569 lxc/storage_bucket.go:661
+#: lxc/storage_bucket.go:803 lxc/storage_bucket.go:890
+#: lxc/storage_bucket.go:987 lxc/storage_bucket.go:1066
+#: lxc/storage_bucket.go:1189
 msgid "Missing bucket name"
 msgstr ""
 
@@ -3749,20 +3749,20 @@ msgstr ""
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1825
+#: lxc/auth.go:123 lxc/auth.go:177 lxc/auth.go:255 lxc/auth.go:417
+#: lxc/auth.go:466 lxc/auth.go:541 lxc/auth.go:600 lxc/auth.go:1826
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:862 lxc/auth.go:1003 lxc/auth.go:1131 lxc/auth.go:1189
+#: lxc/auth.go:863 lxc/auth.go:1004 lxc/auth.go:1132 lxc/auth.go:1190
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1495 lxc/auth.go:1548 lxc/auth.go:1614 lxc/auth.go:1776
+#: lxc/auth.go:1496 lxc/auth.go:1549 lxc/auth.go:1615 lxc/auth.go:1777
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1899 lxc/auth.go:1952
+#: lxc/auth.go:1900 lxc/auth.go:1953
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -3770,12 +3770,12 @@ msgstr ""
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
 #: lxc/config_template.go:377 lxc/profile.go:141 lxc/profile.go:222
-#: lxc/profile.go:808 lxc/rebuild.go:60
+#: lxc/profile.go:808 lxc/rebuild.go:61
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/storage_bucket.go:893 lxc/storage_bucket.go:990
-#: lxc/storage_bucket.go:1069 lxc/storage_bucket.go:1192
+#: lxc/storage_bucket.go:894 lxc/storage_bucket.go:991
+#: lxc/storage_bucket.go:1070 lxc/storage_bucket.go:1193
 msgid "Missing key name"
 msgstr ""
 
@@ -3840,13 +3840,13 @@ msgid "Missing peer name"
 msgstr ""
 
 #: lxc/storage.go:235 lxc/storage.go:313 lxc/storage.go:431 lxc/storage.go:509
-#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:112
-#: lxc/storage_bucket.go:212 lxc/storage_bucket.go:288
-#: lxc/storage_bucket.go:407 lxc/storage_bucket.go:482
-#: lxc/storage_bucket.go:564 lxc/storage_bucket.go:656
-#: lxc/storage_bucket.go:798 lxc/storage_bucket.go:885
-#: lxc/storage_bucket.go:982 lxc/storage_bucket.go:1061
-#: lxc/storage_bucket.go:1184 lxc/storage_volume.go:209
+#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:113
+#: lxc/storage_bucket.go:213 lxc/storage_bucket.go:289
+#: lxc/storage_bucket.go:408 lxc/storage_bucket.go:483
+#: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
+#: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
+#: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
 #: lxc/storage_volume.go:323 lxc/storage_volume.go:643
 #: lxc/storage_volume.go:750 lxc/storage_volume.go:841
 #: lxc/storage_volume.go:939 lxc/storage_volume.go:1053
@@ -3861,9 +3861,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:404 lxc/project.go:146 lxc/project.go:226 lxc/project.go:316
-#: lxc/project.go:433 lxc/project.go:622 lxc/project.go:691 lxc/project.go:819
-#: lxc/project.go:948
+#: lxc/profile.go:404 lxc/project.go:147 lxc/project.go:227 lxc/project.go:317
+#: lxc/project.go:434 lxc/project.go:623 lxc/project.go:692 lxc/project.go:820
+#: lxc/project.go:949
 msgid "Missing project name"
 msgstr ""
 
@@ -3879,7 +3879,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:598
+#: lxc/file.go:599
 msgid "Missing target directory"
 msgstr ""
 
@@ -3901,11 +3901,11 @@ msgstr ""
 msgid "Model: %v"
 msgstr ""
 
-#: lxc/monitor.go:32
+#: lxc/monitor.go:33
 msgid "Monitor a local or remote LXD server"
 msgstr ""
 
-#: lxc/monitor.go:33
+#: lxc/monitor.go:34
 msgid ""
 "Monitor a local or remote LXD server\n"
 "\n"
@@ -3917,11 +3917,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:285
+#: lxc/file.go:286
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:985 lxc/file.go:986
+#: lxc/file.go:986 lxc/file.go:987
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3983,13 +3983,13 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:192
+#: lxc/auth.go:376 lxc/auth.go:816 lxc/auth.go:1736 lxc/cluster.go:192
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
-#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:565
-#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:511
-#: lxc/storage_bucket.go:831 lxc/storage_volume.go:1731
+#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:566
+#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1731
 msgid "NAME"
 msgstr ""
 
@@ -3997,11 +3997,11 @@ msgstr ""
 msgid "NAT"
 msgstr ""
 
-#: lxc/project.go:571
+#: lxc/project.go:572
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:570
+#: lxc/project.go:571
 msgid "NETWORKS"
 msgstr ""
 
@@ -4013,9 +4013,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/operation.go:154 lxc/project.go:523
-#: lxc/project.go:528 lxc/project.go:533 lxc/project.go:538 lxc/project.go:543
-#: lxc/project.go:548 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
+#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:524
+#: lxc/project.go:529 lxc/project.go:534 lxc/project.go:539 lxc/project.go:544
+#: lxc/project.go:549 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
 msgid "NO"
 msgstr ""
 
@@ -4260,7 +4260,7 @@ msgstr ""
 msgid "Only managed networks can be modified"
 msgstr ""
 
-#: lxc/operation.go:86
+#: lxc/operation.go:87
 #, c-format
 msgid "Operation %s deleted"
 msgstr ""
@@ -4307,11 +4307,11 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:567
+#: lxc/list.go:576 lxc/project.go:568
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:212
+#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4373,24 +4373,24 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1102
+#: lxc/file.go:1103
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:860
+#: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
-#: lxc/project.go:363 lxc/storage.go:360 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1151
+#: lxc/project.go:364 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1151
 #: lxc/storage_volume.go:1183
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
-#: lxc/monitor.go:48
+#: lxc/monitor.go:49
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
@@ -4476,17 +4476,17 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:172
+#: lxc/project.go:173
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:236
+#: lxc/project.go:237
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:637
+#: lxc/project.go:638
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -4607,20 +4607,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:241 lxc/file.go:242
+#: lxc/file.go:242 lxc/file.go:243
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:416 lxc/file.go:767
+#: lxc/file.go:417 lxc/file.go:768
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:466 lxc/file.go:467
+#: lxc/file.go:467 lxc/file.go:468
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:701 lxc/file.go:867
+#: lxc/file.go:702 lxc/file.go:868
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4633,11 +4633,11 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:983
+#: lxc/project.go:984
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/storage_bucket.go:833
+#: lxc/storage_bucket.go:834
 msgid "ROLE"
 msgstr ""
 
@@ -4650,15 +4650,15 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/rebuild.go:31
+#: lxc/rebuild.go:32
 msgid "Rebuild as an empty instance"
 msgstr ""
 
-#: lxc/rebuild.go:26
+#: lxc/rebuild.go:27
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:249 lxc/file.go:473
+#: lxc/file.go:250 lxc/file.go:474
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4685,7 +4685,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:882 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
+#: lxc/project.go:883 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
 #: lxc/remote.go:994
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4736,7 +4736,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1164 lxc/auth.go:1165
+#: lxc/auth.go:1165 lxc/auth.go:1166
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4772,7 +4772,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1927 lxc/auth.go:1928
+#: lxc/auth.go:1928 lxc/auth.go:1929
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4784,7 +4784,7 @@ msgstr ""
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:574 lxc/auth.go:575
+#: lxc/auth.go:575 lxc/auth.go:576
 msgid "Remove permissions from groups"
 msgstr ""
 
@@ -4829,11 +4829,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:391 lxc/auth.go:392
+#: lxc/auth.go:392 lxc/auth.go:393
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1751 lxc/auth.go:1752
+#: lxc/auth.go:1752 lxc/auth.go:1753
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -4853,7 +4853,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:589 lxc/project.go:590
+#: lxc/project.go:590 lxc/project.go:591
 msgid "Rename projects"
 msgstr ""
 
@@ -4951,7 +4951,7 @@ msgstr ""
 msgid "Revoke cluster member join token"
 msgstr ""
 
-#: lxc/storage_bucket.go:862
+#: lxc/storage_bucket.go:863
 msgid "Role (admin or read-only)"
 msgstr ""
 
@@ -4967,7 +4967,7 @@ msgstr ""
 msgid "Run against all projects"
 msgstr ""
 
-#: lxc/warning.go:213
+#: lxc/warning.go:214
 msgid "SEVERITY"
 msgstr ""
 
@@ -4987,12 +4987,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1231
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1231
+#: lxc/file.go:1232
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5006,11 +5006,11 @@ msgstr ""
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:173 lxc/warning.go:214
+#: lxc/operation.go:174 lxc/warning.go:215
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:569
+#: lxc/project.go:570
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5018,7 +5018,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:569
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -5026,11 +5026,11 @@ msgstr ""
 msgid "STP"
 msgstr ""
 
-#: lxc/storage_bucket.go:864
+#: lxc/storage_bucket.go:865
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:942
+#: lxc/storage_bucket.go:943
 #, c-format
 msgid "Secret key: %s"
 msgstr ""
@@ -5068,7 +5068,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:995
+#: lxc/file.go:996
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5206,11 +5206,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:654
+#: lxc/project.go:655
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:655
+#: lxc/project.go:656
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5219,11 +5219,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage_bucket.go:534
+#: lxc/storage_bucket.go:535
 msgid "Set storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:535
+#: lxc/storage_bucket.go:536
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -5262,15 +5262,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:476
+#: lxc/file.go:477
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:477
+#: lxc/file.go:478
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:475
+#: lxc/file.go:476
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5310,11 +5310,11 @@ msgstr ""
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 msgid "Set the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:542
+#: lxc/storage_bucket.go:543
 msgid "Set the key as a storage bucket property"
 msgstr ""
 
@@ -5330,7 +5330,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:993
+#: lxc/file.go:994
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5342,7 +5342,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1800 lxc/auth.go:1801
+#: lxc/auth.go:1801 lxc/auth.go:1802
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5358,11 +5358,11 @@ msgstr ""
 msgid "Show details of a cluster member"
 msgstr ""
 
-#: lxc/operation.go:192 lxc/operation.go:193
+#: lxc/operation.go:193 lxc/operation.go:194
 msgid "Show details on a background operation"
 msgstr ""
 
-#: lxc/monitor.go:49
+#: lxc/monitor.go:50
 msgid "Show events from all projects"
 msgstr ""
 
@@ -5370,11 +5370,11 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:440 lxc/auth.go:441
+#: lxc/auth.go:441 lxc/auth.go:442
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:832
+#: lxc/auth.go:833
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5455,15 +5455,15 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:786 lxc/project.go:787
+#: lxc/project.go:787 lxc/project.go:788
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage_bucket.go:628 lxc/storage_bucket.go:629
+#: lxc/storage_bucket.go:629 lxc/storage_bucket.go:630
 msgid "Show storage bucket configurations"
 msgstr ""
 
-#: lxc/storage_bucket.go:1156 lxc/storage_bucket.go:1157
+#: lxc/storage_bucket.go:1157 lxc/storage_bucket.go:1158
 msgid "Show storage bucket key configurations"
 msgstr ""
 
@@ -5479,7 +5479,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:895
+#: lxc/auth.go:896
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5529,7 +5529,7 @@ msgstr ""
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: lxc/warning.go:302 lxc/warning.go:303
+#: lxc/warning.go:303 lxc/warning.go:304
 msgid "Show warning"
 msgstr ""
 
@@ -5613,22 +5613,22 @@ msgstr ""
 msgid "Stopping the instance failed: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:166
+#: lxc/storage_bucket.go:167
 #, c-format
 msgid "Storage bucket %s created"
 msgstr ""
 
-#: lxc/storage_bucket.go:233
+#: lxc/storage_bucket.go:234
 #, c-format
 msgid "Storage bucket %s deleted"
 msgstr ""
 
-#: lxc/storage_bucket.go:940
+#: lxc/storage_bucket.go:941
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr ""
 
-#: lxc/storage_bucket.go:1006
+#: lxc/storage_bucket.go:1007
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr ""
@@ -5697,7 +5697,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:847 lxc/project.go:848
+#: lxc/project.go:848 lxc/project.go:849
 msgid "Switch the current project"
 msgstr ""
 
@@ -5713,10 +5713,10 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1139
+#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1139
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
-#: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:171
-#: lxc/storage_volume.go:1730 lxc/warning.go:215
+#: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
+#: lxc/storage_volume.go:1730 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
@@ -5724,11 +5724,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1032
+#: lxc/file.go:1033
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1026
+#: lxc/file.go:1027
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5856,12 +5856,12 @@ msgstr ""
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:446
+#: lxc/project.go:447
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
 
-#: lxc/storage_bucket.go:431
+#: lxc/storage_bucket.go:432
 #, c-format
 msgid "The property %q does not exist on the storage bucket %q: %v"
 msgstr ""
@@ -6046,7 +6046,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:961
+#: lxc/project.go:962
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6058,17 +6058,17 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:985 lxc/storage_volume.go:1735
+#: lxc/project.go:986 lxc/storage_volume.go:1735
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:573
+#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:574
 #: lxc/storage.go:724 lxc/storage_volume.go:1734
 msgid "USED BY"
 msgstr ""
 
-#: lxc/warning.go:216
+#: lxc/warning.go:217
 msgid "UUID"
 msgstr ""
 
@@ -6077,7 +6077,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:197
+#: lxc/file.go:198
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6091,13 +6091,13 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1253
+#: lxc/file.go:1254
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1153 lxc/list.go:631 lxc/storage_volume.go:1772
-#: lxc/warning.go:241
+#: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6107,7 +6107,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:807
+#: lxc/file.go:808
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6190,11 +6190,11 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:742 lxc/project.go:743
+#: lxc/project.go:743 lxc/project.go:744
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:697 lxc/storage_bucket.go:698
+#: lxc/storage_bucket.go:698 lxc/storage_bucket.go:699
 msgid "Unset storage bucket configuration keys"
 msgstr ""
 
@@ -6242,11 +6242,11 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:747
+#: lxc/project.go:748
 msgid "Unset the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:701
+#: lxc/storage_bucket.go:702
 msgid "Unset the key as a storage bucket property"
 msgstr ""
 
@@ -6325,7 +6325,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:71
+#: lxc/file.go:72
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6362,11 +6362,11 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:831
+#: lxc/auth.go:832
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:894
+#: lxc/auth.go:895
 msgid "View the current identity"
 msgstr ""
 
@@ -6397,15 +6397,15 @@ msgstr ""
 msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
-#: lxc/rebuild.go:27
+#: lxc/rebuild.go:28
 msgid ""
 "Wipe the instance root disk and re-initialize. The original image is used to "
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:156 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
+#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:526
+#: lxc/project.go:531 lxc/project.go:536 lxc/project.go:541 lxc/project.go:546
+#: lxc/project.go:551 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
 msgid "YES"
 msgstr ""
 
@@ -6425,7 +6425,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/rebuild.go:119
+#: lxc/rebuild.go:120
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
@@ -6437,12 +6437,12 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1689
+#: lxc/auth.go:330 lxc/auth.go:763 lxc/auth.go:894 lxc/auth.go:1690
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
-#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
+#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
-#: lxc/operation.go:103 lxc/profile.go:700 lxc/project.go:467
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:68
+#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:468
+#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6470,7 +6470,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1254
+#: lxc/auth.go:1255
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6531,11 +6531,11 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:830
+#: lxc/auth.go:831
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1926
+#: lxc/auth.go:1106 lxc/auth.go:1164 lxc/auth.go:1927
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6543,13 +6543,13 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:954 lxc/auth.go:1470 lxc/cluster_group.go:168
+#: lxc/auth.go:97 lxc/auth.go:150 lxc/auth.go:200 lxc/auth.go:440
+#: lxc/auth.go:955 lxc/auth.go:1471 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:514 lxc/auth.go:572
+#: lxc/auth.go:515 lxc/auth.go:573
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
@@ -6559,19 +6559,19 @@ msgstr ""
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:389
+#: lxc/auth.go:390
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1521 lxc/auth.go:1571 lxc/auth.go:1799
+#: lxc/auth.go:1522 lxc/auth.go:1572 lxc/auth.go:1800
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1873
+#: lxc/auth.go:1874
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1749
+#: lxc/auth.go:1750
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -6591,7 +6591,7 @@ msgstr ""
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
-#: lxc/rebuild.go:25
+#: lxc/rebuild.go:26
 msgid "[<remote>:]<image> [<remote>:]<instance>"
 msgstr ""
 
@@ -6674,20 +6674,20 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:170
+#: lxc/file.go:171
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:120
+#: lxc/file.go:121
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:240
+#: lxc/file.go:241
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:984
+#: lxc/file.go:985
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6838,12 +6838,12 @@ msgstr ""
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
-#: lxc/operation.go:53 lxc/operation.go:191
+#: lxc/operation.go:54 lxc/operation.go:192
 msgid "[<remote>:]<operation>"
 msgstr ""
 
 #: lxc/storage.go:200 lxc/storage.go:259 lxc/storage.go:473 lxc/storage.go:844
-#: lxc/storage_bucket.go:454
+#: lxc/storage_bucket.go:455
 msgid "[<remote>:]<pool>"
 msgstr ""
 
@@ -6851,22 +6851,22 @@ msgstr ""
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
-#: lxc/storage_bucket.go:185 lxc/storage_bucket.go:247
-#: lxc/storage_bucket.go:627 lxc/storage_bucket.go:769
+#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:248
+#: lxc/storage_bucket.go:628 lxc/storage_bucket.go:770
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
 
-#: lxc/storage_bucket.go:380 lxc/storage_bucket.go:696
-#: lxc/storage_bucket.go:850 lxc/storage_bucket.go:956
-#: lxc/storage_bucket.go:1020 lxc/storage_bucket.go:1155
+#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:697
+#: lxc/storage_bucket.go:851 lxc/storage_bucket.go:957
+#: lxc/storage_bucket.go:1021 lxc/storage_bucket.go:1156
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
 
-#: lxc/storage_bucket.go:533
+#: lxc/storage_bucket.go:534
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_bucket.go:81
+#: lxc/storage_bucket.go:82
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
 
@@ -6981,20 +6981,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:91 lxc/project.go:186 lxc/project.go:258 lxc/project.go:785
-#: lxc/project.go:846 lxc/project.go:913
+#: lxc/project.go:92 lxc/project.go:187 lxc/project.go:259 lxc/project.go:786
+#: lxc/project.go:847 lxc/project.go:914
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:394 lxc/project.go:741
+#: lxc/project.go:395 lxc/project.go:742
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:653
+#: lxc/project.go:654
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:587
+#: lxc/project.go:588
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7002,7 +7002,7 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:259 lxc/warning.go:301 lxc/warning.go:354
+#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
@@ -7058,7 +7058,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:555 lxc/remote.go:739
+#: lxc/project.go:556 lxc/remote.go:739
 msgid "current"
 msgstr ""
 
@@ -7105,20 +7105,20 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/auth.go:203
+#: lxc/auth.go:204
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:958
+#: lxc/auth.go:959
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1575
+#: lxc/auth.go:1576
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7196,20 +7196,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:988
+#: lxc/file.go:989
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:244
+#: lxc/file.go:245
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:470
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7291,7 +7291,7 @@ msgid ""
 "  List instances with their running state and user comment."
 msgstr ""
 
-#: lxc/monitor.go:37
+#: lxc/monitor.go:38
 msgid ""
 "lxc monitor --type=logging\n"
 "    Only show log messages.\n"
@@ -7367,7 +7367,7 @@ msgid ""
 "    Create record r1 for zone z1 with configuration from config.yaml"
 msgstr ""
 
-#: lxc/operation.go:195
+#: lxc/operation.go:196
 msgid ""
 "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Show details on that operation UUID"
@@ -7410,7 +7410,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:95
+#: lxc/project.go:96
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7418,7 +7418,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:262
+#: lxc/project.go:263
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7449,7 +7449,7 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:85
 msgid ""
 "lxc storage bucket create p1 b01\n"
 "\tCreate a new storage bucket name b01 in storage pool p1\n"
@@ -7459,19 +7459,19 @@ msgid ""
 "of config.yaml"
 msgstr ""
 
-#: lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:251
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1023
+#: lxc/storage_bucket.go:1024
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:854
 msgid ""
 "lxc storage bucket key create p1 b01 k1\n"
 "\tCreate a key called k1 for the bucket b01 in the pool p1.\n"
@@ -7481,14 +7481,14 @@ msgid ""
 "of config.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1158
+#: lxc/storage_bucket.go:1159
 msgid ""
 "lxc storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_bucket.go:630
+#: lxc/storage_bucket.go:631
 msgid ""
 "lxc storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
@@ -7558,16 +7558,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1142
+#: lxc/file.go:1143
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1101
+#: lxc/file.go:1102
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1054
+#: lxc/file.go:1055
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-04 08:52-0600\n"
+"POT-Creation-Date: 2024-09-05 08:44-0400\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/linux-containers/"
@@ -20,7 +20,7 @@ msgstr ""
 "|| n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: lxc/storage_bucket.go:260 lxc/storage_bucket.go:1033
+#: lxc/storage_bucket.go:261 lxc/storage_bucket.go:1034
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
@@ -207,7 +207,7 @@ msgstr ""
 "###\n"
 "### Nazwa jest widoczna, ale nie może zostać zmieniona"
 
-#: lxc/auth.go:213
+#: lxc/auth.go:214
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -234,7 +234,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:968
+#: lxc/auth.go:969
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -255,7 +255,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1585
+#: lxc/auth.go:1586
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
@@ -635,7 +635,7 @@ msgstr ""
 "###\n"
 "### Nazwa jest widoczna, ale nie może zostać zmieniona"
 
-#: lxc/project.go:280
+#: lxc/project.go:281
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the project.\n"
@@ -695,12 +695,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:935
+#: lxc/file.go:936
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:825
+#: lxc/file.go:826
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -736,7 +736,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:142 lxc/rebuild.go:64
+#: lxc/init.go:142 lxc/rebuild.go:65
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -789,7 +789,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:465
+#: lxc/file.go:466
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -822,7 +822,7 @@ msgstr ""
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:813
+#: lxc/auth.go:814
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -830,11 +830,11 @@ msgstr ""
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/storage_bucket.go:863
+#: lxc/storage_bucket.go:864
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:941
+#: lxc/storage_bucket.go:942
 #, c-format
 msgid "Access key: %s"
 msgstr ""
@@ -843,7 +843,7 @@ msgstr ""
 msgid "Access the expanded configuration"
 msgstr ""
 
-#: lxc/warning.go:261 lxc/warning.go:262
+#: lxc/warning.go:262 lxc/warning.go:263
 msgid "Acknowledge warning"
 msgstr ""
 
@@ -860,11 +860,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1106 lxc/auth.go:1107
+#: lxc/auth.go:1107 lxc/auth.go:1108
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1874 lxc/auth.go:1875
+#: lxc/auth.go:1875 lxc/auth.go:1876
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -933,7 +933,7 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:515 lxc/auth.go:516
+#: lxc/auth.go:516 lxc/auth.go:517
 msgid "Add permissions to groups"
 msgstr ""
 
@@ -962,7 +962,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:169
+#: lxc/storage_bucket.go:170
 #, c-format
 msgid "Admin access key: %s"
 msgstr ""
@@ -972,7 +972,7 @@ msgstr ""
 msgid "Admin password (or token) for %s:"
 msgstr ""
 
-#: lxc/storage_bucket.go:170
+#: lxc/storage_bucket.go:171
 #, c-format
 msgid "Admin secret key: %s"
 msgstr ""
@@ -1031,7 +1031,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:342 lxc/rebuild.go:130
+#: lxc/init.go:342 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -1131,12 +1131,12 @@ msgstr ""
 
 #: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:318
 #: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
-#: lxc/network_zone.go:366 lxc/network_zone.go:1053 lxc/storage_bucket.go:141
+#: lxc/network_zone.go:366 lxc/network_zone.go:1053 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:159
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:160
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1176,7 +1176,7 @@ msgstr ""
 msgid "Bytes sent"
 msgstr ""
 
-#: lxc/operation.go:174
+#: lxc/operation.go:175
 msgid "CANCELABLE"
 msgstr ""
 
@@ -1188,7 +1188,7 @@ msgstr ""
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: lxc/warning.go:209
+#: lxc/warning.go:210
 msgid "COUNT"
 msgstr ""
 
@@ -1214,7 +1214,7 @@ msgstr ""
 msgid "CPUs (%s):"
 msgstr ""
 
-#: lxc/operation.go:175
+#: lxc/operation.go:176
 msgid "CREATED"
 msgstr ""
 
@@ -1244,7 +1244,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:340
+#: lxc/file.go:341
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1269,11 +1269,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:224
+#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:546
+#: lxc/file.go:547
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1282,7 +1282,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:160
+#: lxc/rebuild.go:161
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1405,13 +1405,13 @@ msgstr ""
 #: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
 #: lxc/network_load_balancer.go:1051 lxc/network_load_balancer.go:1125
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
-#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:90
-#: lxc/storage_bucket.go:190 lxc/storage_bucket.go:253
-#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:541
-#: lxc/storage_bucket.go:634 lxc/storage_bucket.go:700
-#: lxc/storage_bucket.go:775 lxc/storage_bucket.go:861
-#: lxc/storage_bucket.go:961 lxc/storage_bucket.go:1026
-#: lxc/storage_bucket.go:1162 lxc/storage_volume.go:394
+#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
+#: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
+#: lxc/storage_bucket.go:385 lxc/storage_bucket.go:542
+#: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
+#: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
+#: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
 #: lxc/storage_volume.go:612 lxc/storage_volume.go:717
 #: lxc/storage_volume.go:1005 lxc/storage_volume.go:1231
 #: lxc/storage_volume.go:1360 lxc/storage_volume.go:1848
@@ -1435,7 +1435,7 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1113 lxc/list.go:132 lxc/storage_volume.go:1589
-#: lxc/warning.go:92
+#: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
@@ -1463,7 +1463,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:100
+#: lxc/project.go:101
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1477,8 +1477,8 @@ msgstr ""
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
-#: lxc/project.go:362 lxc/storage.go:359 lxc/storage_bucket.go:348
-#: lxc/storage_bucket.go:1125 lxc/storage_volume.go:1150
+#: lxc/project.go:363 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1150
 #: lxc/storage_volume.go:1182
 #, c-format
 msgid "Config parsing error: %s"
@@ -1605,12 +1605,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:300 lxc/auth.go:1660
+#: lxc/auth.go:301 lxc/auth.go:1661
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1054
+#: lxc/auth.go:1055
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1659,15 +1659,15 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:248 lxc/file.go:474
+#: lxc/file.go:249 lxc/file.go:475
 msgid "Create any directories necessary"
 msgstr ""
 
-#: lxc/auth.go:97 lxc/auth.go:98
+#: lxc/auth.go:98 lxc/auth.go:99
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1471 lxc/auth.go:1472
+#: lxc/auth.go:1472 lxc/auth.go:1473
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1687,11 +1687,11 @@ msgstr ""
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_bucket.go:851 lxc/storage_bucket.go:852
+#: lxc/storage_bucket.go:852 lxc/storage_bucket.go:853
 msgid "Create key for a storage bucket"
 msgstr ""
 
-#: lxc/storage_bucket.go:82 lxc/storage_bucket.go:83
+#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
 msgid "Create new custom storage buckets"
 msgstr ""
 
@@ -1735,7 +1735,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:92 lxc/project.go:93
+#: lxc/project.go:93 lxc/project.go:94
 msgid "Create projects"
 msgstr ""
 
@@ -1770,13 +1770,13 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:376 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1135 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
-#: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:172
-#: lxc/profile.go:756 lxc/project.go:572 lxc/storage.go:723
-#: lxc/storage_bucket.go:512 lxc/storage_bucket.go:832
+#: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
+#: lxc/profile.go:756 lxc/project.go:573 lxc/storage.go:723
+#: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1732
 msgid "DESCRIPTION"
 msgstr ""
@@ -1801,7 +1801,7 @@ msgstr ""
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
-#: lxc/operation.go:55 lxc/operation.go:56
+#: lxc/operation.go:56 lxc/operation.go:57
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
@@ -1809,19 +1809,19 @@ msgstr ""
 msgid "Delete a cluster group"
 msgstr ""
 
-#: lxc/warning.go:360
+#: lxc/warning.go:361
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:122 lxc/file.go:123
+#: lxc/file.go:123 lxc/file.go:124
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/auth.go:151 lxc/auth.go:152
+#: lxc/auth.go:152 lxc/auth.go:153
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1523 lxc/auth.go:1524
+#: lxc/auth.go:1524 lxc/auth.go:1525
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1841,7 +1841,7 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/storage_bucket.go:957 lxc/storage_bucket.go:958
+#: lxc/storage_bucket.go:958 lxc/storage_bucket.go:959
 msgid "Delete key from a storage bucket"
 msgstr ""
 
@@ -1877,11 +1877,11 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:188 lxc/project.go:189
+#: lxc/project.go:189 lxc/project.go:190
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:187 lxc/storage_bucket.go:188
+#: lxc/storage_bucket.go:188 lxc/storage_bucket.go:189
 msgid "Delete storage buckets"
 msgstr ""
 
@@ -1893,20 +1893,20 @@ msgstr ""
 msgid "Delete storage volumes"
 msgstr ""
 
-#: lxc/warning.go:356 lxc/warning.go:357
+#: lxc/warning.go:357 lxc/warning.go:358
 msgid "Delete warning"
 msgstr ""
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:30 lxc/auth.go:59 lxc/auth.go:98
-#: lxc/auth.go:152 lxc/auth.go:201 lxc/auth.go:332 lxc/auth.go:392
-#: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
-#: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
-#: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
-#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1434 lxc/auth.go:1472
-#: lxc/auth.go:1524 lxc/auth.go:1573 lxc/auth.go:1692 lxc/auth.go:1752
-#: lxc/auth.go:1801 lxc/auth.go:1852 lxc/auth.go:1875 lxc/auth.go:1928
+#: lxc/alias.go:214 lxc/auth.go:31 lxc/auth.go:60 lxc/auth.go:99
+#: lxc/auth.go:153 lxc/auth.go:202 lxc/auth.go:333 lxc/auth.go:393
+#: lxc/auth.go:442 lxc/auth.go:494 lxc/auth.go:517 lxc/auth.go:576
+#: lxc/auth.go:732 lxc/auth.go:766 lxc/auth.go:833 lxc/auth.go:896
+#: lxc/auth.go:957 lxc/auth.go:1085 lxc/auth.go:1108 lxc/auth.go:1166
+#: lxc/auth.go:1235 lxc/auth.go:1257 lxc/auth.go:1435 lxc/auth.go:1473
+#: lxc/auth.go:1525 lxc/auth.go:1574 lxc/auth.go:1693 lxc/auth.go:1753
+#: lxc/auth.go:1802 lxc/auth.go:1853 lxc/auth.go:1876 lxc/auth.go:1929
 #: lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215 lxc/cluster.go:272
 #: lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:484 lxc/cluster.go:528
 #: lxc/cluster.go:586 lxc/cluster.go:677 lxc/cluster.go:770 lxc/cluster.go:893
@@ -1930,15 +1930,15 @@ msgstr ""
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:83 lxc/file.go:123 lxc/file.go:172
-#: lxc/file.go:242 lxc/file.go:467 lxc/file.go:986 lxc/image.go:38
+#: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
+#: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
 #: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
 #: lxc/image.go:697 lxc/image.go:946 lxc/image.go:1088 lxc/image.go:1415
 #: lxc/image.go:1506 lxc/image.go:1572 lxc/image.go:1636 lxc/image.go:1699
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:38 lxc/network.go:33
+#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33
 #: lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405
 #: lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793
 #: lxc/network.go:874 lxc/network.go:1005 lxc/network.go:1106
@@ -1972,27 +1972,27 @@ msgstr ""
 #: lxc/network_zone.go:909 lxc/network_zone.go:985 lxc/network_zone.go:1083
 #: lxc/network_zone.go:1172 lxc/network_zone.go:1219 lxc/network_zone.go:1349
 #: lxc/network_zone.go:1410 lxc/network_zone.go:1425 lxc/network_zone.go:1483
-#: lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:106
-#: lxc/operation.go:193 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
+#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
+#: lxc/operation.go:194 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
 #: lxc/profile.go:271 lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493
 #: lxc/profile.go:629 lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860
-#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:29
-#: lxc/project.go:93 lxc/project.go:189 lxc/project.go:260 lxc/project.go:396
-#: lxc/project.go:470 lxc/project.go:590 lxc/project.go:655 lxc/project.go:743
-#: lxc/project.go:787 lxc/project.go:848 lxc/project.go:915 lxc/publish.go:34
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:35 lxc/remote.go:91
+#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:30
+#: lxc/project.go:94 lxc/project.go:190 lxc/project.go:261 lxc/project.go:397
+#: lxc/project.go:471 lxc/project.go:591 lxc/project.go:656 lxc/project.go:744
+#: lxc/project.go:788 lxc/project.go:849 lxc/project.go:916 lxc/publish.go:34
+#: lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91
 #: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853
 #: lxc/remote.go:917 lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24
 #: lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203
 #: lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655
 #: lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940
-#: lxc/storage_bucket.go:29 lxc/storage_bucket.go:83 lxc/storage_bucket.go:188
-#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:382
-#: lxc/storage_bucket.go:458 lxc/storage_bucket.go:535
-#: lxc/storage_bucket.go:629 lxc/storage_bucket.go:698
-#: lxc/storage_bucket.go:732 lxc/storage_bucket.go:773
-#: lxc/storage_bucket.go:852 lxc/storage_bucket.go:958
-#: lxc/storage_bucket.go:1022 lxc/storage_bucket.go:1157
+#: lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189
+#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:383
+#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:536
+#: lxc/storage_bucket.go:630 lxc/storage_bucket.go:699
+#: lxc/storage_bucket.go:733 lxc/storage_bucket.go:774
+#: lxc/storage_bucket.go:853 lxc/storage_bucket.go:959
+#: lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158
 #: lxc/storage_volume.go:58 lxc/storage_volume.go:169 lxc/storage_volume.go:283
 #: lxc/storage_volume.go:390 lxc/storage_volume.go:605
 #: lxc/storage_volume.go:714 lxc/storage_volume.go:801
@@ -2003,8 +2003,8 @@ msgstr ""
 #: lxc/storage_volume.go:2064 lxc/storage_volume.go:2222
 #: lxc/storage_volume.go:2343 lxc/storage_volume.go:2405
 #: lxc/storage_volume.go:2541 lxc/storage_volume.go:2624
-#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:29
-#: lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
+#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:30
+#: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
@@ -2091,7 +2091,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:994
+#: lxc/file.go:995
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2157,7 +2157,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:74
+#: lxc/file.go:75
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -2167,7 +2167,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:955 lxc/auth.go:956
+#: lxc/auth.go:956 lxc/auth.go:957
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -2175,15 +2175,15 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:171 lxc/file.go:172
+#: lxc/file.go:172 lxc/file.go:173
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/auth.go:200 lxc/auth.go:201
+#: lxc/auth.go:201 lxc/auth.go:202
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1572 lxc/auth.go:1573
+#: lxc/auth.go:1573 lxc/auth.go:1574
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2239,15 +2239,15 @@ msgstr ""
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:259 lxc/project.go:260
+#: lxc/project.go:260 lxc/project.go:261
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:248 lxc/storage_bucket.go:249
+#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:250
 msgid "Edit storage bucket configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:1021 lxc/storage_bucket.go:1022
+#: lxc/storage_bucket.go:1022 lxc/storage_bucket.go:1023
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
@@ -2264,7 +2264,7 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1147 lxc/list.go:622 lxc/storage_volume.go:1766
-#: lxc/warning.go:235
+#: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2319,7 +2319,7 @@ msgstr ""
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
-#: lxc/project.go:718 lxc/storage.go:812 lxc/storage_bucket.go:602
+#: lxc/project.go:719 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2155 lxc/storage_volume.go:2193
 #, c-format
 msgid "Error setting properties: %v"
@@ -2333,8 +2333,8 @@ msgstr ""
 #: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
-#: lxc/profile.go:981 lxc/project.go:712 lxc/storage.go:806
-#: lxc/storage_bucket.go:596 lxc/storage_volume.go:2149
+#: lxc/profile.go:981 lxc/project.go:713 lxc/storage.go:806
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2149
 #: lxc/storage_volume.go:2187
 #, c-format
 msgid "Error unsetting property: %v"
@@ -2354,7 +2354,7 @@ msgstr ""
 msgid "Evacuating cluster member: %s"
 msgstr ""
 
-#: lxc/monitor.go:50
+#: lxc/monitor.go:51
 msgid "Event type to listen for"
 msgstr ""
 
@@ -2441,16 +2441,16 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/warning.go:210
+#: lxc/warning.go:211
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1237
+#: lxc/file.go:1238
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1260
+#: lxc/file.go:1261
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2465,12 +2465,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1287
+#: lxc/file.go:1288
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1072
+#: lxc/file.go:1073
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2500,7 +2500,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1193
+#: lxc/file.go:1194
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2515,7 +2515,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1198
+#: lxc/file.go:1199
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2525,12 +2525,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1098
+#: lxc/file.go:1099
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1225
+#: lxc/file.go:1226
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2569,7 +2569,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1210
+#: lxc/file.go:1211
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2584,7 +2584,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:820
+#: lxc/file.go:821
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2599,7 +2599,7 @@ msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
 #: lxc/network.go:1044 lxc/network_acl.go:133 lxc/network_zone.go:124
-#: lxc/operation.go:136
+#: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
 
@@ -2664,21 +2664,21 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
+#: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:770 lxc/auth.go:1697
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1114 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:57
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
-#: lxc/operation.go:108 lxc/profile.go:707 lxc/project.go:472
-#: lxc/project.go:917 lxc/remote.go:690 lxc/storage.go:657
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:774
-#: lxc/storage_volume.go:1608 lxc/warning.go:93
+#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:473
+#: lxc/project.go:918 lxc/remote.go:690 lxc/storage.go:657
+#: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
+#: lxc/storage_volume.go:1608 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
-#: lxc/monitor.go:52
+#: lxc/monitor.go:53
 msgid "Format (json|pretty|yaml)"
 msgstr ""
 
@@ -2722,7 +2722,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:817 lxc/auth.go:1736
+#: lxc/auth.go:818 lxc/auth.go:1737
 msgid "GROUPS"
 msgstr ""
 
@@ -2738,7 +2738,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:914 lxc/project.go:915
+#: lxc/project.go:915 lxc/project.go:916
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2786,11 +2786,11 @@ msgstr ""
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:400
+#: lxc/project.go:401
 msgid "Get the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:385
+#: lxc/storage_bucket.go:386
 msgid "Get the key as a storage bucket property"
 msgstr ""
 
@@ -2850,11 +2850,11 @@ msgstr ""
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:395 lxc/project.go:396
+#: lxc/project.go:396 lxc/project.go:397
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:382
+#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:383
 msgid "Get values for storage bucket configuration keys"
 msgstr ""
 
@@ -2871,17 +2871,17 @@ msgstr ""
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: lxc/auth.go:136
+#: lxc/auth.go:137
 #, c-format
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:186
+#: lxc/auth.go:187
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:426 lxc/auth.go:1786
+#: lxc/auth.go:427 lxc/auth.go:1787
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2906,27 +2906,27 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1310
+#: lxc/file.go:1311
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1299
+#: lxc/file.go:1300
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1122
+#: lxc/file.go:1123
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1132
+#: lxc/file.go:1133
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:966 lxc/operation.go:170
+#: lxc/network.go:966 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2940,11 +2940,11 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:816
+#: lxc/auth.go:817
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:566
+#: lxc/project.go:567
 msgid "IMAGES"
 msgstr ""
 
@@ -2972,17 +2972,17 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1508
+#: lxc/auth.go:1509
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1558
+#: lxc/auth.go:1559
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
 
-#: lxc/rebuild.go:32
+#: lxc/rebuild.go:33
 msgid "If an instance is running, stop it and then rebuild it"
 msgstr ""
 
@@ -3103,7 +3103,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1233 lxc/auth.go:1234
+#: lxc/auth.go:1234 lxc/auth.go:1235
 msgid "Inspect permissions"
 msgstr ""
 
@@ -3111,11 +3111,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1124
+#: lxc/file.go:1125
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1301
+#: lxc/file.go:1302
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3133,7 +3133,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1044
+#: lxc/file.go:1045
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3142,7 +3142,7 @@ msgstr ""
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/rebuild.go:74
+#: lxc/rebuild.go:75
 #, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
@@ -3175,7 +3175,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/monitor.go:70
+#: lxc/monitor.go:71
 #, c-format
 msgid "Invalid format: %s"
 msgstr ""
@@ -3185,7 +3185,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1039
+#: lxc/file.go:1040
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3227,7 +3227,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:147
+#: lxc/file.go:148
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -3243,12 +3243,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:313
+#: lxc/file.go:314
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:495
+#: lxc/file.go:496
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3262,7 +3262,7 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/warning.go:212
 msgid "LAST SEEN"
 msgstr ""
 
@@ -3270,7 +3270,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:984
+#: lxc/project.go:985
 msgid "LIMIT"
 msgstr ""
 
@@ -3279,8 +3279,8 @@ msgid "LISTEN ADDRESS"
 msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
-#: lxc/network_load_balancer.go:165 lxc/operation.go:177
-#: lxc/storage_bucket.go:516 lxc/storage_volume.go:1739 lxc/warning.go:220
+#: lxc/network_load_balancer.go:165 lxc/operation.go:178
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1739 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3354,7 +3354,7 @@ msgstr ""
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/warning.go:94
+#: lxc/warning.go:95
 msgid "List all warnings"
 msgstr ""
 
@@ -3398,19 +3398,19 @@ msgstr ""
 msgid "List available storage pools"
 msgstr ""
 
-#: lxc/operation.go:105 lxc/operation.go:106
+#: lxc/operation.go:106 lxc/operation.go:107
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:331 lxc/auth.go:332
+#: lxc/auth.go:332 lxc/auth.go:333
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:764 lxc/auth.go:765
+#: lxc/auth.go:765 lxc/auth.go:766
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1691 lxc/auth.go:1692
+#: lxc/auth.go:1692 lxc/auth.go:1693
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3559,11 +3559,11 @@ msgstr ""
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/operation.go:109
+#: lxc/operation.go:110
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1255 lxc/auth.go:1256
+#: lxc/auth.go:1256 lxc/auth.go:1257
 msgid "List permissions"
 msgstr ""
 
@@ -3571,15 +3571,15 @@ msgstr ""
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:469 lxc/project.go:470
+#: lxc/project.go:470 lxc/project.go:471
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:771 lxc/storage_bucket.go:773
+#: lxc/storage_bucket.go:772 lxc/storage_bucket.go:774
 msgid "List storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:456 lxc/storage_bucket.go:458
+#: lxc/storage_bucket.go:457 lxc/storage_bucket.go:459
 msgid "List storage buckets"
 msgstr ""
 
@@ -3615,11 +3615,11 @@ msgstr ""
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/warning.go:70
+#: lxc/warning.go:71
 msgid "List warnings"
 msgstr ""
 
-#: lxc/warning.go:71
+#: lxc/warning.go:72
 msgid ""
 "List warnings\n"
 "\n"
@@ -3642,7 +3642,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/operation.go:23 lxc/operation.go:24
+#: lxc/operation.go:24 lxc/operation.go:25
 msgid "List, show and delete background operations"
 msgstr ""
 
@@ -3651,7 +3651,7 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/monitor.go:79
+#: lxc/monitor.go:80
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
@@ -3755,23 +3755,23 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:82 lxc/file.go:83
+#: lxc/file.go:83 lxc/file.go:84
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1433 lxc/auth.go:1434
+#: lxc/auth.go:59 lxc/auth.go:60 lxc/auth.go:1434 lxc/auth.go:1435
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1083 lxc/auth.go:1084
+#: lxc/auth.go:1084 lxc/auth.go:1085
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:730 lxc/auth.go:731
+#: lxc/auth.go:731 lxc/auth.go:732
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1851 lxc/auth.go:1852
+#: lxc/auth.go:1852 lxc/auth.go:1853
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3862,7 +3862,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:492 lxc/auth.go:493
+#: lxc/auth.go:493 lxc/auth.go:494
 msgid "Manage permissions"
 msgstr ""
 
@@ -3870,23 +3870,23 @@ msgstr ""
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:28 lxc/project.go:29
+#: lxc/project.go:29 lxc/project.go:30
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:731
+#: lxc/storage_bucket.go:732
 msgid "Manage storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:732
+#: lxc/storage_bucket.go:733
 msgid "Manage storage bucket keys."
 msgstr ""
 
-#: lxc/storage_bucket.go:28
+#: lxc/storage_bucket.go:29
 msgid "Manage storage buckets"
 msgstr ""
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:30
 msgid "Manage storage buckets."
 msgstr ""
 
@@ -3914,11 +3914,11 @@ msgstr ""
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/auth.go:29 lxc/auth.go:30
+#: lxc/auth.go:30 lxc/auth.go:31
 msgid "Manage user authorization"
 msgstr ""
 
-#: lxc/warning.go:28 lxc/warning.go:29
+#: lxc/warning.go:29 lxc/warning.go:30
 msgid "Manage warnings"
 msgstr ""
 
@@ -3982,17 +3982,17 @@ msgstr ""
 msgid "Migration operation failure: %w"
 msgstr ""
 
-#: lxc/monitor.go:51
+#: lxc/monitor.go:52
 msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: lxc/storage_bucket.go:116 lxc/storage_bucket.go:216
-#: lxc/storage_bucket.go:292 lxc/storage_bucket.go:411
-#: lxc/storage_bucket.go:568 lxc/storage_bucket.go:660
-#: lxc/storage_bucket.go:802 lxc/storage_bucket.go:889
-#: lxc/storage_bucket.go:986 lxc/storage_bucket.go:1065
-#: lxc/storage_bucket.go:1188
+#: lxc/storage_bucket.go:117 lxc/storage_bucket.go:217
+#: lxc/storage_bucket.go:293 lxc/storage_bucket.go:412
+#: lxc/storage_bucket.go:569 lxc/storage_bucket.go:661
+#: lxc/storage_bucket.go:803 lxc/storage_bucket.go:890
+#: lxc/storage_bucket.go:987 lxc/storage_bucket.go:1066
+#: lxc/storage_bucket.go:1189
 msgid "Missing bucket name"
 msgstr ""
 
@@ -4011,20 +4011,20 @@ msgstr ""
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1825
+#: lxc/auth.go:123 lxc/auth.go:177 lxc/auth.go:255 lxc/auth.go:417
+#: lxc/auth.go:466 lxc/auth.go:541 lxc/auth.go:600 lxc/auth.go:1826
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:862 lxc/auth.go:1003 lxc/auth.go:1131 lxc/auth.go:1189
+#: lxc/auth.go:863 lxc/auth.go:1004 lxc/auth.go:1132 lxc/auth.go:1190
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1495 lxc/auth.go:1548 lxc/auth.go:1614 lxc/auth.go:1776
+#: lxc/auth.go:1496 lxc/auth.go:1549 lxc/auth.go:1615 lxc/auth.go:1777
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1899 lxc/auth.go:1952
+#: lxc/auth.go:1900 lxc/auth.go:1953
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -4032,12 +4032,12 @@ msgstr ""
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
 #: lxc/config_template.go:377 lxc/profile.go:141 lxc/profile.go:222
-#: lxc/profile.go:808 lxc/rebuild.go:60
+#: lxc/profile.go:808 lxc/rebuild.go:61
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/storage_bucket.go:893 lxc/storage_bucket.go:990
-#: lxc/storage_bucket.go:1069 lxc/storage_bucket.go:1192
+#: lxc/storage_bucket.go:894 lxc/storage_bucket.go:991
+#: lxc/storage_bucket.go:1070 lxc/storage_bucket.go:1193
 msgid "Missing key name"
 msgstr ""
 
@@ -4102,13 +4102,13 @@ msgid "Missing peer name"
 msgstr ""
 
 #: lxc/storage.go:235 lxc/storage.go:313 lxc/storage.go:431 lxc/storage.go:509
-#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:112
-#: lxc/storage_bucket.go:212 lxc/storage_bucket.go:288
-#: lxc/storage_bucket.go:407 lxc/storage_bucket.go:482
-#: lxc/storage_bucket.go:564 lxc/storage_bucket.go:656
-#: lxc/storage_bucket.go:798 lxc/storage_bucket.go:885
-#: lxc/storage_bucket.go:982 lxc/storage_bucket.go:1061
-#: lxc/storage_bucket.go:1184 lxc/storage_volume.go:209
+#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:113
+#: lxc/storage_bucket.go:213 lxc/storage_bucket.go:289
+#: lxc/storage_bucket.go:408 lxc/storage_bucket.go:483
+#: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
+#: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
+#: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
 #: lxc/storage_volume.go:323 lxc/storage_volume.go:643
 #: lxc/storage_volume.go:750 lxc/storage_volume.go:841
 #: lxc/storage_volume.go:939 lxc/storage_volume.go:1053
@@ -4123,9 +4123,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:404 lxc/project.go:146 lxc/project.go:226 lxc/project.go:316
-#: lxc/project.go:433 lxc/project.go:622 lxc/project.go:691 lxc/project.go:819
-#: lxc/project.go:948
+#: lxc/profile.go:404 lxc/project.go:147 lxc/project.go:227 lxc/project.go:317
+#: lxc/project.go:434 lxc/project.go:623 lxc/project.go:692 lxc/project.go:820
+#: lxc/project.go:949
 msgid "Missing project name"
 msgstr ""
 
@@ -4141,7 +4141,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:598
+#: lxc/file.go:599
 msgid "Missing target directory"
 msgstr ""
 
@@ -4163,11 +4163,11 @@ msgstr ""
 msgid "Model: %v"
 msgstr ""
 
-#: lxc/monitor.go:32
+#: lxc/monitor.go:33
 msgid "Monitor a local or remote LXD server"
 msgstr ""
 
-#: lxc/monitor.go:33
+#: lxc/monitor.go:34
 msgid ""
 "Monitor a local or remote LXD server\n"
 "\n"
@@ -4179,11 +4179,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:285
+#: lxc/file.go:286
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:985 lxc/file.go:986
+#: lxc/file.go:986 lxc/file.go:987
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4245,13 +4245,13 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:192
+#: lxc/auth.go:376 lxc/auth.go:816 lxc/auth.go:1736 lxc/cluster.go:192
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
-#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:565
-#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:511
-#: lxc/storage_bucket.go:831 lxc/storage_volume.go:1731
+#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:566
+#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1731
 msgid "NAME"
 msgstr ""
 
@@ -4259,11 +4259,11 @@ msgstr ""
 msgid "NAT"
 msgstr ""
 
-#: lxc/project.go:571
+#: lxc/project.go:572
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:570
+#: lxc/project.go:571
 msgid "NETWORKS"
 msgstr ""
 
@@ -4275,9 +4275,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/operation.go:154 lxc/project.go:523
-#: lxc/project.go:528 lxc/project.go:533 lxc/project.go:538 lxc/project.go:543
-#: lxc/project.go:548 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
+#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:524
+#: lxc/project.go:529 lxc/project.go:534 lxc/project.go:539 lxc/project.go:544
+#: lxc/project.go:549 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
 msgid "NO"
 msgstr ""
 
@@ -4522,7 +4522,7 @@ msgstr ""
 msgid "Only managed networks can be modified"
 msgstr ""
 
-#: lxc/operation.go:86
+#: lxc/operation.go:87
 #, c-format
 msgid "Operation %s deleted"
 msgstr ""
@@ -4569,11 +4569,11 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:567
+#: lxc/list.go:576 lxc/project.go:568
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:212
+#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4635,24 +4635,24 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1102
+#: lxc/file.go:1103
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:860
+#: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
-#: lxc/project.go:363 lxc/storage.go:360 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1151
+#: lxc/project.go:364 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1151
 #: lxc/storage_volume.go:1183
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
-#: lxc/monitor.go:48
+#: lxc/monitor.go:49
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
@@ -4738,17 +4738,17 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:172
+#: lxc/project.go:173
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:236
+#: lxc/project.go:237
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:637
+#: lxc/project.go:638
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -4869,20 +4869,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:241 lxc/file.go:242
+#: lxc/file.go:242 lxc/file.go:243
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:416 lxc/file.go:767
+#: lxc/file.go:417 lxc/file.go:768
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:466 lxc/file.go:467
+#: lxc/file.go:467 lxc/file.go:468
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:701 lxc/file.go:867
+#: lxc/file.go:702 lxc/file.go:868
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4895,11 +4895,11 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:983
+#: lxc/project.go:984
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/storage_bucket.go:833
+#: lxc/storage_bucket.go:834
 msgid "ROLE"
 msgstr ""
 
@@ -4912,15 +4912,15 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/rebuild.go:31
+#: lxc/rebuild.go:32
 msgid "Rebuild as an empty instance"
 msgstr ""
 
-#: lxc/rebuild.go:26
+#: lxc/rebuild.go:27
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:249 lxc/file.go:473
+#: lxc/file.go:250 lxc/file.go:474
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4947,7 +4947,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:882 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
+#: lxc/project.go:883 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
 #: lxc/remote.go:994
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4998,7 +4998,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1164 lxc/auth.go:1165
+#: lxc/auth.go:1165 lxc/auth.go:1166
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -5034,7 +5034,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1927 lxc/auth.go:1928
+#: lxc/auth.go:1928 lxc/auth.go:1929
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -5046,7 +5046,7 @@ msgstr ""
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:574 lxc/auth.go:575
+#: lxc/auth.go:575 lxc/auth.go:576
 msgid "Remove permissions from groups"
 msgstr ""
 
@@ -5091,11 +5091,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:391 lxc/auth.go:392
+#: lxc/auth.go:392 lxc/auth.go:393
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1751 lxc/auth.go:1752
+#: lxc/auth.go:1752 lxc/auth.go:1753
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5115,7 +5115,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:589 lxc/project.go:590
+#: lxc/project.go:590 lxc/project.go:591
 msgid "Rename projects"
 msgstr ""
 
@@ -5213,7 +5213,7 @@ msgstr ""
 msgid "Revoke cluster member join token"
 msgstr ""
 
-#: lxc/storage_bucket.go:862
+#: lxc/storage_bucket.go:863
 msgid "Role (admin or read-only)"
 msgstr ""
 
@@ -5229,7 +5229,7 @@ msgstr ""
 msgid "Run against all projects"
 msgstr ""
 
-#: lxc/warning.go:213
+#: lxc/warning.go:214
 msgid "SEVERITY"
 msgstr ""
 
@@ -5249,12 +5249,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1231
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1231
+#: lxc/file.go:1232
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5268,11 +5268,11 @@ msgstr ""
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:173 lxc/warning.go:214
+#: lxc/operation.go:174 lxc/warning.go:215
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:569
+#: lxc/project.go:570
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5280,7 +5280,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:569
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -5288,11 +5288,11 @@ msgstr ""
 msgid "STP"
 msgstr ""
 
-#: lxc/storage_bucket.go:864
+#: lxc/storage_bucket.go:865
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:942
+#: lxc/storage_bucket.go:943
 #, c-format
 msgid "Secret key: %s"
 msgstr ""
@@ -5330,7 +5330,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:995
+#: lxc/file.go:996
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5468,11 +5468,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:654
+#: lxc/project.go:655
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:655
+#: lxc/project.go:656
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5481,11 +5481,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage_bucket.go:534
+#: lxc/storage_bucket.go:535
 msgid "Set storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:535
+#: lxc/storage_bucket.go:536
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -5524,15 +5524,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:476
+#: lxc/file.go:477
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:477
+#: lxc/file.go:478
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:475
+#: lxc/file.go:476
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5572,11 +5572,11 @@ msgstr ""
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 msgid "Set the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:542
+#: lxc/storage_bucket.go:543
 msgid "Set the key as a storage bucket property"
 msgstr ""
 
@@ -5592,7 +5592,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:993
+#: lxc/file.go:994
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5604,7 +5604,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1800 lxc/auth.go:1801
+#: lxc/auth.go:1801 lxc/auth.go:1802
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5620,11 +5620,11 @@ msgstr ""
 msgid "Show details of a cluster member"
 msgstr ""
 
-#: lxc/operation.go:192 lxc/operation.go:193
+#: lxc/operation.go:193 lxc/operation.go:194
 msgid "Show details on a background operation"
 msgstr ""
 
-#: lxc/monitor.go:49
+#: lxc/monitor.go:50
 msgid "Show events from all projects"
 msgstr ""
 
@@ -5632,11 +5632,11 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:440 lxc/auth.go:441
+#: lxc/auth.go:441 lxc/auth.go:442
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:832
+#: lxc/auth.go:833
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5717,15 +5717,15 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:786 lxc/project.go:787
+#: lxc/project.go:787 lxc/project.go:788
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage_bucket.go:628 lxc/storage_bucket.go:629
+#: lxc/storage_bucket.go:629 lxc/storage_bucket.go:630
 msgid "Show storage bucket configurations"
 msgstr ""
 
-#: lxc/storage_bucket.go:1156 lxc/storage_bucket.go:1157
+#: lxc/storage_bucket.go:1157 lxc/storage_bucket.go:1158
 msgid "Show storage bucket key configurations"
 msgstr ""
 
@@ -5741,7 +5741,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:895
+#: lxc/auth.go:896
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5791,7 +5791,7 @@ msgstr ""
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: lxc/warning.go:302 lxc/warning.go:303
+#: lxc/warning.go:303 lxc/warning.go:304
 msgid "Show warning"
 msgstr ""
 
@@ -5875,22 +5875,22 @@ msgstr ""
 msgid "Stopping the instance failed: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:166
+#: lxc/storage_bucket.go:167
 #, c-format
 msgid "Storage bucket %s created"
 msgstr ""
 
-#: lxc/storage_bucket.go:233
+#: lxc/storage_bucket.go:234
 #, c-format
 msgid "Storage bucket %s deleted"
 msgstr ""
 
-#: lxc/storage_bucket.go:940
+#: lxc/storage_bucket.go:941
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr ""
 
-#: lxc/storage_bucket.go:1006
+#: lxc/storage_bucket.go:1007
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr ""
@@ -5959,7 +5959,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:847 lxc/project.go:848
+#: lxc/project.go:848 lxc/project.go:849
 msgid "Switch the current project"
 msgstr ""
 
@@ -5975,10 +5975,10 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1139
+#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1139
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
-#: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:171
-#: lxc/storage_volume.go:1730 lxc/warning.go:215
+#: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
+#: lxc/storage_volume.go:1730 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
@@ -5986,11 +5986,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1032
+#: lxc/file.go:1033
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1026
+#: lxc/file.go:1027
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -6118,12 +6118,12 @@ msgstr ""
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:446
+#: lxc/project.go:447
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
 
-#: lxc/storage_bucket.go:431
+#: lxc/storage_bucket.go:432
 #, c-format
 msgid "The property %q does not exist on the storage bucket %q: %v"
 msgstr ""
@@ -6308,7 +6308,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:961
+#: lxc/project.go:962
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6320,17 +6320,17 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:985 lxc/storage_volume.go:1735
+#: lxc/project.go:986 lxc/storage_volume.go:1735
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:573
+#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:574
 #: lxc/storage.go:724 lxc/storage_volume.go:1734
 msgid "USED BY"
 msgstr ""
 
-#: lxc/warning.go:216
+#: lxc/warning.go:217
 msgid "UUID"
 msgstr ""
 
@@ -6339,7 +6339,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:197
+#: lxc/file.go:198
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6353,13 +6353,13 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1253
+#: lxc/file.go:1254
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1153 lxc/list.go:631 lxc/storage_volume.go:1772
-#: lxc/warning.go:241
+#: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6369,7 +6369,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:807
+#: lxc/file.go:808
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6452,11 +6452,11 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:742 lxc/project.go:743
+#: lxc/project.go:743 lxc/project.go:744
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:697 lxc/storage_bucket.go:698
+#: lxc/storage_bucket.go:698 lxc/storage_bucket.go:699
 msgid "Unset storage bucket configuration keys"
 msgstr ""
 
@@ -6504,11 +6504,11 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:747
+#: lxc/project.go:748
 msgid "Unset the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:701
+#: lxc/storage_bucket.go:702
 msgid "Unset the key as a storage bucket property"
 msgstr ""
 
@@ -6587,7 +6587,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:71
+#: lxc/file.go:72
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6624,11 +6624,11 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:831
+#: lxc/auth.go:832
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:894
+#: lxc/auth.go:895
 msgid "View the current identity"
 msgstr ""
 
@@ -6659,15 +6659,15 @@ msgstr ""
 msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
-#: lxc/rebuild.go:27
+#: lxc/rebuild.go:28
 msgid ""
 "Wipe the instance root disk and re-initialize. The original image is used to "
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:156 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
+#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:526
+#: lxc/project.go:531 lxc/project.go:536 lxc/project.go:541 lxc/project.go:546
+#: lxc/project.go:551 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
 msgid "YES"
 msgstr ""
 
@@ -6687,7 +6687,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/rebuild.go:119
+#: lxc/rebuild.go:120
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
@@ -6699,12 +6699,12 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1689
+#: lxc/auth.go:330 lxc/auth.go:763 lxc/auth.go:894 lxc/auth.go:1690
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
-#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
+#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
-#: lxc/operation.go:103 lxc/profile.go:700 lxc/project.go:467
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:68
+#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:468
+#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6732,7 +6732,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1254
+#: lxc/auth.go:1255
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6793,11 +6793,11 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:830
+#: lxc/auth.go:831
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1926
+#: lxc/auth.go:1106 lxc/auth.go:1164 lxc/auth.go:1927
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6805,13 +6805,13 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:954 lxc/auth.go:1470 lxc/cluster_group.go:168
+#: lxc/auth.go:97 lxc/auth.go:150 lxc/auth.go:200 lxc/auth.go:440
+#: lxc/auth.go:955 lxc/auth.go:1471 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:514 lxc/auth.go:572
+#: lxc/auth.go:515 lxc/auth.go:573
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
@@ -6821,19 +6821,19 @@ msgstr ""
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:389
+#: lxc/auth.go:390
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1521 lxc/auth.go:1571 lxc/auth.go:1799
+#: lxc/auth.go:1522 lxc/auth.go:1572 lxc/auth.go:1800
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1873
+#: lxc/auth.go:1874
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1749
+#: lxc/auth.go:1750
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -6853,7 +6853,7 @@ msgstr ""
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
-#: lxc/rebuild.go:25
+#: lxc/rebuild.go:26
 msgid "[<remote>:]<image> [<remote>:]<instance>"
 msgstr ""
 
@@ -6936,20 +6936,20 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:170
+#: lxc/file.go:171
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:120
+#: lxc/file.go:121
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:240
+#: lxc/file.go:241
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:984
+#: lxc/file.go:985
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7100,12 +7100,12 @@ msgstr ""
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
-#: lxc/operation.go:53 lxc/operation.go:191
+#: lxc/operation.go:54 lxc/operation.go:192
 msgid "[<remote>:]<operation>"
 msgstr ""
 
 #: lxc/storage.go:200 lxc/storage.go:259 lxc/storage.go:473 lxc/storage.go:844
-#: lxc/storage_bucket.go:454
+#: lxc/storage_bucket.go:455
 msgid "[<remote>:]<pool>"
 msgstr ""
 
@@ -7113,22 +7113,22 @@ msgstr ""
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
-#: lxc/storage_bucket.go:185 lxc/storage_bucket.go:247
-#: lxc/storage_bucket.go:627 lxc/storage_bucket.go:769
+#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:248
+#: lxc/storage_bucket.go:628 lxc/storage_bucket.go:770
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
 
-#: lxc/storage_bucket.go:380 lxc/storage_bucket.go:696
-#: lxc/storage_bucket.go:850 lxc/storage_bucket.go:956
-#: lxc/storage_bucket.go:1020 lxc/storage_bucket.go:1155
+#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:697
+#: lxc/storage_bucket.go:851 lxc/storage_bucket.go:957
+#: lxc/storage_bucket.go:1021 lxc/storage_bucket.go:1156
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
 
-#: lxc/storage_bucket.go:533
+#: lxc/storage_bucket.go:534
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_bucket.go:81
+#: lxc/storage_bucket.go:82
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
 
@@ -7243,20 +7243,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:91 lxc/project.go:186 lxc/project.go:258 lxc/project.go:785
-#: lxc/project.go:846 lxc/project.go:913
+#: lxc/project.go:92 lxc/project.go:187 lxc/project.go:259 lxc/project.go:786
+#: lxc/project.go:847 lxc/project.go:914
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:394 lxc/project.go:741
+#: lxc/project.go:395 lxc/project.go:742
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:653
+#: lxc/project.go:654
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:587
+#: lxc/project.go:588
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7264,7 +7264,7 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:259 lxc/warning.go:301 lxc/warning.go:354
+#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
@@ -7320,7 +7320,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:555 lxc/remote.go:739
+#: lxc/project.go:556 lxc/remote.go:739
 msgid "current"
 msgstr ""
 
@@ -7367,20 +7367,20 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/auth.go:203
+#: lxc/auth.go:204
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:958
+#: lxc/auth.go:959
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1575
+#: lxc/auth.go:1576
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7458,20 +7458,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:988
+#: lxc/file.go:989
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:244
+#: lxc/file.go:245
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:470
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7553,7 +7553,7 @@ msgid ""
 "  List instances with their running state and user comment."
 msgstr ""
 
-#: lxc/monitor.go:37
+#: lxc/monitor.go:38
 msgid ""
 "lxc monitor --type=logging\n"
 "    Only show log messages.\n"
@@ -7629,7 +7629,7 @@ msgid ""
 "    Create record r1 for zone z1 with configuration from config.yaml"
 msgstr ""
 
-#: lxc/operation.go:195
+#: lxc/operation.go:196
 msgid ""
 "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Show details on that operation UUID"
@@ -7672,7 +7672,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:95
+#: lxc/project.go:96
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7680,7 +7680,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:262
+#: lxc/project.go:263
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7711,7 +7711,7 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:85
 msgid ""
 "lxc storage bucket create p1 b01\n"
 "\tCreate a new storage bucket name b01 in storage pool p1\n"
@@ -7721,19 +7721,19 @@ msgid ""
 "of config.yaml"
 msgstr ""
 
-#: lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:251
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1023
+#: lxc/storage_bucket.go:1024
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:854
 msgid ""
 "lxc storage bucket key create p1 b01 k1\n"
 "\tCreate a key called k1 for the bucket b01 in the pool p1.\n"
@@ -7743,14 +7743,14 @@ msgid ""
 "of config.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1158
+#: lxc/storage_bucket.go:1159
 msgid ""
 "lxc storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_bucket.go:630
+#: lxc/storage_bucket.go:631
 msgid ""
 "lxc storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
@@ -7820,16 +7820,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1142
+#: lxc/file.go:1143
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1101
+#: lxc/file.go:1102
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1054
+#: lxc/file.go:1055
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/pt.po
+++ b/po/pt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-04 08:52-0600\n"
+"POT-Creation-Date: 2024-09-05 08:44-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: lxc/storage_bucket.go:260 lxc/storage_bucket.go:1033
+#: lxc/storage_bucket.go:261 lxc/storage_bucket.go:1034
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -130,7 +130,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:213
+#: lxc/auth.go:214
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -157,7 +157,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:968
+#: lxc/auth.go:969
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -178,7 +178,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1585
+#: lxc/auth.go:1586
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -388,7 +388,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:280
+#: lxc/project.go:281
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -430,12 +430,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:935
+#: lxc/file.go:936
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:825
+#: lxc/file.go:826
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -471,7 +471,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:142 lxc/rebuild.go:64
+#: lxc/init.go:142 lxc/rebuild.go:65
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -524,7 +524,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:465
+#: lxc/file.go:466
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -557,7 +557,7 @@ msgstr ""
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:813
+#: lxc/auth.go:814
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -565,11 +565,11 @@ msgstr ""
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/storage_bucket.go:863
+#: lxc/storage_bucket.go:864
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:941
+#: lxc/storage_bucket.go:942
 #, c-format
 msgid "Access key: %s"
 msgstr ""
@@ -578,7 +578,7 @@ msgstr ""
 msgid "Access the expanded configuration"
 msgstr ""
 
-#: lxc/warning.go:261 lxc/warning.go:262
+#: lxc/warning.go:262 lxc/warning.go:263
 msgid "Acknowledge warning"
 msgstr ""
 
@@ -595,11 +595,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1106 lxc/auth.go:1107
+#: lxc/auth.go:1107 lxc/auth.go:1108
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1874 lxc/auth.go:1875
+#: lxc/auth.go:1875 lxc/auth.go:1876
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -668,7 +668,7 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:515 lxc/auth.go:516
+#: lxc/auth.go:516 lxc/auth.go:517
 msgid "Add permissions to groups"
 msgstr ""
 
@@ -697,7 +697,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:169
+#: lxc/storage_bucket.go:170
 #, c-format
 msgid "Admin access key: %s"
 msgstr ""
@@ -707,7 +707,7 @@ msgstr ""
 msgid "Admin password (or token) for %s:"
 msgstr ""
 
-#: lxc/storage_bucket.go:170
+#: lxc/storage_bucket.go:171
 #, c-format
 msgid "Admin secret key: %s"
 msgstr ""
@@ -766,7 +766,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:342 lxc/rebuild.go:130
+#: lxc/init.go:342 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -866,12 +866,12 @@ msgstr ""
 
 #: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:318
 #: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
-#: lxc/network_zone.go:366 lxc/network_zone.go:1053 lxc/storage_bucket.go:141
+#: lxc/network_zone.go:366 lxc/network_zone.go:1053 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:159
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:160
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Bytes sent"
 msgstr ""
 
-#: lxc/operation.go:174
+#: lxc/operation.go:175
 msgid "CANCELABLE"
 msgstr ""
 
@@ -923,7 +923,7 @@ msgstr ""
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: lxc/warning.go:209
+#: lxc/warning.go:210
 msgid "COUNT"
 msgstr ""
 
@@ -949,7 +949,7 @@ msgstr ""
 msgid "CPUs (%s):"
 msgstr ""
 
-#: lxc/operation.go:175
+#: lxc/operation.go:176
 msgid "CREATED"
 msgstr ""
 
@@ -979,7 +979,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:340
+#: lxc/file.go:341
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1004,11 +1004,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:224
+#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:546
+#: lxc/file.go:547
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1017,7 +1017,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:160
+#: lxc/rebuild.go:161
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1140,13 +1140,13 @@ msgstr ""
 #: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
 #: lxc/network_load_balancer.go:1051 lxc/network_load_balancer.go:1125
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
-#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:90
-#: lxc/storage_bucket.go:190 lxc/storage_bucket.go:253
-#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:541
-#: lxc/storage_bucket.go:634 lxc/storage_bucket.go:700
-#: lxc/storage_bucket.go:775 lxc/storage_bucket.go:861
-#: lxc/storage_bucket.go:961 lxc/storage_bucket.go:1026
-#: lxc/storage_bucket.go:1162 lxc/storage_volume.go:394
+#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
+#: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
+#: lxc/storage_bucket.go:385 lxc/storage_bucket.go:542
+#: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
+#: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
+#: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
 #: lxc/storage_volume.go:612 lxc/storage_volume.go:717
 #: lxc/storage_volume.go:1005 lxc/storage_volume.go:1231
 #: lxc/storage_volume.go:1360 lxc/storage_volume.go:1848
@@ -1170,7 +1170,7 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1113 lxc/list.go:132 lxc/storage_volume.go:1589
-#: lxc/warning.go:92
+#: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
@@ -1198,7 +1198,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:100
+#: lxc/project.go:101
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1212,8 +1212,8 @@ msgstr ""
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
-#: lxc/project.go:362 lxc/storage.go:359 lxc/storage_bucket.go:348
-#: lxc/storage_bucket.go:1125 lxc/storage_volume.go:1150
+#: lxc/project.go:363 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1150
 #: lxc/storage_volume.go:1182
 #, c-format
 msgid "Config parsing error: %s"
@@ -1340,12 +1340,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:300 lxc/auth.go:1660
+#: lxc/auth.go:301 lxc/auth.go:1661
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1054
+#: lxc/auth.go:1055
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1394,15 +1394,15 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:248 lxc/file.go:474
+#: lxc/file.go:249 lxc/file.go:475
 msgid "Create any directories necessary"
 msgstr ""
 
-#: lxc/auth.go:97 lxc/auth.go:98
+#: lxc/auth.go:98 lxc/auth.go:99
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1471 lxc/auth.go:1472
+#: lxc/auth.go:1472 lxc/auth.go:1473
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1422,11 +1422,11 @@ msgstr ""
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_bucket.go:851 lxc/storage_bucket.go:852
+#: lxc/storage_bucket.go:852 lxc/storage_bucket.go:853
 msgid "Create key for a storage bucket"
 msgstr ""
 
-#: lxc/storage_bucket.go:82 lxc/storage_bucket.go:83
+#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
 msgid "Create new custom storage buckets"
 msgstr ""
 
@@ -1470,7 +1470,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:92 lxc/project.go:93
+#: lxc/project.go:93 lxc/project.go:94
 msgid "Create projects"
 msgstr ""
 
@@ -1505,13 +1505,13 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:376 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1135 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
-#: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:172
-#: lxc/profile.go:756 lxc/project.go:572 lxc/storage.go:723
-#: lxc/storage_bucket.go:512 lxc/storage_bucket.go:832
+#: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
+#: lxc/profile.go:756 lxc/project.go:573 lxc/storage.go:723
+#: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1732
 msgid "DESCRIPTION"
 msgstr ""
@@ -1536,7 +1536,7 @@ msgstr ""
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
-#: lxc/operation.go:55 lxc/operation.go:56
+#: lxc/operation.go:56 lxc/operation.go:57
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
@@ -1544,19 +1544,19 @@ msgstr ""
 msgid "Delete a cluster group"
 msgstr ""
 
-#: lxc/warning.go:360
+#: lxc/warning.go:361
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:122 lxc/file.go:123
+#: lxc/file.go:123 lxc/file.go:124
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/auth.go:151 lxc/auth.go:152
+#: lxc/auth.go:152 lxc/auth.go:153
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1523 lxc/auth.go:1524
+#: lxc/auth.go:1524 lxc/auth.go:1525
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1576,7 +1576,7 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/storage_bucket.go:957 lxc/storage_bucket.go:958
+#: lxc/storage_bucket.go:958 lxc/storage_bucket.go:959
 msgid "Delete key from a storage bucket"
 msgstr ""
 
@@ -1612,11 +1612,11 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:188 lxc/project.go:189
+#: lxc/project.go:189 lxc/project.go:190
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:187 lxc/storage_bucket.go:188
+#: lxc/storage_bucket.go:188 lxc/storage_bucket.go:189
 msgid "Delete storage buckets"
 msgstr ""
 
@@ -1628,20 +1628,20 @@ msgstr ""
 msgid "Delete storage volumes"
 msgstr ""
 
-#: lxc/warning.go:356 lxc/warning.go:357
+#: lxc/warning.go:357 lxc/warning.go:358
 msgid "Delete warning"
 msgstr ""
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:30 lxc/auth.go:59 lxc/auth.go:98
-#: lxc/auth.go:152 lxc/auth.go:201 lxc/auth.go:332 lxc/auth.go:392
-#: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
-#: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
-#: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
-#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1434 lxc/auth.go:1472
-#: lxc/auth.go:1524 lxc/auth.go:1573 lxc/auth.go:1692 lxc/auth.go:1752
-#: lxc/auth.go:1801 lxc/auth.go:1852 lxc/auth.go:1875 lxc/auth.go:1928
+#: lxc/alias.go:214 lxc/auth.go:31 lxc/auth.go:60 lxc/auth.go:99
+#: lxc/auth.go:153 lxc/auth.go:202 lxc/auth.go:333 lxc/auth.go:393
+#: lxc/auth.go:442 lxc/auth.go:494 lxc/auth.go:517 lxc/auth.go:576
+#: lxc/auth.go:732 lxc/auth.go:766 lxc/auth.go:833 lxc/auth.go:896
+#: lxc/auth.go:957 lxc/auth.go:1085 lxc/auth.go:1108 lxc/auth.go:1166
+#: lxc/auth.go:1235 lxc/auth.go:1257 lxc/auth.go:1435 lxc/auth.go:1473
+#: lxc/auth.go:1525 lxc/auth.go:1574 lxc/auth.go:1693 lxc/auth.go:1753
+#: lxc/auth.go:1802 lxc/auth.go:1853 lxc/auth.go:1876 lxc/auth.go:1929
 #: lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215 lxc/cluster.go:272
 #: lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:484 lxc/cluster.go:528
 #: lxc/cluster.go:586 lxc/cluster.go:677 lxc/cluster.go:770 lxc/cluster.go:893
@@ -1665,15 +1665,15 @@ msgstr ""
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:83 lxc/file.go:123 lxc/file.go:172
-#: lxc/file.go:242 lxc/file.go:467 lxc/file.go:986 lxc/image.go:38
+#: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
+#: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
 #: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
 #: lxc/image.go:697 lxc/image.go:946 lxc/image.go:1088 lxc/image.go:1415
 #: lxc/image.go:1506 lxc/image.go:1572 lxc/image.go:1636 lxc/image.go:1699
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:38 lxc/network.go:33
+#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33
 #: lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405
 #: lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793
 #: lxc/network.go:874 lxc/network.go:1005 lxc/network.go:1106
@@ -1707,27 +1707,27 @@ msgstr ""
 #: lxc/network_zone.go:909 lxc/network_zone.go:985 lxc/network_zone.go:1083
 #: lxc/network_zone.go:1172 lxc/network_zone.go:1219 lxc/network_zone.go:1349
 #: lxc/network_zone.go:1410 lxc/network_zone.go:1425 lxc/network_zone.go:1483
-#: lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:106
-#: lxc/operation.go:193 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
+#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
+#: lxc/operation.go:194 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
 #: lxc/profile.go:271 lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493
 #: lxc/profile.go:629 lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860
-#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:29
-#: lxc/project.go:93 lxc/project.go:189 lxc/project.go:260 lxc/project.go:396
-#: lxc/project.go:470 lxc/project.go:590 lxc/project.go:655 lxc/project.go:743
-#: lxc/project.go:787 lxc/project.go:848 lxc/project.go:915 lxc/publish.go:34
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:35 lxc/remote.go:91
+#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:30
+#: lxc/project.go:94 lxc/project.go:190 lxc/project.go:261 lxc/project.go:397
+#: lxc/project.go:471 lxc/project.go:591 lxc/project.go:656 lxc/project.go:744
+#: lxc/project.go:788 lxc/project.go:849 lxc/project.go:916 lxc/publish.go:34
+#: lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91
 #: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853
 #: lxc/remote.go:917 lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24
 #: lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203
 #: lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655
 #: lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940
-#: lxc/storage_bucket.go:29 lxc/storage_bucket.go:83 lxc/storage_bucket.go:188
-#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:382
-#: lxc/storage_bucket.go:458 lxc/storage_bucket.go:535
-#: lxc/storage_bucket.go:629 lxc/storage_bucket.go:698
-#: lxc/storage_bucket.go:732 lxc/storage_bucket.go:773
-#: lxc/storage_bucket.go:852 lxc/storage_bucket.go:958
-#: lxc/storage_bucket.go:1022 lxc/storage_bucket.go:1157
+#: lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189
+#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:383
+#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:536
+#: lxc/storage_bucket.go:630 lxc/storage_bucket.go:699
+#: lxc/storage_bucket.go:733 lxc/storage_bucket.go:774
+#: lxc/storage_bucket.go:853 lxc/storage_bucket.go:959
+#: lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158
 #: lxc/storage_volume.go:58 lxc/storage_volume.go:169 lxc/storage_volume.go:283
 #: lxc/storage_volume.go:390 lxc/storage_volume.go:605
 #: lxc/storage_volume.go:714 lxc/storage_volume.go:801
@@ -1738,8 +1738,8 @@ msgstr ""
 #: lxc/storage_volume.go:2064 lxc/storage_volume.go:2222
 #: lxc/storage_volume.go:2343 lxc/storage_volume.go:2405
 #: lxc/storage_volume.go:2541 lxc/storage_volume.go:2624
-#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:29
-#: lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
+#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:30
+#: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
@@ -1826,7 +1826,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:994
+#: lxc/file.go:995
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1892,7 +1892,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:74
+#: lxc/file.go:75
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1902,7 +1902,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:955 lxc/auth.go:956
+#: lxc/auth.go:956 lxc/auth.go:957
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1910,15 +1910,15 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:171 lxc/file.go:172
+#: lxc/file.go:172 lxc/file.go:173
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/auth.go:200 lxc/auth.go:201
+#: lxc/auth.go:201 lxc/auth.go:202
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1572 lxc/auth.go:1573
+#: lxc/auth.go:1573 lxc/auth.go:1574
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -1974,15 +1974,15 @@ msgstr ""
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:259 lxc/project.go:260
+#: lxc/project.go:260 lxc/project.go:261
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:248 lxc/storage_bucket.go:249
+#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:250
 msgid "Edit storage bucket configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:1021 lxc/storage_bucket.go:1022
+#: lxc/storage_bucket.go:1022 lxc/storage_bucket.go:1023
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
@@ -1999,7 +1999,7 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1147 lxc/list.go:622 lxc/storage_volume.go:1766
-#: lxc/warning.go:235
+#: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2054,7 +2054,7 @@ msgstr ""
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
-#: lxc/project.go:718 lxc/storage.go:812 lxc/storage_bucket.go:602
+#: lxc/project.go:719 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2155 lxc/storage_volume.go:2193
 #, c-format
 msgid "Error setting properties: %v"
@@ -2068,8 +2068,8 @@ msgstr ""
 #: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
-#: lxc/profile.go:981 lxc/project.go:712 lxc/storage.go:806
-#: lxc/storage_bucket.go:596 lxc/storage_volume.go:2149
+#: lxc/profile.go:981 lxc/project.go:713 lxc/storage.go:806
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2149
 #: lxc/storage_volume.go:2187
 #, c-format
 msgid "Error unsetting property: %v"
@@ -2089,7 +2089,7 @@ msgstr ""
 msgid "Evacuating cluster member: %s"
 msgstr ""
 
-#: lxc/monitor.go:50
+#: lxc/monitor.go:51
 msgid "Event type to listen for"
 msgstr ""
 
@@ -2176,16 +2176,16 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/warning.go:210
+#: lxc/warning.go:211
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1237
+#: lxc/file.go:1238
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1260
+#: lxc/file.go:1261
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2200,12 +2200,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1287
+#: lxc/file.go:1288
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1072
+#: lxc/file.go:1073
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2235,7 +2235,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1193
+#: lxc/file.go:1194
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2250,7 +2250,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1198
+#: lxc/file.go:1199
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2260,12 +2260,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1098
+#: lxc/file.go:1099
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1225
+#: lxc/file.go:1226
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2304,7 +2304,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1210
+#: lxc/file.go:1211
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2319,7 +2319,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:820
+#: lxc/file.go:821
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2334,7 +2334,7 @@ msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
 #: lxc/network.go:1044 lxc/network_acl.go:133 lxc/network_zone.go:124
-#: lxc/operation.go:136
+#: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
 
@@ -2399,21 +2399,21 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
+#: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:770 lxc/auth.go:1697
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1114 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:57
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
-#: lxc/operation.go:108 lxc/profile.go:707 lxc/project.go:472
-#: lxc/project.go:917 lxc/remote.go:690 lxc/storage.go:657
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:774
-#: lxc/storage_volume.go:1608 lxc/warning.go:93
+#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:473
+#: lxc/project.go:918 lxc/remote.go:690 lxc/storage.go:657
+#: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
+#: lxc/storage_volume.go:1608 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
-#: lxc/monitor.go:52
+#: lxc/monitor.go:53
 msgid "Format (json|pretty|yaml)"
 msgstr ""
 
@@ -2457,7 +2457,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:817 lxc/auth.go:1736
+#: lxc/auth.go:818 lxc/auth.go:1737
 msgid "GROUPS"
 msgstr ""
 
@@ -2473,7 +2473,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:914 lxc/project.go:915
+#: lxc/project.go:915 lxc/project.go:916
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2521,11 +2521,11 @@ msgstr ""
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:400
+#: lxc/project.go:401
 msgid "Get the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:385
+#: lxc/storage_bucket.go:386
 msgid "Get the key as a storage bucket property"
 msgstr ""
 
@@ -2585,11 +2585,11 @@ msgstr ""
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:395 lxc/project.go:396
+#: lxc/project.go:396 lxc/project.go:397
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:382
+#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:383
 msgid "Get values for storage bucket configuration keys"
 msgstr ""
 
@@ -2606,17 +2606,17 @@ msgstr ""
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: lxc/auth.go:136
+#: lxc/auth.go:137
 #, c-format
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:186
+#: lxc/auth.go:187
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:426 lxc/auth.go:1786
+#: lxc/auth.go:427 lxc/auth.go:1787
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2641,27 +2641,27 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1310
+#: lxc/file.go:1311
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1299
+#: lxc/file.go:1300
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1122
+#: lxc/file.go:1123
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1132
+#: lxc/file.go:1133
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:966 lxc/operation.go:170
+#: lxc/network.go:966 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2675,11 +2675,11 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:816
+#: lxc/auth.go:817
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:566
+#: lxc/project.go:567
 msgid "IMAGES"
 msgstr ""
 
@@ -2707,17 +2707,17 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1508
+#: lxc/auth.go:1509
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1558
+#: lxc/auth.go:1559
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
 
-#: lxc/rebuild.go:32
+#: lxc/rebuild.go:33
 msgid "If an instance is running, stop it and then rebuild it"
 msgstr ""
 
@@ -2838,7 +2838,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1233 lxc/auth.go:1234
+#: lxc/auth.go:1234 lxc/auth.go:1235
 msgid "Inspect permissions"
 msgstr ""
 
@@ -2846,11 +2846,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1124
+#: lxc/file.go:1125
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1301
+#: lxc/file.go:1302
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2868,7 +2868,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1044
+#: lxc/file.go:1045
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2877,7 +2877,7 @@ msgstr ""
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/rebuild.go:74
+#: lxc/rebuild.go:75
 #, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
@@ -2910,7 +2910,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/monitor.go:70
+#: lxc/monitor.go:71
 #, c-format
 msgid "Invalid format: %s"
 msgstr ""
@@ -2920,7 +2920,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1039
+#: lxc/file.go:1040
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2962,7 +2962,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:147
+#: lxc/file.go:148
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2978,12 +2978,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:313
+#: lxc/file.go:314
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:495
+#: lxc/file.go:496
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2997,7 +2997,7 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/warning.go:212
 msgid "LAST SEEN"
 msgstr ""
 
@@ -3005,7 +3005,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:984
+#: lxc/project.go:985
 msgid "LIMIT"
 msgstr ""
 
@@ -3014,8 +3014,8 @@ msgid "LISTEN ADDRESS"
 msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
-#: lxc/network_load_balancer.go:165 lxc/operation.go:177
-#: lxc/storage_bucket.go:516 lxc/storage_volume.go:1739 lxc/warning.go:220
+#: lxc/network_load_balancer.go:165 lxc/operation.go:178
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1739 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3089,7 +3089,7 @@ msgstr ""
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/warning.go:94
+#: lxc/warning.go:95
 msgid "List all warnings"
 msgstr ""
 
@@ -3133,19 +3133,19 @@ msgstr ""
 msgid "List available storage pools"
 msgstr ""
 
-#: lxc/operation.go:105 lxc/operation.go:106
+#: lxc/operation.go:106 lxc/operation.go:107
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:331 lxc/auth.go:332
+#: lxc/auth.go:332 lxc/auth.go:333
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:764 lxc/auth.go:765
+#: lxc/auth.go:765 lxc/auth.go:766
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1691 lxc/auth.go:1692
+#: lxc/auth.go:1692 lxc/auth.go:1693
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3294,11 +3294,11 @@ msgstr ""
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/operation.go:109
+#: lxc/operation.go:110
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1255 lxc/auth.go:1256
+#: lxc/auth.go:1256 lxc/auth.go:1257
 msgid "List permissions"
 msgstr ""
 
@@ -3306,15 +3306,15 @@ msgstr ""
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:469 lxc/project.go:470
+#: lxc/project.go:470 lxc/project.go:471
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:771 lxc/storage_bucket.go:773
+#: lxc/storage_bucket.go:772 lxc/storage_bucket.go:774
 msgid "List storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:456 lxc/storage_bucket.go:458
+#: lxc/storage_bucket.go:457 lxc/storage_bucket.go:459
 msgid "List storage buckets"
 msgstr ""
 
@@ -3350,11 +3350,11 @@ msgstr ""
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/warning.go:70
+#: lxc/warning.go:71
 msgid "List warnings"
 msgstr ""
 
-#: lxc/warning.go:71
+#: lxc/warning.go:72
 msgid ""
 "List warnings\n"
 "\n"
@@ -3377,7 +3377,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/operation.go:23 lxc/operation.go:24
+#: lxc/operation.go:24 lxc/operation.go:25
 msgid "List, show and delete background operations"
 msgstr ""
 
@@ -3386,7 +3386,7 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/monitor.go:79
+#: lxc/monitor.go:80
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
@@ -3490,23 +3490,23 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:82 lxc/file.go:83
+#: lxc/file.go:83 lxc/file.go:84
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1433 lxc/auth.go:1434
+#: lxc/auth.go:59 lxc/auth.go:60 lxc/auth.go:1434 lxc/auth.go:1435
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1083 lxc/auth.go:1084
+#: lxc/auth.go:1084 lxc/auth.go:1085
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:730 lxc/auth.go:731
+#: lxc/auth.go:731 lxc/auth.go:732
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1851 lxc/auth.go:1852
+#: lxc/auth.go:1852 lxc/auth.go:1853
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3597,7 +3597,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:492 lxc/auth.go:493
+#: lxc/auth.go:493 lxc/auth.go:494
 msgid "Manage permissions"
 msgstr ""
 
@@ -3605,23 +3605,23 @@ msgstr ""
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:28 lxc/project.go:29
+#: lxc/project.go:29 lxc/project.go:30
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:731
+#: lxc/storage_bucket.go:732
 msgid "Manage storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:732
+#: lxc/storage_bucket.go:733
 msgid "Manage storage bucket keys."
 msgstr ""
 
-#: lxc/storage_bucket.go:28
+#: lxc/storage_bucket.go:29
 msgid "Manage storage buckets"
 msgstr ""
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:30
 msgid "Manage storage buckets."
 msgstr ""
 
@@ -3649,11 +3649,11 @@ msgstr ""
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/auth.go:29 lxc/auth.go:30
+#: lxc/auth.go:30 lxc/auth.go:31
 msgid "Manage user authorization"
 msgstr ""
 
-#: lxc/warning.go:28 lxc/warning.go:29
+#: lxc/warning.go:29 lxc/warning.go:30
 msgid "Manage warnings"
 msgstr ""
 
@@ -3717,17 +3717,17 @@ msgstr ""
 msgid "Migration operation failure: %w"
 msgstr ""
 
-#: lxc/monitor.go:51
+#: lxc/monitor.go:52
 msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: lxc/storage_bucket.go:116 lxc/storage_bucket.go:216
-#: lxc/storage_bucket.go:292 lxc/storage_bucket.go:411
-#: lxc/storage_bucket.go:568 lxc/storage_bucket.go:660
-#: lxc/storage_bucket.go:802 lxc/storage_bucket.go:889
-#: lxc/storage_bucket.go:986 lxc/storage_bucket.go:1065
-#: lxc/storage_bucket.go:1188
+#: lxc/storage_bucket.go:117 lxc/storage_bucket.go:217
+#: lxc/storage_bucket.go:293 lxc/storage_bucket.go:412
+#: lxc/storage_bucket.go:569 lxc/storage_bucket.go:661
+#: lxc/storage_bucket.go:803 lxc/storage_bucket.go:890
+#: lxc/storage_bucket.go:987 lxc/storage_bucket.go:1066
+#: lxc/storage_bucket.go:1189
 msgid "Missing bucket name"
 msgstr ""
 
@@ -3746,20 +3746,20 @@ msgstr ""
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1825
+#: lxc/auth.go:123 lxc/auth.go:177 lxc/auth.go:255 lxc/auth.go:417
+#: lxc/auth.go:466 lxc/auth.go:541 lxc/auth.go:600 lxc/auth.go:1826
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:862 lxc/auth.go:1003 lxc/auth.go:1131 lxc/auth.go:1189
+#: lxc/auth.go:863 lxc/auth.go:1004 lxc/auth.go:1132 lxc/auth.go:1190
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1495 lxc/auth.go:1548 lxc/auth.go:1614 lxc/auth.go:1776
+#: lxc/auth.go:1496 lxc/auth.go:1549 lxc/auth.go:1615 lxc/auth.go:1777
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1899 lxc/auth.go:1952
+#: lxc/auth.go:1900 lxc/auth.go:1953
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -3767,12 +3767,12 @@ msgstr ""
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
 #: lxc/config_template.go:377 lxc/profile.go:141 lxc/profile.go:222
-#: lxc/profile.go:808 lxc/rebuild.go:60
+#: lxc/profile.go:808 lxc/rebuild.go:61
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/storage_bucket.go:893 lxc/storage_bucket.go:990
-#: lxc/storage_bucket.go:1069 lxc/storage_bucket.go:1192
+#: lxc/storage_bucket.go:894 lxc/storage_bucket.go:991
+#: lxc/storage_bucket.go:1070 lxc/storage_bucket.go:1193
 msgid "Missing key name"
 msgstr ""
 
@@ -3837,13 +3837,13 @@ msgid "Missing peer name"
 msgstr ""
 
 #: lxc/storage.go:235 lxc/storage.go:313 lxc/storage.go:431 lxc/storage.go:509
-#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:112
-#: lxc/storage_bucket.go:212 lxc/storage_bucket.go:288
-#: lxc/storage_bucket.go:407 lxc/storage_bucket.go:482
-#: lxc/storage_bucket.go:564 lxc/storage_bucket.go:656
-#: lxc/storage_bucket.go:798 lxc/storage_bucket.go:885
-#: lxc/storage_bucket.go:982 lxc/storage_bucket.go:1061
-#: lxc/storage_bucket.go:1184 lxc/storage_volume.go:209
+#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:113
+#: lxc/storage_bucket.go:213 lxc/storage_bucket.go:289
+#: lxc/storage_bucket.go:408 lxc/storage_bucket.go:483
+#: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
+#: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
+#: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
 #: lxc/storage_volume.go:323 lxc/storage_volume.go:643
 #: lxc/storage_volume.go:750 lxc/storage_volume.go:841
 #: lxc/storage_volume.go:939 lxc/storage_volume.go:1053
@@ -3858,9 +3858,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:404 lxc/project.go:146 lxc/project.go:226 lxc/project.go:316
-#: lxc/project.go:433 lxc/project.go:622 lxc/project.go:691 lxc/project.go:819
-#: lxc/project.go:948
+#: lxc/profile.go:404 lxc/project.go:147 lxc/project.go:227 lxc/project.go:317
+#: lxc/project.go:434 lxc/project.go:623 lxc/project.go:692 lxc/project.go:820
+#: lxc/project.go:949
 msgid "Missing project name"
 msgstr ""
 
@@ -3876,7 +3876,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:598
+#: lxc/file.go:599
 msgid "Missing target directory"
 msgstr ""
 
@@ -3898,11 +3898,11 @@ msgstr ""
 msgid "Model: %v"
 msgstr ""
 
-#: lxc/monitor.go:32
+#: lxc/monitor.go:33
 msgid "Monitor a local or remote LXD server"
 msgstr ""
 
-#: lxc/monitor.go:33
+#: lxc/monitor.go:34
 msgid ""
 "Monitor a local or remote LXD server\n"
 "\n"
@@ -3914,11 +3914,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:285
+#: lxc/file.go:286
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:985 lxc/file.go:986
+#: lxc/file.go:986 lxc/file.go:987
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3980,13 +3980,13 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:192
+#: lxc/auth.go:376 lxc/auth.go:816 lxc/auth.go:1736 lxc/cluster.go:192
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
-#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:565
-#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:511
-#: lxc/storage_bucket.go:831 lxc/storage_volume.go:1731
+#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:566
+#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1731
 msgid "NAME"
 msgstr ""
 
@@ -3994,11 +3994,11 @@ msgstr ""
 msgid "NAT"
 msgstr ""
 
-#: lxc/project.go:571
+#: lxc/project.go:572
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:570
+#: lxc/project.go:571
 msgid "NETWORKS"
 msgstr ""
 
@@ -4010,9 +4010,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/operation.go:154 lxc/project.go:523
-#: lxc/project.go:528 lxc/project.go:533 lxc/project.go:538 lxc/project.go:543
-#: lxc/project.go:548 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
+#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:524
+#: lxc/project.go:529 lxc/project.go:534 lxc/project.go:539 lxc/project.go:544
+#: lxc/project.go:549 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
 msgid "NO"
 msgstr ""
 
@@ -4257,7 +4257,7 @@ msgstr ""
 msgid "Only managed networks can be modified"
 msgstr ""
 
-#: lxc/operation.go:86
+#: lxc/operation.go:87
 #, c-format
 msgid "Operation %s deleted"
 msgstr ""
@@ -4304,11 +4304,11 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:567
+#: lxc/list.go:576 lxc/project.go:568
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:212
+#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4370,24 +4370,24 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1102
+#: lxc/file.go:1103
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:860
+#: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
-#: lxc/project.go:363 lxc/storage.go:360 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1151
+#: lxc/project.go:364 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1151
 #: lxc/storage_volume.go:1183
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
-#: lxc/monitor.go:48
+#: lxc/monitor.go:49
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
@@ -4473,17 +4473,17 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:172
+#: lxc/project.go:173
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:236
+#: lxc/project.go:237
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:637
+#: lxc/project.go:638
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -4604,20 +4604,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:241 lxc/file.go:242
+#: lxc/file.go:242 lxc/file.go:243
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:416 lxc/file.go:767
+#: lxc/file.go:417 lxc/file.go:768
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:466 lxc/file.go:467
+#: lxc/file.go:467 lxc/file.go:468
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:701 lxc/file.go:867
+#: lxc/file.go:702 lxc/file.go:868
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4630,11 +4630,11 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:983
+#: lxc/project.go:984
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/storage_bucket.go:833
+#: lxc/storage_bucket.go:834
 msgid "ROLE"
 msgstr ""
 
@@ -4647,15 +4647,15 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/rebuild.go:31
+#: lxc/rebuild.go:32
 msgid "Rebuild as an empty instance"
 msgstr ""
 
-#: lxc/rebuild.go:26
+#: lxc/rebuild.go:27
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:249 lxc/file.go:473
+#: lxc/file.go:250 lxc/file.go:474
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4682,7 +4682,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:882 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
+#: lxc/project.go:883 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
 #: lxc/remote.go:994
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4733,7 +4733,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1164 lxc/auth.go:1165
+#: lxc/auth.go:1165 lxc/auth.go:1166
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4769,7 +4769,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1927 lxc/auth.go:1928
+#: lxc/auth.go:1928 lxc/auth.go:1929
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4781,7 +4781,7 @@ msgstr ""
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:574 lxc/auth.go:575
+#: lxc/auth.go:575 lxc/auth.go:576
 msgid "Remove permissions from groups"
 msgstr ""
 
@@ -4826,11 +4826,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:391 lxc/auth.go:392
+#: lxc/auth.go:392 lxc/auth.go:393
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1751 lxc/auth.go:1752
+#: lxc/auth.go:1752 lxc/auth.go:1753
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -4850,7 +4850,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:589 lxc/project.go:590
+#: lxc/project.go:590 lxc/project.go:591
 msgid "Rename projects"
 msgstr ""
 
@@ -4948,7 +4948,7 @@ msgstr ""
 msgid "Revoke cluster member join token"
 msgstr ""
 
-#: lxc/storage_bucket.go:862
+#: lxc/storage_bucket.go:863
 msgid "Role (admin or read-only)"
 msgstr ""
 
@@ -4964,7 +4964,7 @@ msgstr ""
 msgid "Run against all projects"
 msgstr ""
 
-#: lxc/warning.go:213
+#: lxc/warning.go:214
 msgid "SEVERITY"
 msgstr ""
 
@@ -4984,12 +4984,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1231
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1231
+#: lxc/file.go:1232
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5003,11 +5003,11 @@ msgstr ""
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:173 lxc/warning.go:214
+#: lxc/operation.go:174 lxc/warning.go:215
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:569
+#: lxc/project.go:570
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5015,7 +5015,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:569
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -5023,11 +5023,11 @@ msgstr ""
 msgid "STP"
 msgstr ""
 
-#: lxc/storage_bucket.go:864
+#: lxc/storage_bucket.go:865
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:942
+#: lxc/storage_bucket.go:943
 #, c-format
 msgid "Secret key: %s"
 msgstr ""
@@ -5065,7 +5065,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:995
+#: lxc/file.go:996
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5203,11 +5203,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:654
+#: lxc/project.go:655
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:655
+#: lxc/project.go:656
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5216,11 +5216,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage_bucket.go:534
+#: lxc/storage_bucket.go:535
 msgid "Set storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:535
+#: lxc/storage_bucket.go:536
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -5259,15 +5259,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:476
+#: lxc/file.go:477
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:477
+#: lxc/file.go:478
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:475
+#: lxc/file.go:476
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5307,11 +5307,11 @@ msgstr ""
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 msgid "Set the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:542
+#: lxc/storage_bucket.go:543
 msgid "Set the key as a storage bucket property"
 msgstr ""
 
@@ -5327,7 +5327,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:993
+#: lxc/file.go:994
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5339,7 +5339,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1800 lxc/auth.go:1801
+#: lxc/auth.go:1801 lxc/auth.go:1802
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5355,11 +5355,11 @@ msgstr ""
 msgid "Show details of a cluster member"
 msgstr ""
 
-#: lxc/operation.go:192 lxc/operation.go:193
+#: lxc/operation.go:193 lxc/operation.go:194
 msgid "Show details on a background operation"
 msgstr ""
 
-#: lxc/monitor.go:49
+#: lxc/monitor.go:50
 msgid "Show events from all projects"
 msgstr ""
 
@@ -5367,11 +5367,11 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:440 lxc/auth.go:441
+#: lxc/auth.go:441 lxc/auth.go:442
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:832
+#: lxc/auth.go:833
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5452,15 +5452,15 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:786 lxc/project.go:787
+#: lxc/project.go:787 lxc/project.go:788
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage_bucket.go:628 lxc/storage_bucket.go:629
+#: lxc/storage_bucket.go:629 lxc/storage_bucket.go:630
 msgid "Show storage bucket configurations"
 msgstr ""
 
-#: lxc/storage_bucket.go:1156 lxc/storage_bucket.go:1157
+#: lxc/storage_bucket.go:1157 lxc/storage_bucket.go:1158
 msgid "Show storage bucket key configurations"
 msgstr ""
 
@@ -5476,7 +5476,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:895
+#: lxc/auth.go:896
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5526,7 +5526,7 @@ msgstr ""
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: lxc/warning.go:302 lxc/warning.go:303
+#: lxc/warning.go:303 lxc/warning.go:304
 msgid "Show warning"
 msgstr ""
 
@@ -5610,22 +5610,22 @@ msgstr ""
 msgid "Stopping the instance failed: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:166
+#: lxc/storage_bucket.go:167
 #, c-format
 msgid "Storage bucket %s created"
 msgstr ""
 
-#: lxc/storage_bucket.go:233
+#: lxc/storage_bucket.go:234
 #, c-format
 msgid "Storage bucket %s deleted"
 msgstr ""
 
-#: lxc/storage_bucket.go:940
+#: lxc/storage_bucket.go:941
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr ""
 
-#: lxc/storage_bucket.go:1006
+#: lxc/storage_bucket.go:1007
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr ""
@@ -5694,7 +5694,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:847 lxc/project.go:848
+#: lxc/project.go:848 lxc/project.go:849
 msgid "Switch the current project"
 msgstr ""
 
@@ -5710,10 +5710,10 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1139
+#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1139
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
-#: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:171
-#: lxc/storage_volume.go:1730 lxc/warning.go:215
+#: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
+#: lxc/storage_volume.go:1730 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
@@ -5721,11 +5721,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1032
+#: lxc/file.go:1033
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1026
+#: lxc/file.go:1027
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5853,12 +5853,12 @@ msgstr ""
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:446
+#: lxc/project.go:447
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
 
-#: lxc/storage_bucket.go:431
+#: lxc/storage_bucket.go:432
 #, c-format
 msgid "The property %q does not exist on the storage bucket %q: %v"
 msgstr ""
@@ -6043,7 +6043,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:961
+#: lxc/project.go:962
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6055,17 +6055,17 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:985 lxc/storage_volume.go:1735
+#: lxc/project.go:986 lxc/storage_volume.go:1735
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:573
+#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:574
 #: lxc/storage.go:724 lxc/storage_volume.go:1734
 msgid "USED BY"
 msgstr ""
 
-#: lxc/warning.go:216
+#: lxc/warning.go:217
 msgid "UUID"
 msgstr ""
 
@@ -6074,7 +6074,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:197
+#: lxc/file.go:198
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6088,13 +6088,13 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1253
+#: lxc/file.go:1254
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1153 lxc/list.go:631 lxc/storage_volume.go:1772
-#: lxc/warning.go:241
+#: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6104,7 +6104,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:807
+#: lxc/file.go:808
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6187,11 +6187,11 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:742 lxc/project.go:743
+#: lxc/project.go:743 lxc/project.go:744
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:697 lxc/storage_bucket.go:698
+#: lxc/storage_bucket.go:698 lxc/storage_bucket.go:699
 msgid "Unset storage bucket configuration keys"
 msgstr ""
 
@@ -6239,11 +6239,11 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:747
+#: lxc/project.go:748
 msgid "Unset the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:701
+#: lxc/storage_bucket.go:702
 msgid "Unset the key as a storage bucket property"
 msgstr ""
 
@@ -6322,7 +6322,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:71
+#: lxc/file.go:72
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6359,11 +6359,11 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:831
+#: lxc/auth.go:832
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:894
+#: lxc/auth.go:895
 msgid "View the current identity"
 msgstr ""
 
@@ -6394,15 +6394,15 @@ msgstr ""
 msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
-#: lxc/rebuild.go:27
+#: lxc/rebuild.go:28
 msgid ""
 "Wipe the instance root disk and re-initialize. The original image is used to "
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:156 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
+#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:526
+#: lxc/project.go:531 lxc/project.go:536 lxc/project.go:541 lxc/project.go:546
+#: lxc/project.go:551 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
 msgid "YES"
 msgstr ""
 
@@ -6422,7 +6422,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/rebuild.go:119
+#: lxc/rebuild.go:120
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
@@ -6434,12 +6434,12 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1689
+#: lxc/auth.go:330 lxc/auth.go:763 lxc/auth.go:894 lxc/auth.go:1690
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
-#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
+#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
-#: lxc/operation.go:103 lxc/profile.go:700 lxc/project.go:467
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:68
+#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:468
+#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6467,7 +6467,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1254
+#: lxc/auth.go:1255
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6528,11 +6528,11 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:830
+#: lxc/auth.go:831
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1926
+#: lxc/auth.go:1106 lxc/auth.go:1164 lxc/auth.go:1927
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6540,13 +6540,13 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:954 lxc/auth.go:1470 lxc/cluster_group.go:168
+#: lxc/auth.go:97 lxc/auth.go:150 lxc/auth.go:200 lxc/auth.go:440
+#: lxc/auth.go:955 lxc/auth.go:1471 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:514 lxc/auth.go:572
+#: lxc/auth.go:515 lxc/auth.go:573
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
@@ -6556,19 +6556,19 @@ msgstr ""
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:389
+#: lxc/auth.go:390
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1521 lxc/auth.go:1571 lxc/auth.go:1799
+#: lxc/auth.go:1522 lxc/auth.go:1572 lxc/auth.go:1800
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1873
+#: lxc/auth.go:1874
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1749
+#: lxc/auth.go:1750
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -6588,7 +6588,7 @@ msgstr ""
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
-#: lxc/rebuild.go:25
+#: lxc/rebuild.go:26
 msgid "[<remote>:]<image> [<remote>:]<instance>"
 msgstr ""
 
@@ -6671,20 +6671,20 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:170
+#: lxc/file.go:171
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:120
+#: lxc/file.go:121
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:240
+#: lxc/file.go:241
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:984
+#: lxc/file.go:985
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6835,12 +6835,12 @@ msgstr ""
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
-#: lxc/operation.go:53 lxc/operation.go:191
+#: lxc/operation.go:54 lxc/operation.go:192
 msgid "[<remote>:]<operation>"
 msgstr ""
 
 #: lxc/storage.go:200 lxc/storage.go:259 lxc/storage.go:473 lxc/storage.go:844
-#: lxc/storage_bucket.go:454
+#: lxc/storage_bucket.go:455
 msgid "[<remote>:]<pool>"
 msgstr ""
 
@@ -6848,22 +6848,22 @@ msgstr ""
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
-#: lxc/storage_bucket.go:185 lxc/storage_bucket.go:247
-#: lxc/storage_bucket.go:627 lxc/storage_bucket.go:769
+#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:248
+#: lxc/storage_bucket.go:628 lxc/storage_bucket.go:770
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
 
-#: lxc/storage_bucket.go:380 lxc/storage_bucket.go:696
-#: lxc/storage_bucket.go:850 lxc/storage_bucket.go:956
-#: lxc/storage_bucket.go:1020 lxc/storage_bucket.go:1155
+#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:697
+#: lxc/storage_bucket.go:851 lxc/storage_bucket.go:957
+#: lxc/storage_bucket.go:1021 lxc/storage_bucket.go:1156
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
 
-#: lxc/storage_bucket.go:533
+#: lxc/storage_bucket.go:534
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_bucket.go:81
+#: lxc/storage_bucket.go:82
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
 
@@ -6978,20 +6978,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:91 lxc/project.go:186 lxc/project.go:258 lxc/project.go:785
-#: lxc/project.go:846 lxc/project.go:913
+#: lxc/project.go:92 lxc/project.go:187 lxc/project.go:259 lxc/project.go:786
+#: lxc/project.go:847 lxc/project.go:914
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:394 lxc/project.go:741
+#: lxc/project.go:395 lxc/project.go:742
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:653
+#: lxc/project.go:654
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:587
+#: lxc/project.go:588
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -6999,7 +6999,7 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:259 lxc/warning.go:301 lxc/warning.go:354
+#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
@@ -7055,7 +7055,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:555 lxc/remote.go:739
+#: lxc/project.go:556 lxc/remote.go:739
 msgid "current"
 msgstr ""
 
@@ -7102,20 +7102,20 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/auth.go:203
+#: lxc/auth.go:204
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:958
+#: lxc/auth.go:959
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1575
+#: lxc/auth.go:1576
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7193,20 +7193,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:988
+#: lxc/file.go:989
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:244
+#: lxc/file.go:245
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:470
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7288,7 +7288,7 @@ msgid ""
 "  List instances with their running state and user comment."
 msgstr ""
 
-#: lxc/monitor.go:37
+#: lxc/monitor.go:38
 msgid ""
 "lxc monitor --type=logging\n"
 "    Only show log messages.\n"
@@ -7364,7 +7364,7 @@ msgid ""
 "    Create record r1 for zone z1 with configuration from config.yaml"
 msgstr ""
 
-#: lxc/operation.go:195
+#: lxc/operation.go:196
 msgid ""
 "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Show details on that operation UUID"
@@ -7407,7 +7407,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:95
+#: lxc/project.go:96
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7415,7 +7415,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:262
+#: lxc/project.go:263
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7446,7 +7446,7 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:85
 msgid ""
 "lxc storage bucket create p1 b01\n"
 "\tCreate a new storage bucket name b01 in storage pool p1\n"
@@ -7456,19 +7456,19 @@ msgid ""
 "of config.yaml"
 msgstr ""
 
-#: lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:251
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1023
+#: lxc/storage_bucket.go:1024
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:854
 msgid ""
 "lxc storage bucket key create p1 b01 k1\n"
 "\tCreate a key called k1 for the bucket b01 in the pool p1.\n"
@@ -7478,14 +7478,14 @@ msgid ""
 "of config.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1158
+#: lxc/storage_bucket.go:1159
 msgid ""
 "lxc storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_bucket.go:630
+#: lxc/storage_bucket.go:631
 msgid ""
 "lxc storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
@@ -7555,16 +7555,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1142
+#: lxc/file.go:1143
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1101
+#: lxc/file.go:1102
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1054
+#: lxc/file.go:1055
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-04 08:52-0600\n"
+"POT-Creation-Date: 2024-09-05 08:44-0400\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Renato dos Santos <renato.santos@wplex.com.br>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: lxc/storage_bucket.go:260 lxc/storage_bucket.go:1033
+#: lxc/storage_bucket.go:261 lxc/storage_bucket.go:1034
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
@@ -204,7 +204,7 @@ msgstr ""
 "###\n"
 "### Observe que o nome é exibido mas não pode ser modificado"
 
-#: lxc/auth.go:213
+#: lxc/auth.go:214
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -231,7 +231,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:968
+#: lxc/auth.go:969
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -252,7 +252,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1585
+#: lxc/auth.go:1586
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
@@ -622,7 +622,7 @@ msgstr ""
 "###\n"
 "### Note que o nome é exibido, porém não pode ser alterado"
 
-#: lxc/project.go:280
+#: lxc/project.go:281
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the project.\n"
@@ -681,12 +681,12 @@ msgstr "%s (%d mais)"
 msgid "%s (%s) (%d available)"
 msgstr "%s (%d mais)"
 
-#: lxc/file.go:935
+#: lxc/file.go:936
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s não é um diretório"
 
-#: lxc/file.go:825
+#: lxc/file.go:826
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' não é um tipo de arquivo suportado"
@@ -725,7 +725,7 @@ msgstr "--refresh só pode ser usado com containers"
 msgid "--console only works with a single instance"
 msgstr "Configuração chave/valor para aplicar ao novo contêiner"
 
-#: lxc/init.go:142 lxc/rebuild.go:64
+#: lxc/init.go:142 lxc/rebuild.go:65
 #, fuzzy
 msgid "--empty cannot be combined with an image name"
 msgstr "--refresh só pode ser usado com containers"
@@ -785,7 +785,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:465
+#: lxc/file.go:466
 #, fuzzy
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr "Editar templates de arquivo do container"
@@ -819,7 +819,7 @@ msgstr "ARQUITETURA"
 msgid "AUTH TYPE"
 msgstr "TIPO DE AUTENTICAÇÃO"
 
-#: lxc/auth.go:813
+#: lxc/auth.go:814
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -827,11 +827,11 @@ msgstr ""
 msgid "Accept certificate"
 msgstr "Aceitar certificado"
 
-#: lxc/storage_bucket.go:863
+#: lxc/storage_bucket.go:864
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:941
+#: lxc/storage_bucket.go:942
 #, c-format
 msgid "Access key: %s"
 msgstr ""
@@ -841,7 +841,7 @@ msgstr ""
 msgid "Access the expanded configuration"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/warning.go:261 lxc/warning.go:262
+#: lxc/warning.go:262 lxc/warning.go:263
 msgid "Acknowledge warning"
 msgstr ""
 
@@ -859,11 +859,11 @@ msgstr "Ação (padrão para o GET)"
 msgid "Add a cluster member to a cluster group"
 msgstr "Nome de membro do cluster"
 
-#: lxc/auth.go:1106 lxc/auth.go:1107
+#: lxc/auth.go:1107 lxc/auth.go:1108
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1874 lxc/auth.go:1875
+#: lxc/auth.go:1875 lxc/auth.go:1876
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:515 lxc/auth.go:516
+#: lxc/auth.go:516 lxc/auth.go:517
 msgid "Add permissions to groups"
 msgstr ""
 
@@ -967,7 +967,7 @@ msgstr "Adicionar perfis aos containers"
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:169
+#: lxc/storage_bucket.go:170
 #, fuzzy, c-format
 msgid "Admin access key: %s"
 msgstr "Senha de administrador para %s: "
@@ -977,7 +977,7 @@ msgstr "Senha de administrador para %s: "
 msgid "Admin password (or token) for %s:"
 msgstr "Senha de administrador para %s: "
 
-#: lxc/storage_bucket.go:170
+#: lxc/storage_bucket.go:171
 #, fuzzy, c-format
 msgid "Admin secret key: %s"
 msgstr "Criado: %s"
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:342 lxc/rebuild.go:130
+#: lxc/init.go:342 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -1145,12 +1145,12 @@ msgstr "Erro de sintaxe, esperado <dispositivo>,<chave>=<valor>: %s"
 
 #: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:318
 #: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
-#: lxc/network_zone.go:366 lxc/network_zone.go:1053 lxc/storage_bucket.go:141
+#: lxc/network_zone.go:366 lxc/network_zone.go:1053 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr "par de chave/valor inválido %s"
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:159
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:160
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "par de chave=valor inválido %s"
@@ -1190,7 +1190,7 @@ msgstr "Bytes recebido"
 msgid "Bytes sent"
 msgstr "Bytes enviado"
 
-#: lxc/operation.go:174
+#: lxc/operation.go:175
 msgid "CANCELABLE"
 msgstr "CANCELÁVEL"
 
@@ -1202,7 +1202,7 @@ msgstr "NOME COMUM"
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: lxc/warning.go:209
+#: lxc/warning.go:210
 msgid "COUNT"
 msgstr ""
 
@@ -1228,7 +1228,7 @@ msgstr "Utilização do CPU:"
 msgid "CPUs (%s):"
 msgstr "CPUs:"
 
-#: lxc/operation.go:175
+#: lxc/operation.go:176
 msgid "CREATED"
 msgstr "CRIADO"
 
@@ -1259,7 +1259,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr "Não pode fornecer um nome para a imagem de destino"
 
-#: lxc/file.go:340
+#: lxc/file.go:341
 msgid "Can't pull a directory without --recursive"
 msgstr "Não pode pegar um diretório sem --recursive"
 
@@ -1285,11 +1285,11 @@ msgstr "Não é possível especificar --fast com --columns"
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:224
+#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr "Não pode especificar a coluna L, quando não em cluster"
 
-#: lxc/file.go:546
+#: lxc/file.go:547
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr "Não é possível fornecer o uid/gid/modo no modo recursivo"
 
@@ -1298,7 +1298,7 @@ msgstr "Não é possível fornecer o uid/gid/modo no modo recursivo"
 msgid "Can't unset key '%s', it's not currently set"
 msgstr "Não é possível remover chave '%s', não está atualmente definido"
 
-#: lxc/rebuild.go:160
+#: lxc/rebuild.go:161
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1423,13 +1423,13 @@ msgstr "Dispositivo %s removido de %s"
 #: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
 #: lxc/network_load_balancer.go:1051 lxc/network_load_balancer.go:1125
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
-#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:90
-#: lxc/storage_bucket.go:190 lxc/storage_bucket.go:253
-#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:541
-#: lxc/storage_bucket.go:634 lxc/storage_bucket.go:700
-#: lxc/storage_bucket.go:775 lxc/storage_bucket.go:861
-#: lxc/storage_bucket.go:961 lxc/storage_bucket.go:1026
-#: lxc/storage_bucket.go:1162 lxc/storage_volume.go:394
+#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
+#: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
+#: lxc/storage_bucket.go:385 lxc/storage_bucket.go:542
+#: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
+#: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
+#: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
 #: lxc/storage_volume.go:612 lxc/storage_volume.go:717
 #: lxc/storage_volume.go:1005 lxc/storage_volume.go:1231
 #: lxc/storage_volume.go:1360 lxc/storage_volume.go:1848
@@ -1453,7 +1453,7 @@ msgid "Clustering enabled"
 msgstr "Clustering ativado"
 
 #: lxc/image.go:1113 lxc/list.go:132 lxc/storage_volume.go:1589
-#: lxc/warning.go:92
+#: lxc/warning.go:93
 msgid "Columns"
 msgstr "Colunas"
 
@@ -1489,7 +1489,7 @@ msgstr "Definir um algoritmo de compressão: para imagem ou nenhum"
 msgid "Config key/value to apply to the new instance"
 msgstr "Configuração chave/valor para aplicar ao novo contêiner"
 
-#: lxc/project.go:100
+#: lxc/project.go:101
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1504,8 +1504,8 @@ msgstr "Configuração chave/valor para aplicar ao novo contêiner"
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
-#: lxc/project.go:362 lxc/storage.go:359 lxc/storage_bucket.go:348
-#: lxc/storage_bucket.go:1125 lxc/storage_volume.go:1150
+#: lxc/project.go:363 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1150
 #: lxc/storage_volume.go:1182
 #, c-format
 msgid "Config parsing error: %s"
@@ -1634,12 +1634,12 @@ msgstr "Certificado fingerprint: %s"
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:300 lxc/auth.go:1660
+#: lxc/auth.go:301 lxc/auth.go:1661
 #, fuzzy, c-format
 msgid "Could not parse group: %s"
 msgstr "Erro de análise de configuração: %s"
 
-#: lxc/auth.go:1054
+#: lxc/auth.go:1055
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1689,16 +1689,16 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:248 lxc/file.go:474
+#: lxc/file.go:249 lxc/file.go:475
 msgid "Create any directories necessary"
 msgstr ""
 
-#: lxc/auth.go:97 lxc/auth.go:98
+#: lxc/auth.go:98 lxc/auth.go:99
 #, fuzzy
 msgid "Create groups"
 msgstr "Criar perfis"
 
-#: lxc/auth.go:1471 lxc/auth.go:1472
+#: lxc/auth.go:1472 lxc/auth.go:1473
 #, fuzzy
 msgid "Create identity provider groups"
 msgstr "Criar novas redes"
@@ -1724,11 +1724,11 @@ msgstr ""
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_bucket.go:851 lxc/storage_bucket.go:852
+#: lxc/storage_bucket.go:852 lxc/storage_bucket.go:853
 msgid "Create key for a storage bucket"
 msgstr ""
 
-#: lxc/storage_bucket.go:82 lxc/storage_bucket.go:83
+#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
 #, fuzzy
 msgid "Create new custom storage buckets"
 msgstr "Criar novas redes"
@@ -1780,7 +1780,7 @@ msgstr "Criar novas redes"
 msgid "Create profiles"
 msgstr "Criar perfis"
 
-#: lxc/project.go:92 lxc/project.go:93
+#: lxc/project.go:93 lxc/project.go:94
 msgid "Create projects"
 msgstr "Criar projetos"
 
@@ -1816,13 +1816,13 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:376 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1135 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
-#: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:172
-#: lxc/profile.go:756 lxc/project.go:572 lxc/storage.go:723
-#: lxc/storage_bucket.go:512 lxc/storage_bucket.go:832
+#: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
+#: lxc/profile.go:756 lxc/project.go:573 lxc/storage.go:723
+#: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1732
 msgid "DESCRIPTION"
 msgstr ""
@@ -1848,7 +1848,7 @@ msgstr ""
 msgid "Define a compression algorithm: for backup or none"
 msgstr "Definir um algoritmo de compressão: para imagem ou nenhum"
 
-#: lxc/operation.go:55 lxc/operation.go:56
+#: lxc/operation.go:56 lxc/operation.go:57
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
@@ -1856,22 +1856,22 @@ msgstr ""
 msgid "Delete a cluster group"
 msgstr ""
 
-#: lxc/warning.go:360
+#: lxc/warning.go:361
 #, fuzzy
 msgid "Delete all warnings"
 msgstr "Apagar nomes alternativos da imagem"
 
-#: lxc/file.go:122 lxc/file.go:123
+#: lxc/file.go:123 lxc/file.go:124
 #, fuzzy
 msgid "Delete files in instances"
 msgstr "Editar arquivos no container"
 
-#: lxc/auth.go:151 lxc/auth.go:152
+#: lxc/auth.go:152 lxc/auth.go:153
 #, fuzzy
 msgid "Delete groups"
 msgstr "Apagar projetos"
 
-#: lxc/auth.go:1523 lxc/auth.go:1524
+#: lxc/auth.go:1524 lxc/auth.go:1525
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1893,7 +1893,7 @@ msgstr "Editar templates de arquivo do container"
 msgid "Delete instances and snapshots"
 msgstr "Apagar nomes alternativos da imagem"
 
-#: lxc/storage_bucket.go:957 lxc/storage_bucket.go:958
+#: lxc/storage_bucket.go:958 lxc/storage_bucket.go:959
 msgid "Delete key from a storage bucket"
 msgstr ""
 
@@ -1935,11 +1935,11 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:188 lxc/project.go:189
+#: lxc/project.go:189 lxc/project.go:190
 msgid "Delete projects"
 msgstr "Apagar projetos"
 
-#: lxc/storage_bucket.go:187 lxc/storage_bucket.go:188
+#: lxc/storage_bucket.go:188 lxc/storage_bucket.go:189
 #, fuzzy
 msgid "Delete storage buckets"
 msgstr "Apagar projetos"
@@ -1952,20 +1952,20 @@ msgstr ""
 msgid "Delete storage volumes"
 msgstr ""
 
-#: lxc/warning.go:356 lxc/warning.go:357
+#: lxc/warning.go:357 lxc/warning.go:358
 msgid "Delete warning"
 msgstr ""
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:30 lxc/auth.go:59 lxc/auth.go:98
-#: lxc/auth.go:152 lxc/auth.go:201 lxc/auth.go:332 lxc/auth.go:392
-#: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
-#: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
-#: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
-#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1434 lxc/auth.go:1472
-#: lxc/auth.go:1524 lxc/auth.go:1573 lxc/auth.go:1692 lxc/auth.go:1752
-#: lxc/auth.go:1801 lxc/auth.go:1852 lxc/auth.go:1875 lxc/auth.go:1928
+#: lxc/alias.go:214 lxc/auth.go:31 lxc/auth.go:60 lxc/auth.go:99
+#: lxc/auth.go:153 lxc/auth.go:202 lxc/auth.go:333 lxc/auth.go:393
+#: lxc/auth.go:442 lxc/auth.go:494 lxc/auth.go:517 lxc/auth.go:576
+#: lxc/auth.go:732 lxc/auth.go:766 lxc/auth.go:833 lxc/auth.go:896
+#: lxc/auth.go:957 lxc/auth.go:1085 lxc/auth.go:1108 lxc/auth.go:1166
+#: lxc/auth.go:1235 lxc/auth.go:1257 lxc/auth.go:1435 lxc/auth.go:1473
+#: lxc/auth.go:1525 lxc/auth.go:1574 lxc/auth.go:1693 lxc/auth.go:1753
+#: lxc/auth.go:1802 lxc/auth.go:1853 lxc/auth.go:1876 lxc/auth.go:1929
 #: lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215 lxc/cluster.go:272
 #: lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:484 lxc/cluster.go:528
 #: lxc/cluster.go:586 lxc/cluster.go:677 lxc/cluster.go:770 lxc/cluster.go:893
@@ -1989,15 +1989,15 @@ msgstr ""
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:83 lxc/file.go:123 lxc/file.go:172
-#: lxc/file.go:242 lxc/file.go:467 lxc/file.go:986 lxc/image.go:38
+#: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
+#: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
 #: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
 #: lxc/image.go:697 lxc/image.go:946 lxc/image.go:1088 lxc/image.go:1415
 #: lxc/image.go:1506 lxc/image.go:1572 lxc/image.go:1636 lxc/image.go:1699
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:38 lxc/network.go:33
+#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33
 #: lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405
 #: lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793
 #: lxc/network.go:874 lxc/network.go:1005 lxc/network.go:1106
@@ -2031,27 +2031,27 @@ msgstr ""
 #: lxc/network_zone.go:909 lxc/network_zone.go:985 lxc/network_zone.go:1083
 #: lxc/network_zone.go:1172 lxc/network_zone.go:1219 lxc/network_zone.go:1349
 #: lxc/network_zone.go:1410 lxc/network_zone.go:1425 lxc/network_zone.go:1483
-#: lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:106
-#: lxc/operation.go:193 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
+#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
+#: lxc/operation.go:194 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
 #: lxc/profile.go:271 lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493
 #: lxc/profile.go:629 lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860
-#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:29
-#: lxc/project.go:93 lxc/project.go:189 lxc/project.go:260 lxc/project.go:396
-#: lxc/project.go:470 lxc/project.go:590 lxc/project.go:655 lxc/project.go:743
-#: lxc/project.go:787 lxc/project.go:848 lxc/project.go:915 lxc/publish.go:34
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:35 lxc/remote.go:91
+#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:30
+#: lxc/project.go:94 lxc/project.go:190 lxc/project.go:261 lxc/project.go:397
+#: lxc/project.go:471 lxc/project.go:591 lxc/project.go:656 lxc/project.go:744
+#: lxc/project.go:788 lxc/project.go:849 lxc/project.go:916 lxc/publish.go:34
+#: lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91
 #: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853
 #: lxc/remote.go:917 lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24
 #: lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203
 #: lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655
 #: lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940
-#: lxc/storage_bucket.go:29 lxc/storage_bucket.go:83 lxc/storage_bucket.go:188
-#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:382
-#: lxc/storage_bucket.go:458 lxc/storage_bucket.go:535
-#: lxc/storage_bucket.go:629 lxc/storage_bucket.go:698
-#: lxc/storage_bucket.go:732 lxc/storage_bucket.go:773
-#: lxc/storage_bucket.go:852 lxc/storage_bucket.go:958
-#: lxc/storage_bucket.go:1022 lxc/storage_bucket.go:1157
+#: lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189
+#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:383
+#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:536
+#: lxc/storage_bucket.go:630 lxc/storage_bucket.go:699
+#: lxc/storage_bucket.go:733 lxc/storage_bucket.go:774
+#: lxc/storage_bucket.go:853 lxc/storage_bucket.go:959
+#: lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158
 #: lxc/storage_volume.go:58 lxc/storage_volume.go:169 lxc/storage_volume.go:283
 #: lxc/storage_volume.go:390 lxc/storage_volume.go:605
 #: lxc/storage_volume.go:714 lxc/storage_volume.go:801
@@ -2062,8 +2062,8 @@ msgstr ""
 #: lxc/storage_volume.go:2064 lxc/storage_volume.go:2222
 #: lxc/storage_volume.go:2343 lxc/storage_volume.go:2405
 #: lxc/storage_volume.go:2541 lxc/storage_volume.go:2624
-#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:29
-#: lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
+#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:30
+#: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr "Descrição"
 
@@ -2154,7 +2154,7 @@ msgstr "A importação de diretório não está disponível nessa plataforma"
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:994
+#: lxc/file.go:995
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2223,7 +2223,7 @@ msgstr "DATA DE VALIDADE"
 msgid "EXPIRY DATE"
 msgstr "DATA DE VALIDADE"
 
-#: lxc/file.go:74
+#: lxc/file.go:75
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -2233,7 +2233,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:955 lxc/auth.go:956
+#: lxc/auth.go:956 lxc/auth.go:957
 #, fuzzy
 msgid "Edit an identity as YAML"
 msgstr "Editar configurações de rede como YAML"
@@ -2243,17 +2243,17 @@ msgstr "Editar configurações de rede como YAML"
 msgid "Edit cluster member configurations as YAML"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: lxc/file.go:171 lxc/file.go:172
+#: lxc/file.go:172 lxc/file.go:173
 #, fuzzy
 msgid "Edit files in instances"
 msgstr "Editar arquivos no container"
 
-#: lxc/auth.go:200 lxc/auth.go:201
+#: lxc/auth.go:201 lxc/auth.go:202
 #, fuzzy
 msgid "Edit groups as YAML"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/auth.go:1572 lxc/auth.go:1573
+#: lxc/auth.go:1573 lxc/auth.go:1574
 #, fuzzy
 msgid "Edit identity provider groups as YAML"
 msgstr "Editar configurações de perfil como YAML"
@@ -2320,17 +2320,17 @@ msgstr "Editar configurações de rede como YAML"
 msgid "Edit profile configurations as YAML"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/project.go:259 lxc/project.go:260
+#: lxc/project.go:260 lxc/project.go:261
 #, fuzzy
 msgid "Edit project configurations as YAML"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/storage_bucket.go:248 lxc/storage_bucket.go:249
+#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:250
 #, fuzzy
 msgid "Edit storage bucket configurations as YAML"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/storage_bucket.go:1021 lxc/storage_bucket.go:1022
+#: lxc/storage_bucket.go:1022 lxc/storage_bucket.go:1023
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
@@ -2348,7 +2348,7 @@ msgid "Edit trust configurations as YAML"
 msgstr "Editar configurações de perfil como YAML"
 
 #: lxc/image.go:1147 lxc/list.go:622 lxc/storage_volume.go:1766
-#: lxc/warning.go:235
+#: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2403,7 +2403,7 @@ msgstr ""
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
-#: lxc/project.go:718 lxc/storage.go:812 lxc/storage_bucket.go:602
+#: lxc/project.go:719 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2155 lxc/storage_volume.go:2193
 #, fuzzy, c-format
 msgid "Error setting properties: %v"
@@ -2417,8 +2417,8 @@ msgstr "Editar propriedades da imagem"
 #: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
-#: lxc/profile.go:981 lxc/project.go:712 lxc/storage.go:806
-#: lxc/storage_bucket.go:596 lxc/storage_volume.go:2149
+#: lxc/profile.go:981 lxc/project.go:713 lxc/storage.go:806
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2149
 #: lxc/storage_volume.go:2187
 #, c-format
 msgid "Error unsetting property: %v"
@@ -2439,7 +2439,7 @@ msgstr "Nome de membro do cluster"
 msgid "Evacuating cluster member: %s"
 msgstr "Nome de membro do cluster"
 
-#: lxc/monitor.go:50
+#: lxc/monitor.go:51
 msgid "Event type to listen for"
 msgstr "Tipo de evento a escutar"
 
@@ -2526,16 +2526,16 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/warning.go:210
+#: lxc/warning.go:211
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1237
+#: lxc/file.go:1238
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1260
+#: lxc/file.go:1261
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2550,12 +2550,12 @@ msgstr "Nome de membro do cluster"
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "Nome de membro do cluster"
 
-#: lxc/file.go:1287
+#: lxc/file.go:1288
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1072
+#: lxc/file.go:1073
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "Nome de membro do cluster"
@@ -2585,7 +2585,7 @@ msgstr "Nome de membro do cluster"
 msgid "Failed fetching fingerprint %q: %w"
 msgstr "Nome de membro do cluster"
 
-#: lxc/file.go:1193
+#: lxc/file.go:1194
 #, fuzzy, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "Aceitar certificado"
@@ -2600,7 +2600,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr "Nome de membro do cluster"
 
-#: lxc/file.go:1198
+#: lxc/file.go:1199
 #, fuzzy, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "Aceitar certificado"
@@ -2610,12 +2610,12 @@ msgstr "Aceitar certificado"
 msgid "Failed starting command: %w"
 msgstr "Aceitar certificado"
 
-#: lxc/file.go:1098
+#: lxc/file.go:1099
 #, fuzzy, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "Aceitar certificado"
 
-#: lxc/file.go:1225
+#: lxc/file.go:1226
 #, fuzzy, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "Aceitar certificado"
@@ -2654,7 +2654,7 @@ msgstr "Aceitar certificado"
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1210
+#: lxc/file.go:1211
 #, fuzzy, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "Aceitar certificado"
@@ -2669,7 +2669,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr "Aceitar certificado"
 
-#: lxc/file.go:820
+#: lxc/file.go:821
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2684,7 +2684,7 @@ msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
 #: lxc/network.go:1044 lxc/network_acl.go:133 lxc/network_zone.go:124
-#: lxc/operation.go:136
+#: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
 
@@ -2750,21 +2750,21 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
+#: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:770 lxc/auth.go:1697
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1114 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:57
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
-#: lxc/operation.go:108 lxc/profile.go:707 lxc/project.go:472
-#: lxc/project.go:917 lxc/remote.go:690 lxc/storage.go:657
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:774
-#: lxc/storage_volume.go:1608 lxc/warning.go:93
+#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:473
+#: lxc/project.go:918 lxc/remote.go:690 lxc/storage.go:657
+#: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
+#: lxc/storage_volume.go:1608 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
-#: lxc/monitor.go:52
+#: lxc/monitor.go:53
 msgid "Format (json|pretty|yaml)"
 msgstr ""
 
@@ -2808,7 +2808,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:817 lxc/auth.go:1736
+#: lxc/auth.go:818 lxc/auth.go:1737
 msgid "GROUPS"
 msgstr ""
 
@@ -2825,7 +2825,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr "Adicionar perfis aos containers"
 
-#: lxc/project.go:914 lxc/project.go:915
+#: lxc/project.go:915 lxc/project.go:916
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2879,11 +2879,11 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:400
+#: lxc/project.go:401
 msgid "Get the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:385
+#: lxc/storage_bucket.go:386
 #, fuzzy
 msgid "Get the key as a storage bucket property"
 msgstr "Editar configurações de perfil como YAML"
@@ -2954,12 +2954,12 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:395 lxc/project.go:396
+#: lxc/project.go:396 lxc/project.go:397
 #, fuzzy
 msgid "Get values for project configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:382
+#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:383
 #, fuzzy
 msgid "Get values for storage bucket configuration keys"
 msgstr "Editar configurações de perfil como YAML"
@@ -2977,17 +2977,17 @@ msgstr ""
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: lxc/auth.go:136
+#: lxc/auth.go:137
 #, fuzzy, c-format
 msgid "Group %s created"
 msgstr "Clustering ativado"
 
-#: lxc/auth.go:186
+#: lxc/auth.go:187
 #, fuzzy, c-format
 msgid "Group %s deleted"
 msgstr "Clustering ativado"
 
-#: lxc/auth.go:426 lxc/auth.go:1786
+#: lxc/auth.go:427 lxc/auth.go:1787
 #, fuzzy, c-format
 msgid "Group %s renamed to %s"
 msgstr "Dispositivo %s adicionado a %s"
@@ -3012,27 +3012,27 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1310
+#: lxc/file.go:1311
 #, fuzzy, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "Copiar a imagem: %s"
 
-#: lxc/file.go:1299
+#: lxc/file.go:1300
 #, fuzzy, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "Copiar a imagem: %s"
 
-#: lxc/file.go:1122
+#: lxc/file.go:1123
 #, fuzzy, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "Dispositivo %s adicionado a %s"
 
-#: lxc/file.go:1132
+#: lxc/file.go:1133
 #, fuzzy, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "Copiar a imagem: %s"
 
-#: lxc/network.go:966 lxc/operation.go:170
+#: lxc/network.go:966 lxc/operation.go:171
 msgid "ID"
 msgstr "ID"
 
@@ -3046,11 +3046,11 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:816
+#: lxc/auth.go:817
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:566
+#: lxc/project.go:567
 msgid "IMAGES"
 msgstr ""
 
@@ -3078,17 +3078,17 @@ msgstr "IPV6"
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1508
+#: lxc/auth.go:1509
 #, fuzzy, c-format
 msgid "Identity provider group %s created"
 msgstr "Clustering ativado"
 
-#: lxc/auth.go:1558
+#: lxc/auth.go:1559
 #, fuzzy, c-format
 msgid "Identity provider group %s deleted"
 msgstr "Clustering ativado"
 
-#: lxc/rebuild.go:32
+#: lxc/rebuild.go:33
 msgid "If an instance is running, stop it and then rebuild it"
 msgstr ""
 
@@ -3211,7 +3211,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1233 lxc/auth.go:1234
+#: lxc/auth.go:1234 lxc/auth.go:1235
 msgid "Inspect permissions"
 msgstr ""
 
@@ -3219,11 +3219,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1124
+#: lxc/file.go:1125
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1301
+#: lxc/file.go:1302
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3241,7 +3241,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1044
+#: lxc/file.go:1045
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3250,7 +3250,7 @@ msgstr ""
 msgid "Instance published with fingerprint: %s"
 msgstr "Certificado fingerprint: %s"
 
-#: lxc/rebuild.go:74
+#: lxc/rebuild.go:75
 #, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
@@ -3283,7 +3283,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/monitor.go:70
+#: lxc/monitor.go:71
 #, fuzzy, c-format
 msgid "Invalid format: %s"
 msgstr "Editar arquivos no container"
@@ -3293,7 +3293,7 @@ msgstr "Editar arquivos no container"
 msgid "Invalid instance name: %s"
 msgstr "Editar arquivos no container"
 
-#: lxc/file.go:1039
+#: lxc/file.go:1040
 #, fuzzy, c-format
 msgid "Invalid instance path: %q"
 msgstr "Editar arquivos no container"
@@ -3336,7 +3336,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:147
+#: lxc/file.go:148
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -3353,12 +3353,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr "Editar arquivos no container"
 
-#: lxc/file.go:313
+#: lxc/file.go:314
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:495
+#: lxc/file.go:496
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3372,7 +3372,7 @@ msgstr "Em cache: %s"
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/warning.go:212
 msgid "LAST SEEN"
 msgstr ""
 
@@ -3380,7 +3380,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:984
+#: lxc/project.go:985
 msgid "LIMIT"
 msgstr ""
 
@@ -3389,8 +3389,8 @@ msgid "LISTEN ADDRESS"
 msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
-#: lxc/network_load_balancer.go:165 lxc/operation.go:177
-#: lxc/storage_bucket.go:516 lxc/storage_volume.go:1739 lxc/warning.go:220
+#: lxc/network_load_balancer.go:165 lxc/operation.go:178
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1739 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3468,7 +3468,7 @@ msgstr "Nome de membro do cluster"
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/warning.go:94
+#: lxc/warning.go:95
 msgid "List all warnings"
 msgstr ""
 
@@ -3514,19 +3514,19 @@ msgstr ""
 msgid "List available storage pools"
 msgstr ""
 
-#: lxc/operation.go:105 lxc/operation.go:106
+#: lxc/operation.go:106 lxc/operation.go:107
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:331 lxc/auth.go:332
+#: lxc/auth.go:332 lxc/auth.go:333
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:764 lxc/auth.go:765
+#: lxc/auth.go:765 lxc/auth.go:766
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1691 lxc/auth.go:1692
+#: lxc/auth.go:1692 lxc/auth.go:1693
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3677,12 +3677,12 @@ msgstr "Editar configurações de rede como YAML"
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/operation.go:109
+#: lxc/operation.go:110
 #, fuzzy
 msgid "List operations from all projects"
 msgstr "Criar projetos"
 
-#: lxc/auth.go:1255 lxc/auth.go:1256
+#: lxc/auth.go:1256 lxc/auth.go:1257
 msgid "List permissions"
 msgstr ""
 
@@ -3690,15 +3690,15 @@ msgstr ""
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:469 lxc/project.go:470
+#: lxc/project.go:470 lxc/project.go:471
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:771 lxc/storage_bucket.go:773
+#: lxc/storage_bucket.go:772 lxc/storage_bucket.go:774
 msgid "List storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:456 lxc/storage_bucket.go:458
+#: lxc/storage_bucket.go:457 lxc/storage_bucket.go:459
 msgid "List storage buckets"
 msgstr ""
 
@@ -3734,11 +3734,11 @@ msgstr ""
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/warning.go:70
+#: lxc/warning.go:71
 msgid "List warnings"
 msgstr ""
 
-#: lxc/warning.go:71
+#: lxc/warning.go:72
 msgid ""
 "List warnings\n"
 "\n"
@@ -3761,7 +3761,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/operation.go:23 lxc/operation.go:24
+#: lxc/operation.go:24 lxc/operation.go:25
 msgid "List, show and delete background operations"
 msgstr ""
 
@@ -3770,7 +3770,7 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/monitor.go:79
+#: lxc/monitor.go:80
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
@@ -3878,26 +3878,26 @@ msgstr ""
 msgid "Manage devices"
 msgstr "Editar arquivos no container"
 
-#: lxc/file.go:82 lxc/file.go:83
+#: lxc/file.go:83 lxc/file.go:84
 #, fuzzy
 msgid "Manage files in instances"
 msgstr "Editar arquivos no container"
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1433 lxc/auth.go:1434
+#: lxc/auth.go:59 lxc/auth.go:60 lxc/auth.go:1434 lxc/auth.go:1435
 #, fuzzy
 msgid "Manage groups"
 msgstr "Editar arquivos no container"
 
-#: lxc/auth.go:1083 lxc/auth.go:1084
+#: lxc/auth.go:1084 lxc/auth.go:1085
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:730 lxc/auth.go:731
+#: lxc/auth.go:731 lxc/auth.go:732
 #, fuzzy
 msgid "Manage identities"
 msgstr "Editar arquivos no container"
 
-#: lxc/auth.go:1851 lxc/auth.go:1852
+#: lxc/auth.go:1852 lxc/auth.go:1853
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -4002,7 +4002,7 @@ msgstr "Criar novas redes"
 msgid "Manage network zones"
 msgstr "Criar novas redes"
 
-#: lxc/auth.go:492 lxc/auth.go:493
+#: lxc/auth.go:493 lxc/auth.go:494
 #, fuzzy
 msgid "Manage permissions"
 msgstr "Editar arquivos no container"
@@ -4011,25 +4011,25 @@ msgstr "Editar arquivos no container"
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:28 lxc/project.go:29
+#: lxc/project.go:29 lxc/project.go:30
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:731
+#: lxc/storage_bucket.go:732
 #, fuzzy
 msgid "Manage storage bucket keys"
 msgstr "Criar novas redes"
 
-#: lxc/storage_bucket.go:732
+#: lxc/storage_bucket.go:733
 msgid "Manage storage bucket keys."
 msgstr ""
 
-#: lxc/storage_bucket.go:28
+#: lxc/storage_bucket.go:29
 #, fuzzy
 msgid "Manage storage buckets"
 msgstr "Criar novas redes"
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:30
 #, fuzzy
 msgid "Manage storage buckets."
 msgstr "Criar novas redes"
@@ -4058,12 +4058,12 @@ msgstr ""
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/auth.go:29 lxc/auth.go:30
+#: lxc/auth.go:30 lxc/auth.go:31
 #, fuzzy
 msgid "Manage user authorization"
 msgstr "Nome de membro do cluster"
 
-#: lxc/warning.go:28 lxc/warning.go:29
+#: lxc/warning.go:29 lxc/warning.go:30
 #, fuzzy
 msgid "Manage warnings"
 msgstr "Editar arquivos no container"
@@ -4129,17 +4129,17 @@ msgstr ""
 msgid "Migration operation failure: %w"
 msgstr ""
 
-#: lxc/monitor.go:51
+#: lxc/monitor.go:52
 msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: lxc/storage_bucket.go:116 lxc/storage_bucket.go:216
-#: lxc/storage_bucket.go:292 lxc/storage_bucket.go:411
-#: lxc/storage_bucket.go:568 lxc/storage_bucket.go:660
-#: lxc/storage_bucket.go:802 lxc/storage_bucket.go:889
-#: lxc/storage_bucket.go:986 lxc/storage_bucket.go:1065
-#: lxc/storage_bucket.go:1188
+#: lxc/storage_bucket.go:117 lxc/storage_bucket.go:217
+#: lxc/storage_bucket.go:293 lxc/storage_bucket.go:412
+#: lxc/storage_bucket.go:569 lxc/storage_bucket.go:661
+#: lxc/storage_bucket.go:803 lxc/storage_bucket.go:890
+#: lxc/storage_bucket.go:987 lxc/storage_bucket.go:1066
+#: lxc/storage_bucket.go:1189
 #, fuzzy
 msgid "Missing bucket name"
 msgstr "Nome de membro do cluster"
@@ -4162,23 +4162,23 @@ msgstr "Nome de membro do cluster"
 msgid "Missing cluster member name"
 msgstr "Nome de membro do cluster"
 
-#: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1825
+#: lxc/auth.go:123 lxc/auth.go:177 lxc/auth.go:255 lxc/auth.go:417
+#: lxc/auth.go:466 lxc/auth.go:541 lxc/auth.go:600 lxc/auth.go:1826
 #, fuzzy
 msgid "Missing group name"
 msgstr "Nome de membro do cluster"
 
-#: lxc/auth.go:862 lxc/auth.go:1003 lxc/auth.go:1131 lxc/auth.go:1189
+#: lxc/auth.go:863 lxc/auth.go:1004 lxc/auth.go:1132 lxc/auth.go:1190
 #, fuzzy
 msgid "Missing identity argument"
 msgstr "Nome de membro do cluster"
 
-#: lxc/auth.go:1495 lxc/auth.go:1548 lxc/auth.go:1614 lxc/auth.go:1776
+#: lxc/auth.go:1496 lxc/auth.go:1549 lxc/auth.go:1615 lxc/auth.go:1777
 #, fuzzy
 msgid "Missing identity provider group name"
 msgstr "Nome de membro do cluster"
 
-#: lxc/auth.go:1899 lxc/auth.go:1952
+#: lxc/auth.go:1900 lxc/auth.go:1953
 #, fuzzy
 msgid "Missing identity provider group name argument"
 msgstr "Nome de membro do cluster"
@@ -4187,12 +4187,12 @@ msgstr "Nome de membro do cluster"
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
 #: lxc/config_template.go:377 lxc/profile.go:141 lxc/profile.go:222
-#: lxc/profile.go:808 lxc/rebuild.go:60
+#: lxc/profile.go:808 lxc/rebuild.go:61
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/storage_bucket.go:893 lxc/storage_bucket.go:990
-#: lxc/storage_bucket.go:1069 lxc/storage_bucket.go:1192
+#: lxc/storage_bucket.go:894 lxc/storage_bucket.go:991
+#: lxc/storage_bucket.go:1070 lxc/storage_bucket.go:1193
 #, fuzzy
 msgid "Missing key name"
 msgstr "Nome de membro do cluster"
@@ -4263,13 +4263,13 @@ msgid "Missing peer name"
 msgstr "Nome de membro do cluster"
 
 #: lxc/storage.go:235 lxc/storage.go:313 lxc/storage.go:431 lxc/storage.go:509
-#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:112
-#: lxc/storage_bucket.go:212 lxc/storage_bucket.go:288
-#: lxc/storage_bucket.go:407 lxc/storage_bucket.go:482
-#: lxc/storage_bucket.go:564 lxc/storage_bucket.go:656
-#: lxc/storage_bucket.go:798 lxc/storage_bucket.go:885
-#: lxc/storage_bucket.go:982 lxc/storage_bucket.go:1061
-#: lxc/storage_bucket.go:1184 lxc/storage_volume.go:209
+#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:113
+#: lxc/storage_bucket.go:213 lxc/storage_bucket.go:289
+#: lxc/storage_bucket.go:408 lxc/storage_bucket.go:483
+#: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
+#: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
+#: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
 #: lxc/storage_volume.go:323 lxc/storage_volume.go:643
 #: lxc/storage_volume.go:750 lxc/storage_volume.go:841
 #: lxc/storage_volume.go:939 lxc/storage_volume.go:1053
@@ -4284,9 +4284,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:404 lxc/project.go:146 lxc/project.go:226 lxc/project.go:316
-#: lxc/project.go:433 lxc/project.go:622 lxc/project.go:691 lxc/project.go:819
-#: lxc/project.go:948
+#: lxc/profile.go:404 lxc/project.go:147 lxc/project.go:227 lxc/project.go:317
+#: lxc/project.go:434 lxc/project.go:623 lxc/project.go:692 lxc/project.go:820
+#: lxc/project.go:949
 msgid "Missing project name"
 msgstr ""
 
@@ -4303,7 +4303,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr "Nome de membro do cluster"
 
-#: lxc/file.go:598
+#: lxc/file.go:599
 msgid "Missing target directory"
 msgstr ""
 
@@ -4326,11 +4326,11 @@ msgstr ""
 msgid "Model: %v"
 msgstr ""
 
-#: lxc/monitor.go:32
+#: lxc/monitor.go:33
 msgid "Monitor a local or remote LXD server"
 msgstr ""
 
-#: lxc/monitor.go:33
+#: lxc/monitor.go:34
 msgid ""
 "Monitor a local or remote LXD server\n"
 "\n"
@@ -4342,11 +4342,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:285
+#: lxc/file.go:286
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:985 lxc/file.go:986
+#: lxc/file.go:986 lxc/file.go:987
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "Adicionar perfis aos containers"
@@ -4409,13 +4409,13 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:192
+#: lxc/auth.go:376 lxc/auth.go:816 lxc/auth.go:1736 lxc/cluster.go:192
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
-#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:565
-#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:511
-#: lxc/storage_bucket.go:831 lxc/storage_volume.go:1731
+#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:566
+#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1731
 msgid "NAME"
 msgstr ""
 
@@ -4423,11 +4423,11 @@ msgstr ""
 msgid "NAT"
 msgstr ""
 
-#: lxc/project.go:571
+#: lxc/project.go:572
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:570
+#: lxc/project.go:571
 msgid "NETWORKS"
 msgstr ""
 
@@ -4439,9 +4439,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/operation.go:154 lxc/project.go:523
-#: lxc/project.go:528 lxc/project.go:533 lxc/project.go:538 lxc/project.go:543
-#: lxc/project.go:548 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
+#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:524
+#: lxc/project.go:529 lxc/project.go:534 lxc/project.go:539 lxc/project.go:544
+#: lxc/project.go:549 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
 msgid "NO"
 msgstr ""
 
@@ -4686,7 +4686,7 @@ msgstr ""
 msgid "Only managed networks can be modified"
 msgstr ""
 
-#: lxc/operation.go:86
+#: lxc/operation.go:87
 #, c-format
 msgid "Operation %s deleted"
 msgstr ""
@@ -4733,11 +4733,11 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:567
+#: lxc/list.go:576 lxc/project.go:568
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:212
+#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4800,24 +4800,24 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1102
+#: lxc/file.go:1103
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:860
+#: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
-#: lxc/project.go:363 lxc/storage.go:360 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1151
+#: lxc/project.go:364 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1151
 #: lxc/storage_volume.go:1183
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
-#: lxc/monitor.go:48
+#: lxc/monitor.go:49
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
@@ -4908,17 +4908,17 @@ msgstr "Copiar perfis"
 msgid "Profiles: "
 msgstr "Copiar perfis"
 
-#: lxc/project.go:172
+#: lxc/project.go:173
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:236
+#: lxc/project.go:237
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:637
+#: lxc/project.go:638
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -5039,21 +5039,21 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr "Editar arquivos no container"
 
-#: lxc/file.go:241 lxc/file.go:242
+#: lxc/file.go:242 lxc/file.go:243
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:416 lxc/file.go:767
+#: lxc/file.go:417 lxc/file.go:768
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:466 lxc/file.go:467
+#: lxc/file.go:467 lxc/file.go:468
 #, fuzzy
 msgid "Push files into instances"
 msgstr "Editar arquivos no container"
 
-#: lxc/file.go:701 lxc/file.go:867
+#: lxc/file.go:702 lxc/file.go:868
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -5066,11 +5066,11 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:983
+#: lxc/project.go:984
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/storage_bucket.go:833
+#: lxc/storage_bucket.go:834
 msgid "ROLE"
 msgstr ""
 
@@ -5083,17 +5083,17 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/rebuild.go:31
+#: lxc/rebuild.go:32
 #, fuzzy
 msgid "Rebuild as an empty instance"
 msgstr "Editar arquivos no container"
 
-#: lxc/rebuild.go:26
+#: lxc/rebuild.go:27
 #, fuzzy
 msgid "Rebuild instances"
 msgstr "Editar arquivos no container"
 
-#: lxc/file.go:249 lxc/file.go:473
+#: lxc/file.go:250 lxc/file.go:474
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -5120,7 +5120,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:882 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
+#: lxc/project.go:883 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
 #: lxc/remote.go:994
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -5174,7 +5174,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr "Nome de membro do cluster"
 
-#: lxc/auth.go:1164 lxc/auth.go:1165
+#: lxc/auth.go:1165 lxc/auth.go:1166
 #, fuzzy
 msgid "Remove a group from an identity"
 msgstr "Adicionar perfis aos containers"
@@ -5215,7 +5215,7 @@ msgstr "Nome de membro do cluster"
 msgid "Remove entries from a network zone record"
 msgstr "Adicionar perfis aos containers"
 
-#: lxc/auth.go:1927 lxc/auth.go:1928
+#: lxc/auth.go:1928 lxc/auth.go:1929
 #, fuzzy
 msgid "Remove identities from groups"
 msgstr "Adicionar perfis aos containers"
@@ -5228,7 +5228,7 @@ msgstr ""
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:574 lxc/auth.go:575
+#: lxc/auth.go:575 lxc/auth.go:576
 #, fuzzy
 msgid "Remove permissions from groups"
 msgstr "Adicionar perfis aos containers"
@@ -5280,11 +5280,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:391 lxc/auth.go:392
+#: lxc/auth.go:392 lxc/auth.go:393
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1751 lxc/auth.go:1752
+#: lxc/auth.go:1752 lxc/auth.go:1753
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5305,7 +5305,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:589 lxc/project.go:590
+#: lxc/project.go:590 lxc/project.go:591
 msgid "Rename projects"
 msgstr ""
 
@@ -5412,7 +5412,7 @@ msgstr "Nome de membro do cluster"
 msgid "Revoke cluster member join token"
 msgstr "Nome de membro do cluster"
 
-#: lxc/storage_bucket.go:862
+#: lxc/storage_bucket.go:863
 msgid "Role (admin or read-only)"
 msgstr ""
 
@@ -5429,7 +5429,7 @@ msgstr ""
 msgid "Run against all projects"
 msgstr "Criar projetos"
 
-#: lxc/warning.go:213
+#: lxc/warning.go:214
 msgid "SEVERITY"
 msgstr ""
 
@@ -5449,12 +5449,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1231
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1231
+#: lxc/file.go:1232
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5468,11 +5468,11 @@ msgstr ""
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:173 lxc/warning.go:214
+#: lxc/operation.go:174 lxc/warning.go:215
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:569
+#: lxc/project.go:570
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5480,7 +5480,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:569
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -5488,11 +5488,11 @@ msgstr ""
 msgid "STP"
 msgstr ""
 
-#: lxc/storage_bucket.go:864
+#: lxc/storage_bucket.go:865
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:942
+#: lxc/storage_bucket.go:943
 #, fuzzy, c-format
 msgid "Secret key: %s"
 msgstr "Criado: %s"
@@ -5532,7 +5532,7 @@ msgstr "Adicionar perfis aos containers"
 msgid "Set a cluster member's configuration keys"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: lxc/file.go:995
+#: lxc/file.go:996
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5679,12 +5679,12 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:654
+#: lxc/project.go:655
 #, fuzzy
 msgid "Set project configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/project.go:655
+#: lxc/project.go:656
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5693,12 +5693,12 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage_bucket.go:534
+#: lxc/storage_bucket.go:535
 #, fuzzy
 msgid "Set storage bucket configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/storage_bucket.go:535
+#: lxc/storage_bucket.go:536
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -5737,15 +5737,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:476
+#: lxc/file.go:477
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:477
+#: lxc/file.go:478
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:475
+#: lxc/file.go:476
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5790,11 +5790,11 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 msgid "Set the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:542
+#: lxc/storage_bucket.go:543
 #, fuzzy
 msgid "Set the key as a storage bucket property"
 msgstr "Criar novas redes"
@@ -5812,7 +5812,7 @@ msgstr "Desconectar volumes de armazenamento dos perfis"
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:993
+#: lxc/file.go:994
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5824,7 +5824,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1800 lxc/auth.go:1801
+#: lxc/auth.go:1801 lxc/auth.go:1802
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5842,11 +5842,11 @@ msgstr "Editar templates de arquivo do container"
 msgid "Show details of a cluster member"
 msgstr ""
 
-#: lxc/operation.go:192 lxc/operation.go:193
+#: lxc/operation.go:193 lxc/operation.go:194
 msgid "Show details on a background operation"
 msgstr ""
 
-#: lxc/monitor.go:49
+#: lxc/monitor.go:50
 msgid "Show events from all projects"
 msgstr ""
 
@@ -5855,12 +5855,12 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr "Adicionar dispositivos aos containers ou perfis"
 
-#: lxc/auth.go:440 lxc/auth.go:441
+#: lxc/auth.go:441 lxc/auth.go:442
 #, fuzzy
 msgid "Show group configurations"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: lxc/auth.go:832
+#: lxc/auth.go:833
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5953,16 +5953,16 @@ msgstr "Editar configurações do container ou do servidor como YAML"
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:786 lxc/project.go:787
+#: lxc/project.go:787 lxc/project.go:788
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage_bucket.go:628 lxc/storage_bucket.go:629
+#: lxc/storage_bucket.go:629 lxc/storage_bucket.go:630
 #, fuzzy
 msgid "Show storage bucket configurations"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: lxc/storage_bucket.go:1156 lxc/storage_bucket.go:1157
+#: lxc/storage_bucket.go:1157 lxc/storage_bucket.go:1158
 #, fuzzy
 msgid "Show storage bucket key configurations"
 msgstr "Editar configurações do container ou do servidor como YAML"
@@ -5980,7 +5980,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: lxc/auth.go:895
+#: lxc/auth.go:896
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -6032,7 +6032,7 @@ msgstr ""
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: lxc/warning.go:302 lxc/warning.go:303
+#: lxc/warning.go:303 lxc/warning.go:304
 msgid "Show warning"
 msgstr ""
 
@@ -6116,22 +6116,22 @@ msgstr ""
 msgid "Stopping the instance failed: %s"
 msgstr "Copiar a imagem: %s"
 
-#: lxc/storage_bucket.go:166
+#: lxc/storage_bucket.go:167
 #, fuzzy, c-format
 msgid "Storage bucket %s created"
 msgstr "Clustering ativado"
 
-#: lxc/storage_bucket.go:233
+#: lxc/storage_bucket.go:234
 #, fuzzy, c-format
 msgid "Storage bucket %s deleted"
 msgstr "Clustering ativado"
 
-#: lxc/storage_bucket.go:940
+#: lxc/storage_bucket.go:941
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr ""
 
-#: lxc/storage_bucket.go:1006
+#: lxc/storage_bucket.go:1007
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr ""
@@ -6201,7 +6201,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:847 lxc/project.go:848
+#: lxc/project.go:848 lxc/project.go:849
 msgid "Switch the current project"
 msgstr ""
 
@@ -6217,10 +6217,10 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1139
+#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1139
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
-#: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:171
-#: lxc/storage_volume.go:1730 lxc/warning.go:215
+#: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
+#: lxc/storage_volume.go:1730 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
@@ -6228,12 +6228,12 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1032
+#: lxc/file.go:1033
 #, fuzzy
 msgid "Target path and --listen flag cannot be used together"
 msgstr "--refresh só pode ser usado com containers"
 
-#: lxc/file.go:1026
+#: lxc/file.go:1027
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -6364,12 +6364,12 @@ msgstr "Nome de membro do cluster"
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr "Nome de membro do cluster"
 
-#: lxc/project.go:446
+#: lxc/project.go:447
 #, fuzzy, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr "Nome de membro do cluster"
 
-#: lxc/storage_bucket.go:431
+#: lxc/storage_bucket.go:432
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage bucket %q: %v"
 msgstr "Nome de membro do cluster"
@@ -6557,7 +6557,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:961
+#: lxc/project.go:962
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6569,17 +6569,17 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:985 lxc/storage_volume.go:1735
+#: lxc/project.go:986 lxc/storage_volume.go:1735
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:573
+#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:574
 #: lxc/storage.go:724 lxc/storage_volume.go:1734
 msgid "USED BY"
 msgstr ""
 
-#: lxc/warning.go:216
+#: lxc/warning.go:217
 msgid "UUID"
 msgstr ""
 
@@ -6588,7 +6588,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:197
+#: lxc/file.go:198
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6603,13 +6603,13 @@ msgstr "Adicionar novos servidores remoto"
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1253
+#: lxc/file.go:1254
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1153 lxc/list.go:631 lxc/storage_volume.go:1772
-#: lxc/warning.go:241
+#: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6619,7 +6619,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:807
+#: lxc/file.go:808
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6717,12 +6717,12 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:742 lxc/project.go:743
+#: lxc/project.go:743 lxc/project.go:744
 #, fuzzy
 msgid "Unset project configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/storage_bucket.go:697 lxc/storage_bucket.go:698
+#: lxc/storage_bucket.go:698 lxc/storage_bucket.go:699
 #, fuzzy
 msgid "Unset storage bucket configuration keys"
 msgstr "Editar configurações de perfil como YAML"
@@ -6777,11 +6777,11 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:747
+#: lxc/project.go:748
 msgid "Unset the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:701
+#: lxc/storage_bucket.go:702
 #, fuzzy
 msgid "Unset the key as a storage bucket property"
 msgstr "Editar configurações de perfil como YAML"
@@ -6863,7 +6863,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:71
+#: lxc/file.go:72
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6900,11 +6900,11 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr "Em cache: %s"
 
-#: lxc/auth.go:831
+#: lxc/auth.go:832
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:894
+#: lxc/auth.go:895
 msgid "View the current identity"
 msgstr ""
 
@@ -6935,15 +6935,15 @@ msgstr ""
 msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
-#: lxc/rebuild.go:27
+#: lxc/rebuild.go:28
 msgid ""
 "Wipe the instance root disk and re-initialize. The original image is used to "
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:156 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
+#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:526
+#: lxc/project.go:531 lxc/project.go:536 lxc/project.go:541 lxc/project.go:546
+#: lxc/project.go:551 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
 msgid "YES"
 msgstr ""
 
@@ -6963,7 +6963,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/rebuild.go:119
+#: lxc/rebuild.go:120
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
@@ -6976,12 +6976,12 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr "Criar perfis"
 
-#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1689
+#: lxc/auth.go:330 lxc/auth.go:763 lxc/auth.go:894 lxc/auth.go:1690
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
-#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
+#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
-#: lxc/operation.go:103 lxc/profile.go:700 lxc/project.go:467
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:68
+#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:468
+#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
 
@@ -7012,7 +7012,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1254
+#: lxc/auth.go:1255
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -7083,11 +7083,11 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:830
+#: lxc/auth.go:831
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1926
+#: lxc/auth.go:1106 lxc/auth.go:1164 lxc/auth.go:1927
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -7096,14 +7096,14 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr "Criar perfis"
 
-#: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:954 lxc/auth.go:1470 lxc/cluster_group.go:168
+#: lxc/auth.go:97 lxc/auth.go:150 lxc/auth.go:200 lxc/auth.go:440
+#: lxc/auth.go:955 lxc/auth.go:1471 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 #, fuzzy
 msgid "[<remote>:]<group>"
 msgstr "Criar perfis"
 
-#: lxc/auth.go:514 lxc/auth.go:572
+#: lxc/auth.go:515 lxc/auth.go:573
 #, fuzzy
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
@@ -7115,22 +7115,22 @@ msgstr "Criar perfis"
 msgid "[<remote>:]<group> <new-name>"
 msgstr "Criar perfis"
 
-#: lxc/auth.go:389
+#: lxc/auth.go:390
 #, fuzzy
 msgid "[<remote>:]<group> <new_name>"
 msgstr "Criar perfis"
 
-#: lxc/auth.go:1521 lxc/auth.go:1571 lxc/auth.go:1799
+#: lxc/auth.go:1522 lxc/auth.go:1572 lxc/auth.go:1800
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group>"
 msgstr "Criar perfis"
 
-#: lxc/auth.go:1873
+#: lxc/auth.go:1874
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/auth.go:1749
+#: lxc/auth.go:1750
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr "Criar perfis"
@@ -7153,7 +7153,7 @@ msgstr "Editar templates de arquivo do container"
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
-#: lxc/rebuild.go:25
+#: lxc/rebuild.go:26
 #, fuzzy
 msgid "[<remote>:]<image> [<remote>:]<instance>"
 msgstr "Editar templates de arquivo do container"
@@ -7241,20 +7241,20 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:170
+#: lxc/file.go:171
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:120
+#: lxc/file.go:121
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:240
+#: lxc/file.go:241
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:984
+#: lxc/file.go:985
 #, fuzzy
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr "Editar templates de arquivo do container"
@@ -7422,12 +7422,12 @@ msgstr "Criar perfis"
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
-#: lxc/operation.go:53 lxc/operation.go:191
+#: lxc/operation.go:54 lxc/operation.go:192
 msgid "[<remote>:]<operation>"
 msgstr ""
 
 #: lxc/storage.go:200 lxc/storage.go:259 lxc/storage.go:473 lxc/storage.go:844
-#: lxc/storage_bucket.go:454
+#: lxc/storage_bucket.go:455
 msgid "[<remote>:]<pool>"
 msgstr ""
 
@@ -7436,25 +7436,25 @@ msgstr ""
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr "Criar perfis"
 
-#: lxc/storage_bucket.go:185 lxc/storage_bucket.go:247
-#: lxc/storage_bucket.go:627 lxc/storage_bucket.go:769
+#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:248
+#: lxc/storage_bucket.go:628 lxc/storage_bucket.go:770
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket>"
 msgstr "Criar perfis"
 
-#: lxc/storage_bucket.go:380 lxc/storage_bucket.go:696
-#: lxc/storage_bucket.go:850 lxc/storage_bucket.go:956
-#: lxc/storage_bucket.go:1020 lxc/storage_bucket.go:1155
+#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:697
+#: lxc/storage_bucket.go:851 lxc/storage_bucket.go:957
+#: lxc/storage_bucket.go:1021 lxc/storage_bucket.go:1156
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/storage_bucket.go:533
+#: lxc/storage_bucket.go:534
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/storage_bucket.go:81
+#: lxc/storage_bucket.go:82
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr "Editar templates de arquivo do container"
@@ -7580,21 +7580,21 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:91 lxc/project.go:186 lxc/project.go:258 lxc/project.go:785
-#: lxc/project.go:846 lxc/project.go:913
+#: lxc/project.go:92 lxc/project.go:187 lxc/project.go:259 lxc/project.go:786
+#: lxc/project.go:847 lxc/project.go:914
 #, fuzzy
 msgid "[<remote>:]<project>"
 msgstr "Criar projetos"
 
-#: lxc/project.go:394 lxc/project.go:741
+#: lxc/project.go:395 lxc/project.go:742
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:653
+#: lxc/project.go:654
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:587
+#: lxc/project.go:588
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7603,7 +7603,7 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr "Criar perfis"
 
-#: lxc/warning.go:259 lxc/warning.go:301 lxc/warning.go:354
+#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
 #, fuzzy
 msgid "[<remote>:]<warning-uuid>"
 msgstr "Criar perfis"
@@ -7669,7 +7669,7 @@ msgstr "Criar perfis"
 msgid "[[<remote>:]<member>]"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/project.go:555 lxc/remote.go:739
+#: lxc/project.go:556 lxc/remote.go:739
 msgid "current"
 msgstr ""
 
@@ -7716,20 +7716,20 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/auth.go:203
+#: lxc/auth.go:204
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:958
+#: lxc/auth.go:959
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1575
+#: lxc/auth.go:1576
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7807,20 +7807,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:988
+#: lxc/file.go:989
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:244
+#: lxc/file.go:245
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:470
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7902,7 +7902,7 @@ msgid ""
 "  List instances with their running state and user comment."
 msgstr ""
 
-#: lxc/monitor.go:37
+#: lxc/monitor.go:38
 msgid ""
 "lxc monitor --type=logging\n"
 "    Only show log messages.\n"
@@ -7978,7 +7978,7 @@ msgid ""
 "    Create record r1 for zone z1 with configuration from config.yaml"
 msgstr ""
 
-#: lxc/operation.go:195
+#: lxc/operation.go:196
 msgid ""
 "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Show details on that operation UUID"
@@ -8021,7 +8021,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:95
+#: lxc/project.go:96
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -8029,7 +8029,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:262
+#: lxc/project.go:263
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -8060,7 +8060,7 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:85
 msgid ""
 "lxc storage bucket create p1 b01\n"
 "\tCreate a new storage bucket name b01 in storage pool p1\n"
@@ -8070,19 +8070,19 @@ msgid ""
 "of config.yaml"
 msgstr ""
 
-#: lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:251
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1023
+#: lxc/storage_bucket.go:1024
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:854
 msgid ""
 "lxc storage bucket key create p1 b01 k1\n"
 "\tCreate a key called k1 for the bucket b01 in the pool p1.\n"
@@ -8092,14 +8092,14 @@ msgid ""
 "of config.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1158
+#: lxc/storage_bucket.go:1159
 msgid ""
 "lxc storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_bucket.go:630
+#: lxc/storage_bucket.go:631
 msgid ""
 "lxc storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
@@ -8169,16 +8169,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1142
+#: lxc/file.go:1143
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1101
+#: lxc/file.go:1102
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1054
+#: lxc/file.go:1055
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-04 08:52-0600\n"
+"POT-Creation-Date: 2024-09-05 08:44-0400\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Александр Киль <shorrey@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -20,7 +20,7 @@ msgstr ""
 "n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: lxc/storage_bucket.go:260 lxc/storage_bucket.go:1033
+#: lxc/storage_bucket.go:261 lxc/storage_bucket.go:1034
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
@@ -208,7 +208,7 @@ msgstr ""
 "###\n"
 "### Обратите внимание, что имя отображается, но не может быть изменено"
 
-#: lxc/auth.go:213
+#: lxc/auth.go:214
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -235,7 +235,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:968
+#: lxc/auth.go:969
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -256,7 +256,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1585
+#: lxc/auth.go:1586
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
@@ -630,7 +630,7 @@ msgstr ""
 "###\n"
 "### Обратите внимание, что имя отображается, но не может быть изменено"
 
-#: lxc/project.go:280
+#: lxc/project.go:281
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the project.\n"
@@ -690,12 +690,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:935
+#: lxc/file.go:936
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:825
+#: lxc/file.go:826
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -731,7 +731,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:142 lxc/rebuild.go:64
+#: lxc/init.go:142 lxc/rebuild.go:65
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -785,7 +785,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:465
+#: lxc/file.go:466
 #, fuzzy
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
@@ -823,7 +823,7 @@ msgstr "АРХИТЕКТУРА"
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:813
+#: lxc/auth.go:814
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -831,11 +831,11 @@ msgstr ""
 msgid "Accept certificate"
 msgstr "Принять сертификат"
 
-#: lxc/storage_bucket.go:863
+#: lxc/storage_bucket.go:864
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:941
+#: lxc/storage_bucket.go:942
 #, c-format
 msgid "Access key: %s"
 msgstr ""
@@ -844,7 +844,7 @@ msgstr ""
 msgid "Access the expanded configuration"
 msgstr ""
 
-#: lxc/warning.go:261 lxc/warning.go:262
+#: lxc/warning.go:262 lxc/warning.go:263
 msgid "Acknowledge warning"
 msgstr ""
 
@@ -862,11 +862,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr "Копирование образа: %s"
 
-#: lxc/auth.go:1106 lxc/auth.go:1107
+#: lxc/auth.go:1107 lxc/auth.go:1108
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1874 lxc/auth.go:1875
+#: lxc/auth.go:1875 lxc/auth.go:1876
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -938,7 +938,7 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:515 lxc/auth.go:516
+#: lxc/auth.go:516 lxc/auth.go:517
 msgid "Add permissions to groups"
 msgstr ""
 
@@ -968,7 +968,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:169
+#: lxc/storage_bucket.go:170
 #, fuzzy, c-format
 msgid "Admin access key: %s"
 msgstr "Пароль администратора для %s: "
@@ -978,7 +978,7 @@ msgstr "Пароль администратора для %s: "
 msgid "Admin password (or token) for %s:"
 msgstr "Пароль администратора для %s: "
 
-#: lxc/storage_bucket.go:170
+#: lxc/storage_bucket.go:171
 #, fuzzy, c-format
 msgid "Admin secret key: %s"
 msgstr "Авто-обновление: %s"
@@ -1039,7 +1039,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:342 lxc/rebuild.go:130
+#: lxc/init.go:342 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -1142,12 +1142,12 @@ msgstr ""
 
 #: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:318
 #: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
-#: lxc/network_zone.go:366 lxc/network_zone.go:1053 lxc/storage_bucket.go:141
+#: lxc/network_zone.go:366 lxc/network_zone.go:1053 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:159
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:160
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "Имя контейнера: %s"
@@ -1187,7 +1187,7 @@ msgstr "Получено байтов"
 msgid "Bytes sent"
 msgstr "Отправлено байтов"
 
-#: lxc/operation.go:174
+#: lxc/operation.go:175
 msgid "CANCELABLE"
 msgstr ""
 
@@ -1199,7 +1199,7 @@ msgstr "ОБЩЕЕ ИМЯ"
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: lxc/warning.go:209
+#: lxc/warning.go:210
 msgid "COUNT"
 msgstr ""
 
@@ -1226,7 +1226,7 @@ msgstr " Использование ЦП:"
 msgid "CPUs (%s):"
 msgstr ""
 
-#: lxc/operation.go:175
+#: lxc/operation.go:176
 #, fuzzy
 msgid "CREATED"
 msgstr "СОЗДАН"
@@ -1257,7 +1257,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:340
+#: lxc/file.go:341
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1282,11 +1282,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:224
+#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:546
+#: lxc/file.go:547
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1295,7 +1295,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:160
+#: lxc/rebuild.go:161
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1423,13 +1423,13 @@ msgstr ""
 #: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
 #: lxc/network_load_balancer.go:1051 lxc/network_load_balancer.go:1125
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
-#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:90
-#: lxc/storage_bucket.go:190 lxc/storage_bucket.go:253
-#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:541
-#: lxc/storage_bucket.go:634 lxc/storage_bucket.go:700
-#: lxc/storage_bucket.go:775 lxc/storage_bucket.go:861
-#: lxc/storage_bucket.go:961 lxc/storage_bucket.go:1026
-#: lxc/storage_bucket.go:1162 lxc/storage_volume.go:394
+#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
+#: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
+#: lxc/storage_bucket.go:385 lxc/storage_bucket.go:542
+#: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
+#: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
+#: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
 #: lxc/storage_volume.go:612 lxc/storage_volume.go:717
 #: lxc/storage_volume.go:1005 lxc/storage_volume.go:1231
 #: lxc/storage_volume.go:1360 lxc/storage_volume.go:1848
@@ -1453,7 +1453,7 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1113 lxc/list.go:132 lxc/storage_volume.go:1589
-#: lxc/warning.go:92
+#: lxc/warning.go:93
 msgid "Columns"
 msgstr "Столбцы"
 
@@ -1481,7 +1481,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:100
+#: lxc/project.go:101
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1495,8 +1495,8 @@ msgstr ""
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
-#: lxc/project.go:362 lxc/storage.go:359 lxc/storage_bucket.go:348
-#: lxc/storage_bucket.go:1125 lxc/storage_volume.go:1150
+#: lxc/project.go:363 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1150
 #: lxc/storage_volume.go:1182
 #, c-format
 msgid "Config parsing error: %s"
@@ -1625,12 +1625,12 @@ msgstr "Не удалось очистить путь %s"
 msgid "Could not find certificate key file path: %s"
 msgstr "Не удалось очистить путь %s"
 
-#: lxc/auth.go:300 lxc/auth.go:1660
+#: lxc/auth.go:301 lxc/auth.go:1661
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1054
+#: lxc/auth.go:1055
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1681,16 +1681,16 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:248 lxc/file.go:474
+#: lxc/file.go:249 lxc/file.go:475
 msgid "Create any directories necessary"
 msgstr ""
 
-#: lxc/auth.go:97 lxc/auth.go:98
+#: lxc/auth.go:98 lxc/auth.go:99
 #, fuzzy
 msgid "Create groups"
 msgstr "Копирование образа: %s"
 
-#: lxc/auth.go:1471 lxc/auth.go:1472
+#: lxc/auth.go:1472 lxc/auth.go:1473
 #, fuzzy
 msgid "Create identity provider groups"
 msgstr "Копирование образа: %s"
@@ -1713,12 +1713,12 @@ msgstr ""
 msgid "Create instances from images"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/storage_bucket.go:851 lxc/storage_bucket.go:852
+#: lxc/storage_bucket.go:852 lxc/storage_bucket.go:853
 #, fuzzy
 msgid "Create key for a storage bucket"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_bucket.go:82 lxc/storage_bucket.go:83
+#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
 #, fuzzy
 msgid "Create new custom storage buckets"
 msgstr "Копирование образа: %s"
@@ -1770,7 +1770,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:92 lxc/project.go:93
+#: lxc/project.go:93 lxc/project.go:94
 msgid "Create projects"
 msgstr ""
 
@@ -1808,13 +1808,13 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:376 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1135 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
-#: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:172
-#: lxc/profile.go:756 lxc/project.go:572 lxc/storage.go:723
-#: lxc/storage_bucket.go:512 lxc/storage_bucket.go:832
+#: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
+#: lxc/profile.go:756 lxc/project.go:573 lxc/storage.go:723
+#: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1732
 msgid "DESCRIPTION"
 msgstr ""
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
-#: lxc/operation.go:55 lxc/operation.go:56
+#: lxc/operation.go:56 lxc/operation.go:57
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
@@ -1847,21 +1847,21 @@ msgstr ""
 msgid "Delete a cluster group"
 msgstr ""
 
-#: lxc/warning.go:360
+#: lxc/warning.go:361
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:122 lxc/file.go:123
+#: lxc/file.go:123 lxc/file.go:124
 #, fuzzy
 msgid "Delete files in instances"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/auth.go:151 lxc/auth.go:152
+#: lxc/auth.go:152 lxc/auth.go:153
 #, fuzzy
 msgid "Delete groups"
 msgstr "Копирование образа: %s"
 
-#: lxc/auth.go:1523 lxc/auth.go:1524
+#: lxc/auth.go:1524 lxc/auth.go:1525
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1883,7 +1883,7 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Delete instances and snapshots"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/storage_bucket.go:957 lxc/storage_bucket.go:958
+#: lxc/storage_bucket.go:958 lxc/storage_bucket.go:959
 #, fuzzy
 msgid "Delete key from a storage bucket"
 msgstr "Копирование образа: %s"
@@ -1923,11 +1923,11 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:188 lxc/project.go:189
+#: lxc/project.go:189 lxc/project.go:190
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:187 lxc/storage_bucket.go:188
+#: lxc/storage_bucket.go:188 lxc/storage_bucket.go:189
 #, fuzzy
 msgid "Delete storage buckets"
 msgstr "Копирование образа: %s"
@@ -1941,20 +1941,20 @@ msgstr ""
 msgid "Delete storage volumes"
 msgstr "Копирование образа: %s"
 
-#: lxc/warning.go:356 lxc/warning.go:357
+#: lxc/warning.go:357 lxc/warning.go:358
 msgid "Delete warning"
 msgstr ""
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:30 lxc/auth.go:59 lxc/auth.go:98
-#: lxc/auth.go:152 lxc/auth.go:201 lxc/auth.go:332 lxc/auth.go:392
-#: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
-#: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
-#: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
-#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1434 lxc/auth.go:1472
-#: lxc/auth.go:1524 lxc/auth.go:1573 lxc/auth.go:1692 lxc/auth.go:1752
-#: lxc/auth.go:1801 lxc/auth.go:1852 lxc/auth.go:1875 lxc/auth.go:1928
+#: lxc/alias.go:214 lxc/auth.go:31 lxc/auth.go:60 lxc/auth.go:99
+#: lxc/auth.go:153 lxc/auth.go:202 lxc/auth.go:333 lxc/auth.go:393
+#: lxc/auth.go:442 lxc/auth.go:494 lxc/auth.go:517 lxc/auth.go:576
+#: lxc/auth.go:732 lxc/auth.go:766 lxc/auth.go:833 lxc/auth.go:896
+#: lxc/auth.go:957 lxc/auth.go:1085 lxc/auth.go:1108 lxc/auth.go:1166
+#: lxc/auth.go:1235 lxc/auth.go:1257 lxc/auth.go:1435 lxc/auth.go:1473
+#: lxc/auth.go:1525 lxc/auth.go:1574 lxc/auth.go:1693 lxc/auth.go:1753
+#: lxc/auth.go:1802 lxc/auth.go:1853 lxc/auth.go:1876 lxc/auth.go:1929
 #: lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215 lxc/cluster.go:272
 #: lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:484 lxc/cluster.go:528
 #: lxc/cluster.go:586 lxc/cluster.go:677 lxc/cluster.go:770 lxc/cluster.go:893
@@ -1978,15 +1978,15 @@ msgstr ""
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:83 lxc/file.go:123 lxc/file.go:172
-#: lxc/file.go:242 lxc/file.go:467 lxc/file.go:986 lxc/image.go:38
+#: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
+#: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
 #: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
 #: lxc/image.go:697 lxc/image.go:946 lxc/image.go:1088 lxc/image.go:1415
 #: lxc/image.go:1506 lxc/image.go:1572 lxc/image.go:1636 lxc/image.go:1699
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:38 lxc/network.go:33
+#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33
 #: lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405
 #: lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793
 #: lxc/network.go:874 lxc/network.go:1005 lxc/network.go:1106
@@ -2020,27 +2020,27 @@ msgstr ""
 #: lxc/network_zone.go:909 lxc/network_zone.go:985 lxc/network_zone.go:1083
 #: lxc/network_zone.go:1172 lxc/network_zone.go:1219 lxc/network_zone.go:1349
 #: lxc/network_zone.go:1410 lxc/network_zone.go:1425 lxc/network_zone.go:1483
-#: lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:106
-#: lxc/operation.go:193 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
+#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
+#: lxc/operation.go:194 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
 #: lxc/profile.go:271 lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493
 #: lxc/profile.go:629 lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860
-#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:29
-#: lxc/project.go:93 lxc/project.go:189 lxc/project.go:260 lxc/project.go:396
-#: lxc/project.go:470 lxc/project.go:590 lxc/project.go:655 lxc/project.go:743
-#: lxc/project.go:787 lxc/project.go:848 lxc/project.go:915 lxc/publish.go:34
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:35 lxc/remote.go:91
+#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:30
+#: lxc/project.go:94 lxc/project.go:190 lxc/project.go:261 lxc/project.go:397
+#: lxc/project.go:471 lxc/project.go:591 lxc/project.go:656 lxc/project.go:744
+#: lxc/project.go:788 lxc/project.go:849 lxc/project.go:916 lxc/publish.go:34
+#: lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91
 #: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853
 #: lxc/remote.go:917 lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24
 #: lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203
 #: lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655
 #: lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940
-#: lxc/storage_bucket.go:29 lxc/storage_bucket.go:83 lxc/storage_bucket.go:188
-#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:382
-#: lxc/storage_bucket.go:458 lxc/storage_bucket.go:535
-#: lxc/storage_bucket.go:629 lxc/storage_bucket.go:698
-#: lxc/storage_bucket.go:732 lxc/storage_bucket.go:773
-#: lxc/storage_bucket.go:852 lxc/storage_bucket.go:958
-#: lxc/storage_bucket.go:1022 lxc/storage_bucket.go:1157
+#: lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189
+#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:383
+#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:536
+#: lxc/storage_bucket.go:630 lxc/storage_bucket.go:699
+#: lxc/storage_bucket.go:733 lxc/storage_bucket.go:774
+#: lxc/storage_bucket.go:853 lxc/storage_bucket.go:959
+#: lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158
 #: lxc/storage_volume.go:58 lxc/storage_volume.go:169 lxc/storage_volume.go:283
 #: lxc/storage_volume.go:390 lxc/storage_volume.go:605
 #: lxc/storage_volume.go:714 lxc/storage_volume.go:801
@@ -2051,8 +2051,8 @@ msgstr ""
 #: lxc/storage_volume.go:2064 lxc/storage_volume.go:2222
 #: lxc/storage_volume.go:2343 lxc/storage_volume.go:2405
 #: lxc/storage_volume.go:2541 lxc/storage_volume.go:2624
-#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:29
-#: lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
+#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:30
+#: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
@@ -2141,7 +2141,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:994
+#: lxc/file.go:995
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2211,7 +2211,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:74
+#: lxc/file.go:75
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -2221,7 +2221,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:955 lxc/auth.go:956
+#: lxc/auth.go:956 lxc/auth.go:957
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -2229,15 +2229,15 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:171 lxc/file.go:172
+#: lxc/file.go:172 lxc/file.go:173
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/auth.go:200 lxc/auth.go:201
+#: lxc/auth.go:201 lxc/auth.go:202
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1572 lxc/auth.go:1573
+#: lxc/auth.go:1573 lxc/auth.go:1574
 #, fuzzy
 msgid "Edit identity provider groups as YAML"
 msgstr "Копирование образа: %s"
@@ -2301,16 +2301,16 @@ msgstr "Копирование образа: %s"
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:259 lxc/project.go:260
+#: lxc/project.go:260 lxc/project.go:261
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:248 lxc/storage_bucket.go:249
+#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:250
 #, fuzzy
 msgid "Edit storage bucket configurations as YAML"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_bucket.go:1021 lxc/storage_bucket.go:1022
+#: lxc/storage_bucket.go:1022 lxc/storage_bucket.go:1023
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
@@ -2327,7 +2327,7 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1147 lxc/list.go:622 lxc/storage_volume.go:1766
-#: lxc/warning.go:235
+#: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2382,7 +2382,7 @@ msgstr ""
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
-#: lxc/project.go:718 lxc/storage.go:812 lxc/storage_bucket.go:602
+#: lxc/project.go:719 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2155 lxc/storage_volume.go:2193
 #, fuzzy, c-format
 msgid "Error setting properties: %v"
@@ -2396,8 +2396,8 @@ msgstr "Копирование образа: %s"
 #: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
-#: lxc/profile.go:981 lxc/project.go:712 lxc/storage.go:806
-#: lxc/storage_bucket.go:596 lxc/storage_volume.go:2149
+#: lxc/profile.go:981 lxc/project.go:713 lxc/storage.go:806
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2149
 #: lxc/storage_volume.go:2187
 #, c-format
 msgid "Error unsetting property: %v"
@@ -2421,7 +2421,7 @@ msgstr ""
 msgid "Evacuating cluster member: %s"
 msgstr "Копирование образа: %s"
 
-#: lxc/monitor.go:50
+#: lxc/monitor.go:51
 msgid "Event type to listen for"
 msgstr ""
 
@@ -2513,16 +2513,16 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/warning.go:210
+#: lxc/warning.go:211
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1237
+#: lxc/file.go:1238
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1260
+#: lxc/file.go:1261
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2537,12 +2537,12 @@ msgstr "Копирование образа: %s"
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "Копирование образа: %s"
 
-#: lxc/file.go:1287
+#: lxc/file.go:1288
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1072
+#: lxc/file.go:1073
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "Копирование образа: %s"
@@ -2572,7 +2572,7 @@ msgstr "Копирование образа: %s"
 msgid "Failed fetching fingerprint %q: %w"
 msgstr "Копирование образа: %s"
 
-#: lxc/file.go:1193
+#: lxc/file.go:1194
 #, fuzzy, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "Принять сертификат"
@@ -2587,7 +2587,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr "Копирование образа: %s"
 
-#: lxc/file.go:1198
+#: lxc/file.go:1199
 #, fuzzy, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "Принять сертификат"
@@ -2597,12 +2597,12 @@ msgstr "Принять сертификат"
 msgid "Failed starting command: %w"
 msgstr "Принять сертификат"
 
-#: lxc/file.go:1098
+#: lxc/file.go:1099
 #, fuzzy, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "Принять сертификат"
 
-#: lxc/file.go:1225
+#: lxc/file.go:1226
 #, fuzzy, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "Принять сертификат"
@@ -2641,7 +2641,7 @@ msgstr "Принять сертификат"
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1210
+#: lxc/file.go:1211
 #, fuzzy, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "Принять сертификат"
@@ -2656,7 +2656,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr "Принять сертификат"
 
-#: lxc/file.go:820
+#: lxc/file.go:821
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2671,7 +2671,7 @@ msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
 #: lxc/network.go:1044 lxc/network_acl.go:133 lxc/network_zone.go:124
-#: lxc/operation.go:136
+#: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
 
@@ -2737,21 +2737,21 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
+#: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:770 lxc/auth.go:1697
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1114 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:57
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
-#: lxc/operation.go:108 lxc/profile.go:707 lxc/project.go:472
-#: lxc/project.go:917 lxc/remote.go:690 lxc/storage.go:657
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:774
-#: lxc/storage_volume.go:1608 lxc/warning.go:93
+#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:473
+#: lxc/project.go:918 lxc/remote.go:690 lxc/storage.go:657
+#: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
+#: lxc/storage_volume.go:1608 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
-#: lxc/monitor.go:52
+#: lxc/monitor.go:53
 msgid "Format (json|pretty|yaml)"
 msgstr ""
 
@@ -2795,7 +2795,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:817 lxc/auth.go:1736
+#: lxc/auth.go:818 lxc/auth.go:1737
 msgid "GROUPS"
 msgstr ""
 
@@ -2812,7 +2812,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/project.go:914 lxc/project.go:915
+#: lxc/project.go:915 lxc/project.go:916
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2865,11 +2865,11 @@ msgstr "Копирование образа: %s"
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:400
+#: lxc/project.go:401
 msgid "Get the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:385
+#: lxc/storage_bucket.go:386
 #, fuzzy
 msgid "Get the key as a storage bucket property"
 msgstr "Копирование образа: %s"
@@ -2938,11 +2938,11 @@ msgstr "Копирование образа: %s"
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:395 lxc/project.go:396
+#: lxc/project.go:396 lxc/project.go:397
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:382
+#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:383
 #, fuzzy
 msgid "Get values for storage bucket configuration keys"
 msgstr "Копирование образа: %s"
@@ -2960,17 +2960,17 @@ msgstr ""
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: lxc/auth.go:136
+#: lxc/auth.go:137
 #, fuzzy, c-format
 msgid "Group %s created"
 msgstr " Использование сети:"
 
-#: lxc/auth.go:186
+#: lxc/auth.go:187
 #, fuzzy, c-format
 msgid "Group %s deleted"
 msgstr " Использование сети:"
 
-#: lxc/auth.go:426 lxc/auth.go:1786
+#: lxc/auth.go:427 lxc/auth.go:1787
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2996,27 +2996,27 @@ msgstr "Псевдонимы:"
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1310
+#: lxc/file.go:1311
 #, fuzzy, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/file.go:1299
+#: lxc/file.go:1300
 #, fuzzy, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/file.go:1122
+#: lxc/file.go:1123
 #, fuzzy, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/file.go:1132
+#: lxc/file.go:1133
 #, fuzzy, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/network.go:966 lxc/operation.go:170
+#: lxc/network.go:966 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -3030,11 +3030,11 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:816
+#: lxc/auth.go:817
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:566
+#: lxc/project.go:567
 msgid "IMAGES"
 msgstr ""
 
@@ -3062,17 +3062,17 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1508
+#: lxc/auth.go:1509
 #, fuzzy, c-format
 msgid "Identity provider group %s created"
 msgstr " Использование сети:"
 
-#: lxc/auth.go:1558
+#: lxc/auth.go:1559
 #, fuzzy, c-format
 msgid "Identity provider group %s deleted"
 msgstr " Использование сети:"
 
-#: lxc/rebuild.go:32
+#: lxc/rebuild.go:33
 msgid "If an instance is running, stop it and then rebuild it"
 msgstr ""
 
@@ -3197,7 +3197,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1233 lxc/auth.go:1234
+#: lxc/auth.go:1234 lxc/auth.go:1235
 msgid "Inspect permissions"
 msgstr ""
 
@@ -3206,11 +3206,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr "Имя контейнера: %s"
 
-#: lxc/file.go:1124
+#: lxc/file.go:1125
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1301
+#: lxc/file.go:1302
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3230,7 +3230,7 @@ msgstr "Имя контейнера: %s"
 msgid "Instance name must be specified"
 msgstr "Имя контейнера: %s"
 
-#: lxc/file.go:1044
+#: lxc/file.go:1045
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3239,7 +3239,7 @@ msgstr ""
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/rebuild.go:74
+#: lxc/rebuild.go:75
 #, fuzzy, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr "Имя контейнера: %s"
@@ -3272,7 +3272,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/monitor.go:70
+#: lxc/monitor.go:71
 #, fuzzy, c-format
 msgid "Invalid format: %s"
 msgstr "Имя контейнера: %s"
@@ -3282,7 +3282,7 @@ msgstr "Имя контейнера: %s"
 msgid "Invalid instance name: %s"
 msgstr "Имя контейнера: %s"
 
-#: lxc/file.go:1039
+#: lxc/file.go:1040
 #, fuzzy, c-format
 msgid "Invalid instance path: %q"
 msgstr "Имя контейнера: %s"
@@ -3325,7 +3325,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:147
+#: lxc/file.go:148
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -3342,12 +3342,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr "Имя контейнера: %s"
 
-#: lxc/file.go:313
+#: lxc/file.go:314
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:495
+#: lxc/file.go:496
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3361,7 +3361,7 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/warning.go:212
 msgid "LAST SEEN"
 msgstr ""
 
@@ -3369,7 +3369,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:984
+#: lxc/project.go:985
 msgid "LIMIT"
 msgstr ""
 
@@ -3378,8 +3378,8 @@ msgid "LISTEN ADDRESS"
 msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
-#: lxc/network_load_balancer.go:165 lxc/operation.go:177
-#: lxc/storage_bucket.go:516 lxc/storage_volume.go:1739 lxc/warning.go:220
+#: lxc/network_load_balancer.go:165 lxc/operation.go:178
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1739 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3458,7 +3458,7 @@ msgstr "Копирование образа: %s"
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/warning.go:94
+#: lxc/warning.go:95
 #, fuzzy
 msgid "List all warnings"
 msgstr "Псевдонимы:"
@@ -3505,20 +3505,20 @@ msgstr ""
 msgid "List available storage pools"
 msgstr ""
 
-#: lxc/operation.go:105 lxc/operation.go:106
+#: lxc/operation.go:106 lxc/operation.go:107
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:331 lxc/auth.go:332
+#: lxc/auth.go:332 lxc/auth.go:333
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:764 lxc/auth.go:765
+#: lxc/auth.go:765 lxc/auth.go:766
 #, fuzzy
 msgid "List identities"
 msgstr "Псевдонимы:"
 
-#: lxc/auth.go:1691 lxc/auth.go:1692
+#: lxc/auth.go:1692 lxc/auth.go:1693
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3670,12 +3670,12 @@ msgstr ""
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/operation.go:109
+#: lxc/operation.go:110
 #, fuzzy
 msgid "List operations from all projects"
 msgstr "Копирование образа: %s"
 
-#: lxc/auth.go:1255 lxc/auth.go:1256
+#: lxc/auth.go:1256 lxc/auth.go:1257
 #, fuzzy
 msgid "List permissions"
 msgstr "Псевдонимы:"
@@ -3684,16 +3684,16 @@ msgstr "Псевдонимы:"
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:469 lxc/project.go:470
+#: lxc/project.go:470 lxc/project.go:471
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:771 lxc/storage_bucket.go:773
+#: lxc/storage_bucket.go:772 lxc/storage_bucket.go:774
 #, fuzzy
 msgid "List storage bucket keys"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_bucket.go:456 lxc/storage_bucket.go:458
+#: lxc/storage_bucket.go:457 lxc/storage_bucket.go:459
 #, fuzzy
 msgid "List storage buckets"
 msgstr "Копирование образа: %s"
@@ -3731,12 +3731,12 @@ msgstr ""
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/warning.go:70
+#: lxc/warning.go:71
 #, fuzzy
 msgid "List warnings"
 msgstr "Псевдонимы:"
 
-#: lxc/warning.go:71
+#: lxc/warning.go:72
 msgid ""
 "List warnings\n"
 "\n"
@@ -3759,7 +3759,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/operation.go:23 lxc/operation.go:24
+#: lxc/operation.go:24 lxc/operation.go:25
 msgid "List, show and delete background operations"
 msgstr ""
 
@@ -3768,7 +3768,7 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/monitor.go:79
+#: lxc/monitor.go:80
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
@@ -3877,25 +3877,25 @@ msgstr ""
 msgid "Manage devices"
 msgstr "Копирование образа: %s"
 
-#: lxc/file.go:82 lxc/file.go:83
+#: lxc/file.go:83 lxc/file.go:84
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1433 lxc/auth.go:1434
+#: lxc/auth.go:59 lxc/auth.go:60 lxc/auth.go:1434 lxc/auth.go:1435
 #, fuzzy
 msgid "Manage groups"
 msgstr "Копирование образа: %s"
 
-#: lxc/auth.go:1083 lxc/auth.go:1084
+#: lxc/auth.go:1084 lxc/auth.go:1085
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:730 lxc/auth.go:731
+#: lxc/auth.go:731 lxc/auth.go:732
 #, fuzzy
 msgid "Manage identities"
 msgstr "Копирование образа: %s"
 
-#: lxc/auth.go:1851 lxc/auth.go:1852
+#: lxc/auth.go:1852 lxc/auth.go:1853
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3999,7 +3999,7 @@ msgstr "Копирование образа: %s"
 msgid "Manage network zones"
 msgstr "Копирование образа: %s"
 
-#: lxc/auth.go:492 lxc/auth.go:493
+#: lxc/auth.go:493 lxc/auth.go:494
 #, fuzzy
 msgid "Manage permissions"
 msgstr "Копирование образа: %s"
@@ -4008,26 +4008,26 @@ msgstr "Копирование образа: %s"
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:28 lxc/project.go:29
+#: lxc/project.go:29 lxc/project.go:30
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:731
+#: lxc/storage_bucket.go:732
 #, fuzzy
 msgid "Manage storage bucket keys"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_bucket.go:732
+#: lxc/storage_bucket.go:733
 #, fuzzy
 msgid "Manage storage bucket keys."
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_bucket.go:28
+#: lxc/storage_bucket.go:29
 #, fuzzy
 msgid "Manage storage buckets"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:30
 #, fuzzy
 msgid "Manage storage buckets."
 msgstr "Копирование образа: %s"
@@ -4058,12 +4058,12 @@ msgstr ""
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/auth.go:29 lxc/auth.go:30
+#: lxc/auth.go:30 lxc/auth.go:31
 #, fuzzy
 msgid "Manage user authorization"
 msgstr "Копирование образа: %s"
 
-#: lxc/warning.go:28 lxc/warning.go:29
+#: lxc/warning.go:29 lxc/warning.go:30
 #, fuzzy
 msgid "Manage warnings"
 msgstr "Копирование образа: %s"
@@ -4130,17 +4130,17 @@ msgstr ""
 msgid "Migration operation failure: %w"
 msgstr ""
 
-#: lxc/monitor.go:51
+#: lxc/monitor.go:52
 msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: lxc/storage_bucket.go:116 lxc/storage_bucket.go:216
-#: lxc/storage_bucket.go:292 lxc/storage_bucket.go:411
-#: lxc/storage_bucket.go:568 lxc/storage_bucket.go:660
-#: lxc/storage_bucket.go:802 lxc/storage_bucket.go:889
-#: lxc/storage_bucket.go:986 lxc/storage_bucket.go:1065
-#: lxc/storage_bucket.go:1188
+#: lxc/storage_bucket.go:117 lxc/storage_bucket.go:217
+#: lxc/storage_bucket.go:293 lxc/storage_bucket.go:412
+#: lxc/storage_bucket.go:569 lxc/storage_bucket.go:661
+#: lxc/storage_bucket.go:803 lxc/storage_bucket.go:890
+#: lxc/storage_bucket.go:987 lxc/storage_bucket.go:1066
+#: lxc/storage_bucket.go:1189
 #, fuzzy
 msgid "Missing bucket name"
 msgstr "Имя контейнера: %s"
@@ -4162,23 +4162,23 @@ msgstr "Копирование образа: %s"
 msgid "Missing cluster member name"
 msgstr "Копирование образа: %s"
 
-#: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1825
+#: lxc/auth.go:123 lxc/auth.go:177 lxc/auth.go:255 lxc/auth.go:417
+#: lxc/auth.go:466 lxc/auth.go:541 lxc/auth.go:600 lxc/auth.go:1826
 #, fuzzy
 msgid "Missing group name"
 msgstr "Копирование образа: %s"
 
-#: lxc/auth.go:862 lxc/auth.go:1003 lxc/auth.go:1131 lxc/auth.go:1189
+#: lxc/auth.go:863 lxc/auth.go:1004 lxc/auth.go:1132 lxc/auth.go:1190
 #, fuzzy
 msgid "Missing identity argument"
 msgstr "Имя контейнера: %s"
 
-#: lxc/auth.go:1495 lxc/auth.go:1548 lxc/auth.go:1614 lxc/auth.go:1776
+#: lxc/auth.go:1496 lxc/auth.go:1549 lxc/auth.go:1615 lxc/auth.go:1777
 #, fuzzy
 msgid "Missing identity provider group name"
 msgstr "Копирование образа: %s"
 
-#: lxc/auth.go:1899 lxc/auth.go:1952
+#: lxc/auth.go:1900 lxc/auth.go:1953
 #, fuzzy
 msgid "Missing identity provider group name argument"
 msgstr "Копирование образа: %s"
@@ -4187,13 +4187,13 @@ msgstr "Копирование образа: %s"
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
 #: lxc/config_template.go:377 lxc/profile.go:141 lxc/profile.go:222
-#: lxc/profile.go:808 lxc/rebuild.go:60
+#: lxc/profile.go:808 lxc/rebuild.go:61
 #, fuzzy
 msgid "Missing instance name"
 msgstr "Имя контейнера: %s"
 
-#: lxc/storage_bucket.go:893 lxc/storage_bucket.go:990
-#: lxc/storage_bucket.go:1069 lxc/storage_bucket.go:1192
+#: lxc/storage_bucket.go:894 lxc/storage_bucket.go:991
+#: lxc/storage_bucket.go:1070 lxc/storage_bucket.go:1193
 #, fuzzy
 msgid "Missing key name"
 msgstr "Имя контейнера: %s"
@@ -4264,13 +4264,13 @@ msgid "Missing peer name"
 msgstr "Имя контейнера: %s"
 
 #: lxc/storage.go:235 lxc/storage.go:313 lxc/storage.go:431 lxc/storage.go:509
-#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:112
-#: lxc/storage_bucket.go:212 lxc/storage_bucket.go:288
-#: lxc/storage_bucket.go:407 lxc/storage_bucket.go:482
-#: lxc/storage_bucket.go:564 lxc/storage_bucket.go:656
-#: lxc/storage_bucket.go:798 lxc/storage_bucket.go:885
-#: lxc/storage_bucket.go:982 lxc/storage_bucket.go:1061
-#: lxc/storage_bucket.go:1184 lxc/storage_volume.go:209
+#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:113
+#: lxc/storage_bucket.go:213 lxc/storage_bucket.go:289
+#: lxc/storage_bucket.go:408 lxc/storage_bucket.go:483
+#: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
+#: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
+#: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
 #: lxc/storage_volume.go:323 lxc/storage_volume.go:643
 #: lxc/storage_volume.go:750 lxc/storage_volume.go:841
 #: lxc/storage_volume.go:939 lxc/storage_volume.go:1053
@@ -4285,9 +4285,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:404 lxc/project.go:146 lxc/project.go:226 lxc/project.go:316
-#: lxc/project.go:433 lxc/project.go:622 lxc/project.go:691 lxc/project.go:819
-#: lxc/project.go:948
+#: lxc/profile.go:404 lxc/project.go:147 lxc/project.go:227 lxc/project.go:317
+#: lxc/project.go:434 lxc/project.go:623 lxc/project.go:692 lxc/project.go:820
+#: lxc/project.go:949
 #, fuzzy
 msgid "Missing project name"
 msgstr "Имя контейнера: %s"
@@ -4306,7 +4306,7 @@ msgstr "Копирование образа: %s"
 msgid "Missing storage pool name"
 msgstr "Копирование образа: %s"
 
-#: lxc/file.go:598
+#: lxc/file.go:599
 msgid "Missing target directory"
 msgstr ""
 
@@ -4329,11 +4329,11 @@ msgstr ""
 msgid "Model: %v"
 msgstr ""
 
-#: lxc/monitor.go:32
+#: lxc/monitor.go:33
 msgid "Monitor a local or remote LXD server"
 msgstr ""
 
-#: lxc/monitor.go:33
+#: lxc/monitor.go:34
 msgid ""
 "Monitor a local or remote LXD server\n"
 "\n"
@@ -4345,11 +4345,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:285
+#: lxc/file.go:286
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:985 lxc/file.go:986
+#: lxc/file.go:986 lxc/file.go:987
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -4413,13 +4413,13 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:192
+#: lxc/auth.go:376 lxc/auth.go:816 lxc/auth.go:1736 lxc/cluster.go:192
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
-#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:565
-#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:511
-#: lxc/storage_bucket.go:831 lxc/storage_volume.go:1731
+#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:566
+#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1731
 msgid "NAME"
 msgstr ""
 
@@ -4427,11 +4427,11 @@ msgstr ""
 msgid "NAT"
 msgstr ""
 
-#: lxc/project.go:571
+#: lxc/project.go:572
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:570
+#: lxc/project.go:571
 msgid "NETWORKS"
 msgstr ""
 
@@ -4443,9 +4443,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/operation.go:154 lxc/project.go:523
-#: lxc/project.go:528 lxc/project.go:533 lxc/project.go:538 lxc/project.go:543
-#: lxc/project.go:548 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
+#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:524
+#: lxc/project.go:529 lxc/project.go:534 lxc/project.go:539 lxc/project.go:544
+#: lxc/project.go:549 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
 msgid "NO"
 msgstr ""
 
@@ -4694,7 +4694,7 @@ msgstr ""
 msgid "Only managed networks can be modified"
 msgstr ""
 
-#: lxc/operation.go:86
+#: lxc/operation.go:87
 #, c-format
 msgid "Operation %s deleted"
 msgstr ""
@@ -4741,11 +4741,11 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:567
+#: lxc/list.go:576 lxc/project.go:568
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:212
+#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4808,24 +4808,24 @@ msgstr "Авто-обновление: %s"
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1102
+#: lxc/file.go:1103
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:860
+#: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
-#: lxc/project.go:363 lxc/storage.go:360 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1151
+#: lxc/project.go:364 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1151
 #: lxc/storage_volume.go:1183
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
-#: lxc/monitor.go:48
+#: lxc/monitor.go:49
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
@@ -4911,17 +4911,17 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:172
+#: lxc/project.go:173
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:236
+#: lxc/project.go:237
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:637
+#: lxc/project.go:638
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -5042,20 +5042,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/file.go:241 lxc/file.go:242
+#: lxc/file.go:242 lxc/file.go:243
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:416 lxc/file.go:767
+#: lxc/file.go:417 lxc/file.go:768
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:466 lxc/file.go:467
+#: lxc/file.go:467 lxc/file.go:468
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:701 lxc/file.go:867
+#: lxc/file.go:702 lxc/file.go:868
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -5068,11 +5068,11 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:983
+#: lxc/project.go:984
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/storage_bucket.go:833
+#: lxc/storage_bucket.go:834
 msgid "ROLE"
 msgstr ""
 
@@ -5085,17 +5085,17 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/rebuild.go:31
+#: lxc/rebuild.go:32
 #, fuzzy
 msgid "Rebuild as an empty instance"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/rebuild.go:26
+#: lxc/rebuild.go:27
 #, fuzzy
 msgid "Rebuild instances"
 msgstr "Псевдонимы:"
 
-#: lxc/file.go:249 lxc/file.go:473
+#: lxc/file.go:250 lxc/file.go:474
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -5124,7 +5124,7 @@ msgstr "Копирование образа: %s"
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:882 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
+#: lxc/project.go:883 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
 #: lxc/remote.go:994
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -5177,7 +5177,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr "Копирование образа: %s"
 
-#: lxc/auth.go:1164 lxc/auth.go:1165
+#: lxc/auth.go:1165 lxc/auth.go:1166
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -5216,7 +5216,7 @@ msgstr "Копирование образа: %s"
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1927 lxc/auth.go:1928
+#: lxc/auth.go:1928 lxc/auth.go:1929
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -5229,7 +5229,7 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:574 lxc/auth.go:575
+#: lxc/auth.go:575 lxc/auth.go:576
 msgid "Remove permissions from groups"
 msgstr ""
 
@@ -5276,12 +5276,12 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:391 lxc/auth.go:392
+#: lxc/auth.go:392 lxc/auth.go:393
 #, fuzzy
 msgid "Rename groups"
 msgstr "Копирование образа: %s"
 
-#: lxc/auth.go:1751 lxc/auth.go:1752
+#: lxc/auth.go:1752 lxc/auth.go:1753
 #, fuzzy
 msgid "Rename identity provider groups"
 msgstr "Копирование образа: %s"
@@ -5303,7 +5303,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:589 lxc/project.go:590
+#: lxc/project.go:590 lxc/project.go:591
 msgid "Rename projects"
 msgstr ""
 
@@ -5409,7 +5409,7 @@ msgstr "Копирование образа: %s"
 msgid "Revoke cluster member join token"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_bucket.go:862
+#: lxc/storage_bucket.go:863
 msgid "Role (admin or read-only)"
 msgstr ""
 
@@ -5426,7 +5426,7 @@ msgstr ""
 msgid "Run against all projects"
 msgstr "Доступные команды:"
 
-#: lxc/warning.go:213
+#: lxc/warning.go:214
 msgid "SEVERITY"
 msgstr ""
 
@@ -5446,12 +5446,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1231
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1231
+#: lxc/file.go:1232
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5465,11 +5465,11 @@ msgstr ""
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:173 lxc/warning.go:214
+#: lxc/operation.go:174 lxc/warning.go:215
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:569
+#: lxc/project.go:570
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5477,7 +5477,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:569
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -5485,11 +5485,11 @@ msgstr ""
 msgid "STP"
 msgstr ""
 
-#: lxc/storage_bucket.go:864
+#: lxc/storage_bucket.go:865
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:942
+#: lxc/storage_bucket.go:943
 #, fuzzy, c-format
 msgid "Secret key: %s"
 msgstr "Авто-обновление: %s"
@@ -5529,7 +5529,7 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Set a cluster member's configuration keys"
 msgstr "Копирование образа: %s"
 
-#: lxc/file.go:995
+#: lxc/file.go:996
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5672,11 +5672,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:654
+#: lxc/project.go:655
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:655
+#: lxc/project.go:656
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5685,12 +5685,12 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage_bucket.go:534
+#: lxc/storage_bucket.go:535
 #, fuzzy
 msgid "Set storage bucket configuration keys"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_bucket.go:535
+#: lxc/storage_bucket.go:536
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -5729,15 +5729,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:476
+#: lxc/file.go:477
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:477
+#: lxc/file.go:478
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:475
+#: lxc/file.go:476
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5782,11 +5782,11 @@ msgstr "Копирование образа: %s"
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 msgid "Set the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:542
+#: lxc/storage_bucket.go:543
 #, fuzzy
 msgid "Set the key as a storage bucket property"
 msgstr "Копирование образа: %s"
@@ -5805,7 +5805,7 @@ msgstr "Копирование образа: %s"
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:993
+#: lxc/file.go:994
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5817,7 +5817,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1800 lxc/auth.go:1801
+#: lxc/auth.go:1801 lxc/auth.go:1802
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5835,11 +5835,11 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Show details of a cluster member"
 msgstr ""
 
-#: lxc/operation.go:192 lxc/operation.go:193
+#: lxc/operation.go:193 lxc/operation.go:194
 msgid "Show details on a background operation"
 msgstr ""
 
-#: lxc/monitor.go:49
+#: lxc/monitor.go:50
 msgid "Show events from all projects"
 msgstr ""
 
@@ -5847,12 +5847,12 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:440 lxc/auth.go:441
+#: lxc/auth.go:441 lxc/auth.go:442
 #, fuzzy
 msgid "Show group configurations"
 msgstr "Копирование образа: %s"
 
-#: lxc/auth.go:832
+#: lxc/auth.go:833
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5942,16 +5942,16 @@ msgstr "Копирование образа: %s"
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:786 lxc/project.go:787
+#: lxc/project.go:787 lxc/project.go:788
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage_bucket.go:628 lxc/storage_bucket.go:629
+#: lxc/storage_bucket.go:629 lxc/storage_bucket.go:630
 #, fuzzy
 msgid "Show storage bucket configurations"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_bucket.go:1156 lxc/storage_bucket.go:1157
+#: lxc/storage_bucket.go:1157 lxc/storage_bucket.go:1158
 #, fuzzy
 msgid "Show storage bucket key configurations"
 msgstr "Копирование образа: %s"
@@ -5969,7 +5969,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr "Копирование образа: %s"
 
-#: lxc/auth.go:895
+#: lxc/auth.go:896
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -6021,7 +6021,7 @@ msgstr ""
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: lxc/warning.go:302 lxc/warning.go:303
+#: lxc/warning.go:303 lxc/warning.go:304
 msgid "Show warning"
 msgstr ""
 
@@ -6109,22 +6109,22 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Stopping the instance failed: %s"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/storage_bucket.go:166
+#: lxc/storage_bucket.go:167
 #, fuzzy, c-format
 msgid "Storage bucket %s created"
 msgstr " Использование сети:"
 
-#: lxc/storage_bucket.go:233
+#: lxc/storage_bucket.go:234
 #, fuzzy, c-format
 msgid "Storage bucket %s deleted"
 msgstr " Использование сети:"
 
-#: lxc/storage_bucket.go:940
+#: lxc/storage_bucket.go:941
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr ""
 
-#: lxc/storage_bucket.go:1006
+#: lxc/storage_bucket.go:1007
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr ""
@@ -6194,7 +6194,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:847 lxc/project.go:848
+#: lxc/project.go:848 lxc/project.go:849
 msgid "Switch the current project"
 msgstr ""
 
@@ -6210,10 +6210,10 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1139
+#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1139
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
-#: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:171
-#: lxc/storage_volume.go:1730 lxc/warning.go:215
+#: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
+#: lxc/storage_volume.go:1730 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
@@ -6221,11 +6221,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1032
+#: lxc/file.go:1033
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1026
+#: lxc/file.go:1027
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -6353,12 +6353,12 @@ msgstr "Копирование образа: %s"
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr "Копирование образа: %s"
 
-#: lxc/project.go:446
+#: lxc/project.go:447
 #, fuzzy, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_bucket.go:431
+#: lxc/storage_bucket.go:432
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage bucket %q: %v"
 msgstr "Копирование образа: %s"
@@ -6545,7 +6545,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:961
+#: lxc/project.go:962
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6557,17 +6557,17 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:985 lxc/storage_volume.go:1735
+#: lxc/project.go:986 lxc/storage_volume.go:1735
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:573
+#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:574
 #: lxc/storage.go:724 lxc/storage_volume.go:1734
 msgid "USED BY"
 msgstr ""
 
-#: lxc/warning.go:216
+#: lxc/warning.go:217
 msgid "UUID"
 msgstr ""
 
@@ -6576,7 +6576,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:197
+#: lxc/file.go:198
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6590,13 +6590,13 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1253
+#: lxc/file.go:1254
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1153 lxc/list.go:631 lxc/storage_volume.go:1772
-#: lxc/warning.go:241
+#: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6606,7 +6606,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:807
+#: lxc/file.go:808
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6699,11 +6699,11 @@ msgstr "Копирование образа: %s"
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:742 lxc/project.go:743
+#: lxc/project.go:743 lxc/project.go:744
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:697 lxc/storage_bucket.go:698
+#: lxc/storage_bucket.go:698 lxc/storage_bucket.go:699
 #, fuzzy
 msgid "Unset storage bucket configuration keys"
 msgstr "Копирование образа: %s"
@@ -6758,11 +6758,11 @@ msgstr "Копирование образа: %s"
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:747
+#: lxc/project.go:748
 msgid "Unset the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:701
+#: lxc/storage_bucket.go:702
 #, fuzzy
 msgid "Unset the key as a storage bucket property"
 msgstr "Копирование образа: %s"
@@ -6846,7 +6846,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:71
+#: lxc/file.go:72
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6883,11 +6883,11 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:831
+#: lxc/auth.go:832
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:894
+#: lxc/auth.go:895
 msgid "View the current identity"
 msgstr ""
 
@@ -6918,15 +6918,15 @@ msgstr ""
 msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
-#: lxc/rebuild.go:27
+#: lxc/rebuild.go:28
 msgid ""
 "Wipe the instance root disk and re-initialize. The original image is used to "
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:156 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
+#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:526
+#: lxc/project.go:531 lxc/project.go:536 lxc/project.go:541 lxc/project.go:546
+#: lxc/project.go:551 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
 msgid "YES"
 msgstr ""
 
@@ -6946,7 +6946,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/rebuild.go:119
+#: lxc/rebuild.go:120
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
@@ -6966,12 +6966,12 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1689
+#: lxc/auth.go:330 lxc/auth.go:763 lxc/auth.go:894 lxc/auth.go:1690
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
-#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
+#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
-#: lxc/operation.go:103 lxc/profile.go:700 lxc/project.go:467
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:68
+#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:468
+#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 #, fuzzy
 msgid "[<remote>:]"
 msgstr ""
@@ -7027,7 +7027,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/auth.go:1254
+#: lxc/auth.go:1255
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -7144,11 +7144,11 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/auth.go:830
+#: lxc/auth.go:831
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1926
+#: lxc/auth.go:1106 lxc/auth.go:1164 lxc/auth.go:1927
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -7160,8 +7160,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:954 lxc/auth.go:1470 lxc/cluster_group.go:168
+#: lxc/auth.go:97 lxc/auth.go:150 lxc/auth.go:200 lxc/auth.go:440
+#: lxc/auth.go:955 lxc/auth.go:1471 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 #, fuzzy
 msgid "[<remote>:]<group>"
@@ -7170,7 +7170,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/auth.go:514 lxc/auth.go:572
+#: lxc/auth.go:515 lxc/auth.go:573
 #, fuzzy
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
@@ -7188,7 +7188,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/auth.go:389
+#: lxc/auth.go:390
 #, fuzzy
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
@@ -7196,7 +7196,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/auth.go:1521 lxc/auth.go:1571 lxc/auth.go:1799
+#: lxc/auth.go:1522 lxc/auth.go:1572 lxc/auth.go:1800
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
@@ -7204,7 +7204,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/auth.go:1873
+#: lxc/auth.go:1874
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
@@ -7212,7 +7212,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/auth.go:1749
+#: lxc/auth.go:1750
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
@@ -7252,7 +7252,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/rebuild.go:25
+#: lxc/rebuild.go:26
 #, fuzzy
 msgid "[<remote>:]<image> [<remote>:]<instance>"
 msgstr ""
@@ -7415,7 +7415,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/file.go:170
+#: lxc/file.go:171
 #, fuzzy
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
@@ -7423,7 +7423,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/file.go:120
+#: lxc/file.go:121
 #, fuzzy
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
@@ -7431,7 +7431,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/file.go:240
+#: lxc/file.go:241
 #, fuzzy
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
@@ -7440,7 +7440,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/file.go:984
+#: lxc/file.go:985
 #, fuzzy
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
@@ -7723,7 +7723,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/operation.go:53 lxc/operation.go:191
+#: lxc/operation.go:54 lxc/operation.go:192
 #, fuzzy
 msgid "[<remote>:]<operation>"
 msgstr ""
@@ -7732,7 +7732,7 @@ msgstr ""
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
 #: lxc/storage.go:200 lxc/storage.go:259 lxc/storage.go:473 lxc/storage.go:844
-#: lxc/storage_bucket.go:454
+#: lxc/storage_bucket.go:455
 #, fuzzy
 msgid "[<remote>:]<pool>"
 msgstr ""
@@ -7748,8 +7748,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_bucket.go:185 lxc/storage_bucket.go:247
-#: lxc/storage_bucket.go:627 lxc/storage_bucket.go:769
+#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:248
+#: lxc/storage_bucket.go:628 lxc/storage_bucket.go:770
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
@@ -7757,9 +7757,9 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_bucket.go:380 lxc/storage_bucket.go:696
-#: lxc/storage_bucket.go:850 lxc/storage_bucket.go:956
-#: lxc/storage_bucket.go:1020 lxc/storage_bucket.go:1155
+#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:697
+#: lxc/storage_bucket.go:851 lxc/storage_bucket.go:957
+#: lxc/storage_bucket.go:1021 lxc/storage_bucket.go:1156
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
@@ -7767,7 +7767,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_bucket.go:533
+#: lxc/storage_bucket.go:534
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
@@ -7775,7 +7775,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_bucket.go:81
+#: lxc/storage_bucket.go:82
 #, fuzzy
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
@@ -8002,8 +8002,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/project.go:91 lxc/project.go:186 lxc/project.go:258 lxc/project.go:785
-#: lxc/project.go:846 lxc/project.go:913
+#: lxc/project.go:92 lxc/project.go:187 lxc/project.go:259 lxc/project.go:786
+#: lxc/project.go:847 lxc/project.go:914
 #, fuzzy
 msgid "[<remote>:]<project>"
 msgstr ""
@@ -8011,7 +8011,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/project.go:394 lxc/project.go:741
+#: lxc/project.go:395 lxc/project.go:742
 #, fuzzy
 msgid "[<remote>:]<project> <key>"
 msgstr ""
@@ -8019,7 +8019,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/project.go:653
+#: lxc/project.go:654
 #, fuzzy
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
@@ -8027,7 +8027,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/project.go:587
+#: lxc/project.go:588
 #, fuzzy
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
@@ -8043,7 +8043,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/warning.go:259 lxc/warning.go:301 lxc/warning.go:354
+#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
 #, fuzzy
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
@@ -8155,7 +8155,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/project.go:555 lxc/remote.go:739
+#: lxc/project.go:556 lxc/remote.go:739
 msgid "current"
 msgstr ""
 
@@ -8202,20 +8202,20 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/auth.go:203
+#: lxc/auth.go:204
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:958
+#: lxc/auth.go:959
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1575
+#: lxc/auth.go:1576
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -8293,20 +8293,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:988
+#: lxc/file.go:989
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:244
+#: lxc/file.go:245
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:470
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -8388,7 +8388,7 @@ msgid ""
 "  List instances with their running state and user comment."
 msgstr ""
 
-#: lxc/monitor.go:37
+#: lxc/monitor.go:38
 msgid ""
 "lxc monitor --type=logging\n"
 "    Only show log messages.\n"
@@ -8464,7 +8464,7 @@ msgid ""
 "    Create record r1 for zone z1 with configuration from config.yaml"
 msgstr ""
 
-#: lxc/operation.go:195
+#: lxc/operation.go:196
 msgid ""
 "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Show details on that operation UUID"
@@ -8507,7 +8507,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:95
+#: lxc/project.go:96
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -8515,7 +8515,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:262
+#: lxc/project.go:263
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -8546,7 +8546,7 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:85
 msgid ""
 "lxc storage bucket create p1 b01\n"
 "\tCreate a new storage bucket name b01 in storage pool p1\n"
@@ -8556,19 +8556,19 @@ msgid ""
 "of config.yaml"
 msgstr ""
 
-#: lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:251
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1023
+#: lxc/storage_bucket.go:1024
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:854
 msgid ""
 "lxc storage bucket key create p1 b01 k1\n"
 "\tCreate a key called k1 for the bucket b01 in the pool p1.\n"
@@ -8578,14 +8578,14 @@ msgid ""
 "of config.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1158
+#: lxc/storage_bucket.go:1159
 msgid ""
 "lxc storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_bucket.go:630
+#: lxc/storage_bucket.go:631
 msgid ""
 "lxc storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
@@ -8655,16 +8655,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1142
+#: lxc/file.go:1143
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1101
+#: lxc/file.go:1102
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1054
+#: lxc/file.go:1055
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/si.po
+++ b/po/si.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-04 08:52-0600\n"
+"POT-Creation-Date: 2024-09-05 08:44-0400\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Sinhala <https://hosted.weblate.org/projects/linux-containers/"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: lxc/storage_bucket.go:260 lxc/storage_bucket.go:1033
+#: lxc/storage_bucket.go:261 lxc/storage_bucket.go:1034
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -133,7 +133,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:213
+#: lxc/auth.go:214
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -160,7 +160,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:968
+#: lxc/auth.go:969
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -181,7 +181,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1585
+#: lxc/auth.go:1586
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -391,7 +391,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:280
+#: lxc/project.go:281
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -433,12 +433,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:935
+#: lxc/file.go:936
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:825
+#: lxc/file.go:826
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -474,7 +474,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:142 lxc/rebuild.go:64
+#: lxc/init.go:142 lxc/rebuild.go:65
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -527,7 +527,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:465
+#: lxc/file.go:466
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -560,7 +560,7 @@ msgstr ""
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:813
+#: lxc/auth.go:814
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -568,11 +568,11 @@ msgstr ""
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/storage_bucket.go:863
+#: lxc/storage_bucket.go:864
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:941
+#: lxc/storage_bucket.go:942
 #, c-format
 msgid "Access key: %s"
 msgstr ""
@@ -581,7 +581,7 @@ msgstr ""
 msgid "Access the expanded configuration"
 msgstr ""
 
-#: lxc/warning.go:261 lxc/warning.go:262
+#: lxc/warning.go:262 lxc/warning.go:263
 msgid "Acknowledge warning"
 msgstr ""
 
@@ -598,11 +598,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1106 lxc/auth.go:1107
+#: lxc/auth.go:1107 lxc/auth.go:1108
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1874 lxc/auth.go:1875
+#: lxc/auth.go:1875 lxc/auth.go:1876
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -671,7 +671,7 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:515 lxc/auth.go:516
+#: lxc/auth.go:516 lxc/auth.go:517
 msgid "Add permissions to groups"
 msgstr ""
 
@@ -700,7 +700,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:169
+#: lxc/storage_bucket.go:170
 #, c-format
 msgid "Admin access key: %s"
 msgstr ""
@@ -710,7 +710,7 @@ msgstr ""
 msgid "Admin password (or token) for %s:"
 msgstr ""
 
-#: lxc/storage_bucket.go:170
+#: lxc/storage_bucket.go:171
 #, c-format
 msgid "Admin secret key: %s"
 msgstr ""
@@ -769,7 +769,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:342 lxc/rebuild.go:130
+#: lxc/init.go:342 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -869,12 +869,12 @@ msgstr ""
 
 #: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:318
 #: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
-#: lxc/network_zone.go:366 lxc/network_zone.go:1053 lxc/storage_bucket.go:141
+#: lxc/network_zone.go:366 lxc/network_zone.go:1053 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:159
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:160
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -914,7 +914,7 @@ msgstr ""
 msgid "Bytes sent"
 msgstr ""
 
-#: lxc/operation.go:174
+#: lxc/operation.go:175
 msgid "CANCELABLE"
 msgstr ""
 
@@ -926,7 +926,7 @@ msgstr ""
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: lxc/warning.go:209
+#: lxc/warning.go:210
 msgid "COUNT"
 msgstr ""
 
@@ -952,7 +952,7 @@ msgstr ""
 msgid "CPUs (%s):"
 msgstr ""
 
-#: lxc/operation.go:175
+#: lxc/operation.go:176
 msgid "CREATED"
 msgstr ""
 
@@ -982,7 +982,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:340
+#: lxc/file.go:341
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1007,11 +1007,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:224
+#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:546
+#: lxc/file.go:547
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1020,7 +1020,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:160
+#: lxc/rebuild.go:161
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1143,13 +1143,13 @@ msgstr ""
 #: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
 #: lxc/network_load_balancer.go:1051 lxc/network_load_balancer.go:1125
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
-#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:90
-#: lxc/storage_bucket.go:190 lxc/storage_bucket.go:253
-#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:541
-#: lxc/storage_bucket.go:634 lxc/storage_bucket.go:700
-#: lxc/storage_bucket.go:775 lxc/storage_bucket.go:861
-#: lxc/storage_bucket.go:961 lxc/storage_bucket.go:1026
-#: lxc/storage_bucket.go:1162 lxc/storage_volume.go:394
+#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
+#: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
+#: lxc/storage_bucket.go:385 lxc/storage_bucket.go:542
+#: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
+#: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
+#: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
 #: lxc/storage_volume.go:612 lxc/storage_volume.go:717
 #: lxc/storage_volume.go:1005 lxc/storage_volume.go:1231
 #: lxc/storage_volume.go:1360 lxc/storage_volume.go:1848
@@ -1173,7 +1173,7 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1113 lxc/list.go:132 lxc/storage_volume.go:1589
-#: lxc/warning.go:92
+#: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
@@ -1201,7 +1201,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:100
+#: lxc/project.go:101
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1215,8 +1215,8 @@ msgstr ""
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
-#: lxc/project.go:362 lxc/storage.go:359 lxc/storage_bucket.go:348
-#: lxc/storage_bucket.go:1125 lxc/storage_volume.go:1150
+#: lxc/project.go:363 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1150
 #: lxc/storage_volume.go:1182
 #, c-format
 msgid "Config parsing error: %s"
@@ -1343,12 +1343,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:300 lxc/auth.go:1660
+#: lxc/auth.go:301 lxc/auth.go:1661
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1054
+#: lxc/auth.go:1055
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1397,15 +1397,15 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:248 lxc/file.go:474
+#: lxc/file.go:249 lxc/file.go:475
 msgid "Create any directories necessary"
 msgstr ""
 
-#: lxc/auth.go:97 lxc/auth.go:98
+#: lxc/auth.go:98 lxc/auth.go:99
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1471 lxc/auth.go:1472
+#: lxc/auth.go:1472 lxc/auth.go:1473
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1425,11 +1425,11 @@ msgstr ""
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_bucket.go:851 lxc/storage_bucket.go:852
+#: lxc/storage_bucket.go:852 lxc/storage_bucket.go:853
 msgid "Create key for a storage bucket"
 msgstr ""
 
-#: lxc/storage_bucket.go:82 lxc/storage_bucket.go:83
+#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
 msgid "Create new custom storage buckets"
 msgstr ""
 
@@ -1473,7 +1473,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:92 lxc/project.go:93
+#: lxc/project.go:93 lxc/project.go:94
 msgid "Create projects"
 msgstr ""
 
@@ -1508,13 +1508,13 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:376 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1135 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
-#: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:172
-#: lxc/profile.go:756 lxc/project.go:572 lxc/storage.go:723
-#: lxc/storage_bucket.go:512 lxc/storage_bucket.go:832
+#: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
+#: lxc/profile.go:756 lxc/project.go:573 lxc/storage.go:723
+#: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1732
 msgid "DESCRIPTION"
 msgstr ""
@@ -1539,7 +1539,7 @@ msgstr ""
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
-#: lxc/operation.go:55 lxc/operation.go:56
+#: lxc/operation.go:56 lxc/operation.go:57
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
@@ -1547,19 +1547,19 @@ msgstr ""
 msgid "Delete a cluster group"
 msgstr ""
 
-#: lxc/warning.go:360
+#: lxc/warning.go:361
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:122 lxc/file.go:123
+#: lxc/file.go:123 lxc/file.go:124
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/auth.go:151 lxc/auth.go:152
+#: lxc/auth.go:152 lxc/auth.go:153
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1523 lxc/auth.go:1524
+#: lxc/auth.go:1524 lxc/auth.go:1525
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1579,7 +1579,7 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/storage_bucket.go:957 lxc/storage_bucket.go:958
+#: lxc/storage_bucket.go:958 lxc/storage_bucket.go:959
 msgid "Delete key from a storage bucket"
 msgstr ""
 
@@ -1615,11 +1615,11 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:188 lxc/project.go:189
+#: lxc/project.go:189 lxc/project.go:190
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:187 lxc/storage_bucket.go:188
+#: lxc/storage_bucket.go:188 lxc/storage_bucket.go:189
 msgid "Delete storage buckets"
 msgstr ""
 
@@ -1631,20 +1631,20 @@ msgstr ""
 msgid "Delete storage volumes"
 msgstr ""
 
-#: lxc/warning.go:356 lxc/warning.go:357
+#: lxc/warning.go:357 lxc/warning.go:358
 msgid "Delete warning"
 msgstr ""
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:30 lxc/auth.go:59 lxc/auth.go:98
-#: lxc/auth.go:152 lxc/auth.go:201 lxc/auth.go:332 lxc/auth.go:392
-#: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
-#: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
-#: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
-#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1434 lxc/auth.go:1472
-#: lxc/auth.go:1524 lxc/auth.go:1573 lxc/auth.go:1692 lxc/auth.go:1752
-#: lxc/auth.go:1801 lxc/auth.go:1852 lxc/auth.go:1875 lxc/auth.go:1928
+#: lxc/alias.go:214 lxc/auth.go:31 lxc/auth.go:60 lxc/auth.go:99
+#: lxc/auth.go:153 lxc/auth.go:202 lxc/auth.go:333 lxc/auth.go:393
+#: lxc/auth.go:442 lxc/auth.go:494 lxc/auth.go:517 lxc/auth.go:576
+#: lxc/auth.go:732 lxc/auth.go:766 lxc/auth.go:833 lxc/auth.go:896
+#: lxc/auth.go:957 lxc/auth.go:1085 lxc/auth.go:1108 lxc/auth.go:1166
+#: lxc/auth.go:1235 lxc/auth.go:1257 lxc/auth.go:1435 lxc/auth.go:1473
+#: lxc/auth.go:1525 lxc/auth.go:1574 lxc/auth.go:1693 lxc/auth.go:1753
+#: lxc/auth.go:1802 lxc/auth.go:1853 lxc/auth.go:1876 lxc/auth.go:1929
 #: lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215 lxc/cluster.go:272
 #: lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:484 lxc/cluster.go:528
 #: lxc/cluster.go:586 lxc/cluster.go:677 lxc/cluster.go:770 lxc/cluster.go:893
@@ -1668,15 +1668,15 @@ msgstr ""
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:83 lxc/file.go:123 lxc/file.go:172
-#: lxc/file.go:242 lxc/file.go:467 lxc/file.go:986 lxc/image.go:38
+#: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
+#: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
 #: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
 #: lxc/image.go:697 lxc/image.go:946 lxc/image.go:1088 lxc/image.go:1415
 #: lxc/image.go:1506 lxc/image.go:1572 lxc/image.go:1636 lxc/image.go:1699
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:38 lxc/network.go:33
+#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33
 #: lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405
 #: lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793
 #: lxc/network.go:874 lxc/network.go:1005 lxc/network.go:1106
@@ -1710,27 +1710,27 @@ msgstr ""
 #: lxc/network_zone.go:909 lxc/network_zone.go:985 lxc/network_zone.go:1083
 #: lxc/network_zone.go:1172 lxc/network_zone.go:1219 lxc/network_zone.go:1349
 #: lxc/network_zone.go:1410 lxc/network_zone.go:1425 lxc/network_zone.go:1483
-#: lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:106
-#: lxc/operation.go:193 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
+#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
+#: lxc/operation.go:194 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
 #: lxc/profile.go:271 lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493
 #: lxc/profile.go:629 lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860
-#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:29
-#: lxc/project.go:93 lxc/project.go:189 lxc/project.go:260 lxc/project.go:396
-#: lxc/project.go:470 lxc/project.go:590 lxc/project.go:655 lxc/project.go:743
-#: lxc/project.go:787 lxc/project.go:848 lxc/project.go:915 lxc/publish.go:34
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:35 lxc/remote.go:91
+#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:30
+#: lxc/project.go:94 lxc/project.go:190 lxc/project.go:261 lxc/project.go:397
+#: lxc/project.go:471 lxc/project.go:591 lxc/project.go:656 lxc/project.go:744
+#: lxc/project.go:788 lxc/project.go:849 lxc/project.go:916 lxc/publish.go:34
+#: lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91
 #: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853
 #: lxc/remote.go:917 lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24
 #: lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203
 #: lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655
 #: lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940
-#: lxc/storage_bucket.go:29 lxc/storage_bucket.go:83 lxc/storage_bucket.go:188
-#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:382
-#: lxc/storage_bucket.go:458 lxc/storage_bucket.go:535
-#: lxc/storage_bucket.go:629 lxc/storage_bucket.go:698
-#: lxc/storage_bucket.go:732 lxc/storage_bucket.go:773
-#: lxc/storage_bucket.go:852 lxc/storage_bucket.go:958
-#: lxc/storage_bucket.go:1022 lxc/storage_bucket.go:1157
+#: lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189
+#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:383
+#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:536
+#: lxc/storage_bucket.go:630 lxc/storage_bucket.go:699
+#: lxc/storage_bucket.go:733 lxc/storage_bucket.go:774
+#: lxc/storage_bucket.go:853 lxc/storage_bucket.go:959
+#: lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158
 #: lxc/storage_volume.go:58 lxc/storage_volume.go:169 lxc/storage_volume.go:283
 #: lxc/storage_volume.go:390 lxc/storage_volume.go:605
 #: lxc/storage_volume.go:714 lxc/storage_volume.go:801
@@ -1741,8 +1741,8 @@ msgstr ""
 #: lxc/storage_volume.go:2064 lxc/storage_volume.go:2222
 #: lxc/storage_volume.go:2343 lxc/storage_volume.go:2405
 #: lxc/storage_volume.go:2541 lxc/storage_volume.go:2624
-#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:29
-#: lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
+#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:30
+#: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
@@ -1829,7 +1829,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:994
+#: lxc/file.go:995
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1895,7 +1895,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:74
+#: lxc/file.go:75
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1905,7 +1905,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:955 lxc/auth.go:956
+#: lxc/auth.go:956 lxc/auth.go:957
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1913,15 +1913,15 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:171 lxc/file.go:172
+#: lxc/file.go:172 lxc/file.go:173
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/auth.go:200 lxc/auth.go:201
+#: lxc/auth.go:201 lxc/auth.go:202
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1572 lxc/auth.go:1573
+#: lxc/auth.go:1573 lxc/auth.go:1574
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -1977,15 +1977,15 @@ msgstr ""
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:259 lxc/project.go:260
+#: lxc/project.go:260 lxc/project.go:261
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:248 lxc/storage_bucket.go:249
+#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:250
 msgid "Edit storage bucket configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:1021 lxc/storage_bucket.go:1022
+#: lxc/storage_bucket.go:1022 lxc/storage_bucket.go:1023
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
@@ -2002,7 +2002,7 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1147 lxc/list.go:622 lxc/storage_volume.go:1766
-#: lxc/warning.go:235
+#: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2057,7 +2057,7 @@ msgstr ""
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
-#: lxc/project.go:718 lxc/storage.go:812 lxc/storage_bucket.go:602
+#: lxc/project.go:719 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2155 lxc/storage_volume.go:2193
 #, c-format
 msgid "Error setting properties: %v"
@@ -2071,8 +2071,8 @@ msgstr ""
 #: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
-#: lxc/profile.go:981 lxc/project.go:712 lxc/storage.go:806
-#: lxc/storage_bucket.go:596 lxc/storage_volume.go:2149
+#: lxc/profile.go:981 lxc/project.go:713 lxc/storage.go:806
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2149
 #: lxc/storage_volume.go:2187
 #, c-format
 msgid "Error unsetting property: %v"
@@ -2092,7 +2092,7 @@ msgstr ""
 msgid "Evacuating cluster member: %s"
 msgstr ""
 
-#: lxc/monitor.go:50
+#: lxc/monitor.go:51
 msgid "Event type to listen for"
 msgstr ""
 
@@ -2179,16 +2179,16 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/warning.go:210
+#: lxc/warning.go:211
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1237
+#: lxc/file.go:1238
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1260
+#: lxc/file.go:1261
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2203,12 +2203,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1287
+#: lxc/file.go:1288
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1072
+#: lxc/file.go:1073
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2238,7 +2238,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1193
+#: lxc/file.go:1194
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2253,7 +2253,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1198
+#: lxc/file.go:1199
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2263,12 +2263,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1098
+#: lxc/file.go:1099
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1225
+#: lxc/file.go:1226
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2307,7 +2307,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1210
+#: lxc/file.go:1211
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2322,7 +2322,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:820
+#: lxc/file.go:821
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2337,7 +2337,7 @@ msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
 #: lxc/network.go:1044 lxc/network_acl.go:133 lxc/network_zone.go:124
-#: lxc/operation.go:136
+#: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
 
@@ -2402,21 +2402,21 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
+#: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:770 lxc/auth.go:1697
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1114 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:57
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
-#: lxc/operation.go:108 lxc/profile.go:707 lxc/project.go:472
-#: lxc/project.go:917 lxc/remote.go:690 lxc/storage.go:657
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:774
-#: lxc/storage_volume.go:1608 lxc/warning.go:93
+#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:473
+#: lxc/project.go:918 lxc/remote.go:690 lxc/storage.go:657
+#: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
+#: lxc/storage_volume.go:1608 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
-#: lxc/monitor.go:52
+#: lxc/monitor.go:53
 msgid "Format (json|pretty|yaml)"
 msgstr ""
 
@@ -2460,7 +2460,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:817 lxc/auth.go:1736
+#: lxc/auth.go:818 lxc/auth.go:1737
 msgid "GROUPS"
 msgstr ""
 
@@ -2476,7 +2476,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:914 lxc/project.go:915
+#: lxc/project.go:915 lxc/project.go:916
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2524,11 +2524,11 @@ msgstr ""
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:400
+#: lxc/project.go:401
 msgid "Get the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:385
+#: lxc/storage_bucket.go:386
 msgid "Get the key as a storage bucket property"
 msgstr ""
 
@@ -2588,11 +2588,11 @@ msgstr ""
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:395 lxc/project.go:396
+#: lxc/project.go:396 lxc/project.go:397
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:382
+#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:383
 msgid "Get values for storage bucket configuration keys"
 msgstr ""
 
@@ -2609,17 +2609,17 @@ msgstr ""
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: lxc/auth.go:136
+#: lxc/auth.go:137
 #, c-format
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:186
+#: lxc/auth.go:187
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:426 lxc/auth.go:1786
+#: lxc/auth.go:427 lxc/auth.go:1787
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2644,27 +2644,27 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1310
+#: lxc/file.go:1311
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1299
+#: lxc/file.go:1300
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1122
+#: lxc/file.go:1123
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1132
+#: lxc/file.go:1133
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:966 lxc/operation.go:170
+#: lxc/network.go:966 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2678,11 +2678,11 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:816
+#: lxc/auth.go:817
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:566
+#: lxc/project.go:567
 msgid "IMAGES"
 msgstr ""
 
@@ -2710,17 +2710,17 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1508
+#: lxc/auth.go:1509
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1558
+#: lxc/auth.go:1559
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
 
-#: lxc/rebuild.go:32
+#: lxc/rebuild.go:33
 msgid "If an instance is running, stop it and then rebuild it"
 msgstr ""
 
@@ -2841,7 +2841,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1233 lxc/auth.go:1234
+#: lxc/auth.go:1234 lxc/auth.go:1235
 msgid "Inspect permissions"
 msgstr ""
 
@@ -2849,11 +2849,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1124
+#: lxc/file.go:1125
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1301
+#: lxc/file.go:1302
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2871,7 +2871,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1044
+#: lxc/file.go:1045
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2880,7 +2880,7 @@ msgstr ""
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/rebuild.go:74
+#: lxc/rebuild.go:75
 #, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
@@ -2913,7 +2913,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/monitor.go:70
+#: lxc/monitor.go:71
 #, c-format
 msgid "Invalid format: %s"
 msgstr ""
@@ -2923,7 +2923,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1039
+#: lxc/file.go:1040
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2965,7 +2965,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:147
+#: lxc/file.go:148
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2981,12 +2981,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:313
+#: lxc/file.go:314
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:495
+#: lxc/file.go:496
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3000,7 +3000,7 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/warning.go:212
 msgid "LAST SEEN"
 msgstr ""
 
@@ -3008,7 +3008,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:984
+#: lxc/project.go:985
 msgid "LIMIT"
 msgstr ""
 
@@ -3017,8 +3017,8 @@ msgid "LISTEN ADDRESS"
 msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
-#: lxc/network_load_balancer.go:165 lxc/operation.go:177
-#: lxc/storage_bucket.go:516 lxc/storage_volume.go:1739 lxc/warning.go:220
+#: lxc/network_load_balancer.go:165 lxc/operation.go:178
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1739 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3092,7 +3092,7 @@ msgstr ""
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/warning.go:94
+#: lxc/warning.go:95
 msgid "List all warnings"
 msgstr ""
 
@@ -3136,19 +3136,19 @@ msgstr ""
 msgid "List available storage pools"
 msgstr ""
 
-#: lxc/operation.go:105 lxc/operation.go:106
+#: lxc/operation.go:106 lxc/operation.go:107
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:331 lxc/auth.go:332
+#: lxc/auth.go:332 lxc/auth.go:333
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:764 lxc/auth.go:765
+#: lxc/auth.go:765 lxc/auth.go:766
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1691 lxc/auth.go:1692
+#: lxc/auth.go:1692 lxc/auth.go:1693
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3297,11 +3297,11 @@ msgstr ""
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/operation.go:109
+#: lxc/operation.go:110
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1255 lxc/auth.go:1256
+#: lxc/auth.go:1256 lxc/auth.go:1257
 msgid "List permissions"
 msgstr ""
 
@@ -3309,15 +3309,15 @@ msgstr ""
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:469 lxc/project.go:470
+#: lxc/project.go:470 lxc/project.go:471
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:771 lxc/storage_bucket.go:773
+#: lxc/storage_bucket.go:772 lxc/storage_bucket.go:774
 msgid "List storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:456 lxc/storage_bucket.go:458
+#: lxc/storage_bucket.go:457 lxc/storage_bucket.go:459
 msgid "List storage buckets"
 msgstr ""
 
@@ -3353,11 +3353,11 @@ msgstr ""
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/warning.go:70
+#: lxc/warning.go:71
 msgid "List warnings"
 msgstr ""
 
-#: lxc/warning.go:71
+#: lxc/warning.go:72
 msgid ""
 "List warnings\n"
 "\n"
@@ -3380,7 +3380,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/operation.go:23 lxc/operation.go:24
+#: lxc/operation.go:24 lxc/operation.go:25
 msgid "List, show and delete background operations"
 msgstr ""
 
@@ -3389,7 +3389,7 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/monitor.go:79
+#: lxc/monitor.go:80
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
@@ -3493,23 +3493,23 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:82 lxc/file.go:83
+#: lxc/file.go:83 lxc/file.go:84
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1433 lxc/auth.go:1434
+#: lxc/auth.go:59 lxc/auth.go:60 lxc/auth.go:1434 lxc/auth.go:1435
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1083 lxc/auth.go:1084
+#: lxc/auth.go:1084 lxc/auth.go:1085
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:730 lxc/auth.go:731
+#: lxc/auth.go:731 lxc/auth.go:732
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1851 lxc/auth.go:1852
+#: lxc/auth.go:1852 lxc/auth.go:1853
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3600,7 +3600,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:492 lxc/auth.go:493
+#: lxc/auth.go:493 lxc/auth.go:494
 msgid "Manage permissions"
 msgstr ""
 
@@ -3608,23 +3608,23 @@ msgstr ""
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:28 lxc/project.go:29
+#: lxc/project.go:29 lxc/project.go:30
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:731
+#: lxc/storage_bucket.go:732
 msgid "Manage storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:732
+#: lxc/storage_bucket.go:733
 msgid "Manage storage bucket keys."
 msgstr ""
 
-#: lxc/storage_bucket.go:28
+#: lxc/storage_bucket.go:29
 msgid "Manage storage buckets"
 msgstr ""
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:30
 msgid "Manage storage buckets."
 msgstr ""
 
@@ -3652,11 +3652,11 @@ msgstr ""
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/auth.go:29 lxc/auth.go:30
+#: lxc/auth.go:30 lxc/auth.go:31
 msgid "Manage user authorization"
 msgstr ""
 
-#: lxc/warning.go:28 lxc/warning.go:29
+#: lxc/warning.go:29 lxc/warning.go:30
 msgid "Manage warnings"
 msgstr ""
 
@@ -3720,17 +3720,17 @@ msgstr ""
 msgid "Migration operation failure: %w"
 msgstr ""
 
-#: lxc/monitor.go:51
+#: lxc/monitor.go:52
 msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: lxc/storage_bucket.go:116 lxc/storage_bucket.go:216
-#: lxc/storage_bucket.go:292 lxc/storage_bucket.go:411
-#: lxc/storage_bucket.go:568 lxc/storage_bucket.go:660
-#: lxc/storage_bucket.go:802 lxc/storage_bucket.go:889
-#: lxc/storage_bucket.go:986 lxc/storage_bucket.go:1065
-#: lxc/storage_bucket.go:1188
+#: lxc/storage_bucket.go:117 lxc/storage_bucket.go:217
+#: lxc/storage_bucket.go:293 lxc/storage_bucket.go:412
+#: lxc/storage_bucket.go:569 lxc/storage_bucket.go:661
+#: lxc/storage_bucket.go:803 lxc/storage_bucket.go:890
+#: lxc/storage_bucket.go:987 lxc/storage_bucket.go:1066
+#: lxc/storage_bucket.go:1189
 msgid "Missing bucket name"
 msgstr ""
 
@@ -3749,20 +3749,20 @@ msgstr ""
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1825
+#: lxc/auth.go:123 lxc/auth.go:177 lxc/auth.go:255 lxc/auth.go:417
+#: lxc/auth.go:466 lxc/auth.go:541 lxc/auth.go:600 lxc/auth.go:1826
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:862 lxc/auth.go:1003 lxc/auth.go:1131 lxc/auth.go:1189
+#: lxc/auth.go:863 lxc/auth.go:1004 lxc/auth.go:1132 lxc/auth.go:1190
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1495 lxc/auth.go:1548 lxc/auth.go:1614 lxc/auth.go:1776
+#: lxc/auth.go:1496 lxc/auth.go:1549 lxc/auth.go:1615 lxc/auth.go:1777
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1899 lxc/auth.go:1952
+#: lxc/auth.go:1900 lxc/auth.go:1953
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -3770,12 +3770,12 @@ msgstr ""
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
 #: lxc/config_template.go:377 lxc/profile.go:141 lxc/profile.go:222
-#: lxc/profile.go:808 lxc/rebuild.go:60
+#: lxc/profile.go:808 lxc/rebuild.go:61
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/storage_bucket.go:893 lxc/storage_bucket.go:990
-#: lxc/storage_bucket.go:1069 lxc/storage_bucket.go:1192
+#: lxc/storage_bucket.go:894 lxc/storage_bucket.go:991
+#: lxc/storage_bucket.go:1070 lxc/storage_bucket.go:1193
 msgid "Missing key name"
 msgstr ""
 
@@ -3840,13 +3840,13 @@ msgid "Missing peer name"
 msgstr ""
 
 #: lxc/storage.go:235 lxc/storage.go:313 lxc/storage.go:431 lxc/storage.go:509
-#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:112
-#: lxc/storage_bucket.go:212 lxc/storage_bucket.go:288
-#: lxc/storage_bucket.go:407 lxc/storage_bucket.go:482
-#: lxc/storage_bucket.go:564 lxc/storage_bucket.go:656
-#: lxc/storage_bucket.go:798 lxc/storage_bucket.go:885
-#: lxc/storage_bucket.go:982 lxc/storage_bucket.go:1061
-#: lxc/storage_bucket.go:1184 lxc/storage_volume.go:209
+#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:113
+#: lxc/storage_bucket.go:213 lxc/storage_bucket.go:289
+#: lxc/storage_bucket.go:408 lxc/storage_bucket.go:483
+#: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
+#: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
+#: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
 #: lxc/storage_volume.go:323 lxc/storage_volume.go:643
 #: lxc/storage_volume.go:750 lxc/storage_volume.go:841
 #: lxc/storage_volume.go:939 lxc/storage_volume.go:1053
@@ -3861,9 +3861,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:404 lxc/project.go:146 lxc/project.go:226 lxc/project.go:316
-#: lxc/project.go:433 lxc/project.go:622 lxc/project.go:691 lxc/project.go:819
-#: lxc/project.go:948
+#: lxc/profile.go:404 lxc/project.go:147 lxc/project.go:227 lxc/project.go:317
+#: lxc/project.go:434 lxc/project.go:623 lxc/project.go:692 lxc/project.go:820
+#: lxc/project.go:949
 msgid "Missing project name"
 msgstr ""
 
@@ -3879,7 +3879,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:598
+#: lxc/file.go:599
 msgid "Missing target directory"
 msgstr ""
 
@@ -3901,11 +3901,11 @@ msgstr ""
 msgid "Model: %v"
 msgstr ""
 
-#: lxc/monitor.go:32
+#: lxc/monitor.go:33
 msgid "Monitor a local or remote LXD server"
 msgstr ""
 
-#: lxc/monitor.go:33
+#: lxc/monitor.go:34
 msgid ""
 "Monitor a local or remote LXD server\n"
 "\n"
@@ -3917,11 +3917,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:285
+#: lxc/file.go:286
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:985 lxc/file.go:986
+#: lxc/file.go:986 lxc/file.go:987
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3983,13 +3983,13 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:192
+#: lxc/auth.go:376 lxc/auth.go:816 lxc/auth.go:1736 lxc/cluster.go:192
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
-#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:565
-#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:511
-#: lxc/storage_bucket.go:831 lxc/storage_volume.go:1731
+#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:566
+#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1731
 msgid "NAME"
 msgstr ""
 
@@ -3997,11 +3997,11 @@ msgstr ""
 msgid "NAT"
 msgstr ""
 
-#: lxc/project.go:571
+#: lxc/project.go:572
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:570
+#: lxc/project.go:571
 msgid "NETWORKS"
 msgstr ""
 
@@ -4013,9 +4013,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/operation.go:154 lxc/project.go:523
-#: lxc/project.go:528 lxc/project.go:533 lxc/project.go:538 lxc/project.go:543
-#: lxc/project.go:548 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
+#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:524
+#: lxc/project.go:529 lxc/project.go:534 lxc/project.go:539 lxc/project.go:544
+#: lxc/project.go:549 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
 msgid "NO"
 msgstr ""
 
@@ -4260,7 +4260,7 @@ msgstr ""
 msgid "Only managed networks can be modified"
 msgstr ""
 
-#: lxc/operation.go:86
+#: lxc/operation.go:87
 #, c-format
 msgid "Operation %s deleted"
 msgstr ""
@@ -4307,11 +4307,11 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:567
+#: lxc/list.go:576 lxc/project.go:568
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:212
+#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4373,24 +4373,24 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1102
+#: lxc/file.go:1103
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:860
+#: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
-#: lxc/project.go:363 lxc/storage.go:360 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1151
+#: lxc/project.go:364 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1151
 #: lxc/storage_volume.go:1183
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
-#: lxc/monitor.go:48
+#: lxc/monitor.go:49
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
@@ -4476,17 +4476,17 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:172
+#: lxc/project.go:173
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:236
+#: lxc/project.go:237
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:637
+#: lxc/project.go:638
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -4607,20 +4607,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:241 lxc/file.go:242
+#: lxc/file.go:242 lxc/file.go:243
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:416 lxc/file.go:767
+#: lxc/file.go:417 lxc/file.go:768
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:466 lxc/file.go:467
+#: lxc/file.go:467 lxc/file.go:468
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:701 lxc/file.go:867
+#: lxc/file.go:702 lxc/file.go:868
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4633,11 +4633,11 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:983
+#: lxc/project.go:984
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/storage_bucket.go:833
+#: lxc/storage_bucket.go:834
 msgid "ROLE"
 msgstr ""
 
@@ -4650,15 +4650,15 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/rebuild.go:31
+#: lxc/rebuild.go:32
 msgid "Rebuild as an empty instance"
 msgstr ""
 
-#: lxc/rebuild.go:26
+#: lxc/rebuild.go:27
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:249 lxc/file.go:473
+#: lxc/file.go:250 lxc/file.go:474
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4685,7 +4685,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:882 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
+#: lxc/project.go:883 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
 #: lxc/remote.go:994
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4736,7 +4736,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1164 lxc/auth.go:1165
+#: lxc/auth.go:1165 lxc/auth.go:1166
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4772,7 +4772,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1927 lxc/auth.go:1928
+#: lxc/auth.go:1928 lxc/auth.go:1929
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4784,7 +4784,7 @@ msgstr ""
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:574 lxc/auth.go:575
+#: lxc/auth.go:575 lxc/auth.go:576
 msgid "Remove permissions from groups"
 msgstr ""
 
@@ -4829,11 +4829,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:391 lxc/auth.go:392
+#: lxc/auth.go:392 lxc/auth.go:393
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1751 lxc/auth.go:1752
+#: lxc/auth.go:1752 lxc/auth.go:1753
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -4853,7 +4853,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:589 lxc/project.go:590
+#: lxc/project.go:590 lxc/project.go:591
 msgid "Rename projects"
 msgstr ""
 
@@ -4951,7 +4951,7 @@ msgstr ""
 msgid "Revoke cluster member join token"
 msgstr ""
 
-#: lxc/storage_bucket.go:862
+#: lxc/storage_bucket.go:863
 msgid "Role (admin or read-only)"
 msgstr ""
 
@@ -4967,7 +4967,7 @@ msgstr ""
 msgid "Run against all projects"
 msgstr ""
 
-#: lxc/warning.go:213
+#: lxc/warning.go:214
 msgid "SEVERITY"
 msgstr ""
 
@@ -4987,12 +4987,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1231
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1231
+#: lxc/file.go:1232
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5006,11 +5006,11 @@ msgstr ""
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:173 lxc/warning.go:214
+#: lxc/operation.go:174 lxc/warning.go:215
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:569
+#: lxc/project.go:570
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5018,7 +5018,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:569
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -5026,11 +5026,11 @@ msgstr ""
 msgid "STP"
 msgstr ""
 
-#: lxc/storage_bucket.go:864
+#: lxc/storage_bucket.go:865
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:942
+#: lxc/storage_bucket.go:943
 #, c-format
 msgid "Secret key: %s"
 msgstr ""
@@ -5068,7 +5068,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:995
+#: lxc/file.go:996
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5206,11 +5206,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:654
+#: lxc/project.go:655
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:655
+#: lxc/project.go:656
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5219,11 +5219,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage_bucket.go:534
+#: lxc/storage_bucket.go:535
 msgid "Set storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:535
+#: lxc/storage_bucket.go:536
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -5262,15 +5262,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:476
+#: lxc/file.go:477
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:477
+#: lxc/file.go:478
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:475
+#: lxc/file.go:476
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5310,11 +5310,11 @@ msgstr ""
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 msgid "Set the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:542
+#: lxc/storage_bucket.go:543
 msgid "Set the key as a storage bucket property"
 msgstr ""
 
@@ -5330,7 +5330,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:993
+#: lxc/file.go:994
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5342,7 +5342,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1800 lxc/auth.go:1801
+#: lxc/auth.go:1801 lxc/auth.go:1802
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5358,11 +5358,11 @@ msgstr ""
 msgid "Show details of a cluster member"
 msgstr ""
 
-#: lxc/operation.go:192 lxc/operation.go:193
+#: lxc/operation.go:193 lxc/operation.go:194
 msgid "Show details on a background operation"
 msgstr ""
 
-#: lxc/monitor.go:49
+#: lxc/monitor.go:50
 msgid "Show events from all projects"
 msgstr ""
 
@@ -5370,11 +5370,11 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:440 lxc/auth.go:441
+#: lxc/auth.go:441 lxc/auth.go:442
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:832
+#: lxc/auth.go:833
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5455,15 +5455,15 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:786 lxc/project.go:787
+#: lxc/project.go:787 lxc/project.go:788
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage_bucket.go:628 lxc/storage_bucket.go:629
+#: lxc/storage_bucket.go:629 lxc/storage_bucket.go:630
 msgid "Show storage bucket configurations"
 msgstr ""
 
-#: lxc/storage_bucket.go:1156 lxc/storage_bucket.go:1157
+#: lxc/storage_bucket.go:1157 lxc/storage_bucket.go:1158
 msgid "Show storage bucket key configurations"
 msgstr ""
 
@@ -5479,7 +5479,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:895
+#: lxc/auth.go:896
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5529,7 +5529,7 @@ msgstr ""
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: lxc/warning.go:302 lxc/warning.go:303
+#: lxc/warning.go:303 lxc/warning.go:304
 msgid "Show warning"
 msgstr ""
 
@@ -5613,22 +5613,22 @@ msgstr ""
 msgid "Stopping the instance failed: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:166
+#: lxc/storage_bucket.go:167
 #, c-format
 msgid "Storage bucket %s created"
 msgstr ""
 
-#: lxc/storage_bucket.go:233
+#: lxc/storage_bucket.go:234
 #, c-format
 msgid "Storage bucket %s deleted"
 msgstr ""
 
-#: lxc/storage_bucket.go:940
+#: lxc/storage_bucket.go:941
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr ""
 
-#: lxc/storage_bucket.go:1006
+#: lxc/storage_bucket.go:1007
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr ""
@@ -5697,7 +5697,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:847 lxc/project.go:848
+#: lxc/project.go:848 lxc/project.go:849
 msgid "Switch the current project"
 msgstr ""
 
@@ -5713,10 +5713,10 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1139
+#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1139
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
-#: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:171
-#: lxc/storage_volume.go:1730 lxc/warning.go:215
+#: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
+#: lxc/storage_volume.go:1730 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
@@ -5724,11 +5724,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1032
+#: lxc/file.go:1033
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1026
+#: lxc/file.go:1027
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5856,12 +5856,12 @@ msgstr ""
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:446
+#: lxc/project.go:447
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
 
-#: lxc/storage_bucket.go:431
+#: lxc/storage_bucket.go:432
 #, c-format
 msgid "The property %q does not exist on the storage bucket %q: %v"
 msgstr ""
@@ -6046,7 +6046,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:961
+#: lxc/project.go:962
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6058,17 +6058,17 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:985 lxc/storage_volume.go:1735
+#: lxc/project.go:986 lxc/storage_volume.go:1735
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:573
+#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:574
 #: lxc/storage.go:724 lxc/storage_volume.go:1734
 msgid "USED BY"
 msgstr ""
 
-#: lxc/warning.go:216
+#: lxc/warning.go:217
 msgid "UUID"
 msgstr ""
 
@@ -6077,7 +6077,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:197
+#: lxc/file.go:198
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6091,13 +6091,13 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1253
+#: lxc/file.go:1254
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1153 lxc/list.go:631 lxc/storage_volume.go:1772
-#: lxc/warning.go:241
+#: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6107,7 +6107,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:807
+#: lxc/file.go:808
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6190,11 +6190,11 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:742 lxc/project.go:743
+#: lxc/project.go:743 lxc/project.go:744
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:697 lxc/storage_bucket.go:698
+#: lxc/storage_bucket.go:698 lxc/storage_bucket.go:699
 msgid "Unset storage bucket configuration keys"
 msgstr ""
 
@@ -6242,11 +6242,11 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:747
+#: lxc/project.go:748
 msgid "Unset the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:701
+#: lxc/storage_bucket.go:702
 msgid "Unset the key as a storage bucket property"
 msgstr ""
 
@@ -6325,7 +6325,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:71
+#: lxc/file.go:72
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6362,11 +6362,11 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:831
+#: lxc/auth.go:832
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:894
+#: lxc/auth.go:895
 msgid "View the current identity"
 msgstr ""
 
@@ -6397,15 +6397,15 @@ msgstr ""
 msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
-#: lxc/rebuild.go:27
+#: lxc/rebuild.go:28
 msgid ""
 "Wipe the instance root disk and re-initialize. The original image is used to "
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:156 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
+#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:526
+#: lxc/project.go:531 lxc/project.go:536 lxc/project.go:541 lxc/project.go:546
+#: lxc/project.go:551 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
 msgid "YES"
 msgstr ""
 
@@ -6425,7 +6425,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/rebuild.go:119
+#: lxc/rebuild.go:120
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
@@ -6437,12 +6437,12 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1689
+#: lxc/auth.go:330 lxc/auth.go:763 lxc/auth.go:894 lxc/auth.go:1690
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
-#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
+#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
-#: lxc/operation.go:103 lxc/profile.go:700 lxc/project.go:467
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:68
+#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:468
+#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6470,7 +6470,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1254
+#: lxc/auth.go:1255
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6531,11 +6531,11 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:830
+#: lxc/auth.go:831
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1926
+#: lxc/auth.go:1106 lxc/auth.go:1164 lxc/auth.go:1927
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6543,13 +6543,13 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:954 lxc/auth.go:1470 lxc/cluster_group.go:168
+#: lxc/auth.go:97 lxc/auth.go:150 lxc/auth.go:200 lxc/auth.go:440
+#: lxc/auth.go:955 lxc/auth.go:1471 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:514 lxc/auth.go:572
+#: lxc/auth.go:515 lxc/auth.go:573
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
@@ -6559,19 +6559,19 @@ msgstr ""
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:389
+#: lxc/auth.go:390
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1521 lxc/auth.go:1571 lxc/auth.go:1799
+#: lxc/auth.go:1522 lxc/auth.go:1572 lxc/auth.go:1800
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1873
+#: lxc/auth.go:1874
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1749
+#: lxc/auth.go:1750
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -6591,7 +6591,7 @@ msgstr ""
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
-#: lxc/rebuild.go:25
+#: lxc/rebuild.go:26
 msgid "[<remote>:]<image> [<remote>:]<instance>"
 msgstr ""
 
@@ -6674,20 +6674,20 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:170
+#: lxc/file.go:171
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:120
+#: lxc/file.go:121
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:240
+#: lxc/file.go:241
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:984
+#: lxc/file.go:985
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6838,12 +6838,12 @@ msgstr ""
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
-#: lxc/operation.go:53 lxc/operation.go:191
+#: lxc/operation.go:54 lxc/operation.go:192
 msgid "[<remote>:]<operation>"
 msgstr ""
 
 #: lxc/storage.go:200 lxc/storage.go:259 lxc/storage.go:473 lxc/storage.go:844
-#: lxc/storage_bucket.go:454
+#: lxc/storage_bucket.go:455
 msgid "[<remote>:]<pool>"
 msgstr ""
 
@@ -6851,22 +6851,22 @@ msgstr ""
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
-#: lxc/storage_bucket.go:185 lxc/storage_bucket.go:247
-#: lxc/storage_bucket.go:627 lxc/storage_bucket.go:769
+#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:248
+#: lxc/storage_bucket.go:628 lxc/storage_bucket.go:770
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
 
-#: lxc/storage_bucket.go:380 lxc/storage_bucket.go:696
-#: lxc/storage_bucket.go:850 lxc/storage_bucket.go:956
-#: lxc/storage_bucket.go:1020 lxc/storage_bucket.go:1155
+#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:697
+#: lxc/storage_bucket.go:851 lxc/storage_bucket.go:957
+#: lxc/storage_bucket.go:1021 lxc/storage_bucket.go:1156
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
 
-#: lxc/storage_bucket.go:533
+#: lxc/storage_bucket.go:534
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_bucket.go:81
+#: lxc/storage_bucket.go:82
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
 
@@ -6981,20 +6981,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:91 lxc/project.go:186 lxc/project.go:258 lxc/project.go:785
-#: lxc/project.go:846 lxc/project.go:913
+#: lxc/project.go:92 lxc/project.go:187 lxc/project.go:259 lxc/project.go:786
+#: lxc/project.go:847 lxc/project.go:914
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:394 lxc/project.go:741
+#: lxc/project.go:395 lxc/project.go:742
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:653
+#: lxc/project.go:654
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:587
+#: lxc/project.go:588
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7002,7 +7002,7 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:259 lxc/warning.go:301 lxc/warning.go:354
+#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
@@ -7058,7 +7058,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:555 lxc/remote.go:739
+#: lxc/project.go:556 lxc/remote.go:739
 msgid "current"
 msgstr ""
 
@@ -7105,20 +7105,20 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/auth.go:203
+#: lxc/auth.go:204
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:958
+#: lxc/auth.go:959
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1575
+#: lxc/auth.go:1576
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7196,20 +7196,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:988
+#: lxc/file.go:989
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:244
+#: lxc/file.go:245
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:470
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7291,7 +7291,7 @@ msgid ""
 "  List instances with their running state and user comment."
 msgstr ""
 
-#: lxc/monitor.go:37
+#: lxc/monitor.go:38
 msgid ""
 "lxc monitor --type=logging\n"
 "    Only show log messages.\n"
@@ -7367,7 +7367,7 @@ msgid ""
 "    Create record r1 for zone z1 with configuration from config.yaml"
 msgstr ""
 
-#: lxc/operation.go:195
+#: lxc/operation.go:196
 msgid ""
 "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Show details on that operation UUID"
@@ -7410,7 +7410,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:95
+#: lxc/project.go:96
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7418,7 +7418,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:262
+#: lxc/project.go:263
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7449,7 +7449,7 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:85
 msgid ""
 "lxc storage bucket create p1 b01\n"
 "\tCreate a new storage bucket name b01 in storage pool p1\n"
@@ -7459,19 +7459,19 @@ msgid ""
 "of config.yaml"
 msgstr ""
 
-#: lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:251
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1023
+#: lxc/storage_bucket.go:1024
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:854
 msgid ""
 "lxc storage bucket key create p1 b01 k1\n"
 "\tCreate a key called k1 for the bucket b01 in the pool p1.\n"
@@ -7481,14 +7481,14 @@ msgid ""
 "of config.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1158
+#: lxc/storage_bucket.go:1159
 msgid ""
 "lxc storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_bucket.go:630
+#: lxc/storage_bucket.go:631
 msgid ""
 "lxc storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
@@ -7558,16 +7558,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1142
+#: lxc/file.go:1143
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1101
+#: lxc/file.go:1102
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1054
+#: lxc/file.go:1055
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/sl.po
+++ b/po/sl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-04 08:52-0600\n"
+"POT-Creation-Date: 2024-09-05 08:44-0400\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Slovenian <https://hosted.weblate.org/projects/linux-"
@@ -20,7 +20,7 @@ msgstr ""
 "n%100==4 ? 2 : 3;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: lxc/storage_bucket.go:260 lxc/storage_bucket.go:1033
+#: lxc/storage_bucket.go:261 lxc/storage_bucket.go:1034
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -134,7 +134,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:213
+#: lxc/auth.go:214
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -161,7 +161,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:968
+#: lxc/auth.go:969
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -182,7 +182,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1585
+#: lxc/auth.go:1586
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -392,7 +392,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:280
+#: lxc/project.go:281
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -434,12 +434,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:935
+#: lxc/file.go:936
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:825
+#: lxc/file.go:826
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -475,7 +475,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:142 lxc/rebuild.go:64
+#: lxc/init.go:142 lxc/rebuild.go:65
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -528,7 +528,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:465
+#: lxc/file.go:466
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -561,7 +561,7 @@ msgstr ""
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:813
+#: lxc/auth.go:814
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -569,11 +569,11 @@ msgstr ""
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/storage_bucket.go:863
+#: lxc/storage_bucket.go:864
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:941
+#: lxc/storage_bucket.go:942
 #, c-format
 msgid "Access key: %s"
 msgstr ""
@@ -582,7 +582,7 @@ msgstr ""
 msgid "Access the expanded configuration"
 msgstr ""
 
-#: lxc/warning.go:261 lxc/warning.go:262
+#: lxc/warning.go:262 lxc/warning.go:263
 msgid "Acknowledge warning"
 msgstr ""
 
@@ -599,11 +599,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1106 lxc/auth.go:1107
+#: lxc/auth.go:1107 lxc/auth.go:1108
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1874 lxc/auth.go:1875
+#: lxc/auth.go:1875 lxc/auth.go:1876
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -672,7 +672,7 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:515 lxc/auth.go:516
+#: lxc/auth.go:516 lxc/auth.go:517
 msgid "Add permissions to groups"
 msgstr ""
 
@@ -701,7 +701,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:169
+#: lxc/storage_bucket.go:170
 #, c-format
 msgid "Admin access key: %s"
 msgstr ""
@@ -711,7 +711,7 @@ msgstr ""
 msgid "Admin password (or token) for %s:"
 msgstr ""
 
-#: lxc/storage_bucket.go:170
+#: lxc/storage_bucket.go:171
 #, c-format
 msgid "Admin secret key: %s"
 msgstr ""
@@ -770,7 +770,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:342 lxc/rebuild.go:130
+#: lxc/init.go:342 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -870,12 +870,12 @@ msgstr ""
 
 #: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:318
 #: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
-#: lxc/network_zone.go:366 lxc/network_zone.go:1053 lxc/storage_bucket.go:141
+#: lxc/network_zone.go:366 lxc/network_zone.go:1053 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:159
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:160
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -915,7 +915,7 @@ msgstr ""
 msgid "Bytes sent"
 msgstr ""
 
-#: lxc/operation.go:174
+#: lxc/operation.go:175
 msgid "CANCELABLE"
 msgstr ""
 
@@ -927,7 +927,7 @@ msgstr ""
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: lxc/warning.go:209
+#: lxc/warning.go:210
 msgid "COUNT"
 msgstr ""
 
@@ -953,7 +953,7 @@ msgstr ""
 msgid "CPUs (%s):"
 msgstr ""
 
-#: lxc/operation.go:175
+#: lxc/operation.go:176
 msgid "CREATED"
 msgstr ""
 
@@ -983,7 +983,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:340
+#: lxc/file.go:341
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1008,11 +1008,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:224
+#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:546
+#: lxc/file.go:547
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1021,7 +1021,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:160
+#: lxc/rebuild.go:161
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1144,13 +1144,13 @@ msgstr ""
 #: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
 #: lxc/network_load_balancer.go:1051 lxc/network_load_balancer.go:1125
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
-#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:90
-#: lxc/storage_bucket.go:190 lxc/storage_bucket.go:253
-#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:541
-#: lxc/storage_bucket.go:634 lxc/storage_bucket.go:700
-#: lxc/storage_bucket.go:775 lxc/storage_bucket.go:861
-#: lxc/storage_bucket.go:961 lxc/storage_bucket.go:1026
-#: lxc/storage_bucket.go:1162 lxc/storage_volume.go:394
+#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
+#: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
+#: lxc/storage_bucket.go:385 lxc/storage_bucket.go:542
+#: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
+#: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
+#: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
 #: lxc/storage_volume.go:612 lxc/storage_volume.go:717
 #: lxc/storage_volume.go:1005 lxc/storage_volume.go:1231
 #: lxc/storage_volume.go:1360 lxc/storage_volume.go:1848
@@ -1174,7 +1174,7 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1113 lxc/list.go:132 lxc/storage_volume.go:1589
-#: lxc/warning.go:92
+#: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
@@ -1202,7 +1202,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:100
+#: lxc/project.go:101
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1216,8 +1216,8 @@ msgstr ""
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
-#: lxc/project.go:362 lxc/storage.go:359 lxc/storage_bucket.go:348
-#: lxc/storage_bucket.go:1125 lxc/storage_volume.go:1150
+#: lxc/project.go:363 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1150
 #: lxc/storage_volume.go:1182
 #, c-format
 msgid "Config parsing error: %s"
@@ -1344,12 +1344,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:300 lxc/auth.go:1660
+#: lxc/auth.go:301 lxc/auth.go:1661
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1054
+#: lxc/auth.go:1055
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1398,15 +1398,15 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:248 lxc/file.go:474
+#: lxc/file.go:249 lxc/file.go:475
 msgid "Create any directories necessary"
 msgstr ""
 
-#: lxc/auth.go:97 lxc/auth.go:98
+#: lxc/auth.go:98 lxc/auth.go:99
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1471 lxc/auth.go:1472
+#: lxc/auth.go:1472 lxc/auth.go:1473
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1426,11 +1426,11 @@ msgstr ""
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_bucket.go:851 lxc/storage_bucket.go:852
+#: lxc/storage_bucket.go:852 lxc/storage_bucket.go:853
 msgid "Create key for a storage bucket"
 msgstr ""
 
-#: lxc/storage_bucket.go:82 lxc/storage_bucket.go:83
+#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
 msgid "Create new custom storage buckets"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:92 lxc/project.go:93
+#: lxc/project.go:93 lxc/project.go:94
 msgid "Create projects"
 msgstr ""
 
@@ -1509,13 +1509,13 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:376 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1135 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
-#: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:172
-#: lxc/profile.go:756 lxc/project.go:572 lxc/storage.go:723
-#: lxc/storage_bucket.go:512 lxc/storage_bucket.go:832
+#: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
+#: lxc/profile.go:756 lxc/project.go:573 lxc/storage.go:723
+#: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1732
 msgid "DESCRIPTION"
 msgstr ""
@@ -1540,7 +1540,7 @@ msgstr ""
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
-#: lxc/operation.go:55 lxc/operation.go:56
+#: lxc/operation.go:56 lxc/operation.go:57
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
@@ -1548,19 +1548,19 @@ msgstr ""
 msgid "Delete a cluster group"
 msgstr ""
 
-#: lxc/warning.go:360
+#: lxc/warning.go:361
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:122 lxc/file.go:123
+#: lxc/file.go:123 lxc/file.go:124
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/auth.go:151 lxc/auth.go:152
+#: lxc/auth.go:152 lxc/auth.go:153
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1523 lxc/auth.go:1524
+#: lxc/auth.go:1524 lxc/auth.go:1525
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1580,7 +1580,7 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/storage_bucket.go:957 lxc/storage_bucket.go:958
+#: lxc/storage_bucket.go:958 lxc/storage_bucket.go:959
 msgid "Delete key from a storage bucket"
 msgstr ""
 
@@ -1616,11 +1616,11 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:188 lxc/project.go:189
+#: lxc/project.go:189 lxc/project.go:190
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:187 lxc/storage_bucket.go:188
+#: lxc/storage_bucket.go:188 lxc/storage_bucket.go:189
 msgid "Delete storage buckets"
 msgstr ""
 
@@ -1632,20 +1632,20 @@ msgstr ""
 msgid "Delete storage volumes"
 msgstr ""
 
-#: lxc/warning.go:356 lxc/warning.go:357
+#: lxc/warning.go:357 lxc/warning.go:358
 msgid "Delete warning"
 msgstr ""
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:30 lxc/auth.go:59 lxc/auth.go:98
-#: lxc/auth.go:152 lxc/auth.go:201 lxc/auth.go:332 lxc/auth.go:392
-#: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
-#: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
-#: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
-#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1434 lxc/auth.go:1472
-#: lxc/auth.go:1524 lxc/auth.go:1573 lxc/auth.go:1692 lxc/auth.go:1752
-#: lxc/auth.go:1801 lxc/auth.go:1852 lxc/auth.go:1875 lxc/auth.go:1928
+#: lxc/alias.go:214 lxc/auth.go:31 lxc/auth.go:60 lxc/auth.go:99
+#: lxc/auth.go:153 lxc/auth.go:202 lxc/auth.go:333 lxc/auth.go:393
+#: lxc/auth.go:442 lxc/auth.go:494 lxc/auth.go:517 lxc/auth.go:576
+#: lxc/auth.go:732 lxc/auth.go:766 lxc/auth.go:833 lxc/auth.go:896
+#: lxc/auth.go:957 lxc/auth.go:1085 lxc/auth.go:1108 lxc/auth.go:1166
+#: lxc/auth.go:1235 lxc/auth.go:1257 lxc/auth.go:1435 lxc/auth.go:1473
+#: lxc/auth.go:1525 lxc/auth.go:1574 lxc/auth.go:1693 lxc/auth.go:1753
+#: lxc/auth.go:1802 lxc/auth.go:1853 lxc/auth.go:1876 lxc/auth.go:1929
 #: lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215 lxc/cluster.go:272
 #: lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:484 lxc/cluster.go:528
 #: lxc/cluster.go:586 lxc/cluster.go:677 lxc/cluster.go:770 lxc/cluster.go:893
@@ -1669,15 +1669,15 @@ msgstr ""
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:83 lxc/file.go:123 lxc/file.go:172
-#: lxc/file.go:242 lxc/file.go:467 lxc/file.go:986 lxc/image.go:38
+#: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
+#: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
 #: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
 #: lxc/image.go:697 lxc/image.go:946 lxc/image.go:1088 lxc/image.go:1415
 #: lxc/image.go:1506 lxc/image.go:1572 lxc/image.go:1636 lxc/image.go:1699
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:38 lxc/network.go:33
+#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33
 #: lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405
 #: lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793
 #: lxc/network.go:874 lxc/network.go:1005 lxc/network.go:1106
@@ -1711,27 +1711,27 @@ msgstr ""
 #: lxc/network_zone.go:909 lxc/network_zone.go:985 lxc/network_zone.go:1083
 #: lxc/network_zone.go:1172 lxc/network_zone.go:1219 lxc/network_zone.go:1349
 #: lxc/network_zone.go:1410 lxc/network_zone.go:1425 lxc/network_zone.go:1483
-#: lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:106
-#: lxc/operation.go:193 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
+#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
+#: lxc/operation.go:194 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
 #: lxc/profile.go:271 lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493
 #: lxc/profile.go:629 lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860
-#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:29
-#: lxc/project.go:93 lxc/project.go:189 lxc/project.go:260 lxc/project.go:396
-#: lxc/project.go:470 lxc/project.go:590 lxc/project.go:655 lxc/project.go:743
-#: lxc/project.go:787 lxc/project.go:848 lxc/project.go:915 lxc/publish.go:34
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:35 lxc/remote.go:91
+#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:30
+#: lxc/project.go:94 lxc/project.go:190 lxc/project.go:261 lxc/project.go:397
+#: lxc/project.go:471 lxc/project.go:591 lxc/project.go:656 lxc/project.go:744
+#: lxc/project.go:788 lxc/project.go:849 lxc/project.go:916 lxc/publish.go:34
+#: lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91
 #: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853
 #: lxc/remote.go:917 lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24
 #: lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203
 #: lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655
 #: lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940
-#: lxc/storage_bucket.go:29 lxc/storage_bucket.go:83 lxc/storage_bucket.go:188
-#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:382
-#: lxc/storage_bucket.go:458 lxc/storage_bucket.go:535
-#: lxc/storage_bucket.go:629 lxc/storage_bucket.go:698
-#: lxc/storage_bucket.go:732 lxc/storage_bucket.go:773
-#: lxc/storage_bucket.go:852 lxc/storage_bucket.go:958
-#: lxc/storage_bucket.go:1022 lxc/storage_bucket.go:1157
+#: lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189
+#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:383
+#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:536
+#: lxc/storage_bucket.go:630 lxc/storage_bucket.go:699
+#: lxc/storage_bucket.go:733 lxc/storage_bucket.go:774
+#: lxc/storage_bucket.go:853 lxc/storage_bucket.go:959
+#: lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158
 #: lxc/storage_volume.go:58 lxc/storage_volume.go:169 lxc/storage_volume.go:283
 #: lxc/storage_volume.go:390 lxc/storage_volume.go:605
 #: lxc/storage_volume.go:714 lxc/storage_volume.go:801
@@ -1742,8 +1742,8 @@ msgstr ""
 #: lxc/storage_volume.go:2064 lxc/storage_volume.go:2222
 #: lxc/storage_volume.go:2343 lxc/storage_volume.go:2405
 #: lxc/storage_volume.go:2541 lxc/storage_volume.go:2624
-#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:29
-#: lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
+#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:30
+#: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
@@ -1830,7 +1830,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:994
+#: lxc/file.go:995
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1896,7 +1896,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:74
+#: lxc/file.go:75
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1906,7 +1906,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:955 lxc/auth.go:956
+#: lxc/auth.go:956 lxc/auth.go:957
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1914,15 +1914,15 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:171 lxc/file.go:172
+#: lxc/file.go:172 lxc/file.go:173
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/auth.go:200 lxc/auth.go:201
+#: lxc/auth.go:201 lxc/auth.go:202
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1572 lxc/auth.go:1573
+#: lxc/auth.go:1573 lxc/auth.go:1574
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -1978,15 +1978,15 @@ msgstr ""
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:259 lxc/project.go:260
+#: lxc/project.go:260 lxc/project.go:261
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:248 lxc/storage_bucket.go:249
+#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:250
 msgid "Edit storage bucket configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:1021 lxc/storage_bucket.go:1022
+#: lxc/storage_bucket.go:1022 lxc/storage_bucket.go:1023
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
@@ -2003,7 +2003,7 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1147 lxc/list.go:622 lxc/storage_volume.go:1766
-#: lxc/warning.go:235
+#: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2058,7 +2058,7 @@ msgstr ""
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
-#: lxc/project.go:718 lxc/storage.go:812 lxc/storage_bucket.go:602
+#: lxc/project.go:719 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2155 lxc/storage_volume.go:2193
 #, c-format
 msgid "Error setting properties: %v"
@@ -2072,8 +2072,8 @@ msgstr ""
 #: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
-#: lxc/profile.go:981 lxc/project.go:712 lxc/storage.go:806
-#: lxc/storage_bucket.go:596 lxc/storage_volume.go:2149
+#: lxc/profile.go:981 lxc/project.go:713 lxc/storage.go:806
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2149
 #: lxc/storage_volume.go:2187
 #, c-format
 msgid "Error unsetting property: %v"
@@ -2093,7 +2093,7 @@ msgstr ""
 msgid "Evacuating cluster member: %s"
 msgstr ""
 
-#: lxc/monitor.go:50
+#: lxc/monitor.go:51
 msgid "Event type to listen for"
 msgstr ""
 
@@ -2180,16 +2180,16 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/warning.go:210
+#: lxc/warning.go:211
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1237
+#: lxc/file.go:1238
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1260
+#: lxc/file.go:1261
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2204,12 +2204,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1287
+#: lxc/file.go:1288
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1072
+#: lxc/file.go:1073
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2239,7 +2239,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1193
+#: lxc/file.go:1194
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2254,7 +2254,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1198
+#: lxc/file.go:1199
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2264,12 +2264,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1098
+#: lxc/file.go:1099
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1225
+#: lxc/file.go:1226
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2308,7 +2308,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1210
+#: lxc/file.go:1211
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2323,7 +2323,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:820
+#: lxc/file.go:821
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2338,7 +2338,7 @@ msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
 #: lxc/network.go:1044 lxc/network_acl.go:133 lxc/network_zone.go:124
-#: lxc/operation.go:136
+#: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
 
@@ -2403,21 +2403,21 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
+#: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:770 lxc/auth.go:1697
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1114 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:57
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
-#: lxc/operation.go:108 lxc/profile.go:707 lxc/project.go:472
-#: lxc/project.go:917 lxc/remote.go:690 lxc/storage.go:657
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:774
-#: lxc/storage_volume.go:1608 lxc/warning.go:93
+#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:473
+#: lxc/project.go:918 lxc/remote.go:690 lxc/storage.go:657
+#: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
+#: lxc/storage_volume.go:1608 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
-#: lxc/monitor.go:52
+#: lxc/monitor.go:53
 msgid "Format (json|pretty|yaml)"
 msgstr ""
 
@@ -2461,7 +2461,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:817 lxc/auth.go:1736
+#: lxc/auth.go:818 lxc/auth.go:1737
 msgid "GROUPS"
 msgstr ""
 
@@ -2477,7 +2477,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:914 lxc/project.go:915
+#: lxc/project.go:915 lxc/project.go:916
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2525,11 +2525,11 @@ msgstr ""
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:400
+#: lxc/project.go:401
 msgid "Get the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:385
+#: lxc/storage_bucket.go:386
 msgid "Get the key as a storage bucket property"
 msgstr ""
 
@@ -2589,11 +2589,11 @@ msgstr ""
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:395 lxc/project.go:396
+#: lxc/project.go:396 lxc/project.go:397
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:382
+#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:383
 msgid "Get values for storage bucket configuration keys"
 msgstr ""
 
@@ -2610,17 +2610,17 @@ msgstr ""
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: lxc/auth.go:136
+#: lxc/auth.go:137
 #, c-format
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:186
+#: lxc/auth.go:187
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:426 lxc/auth.go:1786
+#: lxc/auth.go:427 lxc/auth.go:1787
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2645,27 +2645,27 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1310
+#: lxc/file.go:1311
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1299
+#: lxc/file.go:1300
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1122
+#: lxc/file.go:1123
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1132
+#: lxc/file.go:1133
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:966 lxc/operation.go:170
+#: lxc/network.go:966 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2679,11 +2679,11 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:816
+#: lxc/auth.go:817
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:566
+#: lxc/project.go:567
 msgid "IMAGES"
 msgstr ""
 
@@ -2711,17 +2711,17 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1508
+#: lxc/auth.go:1509
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1558
+#: lxc/auth.go:1559
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
 
-#: lxc/rebuild.go:32
+#: lxc/rebuild.go:33
 msgid "If an instance is running, stop it and then rebuild it"
 msgstr ""
 
@@ -2842,7 +2842,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1233 lxc/auth.go:1234
+#: lxc/auth.go:1234 lxc/auth.go:1235
 msgid "Inspect permissions"
 msgstr ""
 
@@ -2850,11 +2850,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1124
+#: lxc/file.go:1125
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1301
+#: lxc/file.go:1302
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2872,7 +2872,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1044
+#: lxc/file.go:1045
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2881,7 +2881,7 @@ msgstr ""
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/rebuild.go:74
+#: lxc/rebuild.go:75
 #, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
@@ -2914,7 +2914,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/monitor.go:70
+#: lxc/monitor.go:71
 #, c-format
 msgid "Invalid format: %s"
 msgstr ""
@@ -2924,7 +2924,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1039
+#: lxc/file.go:1040
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2966,7 +2966,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:147
+#: lxc/file.go:148
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2982,12 +2982,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:313
+#: lxc/file.go:314
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:495
+#: lxc/file.go:496
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3001,7 +3001,7 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/warning.go:212
 msgid "LAST SEEN"
 msgstr ""
 
@@ -3009,7 +3009,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:984
+#: lxc/project.go:985
 msgid "LIMIT"
 msgstr ""
 
@@ -3018,8 +3018,8 @@ msgid "LISTEN ADDRESS"
 msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
-#: lxc/network_load_balancer.go:165 lxc/operation.go:177
-#: lxc/storage_bucket.go:516 lxc/storage_volume.go:1739 lxc/warning.go:220
+#: lxc/network_load_balancer.go:165 lxc/operation.go:178
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1739 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3093,7 +3093,7 @@ msgstr ""
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/warning.go:94
+#: lxc/warning.go:95
 msgid "List all warnings"
 msgstr ""
 
@@ -3137,19 +3137,19 @@ msgstr ""
 msgid "List available storage pools"
 msgstr ""
 
-#: lxc/operation.go:105 lxc/operation.go:106
+#: lxc/operation.go:106 lxc/operation.go:107
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:331 lxc/auth.go:332
+#: lxc/auth.go:332 lxc/auth.go:333
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:764 lxc/auth.go:765
+#: lxc/auth.go:765 lxc/auth.go:766
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1691 lxc/auth.go:1692
+#: lxc/auth.go:1692 lxc/auth.go:1693
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3298,11 +3298,11 @@ msgstr ""
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/operation.go:109
+#: lxc/operation.go:110
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1255 lxc/auth.go:1256
+#: lxc/auth.go:1256 lxc/auth.go:1257
 msgid "List permissions"
 msgstr ""
 
@@ -3310,15 +3310,15 @@ msgstr ""
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:469 lxc/project.go:470
+#: lxc/project.go:470 lxc/project.go:471
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:771 lxc/storage_bucket.go:773
+#: lxc/storage_bucket.go:772 lxc/storage_bucket.go:774
 msgid "List storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:456 lxc/storage_bucket.go:458
+#: lxc/storage_bucket.go:457 lxc/storage_bucket.go:459
 msgid "List storage buckets"
 msgstr ""
 
@@ -3354,11 +3354,11 @@ msgstr ""
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/warning.go:70
+#: lxc/warning.go:71
 msgid "List warnings"
 msgstr ""
 
-#: lxc/warning.go:71
+#: lxc/warning.go:72
 msgid ""
 "List warnings\n"
 "\n"
@@ -3381,7 +3381,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/operation.go:23 lxc/operation.go:24
+#: lxc/operation.go:24 lxc/operation.go:25
 msgid "List, show and delete background operations"
 msgstr ""
 
@@ -3390,7 +3390,7 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/monitor.go:79
+#: lxc/monitor.go:80
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
@@ -3494,23 +3494,23 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:82 lxc/file.go:83
+#: lxc/file.go:83 lxc/file.go:84
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1433 lxc/auth.go:1434
+#: lxc/auth.go:59 lxc/auth.go:60 lxc/auth.go:1434 lxc/auth.go:1435
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1083 lxc/auth.go:1084
+#: lxc/auth.go:1084 lxc/auth.go:1085
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:730 lxc/auth.go:731
+#: lxc/auth.go:731 lxc/auth.go:732
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1851 lxc/auth.go:1852
+#: lxc/auth.go:1852 lxc/auth.go:1853
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3601,7 +3601,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:492 lxc/auth.go:493
+#: lxc/auth.go:493 lxc/auth.go:494
 msgid "Manage permissions"
 msgstr ""
 
@@ -3609,23 +3609,23 @@ msgstr ""
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:28 lxc/project.go:29
+#: lxc/project.go:29 lxc/project.go:30
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:731
+#: lxc/storage_bucket.go:732
 msgid "Manage storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:732
+#: lxc/storage_bucket.go:733
 msgid "Manage storage bucket keys."
 msgstr ""
 
-#: lxc/storage_bucket.go:28
+#: lxc/storage_bucket.go:29
 msgid "Manage storage buckets"
 msgstr ""
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:30
 msgid "Manage storage buckets."
 msgstr ""
 
@@ -3653,11 +3653,11 @@ msgstr ""
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/auth.go:29 lxc/auth.go:30
+#: lxc/auth.go:30 lxc/auth.go:31
 msgid "Manage user authorization"
 msgstr ""
 
-#: lxc/warning.go:28 lxc/warning.go:29
+#: lxc/warning.go:29 lxc/warning.go:30
 msgid "Manage warnings"
 msgstr ""
 
@@ -3721,17 +3721,17 @@ msgstr ""
 msgid "Migration operation failure: %w"
 msgstr ""
 
-#: lxc/monitor.go:51
+#: lxc/monitor.go:52
 msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: lxc/storage_bucket.go:116 lxc/storage_bucket.go:216
-#: lxc/storage_bucket.go:292 lxc/storage_bucket.go:411
-#: lxc/storage_bucket.go:568 lxc/storage_bucket.go:660
-#: lxc/storage_bucket.go:802 lxc/storage_bucket.go:889
-#: lxc/storage_bucket.go:986 lxc/storage_bucket.go:1065
-#: lxc/storage_bucket.go:1188
+#: lxc/storage_bucket.go:117 lxc/storage_bucket.go:217
+#: lxc/storage_bucket.go:293 lxc/storage_bucket.go:412
+#: lxc/storage_bucket.go:569 lxc/storage_bucket.go:661
+#: lxc/storage_bucket.go:803 lxc/storage_bucket.go:890
+#: lxc/storage_bucket.go:987 lxc/storage_bucket.go:1066
+#: lxc/storage_bucket.go:1189
 msgid "Missing bucket name"
 msgstr ""
 
@@ -3750,20 +3750,20 @@ msgstr ""
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1825
+#: lxc/auth.go:123 lxc/auth.go:177 lxc/auth.go:255 lxc/auth.go:417
+#: lxc/auth.go:466 lxc/auth.go:541 lxc/auth.go:600 lxc/auth.go:1826
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:862 lxc/auth.go:1003 lxc/auth.go:1131 lxc/auth.go:1189
+#: lxc/auth.go:863 lxc/auth.go:1004 lxc/auth.go:1132 lxc/auth.go:1190
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1495 lxc/auth.go:1548 lxc/auth.go:1614 lxc/auth.go:1776
+#: lxc/auth.go:1496 lxc/auth.go:1549 lxc/auth.go:1615 lxc/auth.go:1777
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1899 lxc/auth.go:1952
+#: lxc/auth.go:1900 lxc/auth.go:1953
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -3771,12 +3771,12 @@ msgstr ""
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
 #: lxc/config_template.go:377 lxc/profile.go:141 lxc/profile.go:222
-#: lxc/profile.go:808 lxc/rebuild.go:60
+#: lxc/profile.go:808 lxc/rebuild.go:61
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/storage_bucket.go:893 lxc/storage_bucket.go:990
-#: lxc/storage_bucket.go:1069 lxc/storage_bucket.go:1192
+#: lxc/storage_bucket.go:894 lxc/storage_bucket.go:991
+#: lxc/storage_bucket.go:1070 lxc/storage_bucket.go:1193
 msgid "Missing key name"
 msgstr ""
 
@@ -3841,13 +3841,13 @@ msgid "Missing peer name"
 msgstr ""
 
 #: lxc/storage.go:235 lxc/storage.go:313 lxc/storage.go:431 lxc/storage.go:509
-#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:112
-#: lxc/storage_bucket.go:212 lxc/storage_bucket.go:288
-#: lxc/storage_bucket.go:407 lxc/storage_bucket.go:482
-#: lxc/storage_bucket.go:564 lxc/storage_bucket.go:656
-#: lxc/storage_bucket.go:798 lxc/storage_bucket.go:885
-#: lxc/storage_bucket.go:982 lxc/storage_bucket.go:1061
-#: lxc/storage_bucket.go:1184 lxc/storage_volume.go:209
+#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:113
+#: lxc/storage_bucket.go:213 lxc/storage_bucket.go:289
+#: lxc/storage_bucket.go:408 lxc/storage_bucket.go:483
+#: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
+#: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
+#: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
 #: lxc/storage_volume.go:323 lxc/storage_volume.go:643
 #: lxc/storage_volume.go:750 lxc/storage_volume.go:841
 #: lxc/storage_volume.go:939 lxc/storage_volume.go:1053
@@ -3862,9 +3862,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:404 lxc/project.go:146 lxc/project.go:226 lxc/project.go:316
-#: lxc/project.go:433 lxc/project.go:622 lxc/project.go:691 lxc/project.go:819
-#: lxc/project.go:948
+#: lxc/profile.go:404 lxc/project.go:147 lxc/project.go:227 lxc/project.go:317
+#: lxc/project.go:434 lxc/project.go:623 lxc/project.go:692 lxc/project.go:820
+#: lxc/project.go:949
 msgid "Missing project name"
 msgstr ""
 
@@ -3880,7 +3880,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:598
+#: lxc/file.go:599
 msgid "Missing target directory"
 msgstr ""
 
@@ -3902,11 +3902,11 @@ msgstr ""
 msgid "Model: %v"
 msgstr ""
 
-#: lxc/monitor.go:32
+#: lxc/monitor.go:33
 msgid "Monitor a local or remote LXD server"
 msgstr ""
 
-#: lxc/monitor.go:33
+#: lxc/monitor.go:34
 msgid ""
 "Monitor a local or remote LXD server\n"
 "\n"
@@ -3918,11 +3918,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:285
+#: lxc/file.go:286
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:985 lxc/file.go:986
+#: lxc/file.go:986 lxc/file.go:987
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3984,13 +3984,13 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:192
+#: lxc/auth.go:376 lxc/auth.go:816 lxc/auth.go:1736 lxc/cluster.go:192
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
-#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:565
-#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:511
-#: lxc/storage_bucket.go:831 lxc/storage_volume.go:1731
+#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:566
+#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1731
 msgid "NAME"
 msgstr ""
 
@@ -3998,11 +3998,11 @@ msgstr ""
 msgid "NAT"
 msgstr ""
 
-#: lxc/project.go:571
+#: lxc/project.go:572
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:570
+#: lxc/project.go:571
 msgid "NETWORKS"
 msgstr ""
 
@@ -4014,9 +4014,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/operation.go:154 lxc/project.go:523
-#: lxc/project.go:528 lxc/project.go:533 lxc/project.go:538 lxc/project.go:543
-#: lxc/project.go:548 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
+#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:524
+#: lxc/project.go:529 lxc/project.go:534 lxc/project.go:539 lxc/project.go:544
+#: lxc/project.go:549 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
 msgid "NO"
 msgstr ""
 
@@ -4261,7 +4261,7 @@ msgstr ""
 msgid "Only managed networks can be modified"
 msgstr ""
 
-#: lxc/operation.go:86
+#: lxc/operation.go:87
 #, c-format
 msgid "Operation %s deleted"
 msgstr ""
@@ -4308,11 +4308,11 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:567
+#: lxc/list.go:576 lxc/project.go:568
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:212
+#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4374,24 +4374,24 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1102
+#: lxc/file.go:1103
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:860
+#: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
-#: lxc/project.go:363 lxc/storage.go:360 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1151
+#: lxc/project.go:364 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1151
 #: lxc/storage_volume.go:1183
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
-#: lxc/monitor.go:48
+#: lxc/monitor.go:49
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
@@ -4477,17 +4477,17 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:172
+#: lxc/project.go:173
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:236
+#: lxc/project.go:237
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:637
+#: lxc/project.go:638
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -4608,20 +4608,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:241 lxc/file.go:242
+#: lxc/file.go:242 lxc/file.go:243
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:416 lxc/file.go:767
+#: lxc/file.go:417 lxc/file.go:768
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:466 lxc/file.go:467
+#: lxc/file.go:467 lxc/file.go:468
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:701 lxc/file.go:867
+#: lxc/file.go:702 lxc/file.go:868
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4634,11 +4634,11 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:983
+#: lxc/project.go:984
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/storage_bucket.go:833
+#: lxc/storage_bucket.go:834
 msgid "ROLE"
 msgstr ""
 
@@ -4651,15 +4651,15 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/rebuild.go:31
+#: lxc/rebuild.go:32
 msgid "Rebuild as an empty instance"
 msgstr ""
 
-#: lxc/rebuild.go:26
+#: lxc/rebuild.go:27
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:249 lxc/file.go:473
+#: lxc/file.go:250 lxc/file.go:474
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4686,7 +4686,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:882 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
+#: lxc/project.go:883 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
 #: lxc/remote.go:994
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4737,7 +4737,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1164 lxc/auth.go:1165
+#: lxc/auth.go:1165 lxc/auth.go:1166
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4773,7 +4773,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1927 lxc/auth.go:1928
+#: lxc/auth.go:1928 lxc/auth.go:1929
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4785,7 +4785,7 @@ msgstr ""
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:574 lxc/auth.go:575
+#: lxc/auth.go:575 lxc/auth.go:576
 msgid "Remove permissions from groups"
 msgstr ""
 
@@ -4830,11 +4830,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:391 lxc/auth.go:392
+#: lxc/auth.go:392 lxc/auth.go:393
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1751 lxc/auth.go:1752
+#: lxc/auth.go:1752 lxc/auth.go:1753
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -4854,7 +4854,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:589 lxc/project.go:590
+#: lxc/project.go:590 lxc/project.go:591
 msgid "Rename projects"
 msgstr ""
 
@@ -4952,7 +4952,7 @@ msgstr ""
 msgid "Revoke cluster member join token"
 msgstr ""
 
-#: lxc/storage_bucket.go:862
+#: lxc/storage_bucket.go:863
 msgid "Role (admin or read-only)"
 msgstr ""
 
@@ -4968,7 +4968,7 @@ msgstr ""
 msgid "Run against all projects"
 msgstr ""
 
-#: lxc/warning.go:213
+#: lxc/warning.go:214
 msgid "SEVERITY"
 msgstr ""
 
@@ -4988,12 +4988,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1231
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1231
+#: lxc/file.go:1232
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5007,11 +5007,11 @@ msgstr ""
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:173 lxc/warning.go:214
+#: lxc/operation.go:174 lxc/warning.go:215
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:569
+#: lxc/project.go:570
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5019,7 +5019,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:569
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -5027,11 +5027,11 @@ msgstr ""
 msgid "STP"
 msgstr ""
 
-#: lxc/storage_bucket.go:864
+#: lxc/storage_bucket.go:865
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:942
+#: lxc/storage_bucket.go:943
 #, c-format
 msgid "Secret key: %s"
 msgstr ""
@@ -5069,7 +5069,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:995
+#: lxc/file.go:996
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5207,11 +5207,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:654
+#: lxc/project.go:655
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:655
+#: lxc/project.go:656
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5220,11 +5220,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage_bucket.go:534
+#: lxc/storage_bucket.go:535
 msgid "Set storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:535
+#: lxc/storage_bucket.go:536
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -5263,15 +5263,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:476
+#: lxc/file.go:477
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:477
+#: lxc/file.go:478
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:475
+#: lxc/file.go:476
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5311,11 +5311,11 @@ msgstr ""
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 msgid "Set the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:542
+#: lxc/storage_bucket.go:543
 msgid "Set the key as a storage bucket property"
 msgstr ""
 
@@ -5331,7 +5331,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:993
+#: lxc/file.go:994
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5343,7 +5343,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1800 lxc/auth.go:1801
+#: lxc/auth.go:1801 lxc/auth.go:1802
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5359,11 +5359,11 @@ msgstr ""
 msgid "Show details of a cluster member"
 msgstr ""
 
-#: lxc/operation.go:192 lxc/operation.go:193
+#: lxc/operation.go:193 lxc/operation.go:194
 msgid "Show details on a background operation"
 msgstr ""
 
-#: lxc/monitor.go:49
+#: lxc/monitor.go:50
 msgid "Show events from all projects"
 msgstr ""
 
@@ -5371,11 +5371,11 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:440 lxc/auth.go:441
+#: lxc/auth.go:441 lxc/auth.go:442
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:832
+#: lxc/auth.go:833
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5456,15 +5456,15 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:786 lxc/project.go:787
+#: lxc/project.go:787 lxc/project.go:788
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage_bucket.go:628 lxc/storage_bucket.go:629
+#: lxc/storage_bucket.go:629 lxc/storage_bucket.go:630
 msgid "Show storage bucket configurations"
 msgstr ""
 
-#: lxc/storage_bucket.go:1156 lxc/storage_bucket.go:1157
+#: lxc/storage_bucket.go:1157 lxc/storage_bucket.go:1158
 msgid "Show storage bucket key configurations"
 msgstr ""
 
@@ -5480,7 +5480,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:895
+#: lxc/auth.go:896
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5530,7 +5530,7 @@ msgstr ""
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: lxc/warning.go:302 lxc/warning.go:303
+#: lxc/warning.go:303 lxc/warning.go:304
 msgid "Show warning"
 msgstr ""
 
@@ -5614,22 +5614,22 @@ msgstr ""
 msgid "Stopping the instance failed: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:166
+#: lxc/storage_bucket.go:167
 #, c-format
 msgid "Storage bucket %s created"
 msgstr ""
 
-#: lxc/storage_bucket.go:233
+#: lxc/storage_bucket.go:234
 #, c-format
 msgid "Storage bucket %s deleted"
 msgstr ""
 
-#: lxc/storage_bucket.go:940
+#: lxc/storage_bucket.go:941
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr ""
 
-#: lxc/storage_bucket.go:1006
+#: lxc/storage_bucket.go:1007
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr ""
@@ -5698,7 +5698,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:847 lxc/project.go:848
+#: lxc/project.go:848 lxc/project.go:849
 msgid "Switch the current project"
 msgstr ""
 
@@ -5714,10 +5714,10 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1139
+#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1139
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
-#: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:171
-#: lxc/storage_volume.go:1730 lxc/warning.go:215
+#: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
+#: lxc/storage_volume.go:1730 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
@@ -5725,11 +5725,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1032
+#: lxc/file.go:1033
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1026
+#: lxc/file.go:1027
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5857,12 +5857,12 @@ msgstr ""
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:446
+#: lxc/project.go:447
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
 
-#: lxc/storage_bucket.go:431
+#: lxc/storage_bucket.go:432
 #, c-format
 msgid "The property %q does not exist on the storage bucket %q: %v"
 msgstr ""
@@ -6047,7 +6047,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:961
+#: lxc/project.go:962
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6059,17 +6059,17 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:985 lxc/storage_volume.go:1735
+#: lxc/project.go:986 lxc/storage_volume.go:1735
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:573
+#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:574
 #: lxc/storage.go:724 lxc/storage_volume.go:1734
 msgid "USED BY"
 msgstr ""
 
-#: lxc/warning.go:216
+#: lxc/warning.go:217
 msgid "UUID"
 msgstr ""
 
@@ -6078,7 +6078,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:197
+#: lxc/file.go:198
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6092,13 +6092,13 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1253
+#: lxc/file.go:1254
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1153 lxc/list.go:631 lxc/storage_volume.go:1772
-#: lxc/warning.go:241
+#: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6108,7 +6108,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:807
+#: lxc/file.go:808
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6191,11 +6191,11 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:742 lxc/project.go:743
+#: lxc/project.go:743 lxc/project.go:744
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:697 lxc/storage_bucket.go:698
+#: lxc/storage_bucket.go:698 lxc/storage_bucket.go:699
 msgid "Unset storage bucket configuration keys"
 msgstr ""
 
@@ -6243,11 +6243,11 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:747
+#: lxc/project.go:748
 msgid "Unset the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:701
+#: lxc/storage_bucket.go:702
 msgid "Unset the key as a storage bucket property"
 msgstr ""
 
@@ -6326,7 +6326,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:71
+#: lxc/file.go:72
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6363,11 +6363,11 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:831
+#: lxc/auth.go:832
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:894
+#: lxc/auth.go:895
 msgid "View the current identity"
 msgstr ""
 
@@ -6398,15 +6398,15 @@ msgstr ""
 msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
-#: lxc/rebuild.go:27
+#: lxc/rebuild.go:28
 msgid ""
 "Wipe the instance root disk and re-initialize. The original image is used to "
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:156 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
+#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:526
+#: lxc/project.go:531 lxc/project.go:536 lxc/project.go:541 lxc/project.go:546
+#: lxc/project.go:551 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
 msgid "YES"
 msgstr ""
 
@@ -6426,7 +6426,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/rebuild.go:119
+#: lxc/rebuild.go:120
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
@@ -6438,12 +6438,12 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1689
+#: lxc/auth.go:330 lxc/auth.go:763 lxc/auth.go:894 lxc/auth.go:1690
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
-#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
+#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
-#: lxc/operation.go:103 lxc/profile.go:700 lxc/project.go:467
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:68
+#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:468
+#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6471,7 +6471,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1254
+#: lxc/auth.go:1255
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6532,11 +6532,11 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:830
+#: lxc/auth.go:831
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1926
+#: lxc/auth.go:1106 lxc/auth.go:1164 lxc/auth.go:1927
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6544,13 +6544,13 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:954 lxc/auth.go:1470 lxc/cluster_group.go:168
+#: lxc/auth.go:97 lxc/auth.go:150 lxc/auth.go:200 lxc/auth.go:440
+#: lxc/auth.go:955 lxc/auth.go:1471 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:514 lxc/auth.go:572
+#: lxc/auth.go:515 lxc/auth.go:573
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
@@ -6560,19 +6560,19 @@ msgstr ""
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:389
+#: lxc/auth.go:390
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1521 lxc/auth.go:1571 lxc/auth.go:1799
+#: lxc/auth.go:1522 lxc/auth.go:1572 lxc/auth.go:1800
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1873
+#: lxc/auth.go:1874
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1749
+#: lxc/auth.go:1750
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -6592,7 +6592,7 @@ msgstr ""
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
-#: lxc/rebuild.go:25
+#: lxc/rebuild.go:26
 msgid "[<remote>:]<image> [<remote>:]<instance>"
 msgstr ""
 
@@ -6675,20 +6675,20 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:170
+#: lxc/file.go:171
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:120
+#: lxc/file.go:121
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:240
+#: lxc/file.go:241
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:984
+#: lxc/file.go:985
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6839,12 +6839,12 @@ msgstr ""
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
-#: lxc/operation.go:53 lxc/operation.go:191
+#: lxc/operation.go:54 lxc/operation.go:192
 msgid "[<remote>:]<operation>"
 msgstr ""
 
 #: lxc/storage.go:200 lxc/storage.go:259 lxc/storage.go:473 lxc/storage.go:844
-#: lxc/storage_bucket.go:454
+#: lxc/storage_bucket.go:455
 msgid "[<remote>:]<pool>"
 msgstr ""
 
@@ -6852,22 +6852,22 @@ msgstr ""
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
-#: lxc/storage_bucket.go:185 lxc/storage_bucket.go:247
-#: lxc/storage_bucket.go:627 lxc/storage_bucket.go:769
+#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:248
+#: lxc/storage_bucket.go:628 lxc/storage_bucket.go:770
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
 
-#: lxc/storage_bucket.go:380 lxc/storage_bucket.go:696
-#: lxc/storage_bucket.go:850 lxc/storage_bucket.go:956
-#: lxc/storage_bucket.go:1020 lxc/storage_bucket.go:1155
+#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:697
+#: lxc/storage_bucket.go:851 lxc/storage_bucket.go:957
+#: lxc/storage_bucket.go:1021 lxc/storage_bucket.go:1156
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
 
-#: lxc/storage_bucket.go:533
+#: lxc/storage_bucket.go:534
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_bucket.go:81
+#: lxc/storage_bucket.go:82
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
 
@@ -6982,20 +6982,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:91 lxc/project.go:186 lxc/project.go:258 lxc/project.go:785
-#: lxc/project.go:846 lxc/project.go:913
+#: lxc/project.go:92 lxc/project.go:187 lxc/project.go:259 lxc/project.go:786
+#: lxc/project.go:847 lxc/project.go:914
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:394 lxc/project.go:741
+#: lxc/project.go:395 lxc/project.go:742
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:653
+#: lxc/project.go:654
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:587
+#: lxc/project.go:588
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7003,7 +7003,7 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:259 lxc/warning.go:301 lxc/warning.go:354
+#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
@@ -7059,7 +7059,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:555 lxc/remote.go:739
+#: lxc/project.go:556 lxc/remote.go:739
 msgid "current"
 msgstr ""
 
@@ -7106,20 +7106,20 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/auth.go:203
+#: lxc/auth.go:204
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:958
+#: lxc/auth.go:959
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1575
+#: lxc/auth.go:1576
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7197,20 +7197,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:988
+#: lxc/file.go:989
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:244
+#: lxc/file.go:245
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:470
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7292,7 +7292,7 @@ msgid ""
 "  List instances with their running state and user comment."
 msgstr ""
 
-#: lxc/monitor.go:37
+#: lxc/monitor.go:38
 msgid ""
 "lxc monitor --type=logging\n"
 "    Only show log messages.\n"
@@ -7368,7 +7368,7 @@ msgid ""
 "    Create record r1 for zone z1 with configuration from config.yaml"
 msgstr ""
 
-#: lxc/operation.go:195
+#: lxc/operation.go:196
 msgid ""
 "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Show details on that operation UUID"
@@ -7411,7 +7411,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:95
+#: lxc/project.go:96
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7419,7 +7419,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:262
+#: lxc/project.go:263
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7450,7 +7450,7 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:85
 msgid ""
 "lxc storage bucket create p1 b01\n"
 "\tCreate a new storage bucket name b01 in storage pool p1\n"
@@ -7460,19 +7460,19 @@ msgid ""
 "of config.yaml"
 msgstr ""
 
-#: lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:251
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1023
+#: lxc/storage_bucket.go:1024
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:854
 msgid ""
 "lxc storage bucket key create p1 b01 k1\n"
 "\tCreate a key called k1 for the bucket b01 in the pool p1.\n"
@@ -7482,14 +7482,14 @@ msgid ""
 "of config.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1158
+#: lxc/storage_bucket.go:1159
 msgid ""
 "lxc storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_bucket.go:630
+#: lxc/storage_bucket.go:631
 msgid ""
 "lxc storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
@@ -7559,16 +7559,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1142
+#: lxc/file.go:1143
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1101
+#: lxc/file.go:1102
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1054
+#: lxc/file.go:1055
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-04 08:52-0600\n"
+"POT-Creation-Date: 2024-09-05 08:44-0400\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Serbian <https://hosted.weblate.org/projects/linux-containers/"
@@ -20,7 +20,7 @@ msgstr ""
 "n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: lxc/storage_bucket.go:260 lxc/storage_bucket.go:1033
+#: lxc/storage_bucket.go:261 lxc/storage_bucket.go:1034
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -134,7 +134,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:213
+#: lxc/auth.go:214
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -161,7 +161,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:968
+#: lxc/auth.go:969
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -182,7 +182,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1585
+#: lxc/auth.go:1586
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -392,7 +392,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:280
+#: lxc/project.go:281
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -434,12 +434,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:935
+#: lxc/file.go:936
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:825
+#: lxc/file.go:826
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -475,7 +475,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:142 lxc/rebuild.go:64
+#: lxc/init.go:142 lxc/rebuild.go:65
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -528,7 +528,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:465
+#: lxc/file.go:466
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -561,7 +561,7 @@ msgstr ""
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:813
+#: lxc/auth.go:814
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -569,11 +569,11 @@ msgstr ""
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/storage_bucket.go:863
+#: lxc/storage_bucket.go:864
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:941
+#: lxc/storage_bucket.go:942
 #, c-format
 msgid "Access key: %s"
 msgstr ""
@@ -582,7 +582,7 @@ msgstr ""
 msgid "Access the expanded configuration"
 msgstr ""
 
-#: lxc/warning.go:261 lxc/warning.go:262
+#: lxc/warning.go:262 lxc/warning.go:263
 msgid "Acknowledge warning"
 msgstr ""
 
@@ -599,11 +599,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1106 lxc/auth.go:1107
+#: lxc/auth.go:1107 lxc/auth.go:1108
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1874 lxc/auth.go:1875
+#: lxc/auth.go:1875 lxc/auth.go:1876
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -672,7 +672,7 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:515 lxc/auth.go:516
+#: lxc/auth.go:516 lxc/auth.go:517
 msgid "Add permissions to groups"
 msgstr ""
 
@@ -701,7 +701,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:169
+#: lxc/storage_bucket.go:170
 #, c-format
 msgid "Admin access key: %s"
 msgstr ""
@@ -711,7 +711,7 @@ msgstr ""
 msgid "Admin password (or token) for %s:"
 msgstr ""
 
-#: lxc/storage_bucket.go:170
+#: lxc/storage_bucket.go:171
 #, c-format
 msgid "Admin secret key: %s"
 msgstr ""
@@ -770,7 +770,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:342 lxc/rebuild.go:130
+#: lxc/init.go:342 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -870,12 +870,12 @@ msgstr ""
 
 #: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:318
 #: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
-#: lxc/network_zone.go:366 lxc/network_zone.go:1053 lxc/storage_bucket.go:141
+#: lxc/network_zone.go:366 lxc/network_zone.go:1053 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:159
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:160
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -915,7 +915,7 @@ msgstr ""
 msgid "Bytes sent"
 msgstr ""
 
-#: lxc/operation.go:174
+#: lxc/operation.go:175
 msgid "CANCELABLE"
 msgstr ""
 
@@ -927,7 +927,7 @@ msgstr ""
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: lxc/warning.go:209
+#: lxc/warning.go:210
 msgid "COUNT"
 msgstr ""
 
@@ -953,7 +953,7 @@ msgstr ""
 msgid "CPUs (%s):"
 msgstr ""
 
-#: lxc/operation.go:175
+#: lxc/operation.go:176
 msgid "CREATED"
 msgstr ""
 
@@ -983,7 +983,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:340
+#: lxc/file.go:341
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1008,11 +1008,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:224
+#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:546
+#: lxc/file.go:547
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1021,7 +1021,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:160
+#: lxc/rebuild.go:161
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1144,13 +1144,13 @@ msgstr ""
 #: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
 #: lxc/network_load_balancer.go:1051 lxc/network_load_balancer.go:1125
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
-#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:90
-#: lxc/storage_bucket.go:190 lxc/storage_bucket.go:253
-#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:541
-#: lxc/storage_bucket.go:634 lxc/storage_bucket.go:700
-#: lxc/storage_bucket.go:775 lxc/storage_bucket.go:861
-#: lxc/storage_bucket.go:961 lxc/storage_bucket.go:1026
-#: lxc/storage_bucket.go:1162 lxc/storage_volume.go:394
+#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
+#: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
+#: lxc/storage_bucket.go:385 lxc/storage_bucket.go:542
+#: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
+#: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
+#: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
 #: lxc/storage_volume.go:612 lxc/storage_volume.go:717
 #: lxc/storage_volume.go:1005 lxc/storage_volume.go:1231
 #: lxc/storage_volume.go:1360 lxc/storage_volume.go:1848
@@ -1174,7 +1174,7 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1113 lxc/list.go:132 lxc/storage_volume.go:1589
-#: lxc/warning.go:92
+#: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
@@ -1202,7 +1202,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:100
+#: lxc/project.go:101
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1216,8 +1216,8 @@ msgstr ""
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
-#: lxc/project.go:362 lxc/storage.go:359 lxc/storage_bucket.go:348
-#: lxc/storage_bucket.go:1125 lxc/storage_volume.go:1150
+#: lxc/project.go:363 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1150
 #: lxc/storage_volume.go:1182
 #, c-format
 msgid "Config parsing error: %s"
@@ -1344,12 +1344,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:300 lxc/auth.go:1660
+#: lxc/auth.go:301 lxc/auth.go:1661
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1054
+#: lxc/auth.go:1055
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1398,15 +1398,15 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:248 lxc/file.go:474
+#: lxc/file.go:249 lxc/file.go:475
 msgid "Create any directories necessary"
 msgstr ""
 
-#: lxc/auth.go:97 lxc/auth.go:98
+#: lxc/auth.go:98 lxc/auth.go:99
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1471 lxc/auth.go:1472
+#: lxc/auth.go:1472 lxc/auth.go:1473
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1426,11 +1426,11 @@ msgstr ""
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_bucket.go:851 lxc/storage_bucket.go:852
+#: lxc/storage_bucket.go:852 lxc/storage_bucket.go:853
 msgid "Create key for a storage bucket"
 msgstr ""
 
-#: lxc/storage_bucket.go:82 lxc/storage_bucket.go:83
+#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
 msgid "Create new custom storage buckets"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:92 lxc/project.go:93
+#: lxc/project.go:93 lxc/project.go:94
 msgid "Create projects"
 msgstr ""
 
@@ -1509,13 +1509,13 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:376 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1135 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
-#: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:172
-#: lxc/profile.go:756 lxc/project.go:572 lxc/storage.go:723
-#: lxc/storage_bucket.go:512 lxc/storage_bucket.go:832
+#: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
+#: lxc/profile.go:756 lxc/project.go:573 lxc/storage.go:723
+#: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1732
 msgid "DESCRIPTION"
 msgstr ""
@@ -1540,7 +1540,7 @@ msgstr ""
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
-#: lxc/operation.go:55 lxc/operation.go:56
+#: lxc/operation.go:56 lxc/operation.go:57
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
@@ -1548,19 +1548,19 @@ msgstr ""
 msgid "Delete a cluster group"
 msgstr ""
 
-#: lxc/warning.go:360
+#: lxc/warning.go:361
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:122 lxc/file.go:123
+#: lxc/file.go:123 lxc/file.go:124
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/auth.go:151 lxc/auth.go:152
+#: lxc/auth.go:152 lxc/auth.go:153
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1523 lxc/auth.go:1524
+#: lxc/auth.go:1524 lxc/auth.go:1525
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1580,7 +1580,7 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/storage_bucket.go:957 lxc/storage_bucket.go:958
+#: lxc/storage_bucket.go:958 lxc/storage_bucket.go:959
 msgid "Delete key from a storage bucket"
 msgstr ""
 
@@ -1616,11 +1616,11 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:188 lxc/project.go:189
+#: lxc/project.go:189 lxc/project.go:190
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:187 lxc/storage_bucket.go:188
+#: lxc/storage_bucket.go:188 lxc/storage_bucket.go:189
 msgid "Delete storage buckets"
 msgstr ""
 
@@ -1632,20 +1632,20 @@ msgstr ""
 msgid "Delete storage volumes"
 msgstr ""
 
-#: lxc/warning.go:356 lxc/warning.go:357
+#: lxc/warning.go:357 lxc/warning.go:358
 msgid "Delete warning"
 msgstr ""
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:30 lxc/auth.go:59 lxc/auth.go:98
-#: lxc/auth.go:152 lxc/auth.go:201 lxc/auth.go:332 lxc/auth.go:392
-#: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
-#: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
-#: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
-#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1434 lxc/auth.go:1472
-#: lxc/auth.go:1524 lxc/auth.go:1573 lxc/auth.go:1692 lxc/auth.go:1752
-#: lxc/auth.go:1801 lxc/auth.go:1852 lxc/auth.go:1875 lxc/auth.go:1928
+#: lxc/alias.go:214 lxc/auth.go:31 lxc/auth.go:60 lxc/auth.go:99
+#: lxc/auth.go:153 lxc/auth.go:202 lxc/auth.go:333 lxc/auth.go:393
+#: lxc/auth.go:442 lxc/auth.go:494 lxc/auth.go:517 lxc/auth.go:576
+#: lxc/auth.go:732 lxc/auth.go:766 lxc/auth.go:833 lxc/auth.go:896
+#: lxc/auth.go:957 lxc/auth.go:1085 lxc/auth.go:1108 lxc/auth.go:1166
+#: lxc/auth.go:1235 lxc/auth.go:1257 lxc/auth.go:1435 lxc/auth.go:1473
+#: lxc/auth.go:1525 lxc/auth.go:1574 lxc/auth.go:1693 lxc/auth.go:1753
+#: lxc/auth.go:1802 lxc/auth.go:1853 lxc/auth.go:1876 lxc/auth.go:1929
 #: lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215 lxc/cluster.go:272
 #: lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:484 lxc/cluster.go:528
 #: lxc/cluster.go:586 lxc/cluster.go:677 lxc/cluster.go:770 lxc/cluster.go:893
@@ -1669,15 +1669,15 @@ msgstr ""
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:83 lxc/file.go:123 lxc/file.go:172
-#: lxc/file.go:242 lxc/file.go:467 lxc/file.go:986 lxc/image.go:38
+#: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
+#: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
 #: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
 #: lxc/image.go:697 lxc/image.go:946 lxc/image.go:1088 lxc/image.go:1415
 #: lxc/image.go:1506 lxc/image.go:1572 lxc/image.go:1636 lxc/image.go:1699
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:38 lxc/network.go:33
+#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33
 #: lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405
 #: lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793
 #: lxc/network.go:874 lxc/network.go:1005 lxc/network.go:1106
@@ -1711,27 +1711,27 @@ msgstr ""
 #: lxc/network_zone.go:909 lxc/network_zone.go:985 lxc/network_zone.go:1083
 #: lxc/network_zone.go:1172 lxc/network_zone.go:1219 lxc/network_zone.go:1349
 #: lxc/network_zone.go:1410 lxc/network_zone.go:1425 lxc/network_zone.go:1483
-#: lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:106
-#: lxc/operation.go:193 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
+#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
+#: lxc/operation.go:194 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
 #: lxc/profile.go:271 lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493
 #: lxc/profile.go:629 lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860
-#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:29
-#: lxc/project.go:93 lxc/project.go:189 lxc/project.go:260 lxc/project.go:396
-#: lxc/project.go:470 lxc/project.go:590 lxc/project.go:655 lxc/project.go:743
-#: lxc/project.go:787 lxc/project.go:848 lxc/project.go:915 lxc/publish.go:34
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:35 lxc/remote.go:91
+#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:30
+#: lxc/project.go:94 lxc/project.go:190 lxc/project.go:261 lxc/project.go:397
+#: lxc/project.go:471 lxc/project.go:591 lxc/project.go:656 lxc/project.go:744
+#: lxc/project.go:788 lxc/project.go:849 lxc/project.go:916 lxc/publish.go:34
+#: lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91
 #: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853
 #: lxc/remote.go:917 lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24
 #: lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203
 #: lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655
 #: lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940
-#: lxc/storage_bucket.go:29 lxc/storage_bucket.go:83 lxc/storage_bucket.go:188
-#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:382
-#: lxc/storage_bucket.go:458 lxc/storage_bucket.go:535
-#: lxc/storage_bucket.go:629 lxc/storage_bucket.go:698
-#: lxc/storage_bucket.go:732 lxc/storage_bucket.go:773
-#: lxc/storage_bucket.go:852 lxc/storage_bucket.go:958
-#: lxc/storage_bucket.go:1022 lxc/storage_bucket.go:1157
+#: lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189
+#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:383
+#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:536
+#: lxc/storage_bucket.go:630 lxc/storage_bucket.go:699
+#: lxc/storage_bucket.go:733 lxc/storage_bucket.go:774
+#: lxc/storage_bucket.go:853 lxc/storage_bucket.go:959
+#: lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158
 #: lxc/storage_volume.go:58 lxc/storage_volume.go:169 lxc/storage_volume.go:283
 #: lxc/storage_volume.go:390 lxc/storage_volume.go:605
 #: lxc/storage_volume.go:714 lxc/storage_volume.go:801
@@ -1742,8 +1742,8 @@ msgstr ""
 #: lxc/storage_volume.go:2064 lxc/storage_volume.go:2222
 #: lxc/storage_volume.go:2343 lxc/storage_volume.go:2405
 #: lxc/storage_volume.go:2541 lxc/storage_volume.go:2624
-#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:29
-#: lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
+#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:30
+#: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
@@ -1830,7 +1830,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:994
+#: lxc/file.go:995
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1896,7 +1896,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:74
+#: lxc/file.go:75
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1906,7 +1906,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:955 lxc/auth.go:956
+#: lxc/auth.go:956 lxc/auth.go:957
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1914,15 +1914,15 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:171 lxc/file.go:172
+#: lxc/file.go:172 lxc/file.go:173
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/auth.go:200 lxc/auth.go:201
+#: lxc/auth.go:201 lxc/auth.go:202
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1572 lxc/auth.go:1573
+#: lxc/auth.go:1573 lxc/auth.go:1574
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -1978,15 +1978,15 @@ msgstr ""
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:259 lxc/project.go:260
+#: lxc/project.go:260 lxc/project.go:261
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:248 lxc/storage_bucket.go:249
+#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:250
 msgid "Edit storage bucket configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:1021 lxc/storage_bucket.go:1022
+#: lxc/storage_bucket.go:1022 lxc/storage_bucket.go:1023
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
@@ -2003,7 +2003,7 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1147 lxc/list.go:622 lxc/storage_volume.go:1766
-#: lxc/warning.go:235
+#: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2058,7 +2058,7 @@ msgstr ""
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
-#: lxc/project.go:718 lxc/storage.go:812 lxc/storage_bucket.go:602
+#: lxc/project.go:719 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2155 lxc/storage_volume.go:2193
 #, c-format
 msgid "Error setting properties: %v"
@@ -2072,8 +2072,8 @@ msgstr ""
 #: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
-#: lxc/profile.go:981 lxc/project.go:712 lxc/storage.go:806
-#: lxc/storage_bucket.go:596 lxc/storage_volume.go:2149
+#: lxc/profile.go:981 lxc/project.go:713 lxc/storage.go:806
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2149
 #: lxc/storage_volume.go:2187
 #, c-format
 msgid "Error unsetting property: %v"
@@ -2093,7 +2093,7 @@ msgstr ""
 msgid "Evacuating cluster member: %s"
 msgstr ""
 
-#: lxc/monitor.go:50
+#: lxc/monitor.go:51
 msgid "Event type to listen for"
 msgstr ""
 
@@ -2180,16 +2180,16 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/warning.go:210
+#: lxc/warning.go:211
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1237
+#: lxc/file.go:1238
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1260
+#: lxc/file.go:1261
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2204,12 +2204,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1287
+#: lxc/file.go:1288
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1072
+#: lxc/file.go:1073
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2239,7 +2239,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1193
+#: lxc/file.go:1194
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2254,7 +2254,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1198
+#: lxc/file.go:1199
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2264,12 +2264,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1098
+#: lxc/file.go:1099
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1225
+#: lxc/file.go:1226
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2308,7 +2308,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1210
+#: lxc/file.go:1211
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2323,7 +2323,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:820
+#: lxc/file.go:821
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2338,7 +2338,7 @@ msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
 #: lxc/network.go:1044 lxc/network_acl.go:133 lxc/network_zone.go:124
-#: lxc/operation.go:136
+#: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
 
@@ -2403,21 +2403,21 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
+#: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:770 lxc/auth.go:1697
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1114 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:57
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
-#: lxc/operation.go:108 lxc/profile.go:707 lxc/project.go:472
-#: lxc/project.go:917 lxc/remote.go:690 lxc/storage.go:657
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:774
-#: lxc/storage_volume.go:1608 lxc/warning.go:93
+#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:473
+#: lxc/project.go:918 lxc/remote.go:690 lxc/storage.go:657
+#: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
+#: lxc/storage_volume.go:1608 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
-#: lxc/monitor.go:52
+#: lxc/monitor.go:53
 msgid "Format (json|pretty|yaml)"
 msgstr ""
 
@@ -2461,7 +2461,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:817 lxc/auth.go:1736
+#: lxc/auth.go:818 lxc/auth.go:1737
 msgid "GROUPS"
 msgstr ""
 
@@ -2477,7 +2477,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:914 lxc/project.go:915
+#: lxc/project.go:915 lxc/project.go:916
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2525,11 +2525,11 @@ msgstr ""
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:400
+#: lxc/project.go:401
 msgid "Get the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:385
+#: lxc/storage_bucket.go:386
 msgid "Get the key as a storage bucket property"
 msgstr ""
 
@@ -2589,11 +2589,11 @@ msgstr ""
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:395 lxc/project.go:396
+#: lxc/project.go:396 lxc/project.go:397
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:382
+#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:383
 msgid "Get values for storage bucket configuration keys"
 msgstr ""
 
@@ -2610,17 +2610,17 @@ msgstr ""
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: lxc/auth.go:136
+#: lxc/auth.go:137
 #, c-format
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:186
+#: lxc/auth.go:187
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:426 lxc/auth.go:1786
+#: lxc/auth.go:427 lxc/auth.go:1787
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2645,27 +2645,27 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1310
+#: lxc/file.go:1311
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1299
+#: lxc/file.go:1300
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1122
+#: lxc/file.go:1123
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1132
+#: lxc/file.go:1133
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:966 lxc/operation.go:170
+#: lxc/network.go:966 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2679,11 +2679,11 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:816
+#: lxc/auth.go:817
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:566
+#: lxc/project.go:567
 msgid "IMAGES"
 msgstr ""
 
@@ -2711,17 +2711,17 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1508
+#: lxc/auth.go:1509
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1558
+#: lxc/auth.go:1559
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
 
-#: lxc/rebuild.go:32
+#: lxc/rebuild.go:33
 msgid "If an instance is running, stop it and then rebuild it"
 msgstr ""
 
@@ -2842,7 +2842,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1233 lxc/auth.go:1234
+#: lxc/auth.go:1234 lxc/auth.go:1235
 msgid "Inspect permissions"
 msgstr ""
 
@@ -2850,11 +2850,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1124
+#: lxc/file.go:1125
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1301
+#: lxc/file.go:1302
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2872,7 +2872,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1044
+#: lxc/file.go:1045
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2881,7 +2881,7 @@ msgstr ""
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/rebuild.go:74
+#: lxc/rebuild.go:75
 #, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
@@ -2914,7 +2914,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/monitor.go:70
+#: lxc/monitor.go:71
 #, c-format
 msgid "Invalid format: %s"
 msgstr ""
@@ -2924,7 +2924,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1039
+#: lxc/file.go:1040
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2966,7 +2966,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:147
+#: lxc/file.go:148
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2982,12 +2982,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:313
+#: lxc/file.go:314
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:495
+#: lxc/file.go:496
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3001,7 +3001,7 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/warning.go:212
 msgid "LAST SEEN"
 msgstr ""
 
@@ -3009,7 +3009,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:984
+#: lxc/project.go:985
 msgid "LIMIT"
 msgstr ""
 
@@ -3018,8 +3018,8 @@ msgid "LISTEN ADDRESS"
 msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
-#: lxc/network_load_balancer.go:165 lxc/operation.go:177
-#: lxc/storage_bucket.go:516 lxc/storage_volume.go:1739 lxc/warning.go:220
+#: lxc/network_load_balancer.go:165 lxc/operation.go:178
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1739 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3093,7 +3093,7 @@ msgstr ""
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/warning.go:94
+#: lxc/warning.go:95
 msgid "List all warnings"
 msgstr ""
 
@@ -3137,19 +3137,19 @@ msgstr ""
 msgid "List available storage pools"
 msgstr ""
 
-#: lxc/operation.go:105 lxc/operation.go:106
+#: lxc/operation.go:106 lxc/operation.go:107
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:331 lxc/auth.go:332
+#: lxc/auth.go:332 lxc/auth.go:333
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:764 lxc/auth.go:765
+#: lxc/auth.go:765 lxc/auth.go:766
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1691 lxc/auth.go:1692
+#: lxc/auth.go:1692 lxc/auth.go:1693
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3298,11 +3298,11 @@ msgstr ""
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/operation.go:109
+#: lxc/operation.go:110
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1255 lxc/auth.go:1256
+#: lxc/auth.go:1256 lxc/auth.go:1257
 msgid "List permissions"
 msgstr ""
 
@@ -3310,15 +3310,15 @@ msgstr ""
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:469 lxc/project.go:470
+#: lxc/project.go:470 lxc/project.go:471
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:771 lxc/storage_bucket.go:773
+#: lxc/storage_bucket.go:772 lxc/storage_bucket.go:774
 msgid "List storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:456 lxc/storage_bucket.go:458
+#: lxc/storage_bucket.go:457 lxc/storage_bucket.go:459
 msgid "List storage buckets"
 msgstr ""
 
@@ -3354,11 +3354,11 @@ msgstr ""
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/warning.go:70
+#: lxc/warning.go:71
 msgid "List warnings"
 msgstr ""
 
-#: lxc/warning.go:71
+#: lxc/warning.go:72
 msgid ""
 "List warnings\n"
 "\n"
@@ -3381,7 +3381,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/operation.go:23 lxc/operation.go:24
+#: lxc/operation.go:24 lxc/operation.go:25
 msgid "List, show and delete background operations"
 msgstr ""
 
@@ -3390,7 +3390,7 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/monitor.go:79
+#: lxc/monitor.go:80
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
@@ -3494,23 +3494,23 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:82 lxc/file.go:83
+#: lxc/file.go:83 lxc/file.go:84
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1433 lxc/auth.go:1434
+#: lxc/auth.go:59 lxc/auth.go:60 lxc/auth.go:1434 lxc/auth.go:1435
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1083 lxc/auth.go:1084
+#: lxc/auth.go:1084 lxc/auth.go:1085
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:730 lxc/auth.go:731
+#: lxc/auth.go:731 lxc/auth.go:732
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1851 lxc/auth.go:1852
+#: lxc/auth.go:1852 lxc/auth.go:1853
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3601,7 +3601,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:492 lxc/auth.go:493
+#: lxc/auth.go:493 lxc/auth.go:494
 msgid "Manage permissions"
 msgstr ""
 
@@ -3609,23 +3609,23 @@ msgstr ""
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:28 lxc/project.go:29
+#: lxc/project.go:29 lxc/project.go:30
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:731
+#: lxc/storage_bucket.go:732
 msgid "Manage storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:732
+#: lxc/storage_bucket.go:733
 msgid "Manage storage bucket keys."
 msgstr ""
 
-#: lxc/storage_bucket.go:28
+#: lxc/storage_bucket.go:29
 msgid "Manage storage buckets"
 msgstr ""
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:30
 msgid "Manage storage buckets."
 msgstr ""
 
@@ -3653,11 +3653,11 @@ msgstr ""
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/auth.go:29 lxc/auth.go:30
+#: lxc/auth.go:30 lxc/auth.go:31
 msgid "Manage user authorization"
 msgstr ""
 
-#: lxc/warning.go:28 lxc/warning.go:29
+#: lxc/warning.go:29 lxc/warning.go:30
 msgid "Manage warnings"
 msgstr ""
 
@@ -3721,17 +3721,17 @@ msgstr ""
 msgid "Migration operation failure: %w"
 msgstr ""
 
-#: lxc/monitor.go:51
+#: lxc/monitor.go:52
 msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: lxc/storage_bucket.go:116 lxc/storage_bucket.go:216
-#: lxc/storage_bucket.go:292 lxc/storage_bucket.go:411
-#: lxc/storage_bucket.go:568 lxc/storage_bucket.go:660
-#: lxc/storage_bucket.go:802 lxc/storage_bucket.go:889
-#: lxc/storage_bucket.go:986 lxc/storage_bucket.go:1065
-#: lxc/storage_bucket.go:1188
+#: lxc/storage_bucket.go:117 lxc/storage_bucket.go:217
+#: lxc/storage_bucket.go:293 lxc/storage_bucket.go:412
+#: lxc/storage_bucket.go:569 lxc/storage_bucket.go:661
+#: lxc/storage_bucket.go:803 lxc/storage_bucket.go:890
+#: lxc/storage_bucket.go:987 lxc/storage_bucket.go:1066
+#: lxc/storage_bucket.go:1189
 msgid "Missing bucket name"
 msgstr ""
 
@@ -3750,20 +3750,20 @@ msgstr ""
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1825
+#: lxc/auth.go:123 lxc/auth.go:177 lxc/auth.go:255 lxc/auth.go:417
+#: lxc/auth.go:466 lxc/auth.go:541 lxc/auth.go:600 lxc/auth.go:1826
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:862 lxc/auth.go:1003 lxc/auth.go:1131 lxc/auth.go:1189
+#: lxc/auth.go:863 lxc/auth.go:1004 lxc/auth.go:1132 lxc/auth.go:1190
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1495 lxc/auth.go:1548 lxc/auth.go:1614 lxc/auth.go:1776
+#: lxc/auth.go:1496 lxc/auth.go:1549 lxc/auth.go:1615 lxc/auth.go:1777
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1899 lxc/auth.go:1952
+#: lxc/auth.go:1900 lxc/auth.go:1953
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -3771,12 +3771,12 @@ msgstr ""
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
 #: lxc/config_template.go:377 lxc/profile.go:141 lxc/profile.go:222
-#: lxc/profile.go:808 lxc/rebuild.go:60
+#: lxc/profile.go:808 lxc/rebuild.go:61
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/storage_bucket.go:893 lxc/storage_bucket.go:990
-#: lxc/storage_bucket.go:1069 lxc/storage_bucket.go:1192
+#: lxc/storage_bucket.go:894 lxc/storage_bucket.go:991
+#: lxc/storage_bucket.go:1070 lxc/storage_bucket.go:1193
 msgid "Missing key name"
 msgstr ""
 
@@ -3841,13 +3841,13 @@ msgid "Missing peer name"
 msgstr ""
 
 #: lxc/storage.go:235 lxc/storage.go:313 lxc/storage.go:431 lxc/storage.go:509
-#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:112
-#: lxc/storage_bucket.go:212 lxc/storage_bucket.go:288
-#: lxc/storage_bucket.go:407 lxc/storage_bucket.go:482
-#: lxc/storage_bucket.go:564 lxc/storage_bucket.go:656
-#: lxc/storage_bucket.go:798 lxc/storage_bucket.go:885
-#: lxc/storage_bucket.go:982 lxc/storage_bucket.go:1061
-#: lxc/storage_bucket.go:1184 lxc/storage_volume.go:209
+#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:113
+#: lxc/storage_bucket.go:213 lxc/storage_bucket.go:289
+#: lxc/storage_bucket.go:408 lxc/storage_bucket.go:483
+#: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
+#: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
+#: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
 #: lxc/storage_volume.go:323 lxc/storage_volume.go:643
 #: lxc/storage_volume.go:750 lxc/storage_volume.go:841
 #: lxc/storage_volume.go:939 lxc/storage_volume.go:1053
@@ -3862,9 +3862,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:404 lxc/project.go:146 lxc/project.go:226 lxc/project.go:316
-#: lxc/project.go:433 lxc/project.go:622 lxc/project.go:691 lxc/project.go:819
-#: lxc/project.go:948
+#: lxc/profile.go:404 lxc/project.go:147 lxc/project.go:227 lxc/project.go:317
+#: lxc/project.go:434 lxc/project.go:623 lxc/project.go:692 lxc/project.go:820
+#: lxc/project.go:949
 msgid "Missing project name"
 msgstr ""
 
@@ -3880,7 +3880,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:598
+#: lxc/file.go:599
 msgid "Missing target directory"
 msgstr ""
 
@@ -3902,11 +3902,11 @@ msgstr ""
 msgid "Model: %v"
 msgstr ""
 
-#: lxc/monitor.go:32
+#: lxc/monitor.go:33
 msgid "Monitor a local or remote LXD server"
 msgstr ""
 
-#: lxc/monitor.go:33
+#: lxc/monitor.go:34
 msgid ""
 "Monitor a local or remote LXD server\n"
 "\n"
@@ -3918,11 +3918,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:285
+#: lxc/file.go:286
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:985 lxc/file.go:986
+#: lxc/file.go:986 lxc/file.go:987
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3984,13 +3984,13 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:192
+#: lxc/auth.go:376 lxc/auth.go:816 lxc/auth.go:1736 lxc/cluster.go:192
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
-#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:565
-#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:511
-#: lxc/storage_bucket.go:831 lxc/storage_volume.go:1731
+#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:566
+#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1731
 msgid "NAME"
 msgstr ""
 
@@ -3998,11 +3998,11 @@ msgstr ""
 msgid "NAT"
 msgstr ""
 
-#: lxc/project.go:571
+#: lxc/project.go:572
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:570
+#: lxc/project.go:571
 msgid "NETWORKS"
 msgstr ""
 
@@ -4014,9 +4014,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/operation.go:154 lxc/project.go:523
-#: lxc/project.go:528 lxc/project.go:533 lxc/project.go:538 lxc/project.go:543
-#: lxc/project.go:548 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
+#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:524
+#: lxc/project.go:529 lxc/project.go:534 lxc/project.go:539 lxc/project.go:544
+#: lxc/project.go:549 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
 msgid "NO"
 msgstr ""
 
@@ -4261,7 +4261,7 @@ msgstr ""
 msgid "Only managed networks can be modified"
 msgstr ""
 
-#: lxc/operation.go:86
+#: lxc/operation.go:87
 #, c-format
 msgid "Operation %s deleted"
 msgstr ""
@@ -4308,11 +4308,11 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:567
+#: lxc/list.go:576 lxc/project.go:568
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:212
+#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4374,24 +4374,24 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1102
+#: lxc/file.go:1103
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:860
+#: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
-#: lxc/project.go:363 lxc/storage.go:360 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1151
+#: lxc/project.go:364 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1151
 #: lxc/storage_volume.go:1183
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
-#: lxc/monitor.go:48
+#: lxc/monitor.go:49
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
@@ -4477,17 +4477,17 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:172
+#: lxc/project.go:173
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:236
+#: lxc/project.go:237
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:637
+#: lxc/project.go:638
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -4608,20 +4608,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:241 lxc/file.go:242
+#: lxc/file.go:242 lxc/file.go:243
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:416 lxc/file.go:767
+#: lxc/file.go:417 lxc/file.go:768
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:466 lxc/file.go:467
+#: lxc/file.go:467 lxc/file.go:468
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:701 lxc/file.go:867
+#: lxc/file.go:702 lxc/file.go:868
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4634,11 +4634,11 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:983
+#: lxc/project.go:984
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/storage_bucket.go:833
+#: lxc/storage_bucket.go:834
 msgid "ROLE"
 msgstr ""
 
@@ -4651,15 +4651,15 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/rebuild.go:31
+#: lxc/rebuild.go:32
 msgid "Rebuild as an empty instance"
 msgstr ""
 
-#: lxc/rebuild.go:26
+#: lxc/rebuild.go:27
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:249 lxc/file.go:473
+#: lxc/file.go:250 lxc/file.go:474
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4686,7 +4686,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:882 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
+#: lxc/project.go:883 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
 #: lxc/remote.go:994
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4737,7 +4737,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1164 lxc/auth.go:1165
+#: lxc/auth.go:1165 lxc/auth.go:1166
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4773,7 +4773,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1927 lxc/auth.go:1928
+#: lxc/auth.go:1928 lxc/auth.go:1929
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4785,7 +4785,7 @@ msgstr ""
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:574 lxc/auth.go:575
+#: lxc/auth.go:575 lxc/auth.go:576
 msgid "Remove permissions from groups"
 msgstr ""
 
@@ -4830,11 +4830,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:391 lxc/auth.go:392
+#: lxc/auth.go:392 lxc/auth.go:393
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1751 lxc/auth.go:1752
+#: lxc/auth.go:1752 lxc/auth.go:1753
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -4854,7 +4854,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:589 lxc/project.go:590
+#: lxc/project.go:590 lxc/project.go:591
 msgid "Rename projects"
 msgstr ""
 
@@ -4952,7 +4952,7 @@ msgstr ""
 msgid "Revoke cluster member join token"
 msgstr ""
 
-#: lxc/storage_bucket.go:862
+#: lxc/storage_bucket.go:863
 msgid "Role (admin or read-only)"
 msgstr ""
 
@@ -4968,7 +4968,7 @@ msgstr ""
 msgid "Run against all projects"
 msgstr ""
 
-#: lxc/warning.go:213
+#: lxc/warning.go:214
 msgid "SEVERITY"
 msgstr ""
 
@@ -4988,12 +4988,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1231
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1231
+#: lxc/file.go:1232
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5007,11 +5007,11 @@ msgstr ""
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:173 lxc/warning.go:214
+#: lxc/operation.go:174 lxc/warning.go:215
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:569
+#: lxc/project.go:570
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5019,7 +5019,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:569
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -5027,11 +5027,11 @@ msgstr ""
 msgid "STP"
 msgstr ""
 
-#: lxc/storage_bucket.go:864
+#: lxc/storage_bucket.go:865
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:942
+#: lxc/storage_bucket.go:943
 #, c-format
 msgid "Secret key: %s"
 msgstr ""
@@ -5069,7 +5069,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:995
+#: lxc/file.go:996
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5207,11 +5207,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:654
+#: lxc/project.go:655
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:655
+#: lxc/project.go:656
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5220,11 +5220,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage_bucket.go:534
+#: lxc/storage_bucket.go:535
 msgid "Set storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:535
+#: lxc/storage_bucket.go:536
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -5263,15 +5263,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:476
+#: lxc/file.go:477
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:477
+#: lxc/file.go:478
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:475
+#: lxc/file.go:476
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5311,11 +5311,11 @@ msgstr ""
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 msgid "Set the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:542
+#: lxc/storage_bucket.go:543
 msgid "Set the key as a storage bucket property"
 msgstr ""
 
@@ -5331,7 +5331,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:993
+#: lxc/file.go:994
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5343,7 +5343,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1800 lxc/auth.go:1801
+#: lxc/auth.go:1801 lxc/auth.go:1802
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5359,11 +5359,11 @@ msgstr ""
 msgid "Show details of a cluster member"
 msgstr ""
 
-#: lxc/operation.go:192 lxc/operation.go:193
+#: lxc/operation.go:193 lxc/operation.go:194
 msgid "Show details on a background operation"
 msgstr ""
 
-#: lxc/monitor.go:49
+#: lxc/monitor.go:50
 msgid "Show events from all projects"
 msgstr ""
 
@@ -5371,11 +5371,11 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:440 lxc/auth.go:441
+#: lxc/auth.go:441 lxc/auth.go:442
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:832
+#: lxc/auth.go:833
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5456,15 +5456,15 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:786 lxc/project.go:787
+#: lxc/project.go:787 lxc/project.go:788
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage_bucket.go:628 lxc/storage_bucket.go:629
+#: lxc/storage_bucket.go:629 lxc/storage_bucket.go:630
 msgid "Show storage bucket configurations"
 msgstr ""
 
-#: lxc/storage_bucket.go:1156 lxc/storage_bucket.go:1157
+#: lxc/storage_bucket.go:1157 lxc/storage_bucket.go:1158
 msgid "Show storage bucket key configurations"
 msgstr ""
 
@@ -5480,7 +5480,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:895
+#: lxc/auth.go:896
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5530,7 +5530,7 @@ msgstr ""
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: lxc/warning.go:302 lxc/warning.go:303
+#: lxc/warning.go:303 lxc/warning.go:304
 msgid "Show warning"
 msgstr ""
 
@@ -5614,22 +5614,22 @@ msgstr ""
 msgid "Stopping the instance failed: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:166
+#: lxc/storage_bucket.go:167
 #, c-format
 msgid "Storage bucket %s created"
 msgstr ""
 
-#: lxc/storage_bucket.go:233
+#: lxc/storage_bucket.go:234
 #, c-format
 msgid "Storage bucket %s deleted"
 msgstr ""
 
-#: lxc/storage_bucket.go:940
+#: lxc/storage_bucket.go:941
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr ""
 
-#: lxc/storage_bucket.go:1006
+#: lxc/storage_bucket.go:1007
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr ""
@@ -5698,7 +5698,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:847 lxc/project.go:848
+#: lxc/project.go:848 lxc/project.go:849
 msgid "Switch the current project"
 msgstr ""
 
@@ -5714,10 +5714,10 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1139
+#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1139
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
-#: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:171
-#: lxc/storage_volume.go:1730 lxc/warning.go:215
+#: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
+#: lxc/storage_volume.go:1730 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
@@ -5725,11 +5725,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1032
+#: lxc/file.go:1033
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1026
+#: lxc/file.go:1027
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5857,12 +5857,12 @@ msgstr ""
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:446
+#: lxc/project.go:447
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
 
-#: lxc/storage_bucket.go:431
+#: lxc/storage_bucket.go:432
 #, c-format
 msgid "The property %q does not exist on the storage bucket %q: %v"
 msgstr ""
@@ -6047,7 +6047,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:961
+#: lxc/project.go:962
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6059,17 +6059,17 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:985 lxc/storage_volume.go:1735
+#: lxc/project.go:986 lxc/storage_volume.go:1735
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:573
+#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:574
 #: lxc/storage.go:724 lxc/storage_volume.go:1734
 msgid "USED BY"
 msgstr ""
 
-#: lxc/warning.go:216
+#: lxc/warning.go:217
 msgid "UUID"
 msgstr ""
 
@@ -6078,7 +6078,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:197
+#: lxc/file.go:198
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6092,13 +6092,13 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1253
+#: lxc/file.go:1254
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1153 lxc/list.go:631 lxc/storage_volume.go:1772
-#: lxc/warning.go:241
+#: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6108,7 +6108,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:807
+#: lxc/file.go:808
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6191,11 +6191,11 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:742 lxc/project.go:743
+#: lxc/project.go:743 lxc/project.go:744
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:697 lxc/storage_bucket.go:698
+#: lxc/storage_bucket.go:698 lxc/storage_bucket.go:699
 msgid "Unset storage bucket configuration keys"
 msgstr ""
 
@@ -6243,11 +6243,11 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:747
+#: lxc/project.go:748
 msgid "Unset the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:701
+#: lxc/storage_bucket.go:702
 msgid "Unset the key as a storage bucket property"
 msgstr ""
 
@@ -6326,7 +6326,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:71
+#: lxc/file.go:72
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6363,11 +6363,11 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:831
+#: lxc/auth.go:832
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:894
+#: lxc/auth.go:895
 msgid "View the current identity"
 msgstr ""
 
@@ -6398,15 +6398,15 @@ msgstr ""
 msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
-#: lxc/rebuild.go:27
+#: lxc/rebuild.go:28
 msgid ""
 "Wipe the instance root disk and re-initialize. The original image is used to "
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:156 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
+#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:526
+#: lxc/project.go:531 lxc/project.go:536 lxc/project.go:541 lxc/project.go:546
+#: lxc/project.go:551 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
 msgid "YES"
 msgstr ""
 
@@ -6426,7 +6426,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/rebuild.go:119
+#: lxc/rebuild.go:120
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
@@ -6438,12 +6438,12 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1689
+#: lxc/auth.go:330 lxc/auth.go:763 lxc/auth.go:894 lxc/auth.go:1690
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
-#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
+#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
-#: lxc/operation.go:103 lxc/profile.go:700 lxc/project.go:467
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:68
+#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:468
+#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6471,7 +6471,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1254
+#: lxc/auth.go:1255
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6532,11 +6532,11 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:830
+#: lxc/auth.go:831
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1926
+#: lxc/auth.go:1106 lxc/auth.go:1164 lxc/auth.go:1927
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6544,13 +6544,13 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:954 lxc/auth.go:1470 lxc/cluster_group.go:168
+#: lxc/auth.go:97 lxc/auth.go:150 lxc/auth.go:200 lxc/auth.go:440
+#: lxc/auth.go:955 lxc/auth.go:1471 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:514 lxc/auth.go:572
+#: lxc/auth.go:515 lxc/auth.go:573
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
@@ -6560,19 +6560,19 @@ msgstr ""
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:389
+#: lxc/auth.go:390
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1521 lxc/auth.go:1571 lxc/auth.go:1799
+#: lxc/auth.go:1522 lxc/auth.go:1572 lxc/auth.go:1800
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1873
+#: lxc/auth.go:1874
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1749
+#: lxc/auth.go:1750
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -6592,7 +6592,7 @@ msgstr ""
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
-#: lxc/rebuild.go:25
+#: lxc/rebuild.go:26
 msgid "[<remote>:]<image> [<remote>:]<instance>"
 msgstr ""
 
@@ -6675,20 +6675,20 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:170
+#: lxc/file.go:171
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:120
+#: lxc/file.go:121
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:240
+#: lxc/file.go:241
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:984
+#: lxc/file.go:985
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6839,12 +6839,12 @@ msgstr ""
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
-#: lxc/operation.go:53 lxc/operation.go:191
+#: lxc/operation.go:54 lxc/operation.go:192
 msgid "[<remote>:]<operation>"
 msgstr ""
 
 #: lxc/storage.go:200 lxc/storage.go:259 lxc/storage.go:473 lxc/storage.go:844
-#: lxc/storage_bucket.go:454
+#: lxc/storage_bucket.go:455
 msgid "[<remote>:]<pool>"
 msgstr ""
 
@@ -6852,22 +6852,22 @@ msgstr ""
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
-#: lxc/storage_bucket.go:185 lxc/storage_bucket.go:247
-#: lxc/storage_bucket.go:627 lxc/storage_bucket.go:769
+#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:248
+#: lxc/storage_bucket.go:628 lxc/storage_bucket.go:770
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
 
-#: lxc/storage_bucket.go:380 lxc/storage_bucket.go:696
-#: lxc/storage_bucket.go:850 lxc/storage_bucket.go:956
-#: lxc/storage_bucket.go:1020 lxc/storage_bucket.go:1155
+#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:697
+#: lxc/storage_bucket.go:851 lxc/storage_bucket.go:957
+#: lxc/storage_bucket.go:1021 lxc/storage_bucket.go:1156
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
 
-#: lxc/storage_bucket.go:533
+#: lxc/storage_bucket.go:534
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_bucket.go:81
+#: lxc/storage_bucket.go:82
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
 
@@ -6982,20 +6982,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:91 lxc/project.go:186 lxc/project.go:258 lxc/project.go:785
-#: lxc/project.go:846 lxc/project.go:913
+#: lxc/project.go:92 lxc/project.go:187 lxc/project.go:259 lxc/project.go:786
+#: lxc/project.go:847 lxc/project.go:914
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:394 lxc/project.go:741
+#: lxc/project.go:395 lxc/project.go:742
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:653
+#: lxc/project.go:654
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:587
+#: lxc/project.go:588
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7003,7 +7003,7 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:259 lxc/warning.go:301 lxc/warning.go:354
+#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
@@ -7059,7 +7059,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:555 lxc/remote.go:739
+#: lxc/project.go:556 lxc/remote.go:739
 msgid "current"
 msgstr ""
 
@@ -7106,20 +7106,20 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/auth.go:203
+#: lxc/auth.go:204
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:958
+#: lxc/auth.go:959
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1575
+#: lxc/auth.go:1576
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7197,20 +7197,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:988
+#: lxc/file.go:989
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:244
+#: lxc/file.go:245
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:470
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7292,7 +7292,7 @@ msgid ""
 "  List instances with their running state and user comment."
 msgstr ""
 
-#: lxc/monitor.go:37
+#: lxc/monitor.go:38
 msgid ""
 "lxc monitor --type=logging\n"
 "    Only show log messages.\n"
@@ -7368,7 +7368,7 @@ msgid ""
 "    Create record r1 for zone z1 with configuration from config.yaml"
 msgstr ""
 
-#: lxc/operation.go:195
+#: lxc/operation.go:196
 msgid ""
 "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Show details on that operation UUID"
@@ -7411,7 +7411,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:95
+#: lxc/project.go:96
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7419,7 +7419,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:262
+#: lxc/project.go:263
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7450,7 +7450,7 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:85
 msgid ""
 "lxc storage bucket create p1 b01\n"
 "\tCreate a new storage bucket name b01 in storage pool p1\n"
@@ -7460,19 +7460,19 @@ msgid ""
 "of config.yaml"
 msgstr ""
 
-#: lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:251
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1023
+#: lxc/storage_bucket.go:1024
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:854
 msgid ""
 "lxc storage bucket key create p1 b01 k1\n"
 "\tCreate a key called k1 for the bucket b01 in the pool p1.\n"
@@ -7482,14 +7482,14 @@ msgid ""
 "of config.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1158
+#: lxc/storage_bucket.go:1159
 msgid ""
 "lxc storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_bucket.go:630
+#: lxc/storage_bucket.go:631
 msgid ""
 "lxc storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
@@ -7559,16 +7559,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1142
+#: lxc/file.go:1143
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1101
+#: lxc/file.go:1102
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1054
+#: lxc/file.go:1055
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-04 08:52-0600\n"
+"POT-Creation-Date: 2024-09-05 08:44-0400\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Swedish <https://hosted.weblate.org/projects/linux-containers/"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: lxc/storage_bucket.go:260 lxc/storage_bucket.go:1033
+#: lxc/storage_bucket.go:261 lxc/storage_bucket.go:1034
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -133,7 +133,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:213
+#: lxc/auth.go:214
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -160,7 +160,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:968
+#: lxc/auth.go:969
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -181,7 +181,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1585
+#: lxc/auth.go:1586
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -391,7 +391,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:280
+#: lxc/project.go:281
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -433,12 +433,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:935
+#: lxc/file.go:936
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:825
+#: lxc/file.go:826
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -474,7 +474,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:142 lxc/rebuild.go:64
+#: lxc/init.go:142 lxc/rebuild.go:65
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -527,7 +527,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:465
+#: lxc/file.go:466
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -560,7 +560,7 @@ msgstr ""
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:813
+#: lxc/auth.go:814
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -568,11 +568,11 @@ msgstr ""
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/storage_bucket.go:863
+#: lxc/storage_bucket.go:864
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:941
+#: lxc/storage_bucket.go:942
 #, c-format
 msgid "Access key: %s"
 msgstr ""
@@ -581,7 +581,7 @@ msgstr ""
 msgid "Access the expanded configuration"
 msgstr ""
 
-#: lxc/warning.go:261 lxc/warning.go:262
+#: lxc/warning.go:262 lxc/warning.go:263
 msgid "Acknowledge warning"
 msgstr ""
 
@@ -598,11 +598,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1106 lxc/auth.go:1107
+#: lxc/auth.go:1107 lxc/auth.go:1108
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1874 lxc/auth.go:1875
+#: lxc/auth.go:1875 lxc/auth.go:1876
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -671,7 +671,7 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:515 lxc/auth.go:516
+#: lxc/auth.go:516 lxc/auth.go:517
 msgid "Add permissions to groups"
 msgstr ""
 
@@ -700,7 +700,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:169
+#: lxc/storage_bucket.go:170
 #, c-format
 msgid "Admin access key: %s"
 msgstr ""
@@ -710,7 +710,7 @@ msgstr ""
 msgid "Admin password (or token) for %s:"
 msgstr ""
 
-#: lxc/storage_bucket.go:170
+#: lxc/storage_bucket.go:171
 #, c-format
 msgid "Admin secret key: %s"
 msgstr ""
@@ -769,7 +769,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:342 lxc/rebuild.go:130
+#: lxc/init.go:342 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -869,12 +869,12 @@ msgstr ""
 
 #: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:318
 #: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
-#: lxc/network_zone.go:366 lxc/network_zone.go:1053 lxc/storage_bucket.go:141
+#: lxc/network_zone.go:366 lxc/network_zone.go:1053 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:159
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:160
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -914,7 +914,7 @@ msgstr ""
 msgid "Bytes sent"
 msgstr ""
 
-#: lxc/operation.go:174
+#: lxc/operation.go:175
 msgid "CANCELABLE"
 msgstr ""
 
@@ -926,7 +926,7 @@ msgstr ""
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: lxc/warning.go:209
+#: lxc/warning.go:210
 msgid "COUNT"
 msgstr ""
 
@@ -952,7 +952,7 @@ msgstr ""
 msgid "CPUs (%s):"
 msgstr ""
 
-#: lxc/operation.go:175
+#: lxc/operation.go:176
 msgid "CREATED"
 msgstr ""
 
@@ -982,7 +982,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:340
+#: lxc/file.go:341
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1007,11 +1007,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:224
+#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:546
+#: lxc/file.go:547
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1020,7 +1020,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:160
+#: lxc/rebuild.go:161
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1143,13 +1143,13 @@ msgstr ""
 #: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
 #: lxc/network_load_balancer.go:1051 lxc/network_load_balancer.go:1125
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
-#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:90
-#: lxc/storage_bucket.go:190 lxc/storage_bucket.go:253
-#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:541
-#: lxc/storage_bucket.go:634 lxc/storage_bucket.go:700
-#: lxc/storage_bucket.go:775 lxc/storage_bucket.go:861
-#: lxc/storage_bucket.go:961 lxc/storage_bucket.go:1026
-#: lxc/storage_bucket.go:1162 lxc/storage_volume.go:394
+#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
+#: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
+#: lxc/storage_bucket.go:385 lxc/storage_bucket.go:542
+#: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
+#: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
+#: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
 #: lxc/storage_volume.go:612 lxc/storage_volume.go:717
 #: lxc/storage_volume.go:1005 lxc/storage_volume.go:1231
 #: lxc/storage_volume.go:1360 lxc/storage_volume.go:1848
@@ -1173,7 +1173,7 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1113 lxc/list.go:132 lxc/storage_volume.go:1589
-#: lxc/warning.go:92
+#: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
@@ -1201,7 +1201,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:100
+#: lxc/project.go:101
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1215,8 +1215,8 @@ msgstr ""
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
-#: lxc/project.go:362 lxc/storage.go:359 lxc/storage_bucket.go:348
-#: lxc/storage_bucket.go:1125 lxc/storage_volume.go:1150
+#: lxc/project.go:363 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1150
 #: lxc/storage_volume.go:1182
 #, c-format
 msgid "Config parsing error: %s"
@@ -1343,12 +1343,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:300 lxc/auth.go:1660
+#: lxc/auth.go:301 lxc/auth.go:1661
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1054
+#: lxc/auth.go:1055
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1397,15 +1397,15 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:248 lxc/file.go:474
+#: lxc/file.go:249 lxc/file.go:475
 msgid "Create any directories necessary"
 msgstr ""
 
-#: lxc/auth.go:97 lxc/auth.go:98
+#: lxc/auth.go:98 lxc/auth.go:99
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1471 lxc/auth.go:1472
+#: lxc/auth.go:1472 lxc/auth.go:1473
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1425,11 +1425,11 @@ msgstr ""
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_bucket.go:851 lxc/storage_bucket.go:852
+#: lxc/storage_bucket.go:852 lxc/storage_bucket.go:853
 msgid "Create key for a storage bucket"
 msgstr ""
 
-#: lxc/storage_bucket.go:82 lxc/storage_bucket.go:83
+#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
 msgid "Create new custom storage buckets"
 msgstr ""
 
@@ -1473,7 +1473,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:92 lxc/project.go:93
+#: lxc/project.go:93 lxc/project.go:94
 msgid "Create projects"
 msgstr ""
 
@@ -1508,13 +1508,13 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:376 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1135 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
-#: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:172
-#: lxc/profile.go:756 lxc/project.go:572 lxc/storage.go:723
-#: lxc/storage_bucket.go:512 lxc/storage_bucket.go:832
+#: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
+#: lxc/profile.go:756 lxc/project.go:573 lxc/storage.go:723
+#: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1732
 msgid "DESCRIPTION"
 msgstr ""
@@ -1539,7 +1539,7 @@ msgstr ""
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
-#: lxc/operation.go:55 lxc/operation.go:56
+#: lxc/operation.go:56 lxc/operation.go:57
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
@@ -1547,19 +1547,19 @@ msgstr ""
 msgid "Delete a cluster group"
 msgstr ""
 
-#: lxc/warning.go:360
+#: lxc/warning.go:361
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:122 lxc/file.go:123
+#: lxc/file.go:123 lxc/file.go:124
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/auth.go:151 lxc/auth.go:152
+#: lxc/auth.go:152 lxc/auth.go:153
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1523 lxc/auth.go:1524
+#: lxc/auth.go:1524 lxc/auth.go:1525
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1579,7 +1579,7 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/storage_bucket.go:957 lxc/storage_bucket.go:958
+#: lxc/storage_bucket.go:958 lxc/storage_bucket.go:959
 msgid "Delete key from a storage bucket"
 msgstr ""
 
@@ -1615,11 +1615,11 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:188 lxc/project.go:189
+#: lxc/project.go:189 lxc/project.go:190
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:187 lxc/storage_bucket.go:188
+#: lxc/storage_bucket.go:188 lxc/storage_bucket.go:189
 msgid "Delete storage buckets"
 msgstr ""
 
@@ -1631,20 +1631,20 @@ msgstr ""
 msgid "Delete storage volumes"
 msgstr ""
 
-#: lxc/warning.go:356 lxc/warning.go:357
+#: lxc/warning.go:357 lxc/warning.go:358
 msgid "Delete warning"
 msgstr ""
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:30 lxc/auth.go:59 lxc/auth.go:98
-#: lxc/auth.go:152 lxc/auth.go:201 lxc/auth.go:332 lxc/auth.go:392
-#: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
-#: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
-#: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
-#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1434 lxc/auth.go:1472
-#: lxc/auth.go:1524 lxc/auth.go:1573 lxc/auth.go:1692 lxc/auth.go:1752
-#: lxc/auth.go:1801 lxc/auth.go:1852 lxc/auth.go:1875 lxc/auth.go:1928
+#: lxc/alias.go:214 lxc/auth.go:31 lxc/auth.go:60 lxc/auth.go:99
+#: lxc/auth.go:153 lxc/auth.go:202 lxc/auth.go:333 lxc/auth.go:393
+#: lxc/auth.go:442 lxc/auth.go:494 lxc/auth.go:517 lxc/auth.go:576
+#: lxc/auth.go:732 lxc/auth.go:766 lxc/auth.go:833 lxc/auth.go:896
+#: lxc/auth.go:957 lxc/auth.go:1085 lxc/auth.go:1108 lxc/auth.go:1166
+#: lxc/auth.go:1235 lxc/auth.go:1257 lxc/auth.go:1435 lxc/auth.go:1473
+#: lxc/auth.go:1525 lxc/auth.go:1574 lxc/auth.go:1693 lxc/auth.go:1753
+#: lxc/auth.go:1802 lxc/auth.go:1853 lxc/auth.go:1876 lxc/auth.go:1929
 #: lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215 lxc/cluster.go:272
 #: lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:484 lxc/cluster.go:528
 #: lxc/cluster.go:586 lxc/cluster.go:677 lxc/cluster.go:770 lxc/cluster.go:893
@@ -1668,15 +1668,15 @@ msgstr ""
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:83 lxc/file.go:123 lxc/file.go:172
-#: lxc/file.go:242 lxc/file.go:467 lxc/file.go:986 lxc/image.go:38
+#: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
+#: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
 #: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
 #: lxc/image.go:697 lxc/image.go:946 lxc/image.go:1088 lxc/image.go:1415
 #: lxc/image.go:1506 lxc/image.go:1572 lxc/image.go:1636 lxc/image.go:1699
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:38 lxc/network.go:33
+#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33
 #: lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405
 #: lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793
 #: lxc/network.go:874 lxc/network.go:1005 lxc/network.go:1106
@@ -1710,27 +1710,27 @@ msgstr ""
 #: lxc/network_zone.go:909 lxc/network_zone.go:985 lxc/network_zone.go:1083
 #: lxc/network_zone.go:1172 lxc/network_zone.go:1219 lxc/network_zone.go:1349
 #: lxc/network_zone.go:1410 lxc/network_zone.go:1425 lxc/network_zone.go:1483
-#: lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:106
-#: lxc/operation.go:193 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
+#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
+#: lxc/operation.go:194 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
 #: lxc/profile.go:271 lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493
 #: lxc/profile.go:629 lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860
-#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:29
-#: lxc/project.go:93 lxc/project.go:189 lxc/project.go:260 lxc/project.go:396
-#: lxc/project.go:470 lxc/project.go:590 lxc/project.go:655 lxc/project.go:743
-#: lxc/project.go:787 lxc/project.go:848 lxc/project.go:915 lxc/publish.go:34
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:35 lxc/remote.go:91
+#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:30
+#: lxc/project.go:94 lxc/project.go:190 lxc/project.go:261 lxc/project.go:397
+#: lxc/project.go:471 lxc/project.go:591 lxc/project.go:656 lxc/project.go:744
+#: lxc/project.go:788 lxc/project.go:849 lxc/project.go:916 lxc/publish.go:34
+#: lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91
 #: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853
 #: lxc/remote.go:917 lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24
 #: lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203
 #: lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655
 #: lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940
-#: lxc/storage_bucket.go:29 lxc/storage_bucket.go:83 lxc/storage_bucket.go:188
-#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:382
-#: lxc/storage_bucket.go:458 lxc/storage_bucket.go:535
-#: lxc/storage_bucket.go:629 lxc/storage_bucket.go:698
-#: lxc/storage_bucket.go:732 lxc/storage_bucket.go:773
-#: lxc/storage_bucket.go:852 lxc/storage_bucket.go:958
-#: lxc/storage_bucket.go:1022 lxc/storage_bucket.go:1157
+#: lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189
+#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:383
+#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:536
+#: lxc/storage_bucket.go:630 lxc/storage_bucket.go:699
+#: lxc/storage_bucket.go:733 lxc/storage_bucket.go:774
+#: lxc/storage_bucket.go:853 lxc/storage_bucket.go:959
+#: lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158
 #: lxc/storage_volume.go:58 lxc/storage_volume.go:169 lxc/storage_volume.go:283
 #: lxc/storage_volume.go:390 lxc/storage_volume.go:605
 #: lxc/storage_volume.go:714 lxc/storage_volume.go:801
@@ -1741,8 +1741,8 @@ msgstr ""
 #: lxc/storage_volume.go:2064 lxc/storage_volume.go:2222
 #: lxc/storage_volume.go:2343 lxc/storage_volume.go:2405
 #: lxc/storage_volume.go:2541 lxc/storage_volume.go:2624
-#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:29
-#: lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
+#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:30
+#: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
@@ -1829,7 +1829,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:994
+#: lxc/file.go:995
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1895,7 +1895,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:74
+#: lxc/file.go:75
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1905,7 +1905,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:955 lxc/auth.go:956
+#: lxc/auth.go:956 lxc/auth.go:957
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1913,15 +1913,15 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:171 lxc/file.go:172
+#: lxc/file.go:172 lxc/file.go:173
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/auth.go:200 lxc/auth.go:201
+#: lxc/auth.go:201 lxc/auth.go:202
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1572 lxc/auth.go:1573
+#: lxc/auth.go:1573 lxc/auth.go:1574
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -1977,15 +1977,15 @@ msgstr ""
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:259 lxc/project.go:260
+#: lxc/project.go:260 lxc/project.go:261
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:248 lxc/storage_bucket.go:249
+#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:250
 msgid "Edit storage bucket configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:1021 lxc/storage_bucket.go:1022
+#: lxc/storage_bucket.go:1022 lxc/storage_bucket.go:1023
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
@@ -2002,7 +2002,7 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1147 lxc/list.go:622 lxc/storage_volume.go:1766
-#: lxc/warning.go:235
+#: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2057,7 +2057,7 @@ msgstr ""
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
-#: lxc/project.go:718 lxc/storage.go:812 lxc/storage_bucket.go:602
+#: lxc/project.go:719 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2155 lxc/storage_volume.go:2193
 #, c-format
 msgid "Error setting properties: %v"
@@ -2071,8 +2071,8 @@ msgstr ""
 #: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
-#: lxc/profile.go:981 lxc/project.go:712 lxc/storage.go:806
-#: lxc/storage_bucket.go:596 lxc/storage_volume.go:2149
+#: lxc/profile.go:981 lxc/project.go:713 lxc/storage.go:806
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2149
 #: lxc/storage_volume.go:2187
 #, c-format
 msgid "Error unsetting property: %v"
@@ -2092,7 +2092,7 @@ msgstr ""
 msgid "Evacuating cluster member: %s"
 msgstr ""
 
-#: lxc/monitor.go:50
+#: lxc/monitor.go:51
 msgid "Event type to listen for"
 msgstr ""
 
@@ -2179,16 +2179,16 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/warning.go:210
+#: lxc/warning.go:211
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1237
+#: lxc/file.go:1238
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1260
+#: lxc/file.go:1261
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2203,12 +2203,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1287
+#: lxc/file.go:1288
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1072
+#: lxc/file.go:1073
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2238,7 +2238,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1193
+#: lxc/file.go:1194
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2253,7 +2253,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1198
+#: lxc/file.go:1199
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2263,12 +2263,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1098
+#: lxc/file.go:1099
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1225
+#: lxc/file.go:1226
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2307,7 +2307,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1210
+#: lxc/file.go:1211
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2322,7 +2322,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:820
+#: lxc/file.go:821
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2337,7 +2337,7 @@ msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
 #: lxc/network.go:1044 lxc/network_acl.go:133 lxc/network_zone.go:124
-#: lxc/operation.go:136
+#: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
 
@@ -2402,21 +2402,21 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
+#: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:770 lxc/auth.go:1697
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1114 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:57
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
-#: lxc/operation.go:108 lxc/profile.go:707 lxc/project.go:472
-#: lxc/project.go:917 lxc/remote.go:690 lxc/storage.go:657
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:774
-#: lxc/storage_volume.go:1608 lxc/warning.go:93
+#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:473
+#: lxc/project.go:918 lxc/remote.go:690 lxc/storage.go:657
+#: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
+#: lxc/storage_volume.go:1608 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
-#: lxc/monitor.go:52
+#: lxc/monitor.go:53
 msgid "Format (json|pretty|yaml)"
 msgstr ""
 
@@ -2460,7 +2460,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:817 lxc/auth.go:1736
+#: lxc/auth.go:818 lxc/auth.go:1737
 msgid "GROUPS"
 msgstr ""
 
@@ -2476,7 +2476,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:914 lxc/project.go:915
+#: lxc/project.go:915 lxc/project.go:916
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2524,11 +2524,11 @@ msgstr ""
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:400
+#: lxc/project.go:401
 msgid "Get the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:385
+#: lxc/storage_bucket.go:386
 msgid "Get the key as a storage bucket property"
 msgstr ""
 
@@ -2588,11 +2588,11 @@ msgstr ""
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:395 lxc/project.go:396
+#: lxc/project.go:396 lxc/project.go:397
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:382
+#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:383
 msgid "Get values for storage bucket configuration keys"
 msgstr ""
 
@@ -2609,17 +2609,17 @@ msgstr ""
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: lxc/auth.go:136
+#: lxc/auth.go:137
 #, c-format
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:186
+#: lxc/auth.go:187
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:426 lxc/auth.go:1786
+#: lxc/auth.go:427 lxc/auth.go:1787
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2644,27 +2644,27 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1310
+#: lxc/file.go:1311
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1299
+#: lxc/file.go:1300
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1122
+#: lxc/file.go:1123
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1132
+#: lxc/file.go:1133
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:966 lxc/operation.go:170
+#: lxc/network.go:966 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2678,11 +2678,11 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:816
+#: lxc/auth.go:817
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:566
+#: lxc/project.go:567
 msgid "IMAGES"
 msgstr ""
 
@@ -2710,17 +2710,17 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1508
+#: lxc/auth.go:1509
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1558
+#: lxc/auth.go:1559
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
 
-#: lxc/rebuild.go:32
+#: lxc/rebuild.go:33
 msgid "If an instance is running, stop it and then rebuild it"
 msgstr ""
 
@@ -2841,7 +2841,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1233 lxc/auth.go:1234
+#: lxc/auth.go:1234 lxc/auth.go:1235
 msgid "Inspect permissions"
 msgstr ""
 
@@ -2849,11 +2849,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1124
+#: lxc/file.go:1125
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1301
+#: lxc/file.go:1302
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2871,7 +2871,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1044
+#: lxc/file.go:1045
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2880,7 +2880,7 @@ msgstr ""
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/rebuild.go:74
+#: lxc/rebuild.go:75
 #, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
@@ -2913,7 +2913,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/monitor.go:70
+#: lxc/monitor.go:71
 #, c-format
 msgid "Invalid format: %s"
 msgstr ""
@@ -2923,7 +2923,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1039
+#: lxc/file.go:1040
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2965,7 +2965,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:147
+#: lxc/file.go:148
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2981,12 +2981,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:313
+#: lxc/file.go:314
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:495
+#: lxc/file.go:496
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3000,7 +3000,7 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/warning.go:212
 msgid "LAST SEEN"
 msgstr ""
 
@@ -3008,7 +3008,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:984
+#: lxc/project.go:985
 msgid "LIMIT"
 msgstr ""
 
@@ -3017,8 +3017,8 @@ msgid "LISTEN ADDRESS"
 msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
-#: lxc/network_load_balancer.go:165 lxc/operation.go:177
-#: lxc/storage_bucket.go:516 lxc/storage_volume.go:1739 lxc/warning.go:220
+#: lxc/network_load_balancer.go:165 lxc/operation.go:178
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1739 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3092,7 +3092,7 @@ msgstr ""
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/warning.go:94
+#: lxc/warning.go:95
 msgid "List all warnings"
 msgstr ""
 
@@ -3136,19 +3136,19 @@ msgstr ""
 msgid "List available storage pools"
 msgstr ""
 
-#: lxc/operation.go:105 lxc/operation.go:106
+#: lxc/operation.go:106 lxc/operation.go:107
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:331 lxc/auth.go:332
+#: lxc/auth.go:332 lxc/auth.go:333
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:764 lxc/auth.go:765
+#: lxc/auth.go:765 lxc/auth.go:766
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1691 lxc/auth.go:1692
+#: lxc/auth.go:1692 lxc/auth.go:1693
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3297,11 +3297,11 @@ msgstr ""
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/operation.go:109
+#: lxc/operation.go:110
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1255 lxc/auth.go:1256
+#: lxc/auth.go:1256 lxc/auth.go:1257
 msgid "List permissions"
 msgstr ""
 
@@ -3309,15 +3309,15 @@ msgstr ""
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:469 lxc/project.go:470
+#: lxc/project.go:470 lxc/project.go:471
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:771 lxc/storage_bucket.go:773
+#: lxc/storage_bucket.go:772 lxc/storage_bucket.go:774
 msgid "List storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:456 lxc/storage_bucket.go:458
+#: lxc/storage_bucket.go:457 lxc/storage_bucket.go:459
 msgid "List storage buckets"
 msgstr ""
 
@@ -3353,11 +3353,11 @@ msgstr ""
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/warning.go:70
+#: lxc/warning.go:71
 msgid "List warnings"
 msgstr ""
 
-#: lxc/warning.go:71
+#: lxc/warning.go:72
 msgid ""
 "List warnings\n"
 "\n"
@@ -3380,7 +3380,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/operation.go:23 lxc/operation.go:24
+#: lxc/operation.go:24 lxc/operation.go:25
 msgid "List, show and delete background operations"
 msgstr ""
 
@@ -3389,7 +3389,7 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/monitor.go:79
+#: lxc/monitor.go:80
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
@@ -3493,23 +3493,23 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:82 lxc/file.go:83
+#: lxc/file.go:83 lxc/file.go:84
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1433 lxc/auth.go:1434
+#: lxc/auth.go:59 lxc/auth.go:60 lxc/auth.go:1434 lxc/auth.go:1435
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1083 lxc/auth.go:1084
+#: lxc/auth.go:1084 lxc/auth.go:1085
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:730 lxc/auth.go:731
+#: lxc/auth.go:731 lxc/auth.go:732
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1851 lxc/auth.go:1852
+#: lxc/auth.go:1852 lxc/auth.go:1853
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3600,7 +3600,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:492 lxc/auth.go:493
+#: lxc/auth.go:493 lxc/auth.go:494
 msgid "Manage permissions"
 msgstr ""
 
@@ -3608,23 +3608,23 @@ msgstr ""
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:28 lxc/project.go:29
+#: lxc/project.go:29 lxc/project.go:30
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:731
+#: lxc/storage_bucket.go:732
 msgid "Manage storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:732
+#: lxc/storage_bucket.go:733
 msgid "Manage storage bucket keys."
 msgstr ""
 
-#: lxc/storage_bucket.go:28
+#: lxc/storage_bucket.go:29
 msgid "Manage storage buckets"
 msgstr ""
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:30
 msgid "Manage storage buckets."
 msgstr ""
 
@@ -3652,11 +3652,11 @@ msgstr ""
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/auth.go:29 lxc/auth.go:30
+#: lxc/auth.go:30 lxc/auth.go:31
 msgid "Manage user authorization"
 msgstr ""
 
-#: lxc/warning.go:28 lxc/warning.go:29
+#: lxc/warning.go:29 lxc/warning.go:30
 msgid "Manage warnings"
 msgstr ""
 
@@ -3720,17 +3720,17 @@ msgstr ""
 msgid "Migration operation failure: %w"
 msgstr ""
 
-#: lxc/monitor.go:51
+#: lxc/monitor.go:52
 msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: lxc/storage_bucket.go:116 lxc/storage_bucket.go:216
-#: lxc/storage_bucket.go:292 lxc/storage_bucket.go:411
-#: lxc/storage_bucket.go:568 lxc/storage_bucket.go:660
-#: lxc/storage_bucket.go:802 lxc/storage_bucket.go:889
-#: lxc/storage_bucket.go:986 lxc/storage_bucket.go:1065
-#: lxc/storage_bucket.go:1188
+#: lxc/storage_bucket.go:117 lxc/storage_bucket.go:217
+#: lxc/storage_bucket.go:293 lxc/storage_bucket.go:412
+#: lxc/storage_bucket.go:569 lxc/storage_bucket.go:661
+#: lxc/storage_bucket.go:803 lxc/storage_bucket.go:890
+#: lxc/storage_bucket.go:987 lxc/storage_bucket.go:1066
+#: lxc/storage_bucket.go:1189
 msgid "Missing bucket name"
 msgstr ""
 
@@ -3749,20 +3749,20 @@ msgstr ""
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1825
+#: lxc/auth.go:123 lxc/auth.go:177 lxc/auth.go:255 lxc/auth.go:417
+#: lxc/auth.go:466 lxc/auth.go:541 lxc/auth.go:600 lxc/auth.go:1826
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:862 lxc/auth.go:1003 lxc/auth.go:1131 lxc/auth.go:1189
+#: lxc/auth.go:863 lxc/auth.go:1004 lxc/auth.go:1132 lxc/auth.go:1190
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1495 lxc/auth.go:1548 lxc/auth.go:1614 lxc/auth.go:1776
+#: lxc/auth.go:1496 lxc/auth.go:1549 lxc/auth.go:1615 lxc/auth.go:1777
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1899 lxc/auth.go:1952
+#: lxc/auth.go:1900 lxc/auth.go:1953
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -3770,12 +3770,12 @@ msgstr ""
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
 #: lxc/config_template.go:377 lxc/profile.go:141 lxc/profile.go:222
-#: lxc/profile.go:808 lxc/rebuild.go:60
+#: lxc/profile.go:808 lxc/rebuild.go:61
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/storage_bucket.go:893 lxc/storage_bucket.go:990
-#: lxc/storage_bucket.go:1069 lxc/storage_bucket.go:1192
+#: lxc/storage_bucket.go:894 lxc/storage_bucket.go:991
+#: lxc/storage_bucket.go:1070 lxc/storage_bucket.go:1193
 msgid "Missing key name"
 msgstr ""
 
@@ -3840,13 +3840,13 @@ msgid "Missing peer name"
 msgstr ""
 
 #: lxc/storage.go:235 lxc/storage.go:313 lxc/storage.go:431 lxc/storage.go:509
-#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:112
-#: lxc/storage_bucket.go:212 lxc/storage_bucket.go:288
-#: lxc/storage_bucket.go:407 lxc/storage_bucket.go:482
-#: lxc/storage_bucket.go:564 lxc/storage_bucket.go:656
-#: lxc/storage_bucket.go:798 lxc/storage_bucket.go:885
-#: lxc/storage_bucket.go:982 lxc/storage_bucket.go:1061
-#: lxc/storage_bucket.go:1184 lxc/storage_volume.go:209
+#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:113
+#: lxc/storage_bucket.go:213 lxc/storage_bucket.go:289
+#: lxc/storage_bucket.go:408 lxc/storage_bucket.go:483
+#: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
+#: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
+#: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
 #: lxc/storage_volume.go:323 lxc/storage_volume.go:643
 #: lxc/storage_volume.go:750 lxc/storage_volume.go:841
 #: lxc/storage_volume.go:939 lxc/storage_volume.go:1053
@@ -3861,9 +3861,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:404 lxc/project.go:146 lxc/project.go:226 lxc/project.go:316
-#: lxc/project.go:433 lxc/project.go:622 lxc/project.go:691 lxc/project.go:819
-#: lxc/project.go:948
+#: lxc/profile.go:404 lxc/project.go:147 lxc/project.go:227 lxc/project.go:317
+#: lxc/project.go:434 lxc/project.go:623 lxc/project.go:692 lxc/project.go:820
+#: lxc/project.go:949
 msgid "Missing project name"
 msgstr ""
 
@@ -3879,7 +3879,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:598
+#: lxc/file.go:599
 msgid "Missing target directory"
 msgstr ""
 
@@ -3901,11 +3901,11 @@ msgstr ""
 msgid "Model: %v"
 msgstr ""
 
-#: lxc/monitor.go:32
+#: lxc/monitor.go:33
 msgid "Monitor a local or remote LXD server"
 msgstr ""
 
-#: lxc/monitor.go:33
+#: lxc/monitor.go:34
 msgid ""
 "Monitor a local or remote LXD server\n"
 "\n"
@@ -3917,11 +3917,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:285
+#: lxc/file.go:286
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:985 lxc/file.go:986
+#: lxc/file.go:986 lxc/file.go:987
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3983,13 +3983,13 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:192
+#: lxc/auth.go:376 lxc/auth.go:816 lxc/auth.go:1736 lxc/cluster.go:192
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
-#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:565
-#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:511
-#: lxc/storage_bucket.go:831 lxc/storage_volume.go:1731
+#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:566
+#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1731
 msgid "NAME"
 msgstr ""
 
@@ -3997,11 +3997,11 @@ msgstr ""
 msgid "NAT"
 msgstr ""
 
-#: lxc/project.go:571
+#: lxc/project.go:572
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:570
+#: lxc/project.go:571
 msgid "NETWORKS"
 msgstr ""
 
@@ -4013,9 +4013,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/operation.go:154 lxc/project.go:523
-#: lxc/project.go:528 lxc/project.go:533 lxc/project.go:538 lxc/project.go:543
-#: lxc/project.go:548 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
+#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:524
+#: lxc/project.go:529 lxc/project.go:534 lxc/project.go:539 lxc/project.go:544
+#: lxc/project.go:549 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
 msgid "NO"
 msgstr ""
 
@@ -4260,7 +4260,7 @@ msgstr ""
 msgid "Only managed networks can be modified"
 msgstr ""
 
-#: lxc/operation.go:86
+#: lxc/operation.go:87
 #, c-format
 msgid "Operation %s deleted"
 msgstr ""
@@ -4307,11 +4307,11 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:567
+#: lxc/list.go:576 lxc/project.go:568
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:212
+#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4373,24 +4373,24 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1102
+#: lxc/file.go:1103
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:860
+#: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
-#: lxc/project.go:363 lxc/storage.go:360 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1151
+#: lxc/project.go:364 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1151
 #: lxc/storage_volume.go:1183
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
-#: lxc/monitor.go:48
+#: lxc/monitor.go:49
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
@@ -4476,17 +4476,17 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:172
+#: lxc/project.go:173
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:236
+#: lxc/project.go:237
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:637
+#: lxc/project.go:638
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -4607,20 +4607,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:241 lxc/file.go:242
+#: lxc/file.go:242 lxc/file.go:243
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:416 lxc/file.go:767
+#: lxc/file.go:417 lxc/file.go:768
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:466 lxc/file.go:467
+#: lxc/file.go:467 lxc/file.go:468
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:701 lxc/file.go:867
+#: lxc/file.go:702 lxc/file.go:868
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4633,11 +4633,11 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:983
+#: lxc/project.go:984
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/storage_bucket.go:833
+#: lxc/storage_bucket.go:834
 msgid "ROLE"
 msgstr ""
 
@@ -4650,15 +4650,15 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/rebuild.go:31
+#: lxc/rebuild.go:32
 msgid "Rebuild as an empty instance"
 msgstr ""
 
-#: lxc/rebuild.go:26
+#: lxc/rebuild.go:27
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:249 lxc/file.go:473
+#: lxc/file.go:250 lxc/file.go:474
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4685,7 +4685,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:882 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
+#: lxc/project.go:883 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
 #: lxc/remote.go:994
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4736,7 +4736,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1164 lxc/auth.go:1165
+#: lxc/auth.go:1165 lxc/auth.go:1166
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4772,7 +4772,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1927 lxc/auth.go:1928
+#: lxc/auth.go:1928 lxc/auth.go:1929
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4784,7 +4784,7 @@ msgstr ""
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:574 lxc/auth.go:575
+#: lxc/auth.go:575 lxc/auth.go:576
 msgid "Remove permissions from groups"
 msgstr ""
 
@@ -4829,11 +4829,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:391 lxc/auth.go:392
+#: lxc/auth.go:392 lxc/auth.go:393
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1751 lxc/auth.go:1752
+#: lxc/auth.go:1752 lxc/auth.go:1753
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -4853,7 +4853,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:589 lxc/project.go:590
+#: lxc/project.go:590 lxc/project.go:591
 msgid "Rename projects"
 msgstr ""
 
@@ -4951,7 +4951,7 @@ msgstr ""
 msgid "Revoke cluster member join token"
 msgstr ""
 
-#: lxc/storage_bucket.go:862
+#: lxc/storage_bucket.go:863
 msgid "Role (admin or read-only)"
 msgstr ""
 
@@ -4967,7 +4967,7 @@ msgstr ""
 msgid "Run against all projects"
 msgstr ""
 
-#: lxc/warning.go:213
+#: lxc/warning.go:214
 msgid "SEVERITY"
 msgstr ""
 
@@ -4987,12 +4987,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1231
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1231
+#: lxc/file.go:1232
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5006,11 +5006,11 @@ msgstr ""
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:173 lxc/warning.go:214
+#: lxc/operation.go:174 lxc/warning.go:215
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:569
+#: lxc/project.go:570
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5018,7 +5018,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:569
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -5026,11 +5026,11 @@ msgstr ""
 msgid "STP"
 msgstr ""
 
-#: lxc/storage_bucket.go:864
+#: lxc/storage_bucket.go:865
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:942
+#: lxc/storage_bucket.go:943
 #, c-format
 msgid "Secret key: %s"
 msgstr ""
@@ -5068,7 +5068,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:995
+#: lxc/file.go:996
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5206,11 +5206,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:654
+#: lxc/project.go:655
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:655
+#: lxc/project.go:656
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5219,11 +5219,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage_bucket.go:534
+#: lxc/storage_bucket.go:535
 msgid "Set storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:535
+#: lxc/storage_bucket.go:536
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -5262,15 +5262,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:476
+#: lxc/file.go:477
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:477
+#: lxc/file.go:478
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:475
+#: lxc/file.go:476
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5310,11 +5310,11 @@ msgstr ""
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 msgid "Set the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:542
+#: lxc/storage_bucket.go:543
 msgid "Set the key as a storage bucket property"
 msgstr ""
 
@@ -5330,7 +5330,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:993
+#: lxc/file.go:994
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5342,7 +5342,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1800 lxc/auth.go:1801
+#: lxc/auth.go:1801 lxc/auth.go:1802
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5358,11 +5358,11 @@ msgstr ""
 msgid "Show details of a cluster member"
 msgstr ""
 
-#: lxc/operation.go:192 lxc/operation.go:193
+#: lxc/operation.go:193 lxc/operation.go:194
 msgid "Show details on a background operation"
 msgstr ""
 
-#: lxc/monitor.go:49
+#: lxc/monitor.go:50
 msgid "Show events from all projects"
 msgstr ""
 
@@ -5370,11 +5370,11 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:440 lxc/auth.go:441
+#: lxc/auth.go:441 lxc/auth.go:442
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:832
+#: lxc/auth.go:833
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5455,15 +5455,15 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:786 lxc/project.go:787
+#: lxc/project.go:787 lxc/project.go:788
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage_bucket.go:628 lxc/storage_bucket.go:629
+#: lxc/storage_bucket.go:629 lxc/storage_bucket.go:630
 msgid "Show storage bucket configurations"
 msgstr ""
 
-#: lxc/storage_bucket.go:1156 lxc/storage_bucket.go:1157
+#: lxc/storage_bucket.go:1157 lxc/storage_bucket.go:1158
 msgid "Show storage bucket key configurations"
 msgstr ""
 
@@ -5479,7 +5479,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:895
+#: lxc/auth.go:896
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5529,7 +5529,7 @@ msgstr ""
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: lxc/warning.go:302 lxc/warning.go:303
+#: lxc/warning.go:303 lxc/warning.go:304
 msgid "Show warning"
 msgstr ""
 
@@ -5613,22 +5613,22 @@ msgstr ""
 msgid "Stopping the instance failed: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:166
+#: lxc/storage_bucket.go:167
 #, c-format
 msgid "Storage bucket %s created"
 msgstr ""
 
-#: lxc/storage_bucket.go:233
+#: lxc/storage_bucket.go:234
 #, c-format
 msgid "Storage bucket %s deleted"
 msgstr ""
 
-#: lxc/storage_bucket.go:940
+#: lxc/storage_bucket.go:941
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr ""
 
-#: lxc/storage_bucket.go:1006
+#: lxc/storage_bucket.go:1007
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr ""
@@ -5697,7 +5697,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:847 lxc/project.go:848
+#: lxc/project.go:848 lxc/project.go:849
 msgid "Switch the current project"
 msgstr ""
 
@@ -5713,10 +5713,10 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1139
+#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1139
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
-#: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:171
-#: lxc/storage_volume.go:1730 lxc/warning.go:215
+#: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
+#: lxc/storage_volume.go:1730 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
@@ -5724,11 +5724,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1032
+#: lxc/file.go:1033
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1026
+#: lxc/file.go:1027
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5856,12 +5856,12 @@ msgstr ""
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:446
+#: lxc/project.go:447
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
 
-#: lxc/storage_bucket.go:431
+#: lxc/storage_bucket.go:432
 #, c-format
 msgid "The property %q does not exist on the storage bucket %q: %v"
 msgstr ""
@@ -6046,7 +6046,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:961
+#: lxc/project.go:962
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6058,17 +6058,17 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:985 lxc/storage_volume.go:1735
+#: lxc/project.go:986 lxc/storage_volume.go:1735
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:573
+#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:574
 #: lxc/storage.go:724 lxc/storage_volume.go:1734
 msgid "USED BY"
 msgstr ""
 
-#: lxc/warning.go:216
+#: lxc/warning.go:217
 msgid "UUID"
 msgstr ""
 
@@ -6077,7 +6077,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:197
+#: lxc/file.go:198
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6091,13 +6091,13 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1253
+#: lxc/file.go:1254
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1153 lxc/list.go:631 lxc/storage_volume.go:1772
-#: lxc/warning.go:241
+#: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6107,7 +6107,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:807
+#: lxc/file.go:808
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6190,11 +6190,11 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:742 lxc/project.go:743
+#: lxc/project.go:743 lxc/project.go:744
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:697 lxc/storage_bucket.go:698
+#: lxc/storage_bucket.go:698 lxc/storage_bucket.go:699
 msgid "Unset storage bucket configuration keys"
 msgstr ""
 
@@ -6242,11 +6242,11 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:747
+#: lxc/project.go:748
 msgid "Unset the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:701
+#: lxc/storage_bucket.go:702
 msgid "Unset the key as a storage bucket property"
 msgstr ""
 
@@ -6325,7 +6325,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:71
+#: lxc/file.go:72
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6362,11 +6362,11 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:831
+#: lxc/auth.go:832
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:894
+#: lxc/auth.go:895
 msgid "View the current identity"
 msgstr ""
 
@@ -6397,15 +6397,15 @@ msgstr ""
 msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
-#: lxc/rebuild.go:27
+#: lxc/rebuild.go:28
 msgid ""
 "Wipe the instance root disk and re-initialize. The original image is used to "
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:156 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
+#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:526
+#: lxc/project.go:531 lxc/project.go:536 lxc/project.go:541 lxc/project.go:546
+#: lxc/project.go:551 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
 msgid "YES"
 msgstr ""
 
@@ -6425,7 +6425,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/rebuild.go:119
+#: lxc/rebuild.go:120
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
@@ -6437,12 +6437,12 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1689
+#: lxc/auth.go:330 lxc/auth.go:763 lxc/auth.go:894 lxc/auth.go:1690
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
-#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
+#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
-#: lxc/operation.go:103 lxc/profile.go:700 lxc/project.go:467
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:68
+#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:468
+#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6470,7 +6470,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1254
+#: lxc/auth.go:1255
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6531,11 +6531,11 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:830
+#: lxc/auth.go:831
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1926
+#: lxc/auth.go:1106 lxc/auth.go:1164 lxc/auth.go:1927
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6543,13 +6543,13 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:954 lxc/auth.go:1470 lxc/cluster_group.go:168
+#: lxc/auth.go:97 lxc/auth.go:150 lxc/auth.go:200 lxc/auth.go:440
+#: lxc/auth.go:955 lxc/auth.go:1471 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:514 lxc/auth.go:572
+#: lxc/auth.go:515 lxc/auth.go:573
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
@@ -6559,19 +6559,19 @@ msgstr ""
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:389
+#: lxc/auth.go:390
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1521 lxc/auth.go:1571 lxc/auth.go:1799
+#: lxc/auth.go:1522 lxc/auth.go:1572 lxc/auth.go:1800
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1873
+#: lxc/auth.go:1874
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1749
+#: lxc/auth.go:1750
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -6591,7 +6591,7 @@ msgstr ""
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
-#: lxc/rebuild.go:25
+#: lxc/rebuild.go:26
 msgid "[<remote>:]<image> [<remote>:]<instance>"
 msgstr ""
 
@@ -6674,20 +6674,20 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:170
+#: lxc/file.go:171
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:120
+#: lxc/file.go:121
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:240
+#: lxc/file.go:241
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:984
+#: lxc/file.go:985
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6838,12 +6838,12 @@ msgstr ""
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
-#: lxc/operation.go:53 lxc/operation.go:191
+#: lxc/operation.go:54 lxc/operation.go:192
 msgid "[<remote>:]<operation>"
 msgstr ""
 
 #: lxc/storage.go:200 lxc/storage.go:259 lxc/storage.go:473 lxc/storage.go:844
-#: lxc/storage_bucket.go:454
+#: lxc/storage_bucket.go:455
 msgid "[<remote>:]<pool>"
 msgstr ""
 
@@ -6851,22 +6851,22 @@ msgstr ""
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
-#: lxc/storage_bucket.go:185 lxc/storage_bucket.go:247
-#: lxc/storage_bucket.go:627 lxc/storage_bucket.go:769
+#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:248
+#: lxc/storage_bucket.go:628 lxc/storage_bucket.go:770
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
 
-#: lxc/storage_bucket.go:380 lxc/storage_bucket.go:696
-#: lxc/storage_bucket.go:850 lxc/storage_bucket.go:956
-#: lxc/storage_bucket.go:1020 lxc/storage_bucket.go:1155
+#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:697
+#: lxc/storage_bucket.go:851 lxc/storage_bucket.go:957
+#: lxc/storage_bucket.go:1021 lxc/storage_bucket.go:1156
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
 
-#: lxc/storage_bucket.go:533
+#: lxc/storage_bucket.go:534
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_bucket.go:81
+#: lxc/storage_bucket.go:82
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
 
@@ -6981,20 +6981,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:91 lxc/project.go:186 lxc/project.go:258 lxc/project.go:785
-#: lxc/project.go:846 lxc/project.go:913
+#: lxc/project.go:92 lxc/project.go:187 lxc/project.go:259 lxc/project.go:786
+#: lxc/project.go:847 lxc/project.go:914
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:394 lxc/project.go:741
+#: lxc/project.go:395 lxc/project.go:742
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:653
+#: lxc/project.go:654
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:587
+#: lxc/project.go:588
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7002,7 +7002,7 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:259 lxc/warning.go:301 lxc/warning.go:354
+#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
@@ -7058,7 +7058,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:555 lxc/remote.go:739
+#: lxc/project.go:556 lxc/remote.go:739
 msgid "current"
 msgstr ""
 
@@ -7105,20 +7105,20 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/auth.go:203
+#: lxc/auth.go:204
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:958
+#: lxc/auth.go:959
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1575
+#: lxc/auth.go:1576
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7196,20 +7196,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:988
+#: lxc/file.go:989
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:244
+#: lxc/file.go:245
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:470
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7291,7 +7291,7 @@ msgid ""
 "  List instances with their running state and user comment."
 msgstr ""
 
-#: lxc/monitor.go:37
+#: lxc/monitor.go:38
 msgid ""
 "lxc monitor --type=logging\n"
 "    Only show log messages.\n"
@@ -7367,7 +7367,7 @@ msgid ""
 "    Create record r1 for zone z1 with configuration from config.yaml"
 msgstr ""
 
-#: lxc/operation.go:195
+#: lxc/operation.go:196
 msgid ""
 "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Show details on that operation UUID"
@@ -7410,7 +7410,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:95
+#: lxc/project.go:96
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7418,7 +7418,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:262
+#: lxc/project.go:263
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7449,7 +7449,7 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:85
 msgid ""
 "lxc storage bucket create p1 b01\n"
 "\tCreate a new storage bucket name b01 in storage pool p1\n"
@@ -7459,19 +7459,19 @@ msgid ""
 "of config.yaml"
 msgstr ""
 
-#: lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:251
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1023
+#: lxc/storage_bucket.go:1024
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:854
 msgid ""
 "lxc storage bucket key create p1 b01 k1\n"
 "\tCreate a key called k1 for the bucket b01 in the pool p1.\n"
@@ -7481,14 +7481,14 @@ msgid ""
 "of config.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1158
+#: lxc/storage_bucket.go:1159
 msgid ""
 "lxc storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_bucket.go:630
+#: lxc/storage_bucket.go:631
 msgid ""
 "lxc storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
@@ -7558,16 +7558,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1142
+#: lxc/file.go:1143
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1101
+#: lxc/file.go:1102
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1054
+#: lxc/file.go:1055
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/te.po
+++ b/po/te.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-04 08:52-0600\n"
+"POT-Creation-Date: 2024-09-05 08:44-0400\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Telugu <https://hosted.weblate.org/projects/linux-containers/"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: lxc/storage_bucket.go:260 lxc/storage_bucket.go:1033
+#: lxc/storage_bucket.go:261 lxc/storage_bucket.go:1034
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -133,7 +133,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:213
+#: lxc/auth.go:214
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -160,7 +160,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:968
+#: lxc/auth.go:969
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -181,7 +181,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1585
+#: lxc/auth.go:1586
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -391,7 +391,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:280
+#: lxc/project.go:281
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -433,12 +433,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:935
+#: lxc/file.go:936
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:825
+#: lxc/file.go:826
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -474,7 +474,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:142 lxc/rebuild.go:64
+#: lxc/init.go:142 lxc/rebuild.go:65
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -527,7 +527,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:465
+#: lxc/file.go:466
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -560,7 +560,7 @@ msgstr ""
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:813
+#: lxc/auth.go:814
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -568,11 +568,11 @@ msgstr ""
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/storage_bucket.go:863
+#: lxc/storage_bucket.go:864
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:941
+#: lxc/storage_bucket.go:942
 #, c-format
 msgid "Access key: %s"
 msgstr ""
@@ -581,7 +581,7 @@ msgstr ""
 msgid "Access the expanded configuration"
 msgstr ""
 
-#: lxc/warning.go:261 lxc/warning.go:262
+#: lxc/warning.go:262 lxc/warning.go:263
 msgid "Acknowledge warning"
 msgstr ""
 
@@ -598,11 +598,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1106 lxc/auth.go:1107
+#: lxc/auth.go:1107 lxc/auth.go:1108
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1874 lxc/auth.go:1875
+#: lxc/auth.go:1875 lxc/auth.go:1876
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -671,7 +671,7 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:515 lxc/auth.go:516
+#: lxc/auth.go:516 lxc/auth.go:517
 msgid "Add permissions to groups"
 msgstr ""
 
@@ -700,7 +700,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:169
+#: lxc/storage_bucket.go:170
 #, c-format
 msgid "Admin access key: %s"
 msgstr ""
@@ -710,7 +710,7 @@ msgstr ""
 msgid "Admin password (or token) for %s:"
 msgstr ""
 
-#: lxc/storage_bucket.go:170
+#: lxc/storage_bucket.go:171
 #, c-format
 msgid "Admin secret key: %s"
 msgstr ""
@@ -769,7 +769,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:342 lxc/rebuild.go:130
+#: lxc/init.go:342 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -869,12 +869,12 @@ msgstr ""
 
 #: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:318
 #: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
-#: lxc/network_zone.go:366 lxc/network_zone.go:1053 lxc/storage_bucket.go:141
+#: lxc/network_zone.go:366 lxc/network_zone.go:1053 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:159
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:160
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -914,7 +914,7 @@ msgstr ""
 msgid "Bytes sent"
 msgstr ""
 
-#: lxc/operation.go:174
+#: lxc/operation.go:175
 msgid "CANCELABLE"
 msgstr ""
 
@@ -926,7 +926,7 @@ msgstr ""
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: lxc/warning.go:209
+#: lxc/warning.go:210
 msgid "COUNT"
 msgstr ""
 
@@ -952,7 +952,7 @@ msgstr ""
 msgid "CPUs (%s):"
 msgstr ""
 
-#: lxc/operation.go:175
+#: lxc/operation.go:176
 msgid "CREATED"
 msgstr ""
 
@@ -982,7 +982,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:340
+#: lxc/file.go:341
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1007,11 +1007,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:224
+#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:546
+#: lxc/file.go:547
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1020,7 +1020,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:160
+#: lxc/rebuild.go:161
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1143,13 +1143,13 @@ msgstr ""
 #: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
 #: lxc/network_load_balancer.go:1051 lxc/network_load_balancer.go:1125
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
-#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:90
-#: lxc/storage_bucket.go:190 lxc/storage_bucket.go:253
-#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:541
-#: lxc/storage_bucket.go:634 lxc/storage_bucket.go:700
-#: lxc/storage_bucket.go:775 lxc/storage_bucket.go:861
-#: lxc/storage_bucket.go:961 lxc/storage_bucket.go:1026
-#: lxc/storage_bucket.go:1162 lxc/storage_volume.go:394
+#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
+#: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
+#: lxc/storage_bucket.go:385 lxc/storage_bucket.go:542
+#: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
+#: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
+#: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
 #: lxc/storage_volume.go:612 lxc/storage_volume.go:717
 #: lxc/storage_volume.go:1005 lxc/storage_volume.go:1231
 #: lxc/storage_volume.go:1360 lxc/storage_volume.go:1848
@@ -1173,7 +1173,7 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1113 lxc/list.go:132 lxc/storage_volume.go:1589
-#: lxc/warning.go:92
+#: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
@@ -1201,7 +1201,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:100
+#: lxc/project.go:101
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1215,8 +1215,8 @@ msgstr ""
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
-#: lxc/project.go:362 lxc/storage.go:359 lxc/storage_bucket.go:348
-#: lxc/storage_bucket.go:1125 lxc/storage_volume.go:1150
+#: lxc/project.go:363 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1150
 #: lxc/storage_volume.go:1182
 #, c-format
 msgid "Config parsing error: %s"
@@ -1343,12 +1343,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:300 lxc/auth.go:1660
+#: lxc/auth.go:301 lxc/auth.go:1661
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1054
+#: lxc/auth.go:1055
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1397,15 +1397,15 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:248 lxc/file.go:474
+#: lxc/file.go:249 lxc/file.go:475
 msgid "Create any directories necessary"
 msgstr ""
 
-#: lxc/auth.go:97 lxc/auth.go:98
+#: lxc/auth.go:98 lxc/auth.go:99
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1471 lxc/auth.go:1472
+#: lxc/auth.go:1472 lxc/auth.go:1473
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1425,11 +1425,11 @@ msgstr ""
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_bucket.go:851 lxc/storage_bucket.go:852
+#: lxc/storage_bucket.go:852 lxc/storage_bucket.go:853
 msgid "Create key for a storage bucket"
 msgstr ""
 
-#: lxc/storage_bucket.go:82 lxc/storage_bucket.go:83
+#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
 msgid "Create new custom storage buckets"
 msgstr ""
 
@@ -1473,7 +1473,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:92 lxc/project.go:93
+#: lxc/project.go:93 lxc/project.go:94
 msgid "Create projects"
 msgstr ""
 
@@ -1508,13 +1508,13 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:376 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1135 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
-#: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:172
-#: lxc/profile.go:756 lxc/project.go:572 lxc/storage.go:723
-#: lxc/storage_bucket.go:512 lxc/storage_bucket.go:832
+#: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
+#: lxc/profile.go:756 lxc/project.go:573 lxc/storage.go:723
+#: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1732
 msgid "DESCRIPTION"
 msgstr ""
@@ -1539,7 +1539,7 @@ msgstr ""
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
-#: lxc/operation.go:55 lxc/operation.go:56
+#: lxc/operation.go:56 lxc/operation.go:57
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
@@ -1547,19 +1547,19 @@ msgstr ""
 msgid "Delete a cluster group"
 msgstr ""
 
-#: lxc/warning.go:360
+#: lxc/warning.go:361
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:122 lxc/file.go:123
+#: lxc/file.go:123 lxc/file.go:124
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/auth.go:151 lxc/auth.go:152
+#: lxc/auth.go:152 lxc/auth.go:153
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1523 lxc/auth.go:1524
+#: lxc/auth.go:1524 lxc/auth.go:1525
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1579,7 +1579,7 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/storage_bucket.go:957 lxc/storage_bucket.go:958
+#: lxc/storage_bucket.go:958 lxc/storage_bucket.go:959
 msgid "Delete key from a storage bucket"
 msgstr ""
 
@@ -1615,11 +1615,11 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:188 lxc/project.go:189
+#: lxc/project.go:189 lxc/project.go:190
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:187 lxc/storage_bucket.go:188
+#: lxc/storage_bucket.go:188 lxc/storage_bucket.go:189
 msgid "Delete storage buckets"
 msgstr ""
 
@@ -1631,20 +1631,20 @@ msgstr ""
 msgid "Delete storage volumes"
 msgstr ""
 
-#: lxc/warning.go:356 lxc/warning.go:357
+#: lxc/warning.go:357 lxc/warning.go:358
 msgid "Delete warning"
 msgstr ""
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:30 lxc/auth.go:59 lxc/auth.go:98
-#: lxc/auth.go:152 lxc/auth.go:201 lxc/auth.go:332 lxc/auth.go:392
-#: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
-#: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
-#: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
-#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1434 lxc/auth.go:1472
-#: lxc/auth.go:1524 lxc/auth.go:1573 lxc/auth.go:1692 lxc/auth.go:1752
-#: lxc/auth.go:1801 lxc/auth.go:1852 lxc/auth.go:1875 lxc/auth.go:1928
+#: lxc/alias.go:214 lxc/auth.go:31 lxc/auth.go:60 lxc/auth.go:99
+#: lxc/auth.go:153 lxc/auth.go:202 lxc/auth.go:333 lxc/auth.go:393
+#: lxc/auth.go:442 lxc/auth.go:494 lxc/auth.go:517 lxc/auth.go:576
+#: lxc/auth.go:732 lxc/auth.go:766 lxc/auth.go:833 lxc/auth.go:896
+#: lxc/auth.go:957 lxc/auth.go:1085 lxc/auth.go:1108 lxc/auth.go:1166
+#: lxc/auth.go:1235 lxc/auth.go:1257 lxc/auth.go:1435 lxc/auth.go:1473
+#: lxc/auth.go:1525 lxc/auth.go:1574 lxc/auth.go:1693 lxc/auth.go:1753
+#: lxc/auth.go:1802 lxc/auth.go:1853 lxc/auth.go:1876 lxc/auth.go:1929
 #: lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215 lxc/cluster.go:272
 #: lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:484 lxc/cluster.go:528
 #: lxc/cluster.go:586 lxc/cluster.go:677 lxc/cluster.go:770 lxc/cluster.go:893
@@ -1668,15 +1668,15 @@ msgstr ""
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:83 lxc/file.go:123 lxc/file.go:172
-#: lxc/file.go:242 lxc/file.go:467 lxc/file.go:986 lxc/image.go:38
+#: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
+#: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
 #: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
 #: lxc/image.go:697 lxc/image.go:946 lxc/image.go:1088 lxc/image.go:1415
 #: lxc/image.go:1506 lxc/image.go:1572 lxc/image.go:1636 lxc/image.go:1699
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:38 lxc/network.go:33
+#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33
 #: lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405
 #: lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793
 #: lxc/network.go:874 lxc/network.go:1005 lxc/network.go:1106
@@ -1710,27 +1710,27 @@ msgstr ""
 #: lxc/network_zone.go:909 lxc/network_zone.go:985 lxc/network_zone.go:1083
 #: lxc/network_zone.go:1172 lxc/network_zone.go:1219 lxc/network_zone.go:1349
 #: lxc/network_zone.go:1410 lxc/network_zone.go:1425 lxc/network_zone.go:1483
-#: lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:106
-#: lxc/operation.go:193 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
+#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
+#: lxc/operation.go:194 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
 #: lxc/profile.go:271 lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493
 #: lxc/profile.go:629 lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860
-#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:29
-#: lxc/project.go:93 lxc/project.go:189 lxc/project.go:260 lxc/project.go:396
-#: lxc/project.go:470 lxc/project.go:590 lxc/project.go:655 lxc/project.go:743
-#: lxc/project.go:787 lxc/project.go:848 lxc/project.go:915 lxc/publish.go:34
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:35 lxc/remote.go:91
+#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:30
+#: lxc/project.go:94 lxc/project.go:190 lxc/project.go:261 lxc/project.go:397
+#: lxc/project.go:471 lxc/project.go:591 lxc/project.go:656 lxc/project.go:744
+#: lxc/project.go:788 lxc/project.go:849 lxc/project.go:916 lxc/publish.go:34
+#: lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91
 #: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853
 #: lxc/remote.go:917 lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24
 #: lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203
 #: lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655
 #: lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940
-#: lxc/storage_bucket.go:29 lxc/storage_bucket.go:83 lxc/storage_bucket.go:188
-#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:382
-#: lxc/storage_bucket.go:458 lxc/storage_bucket.go:535
-#: lxc/storage_bucket.go:629 lxc/storage_bucket.go:698
-#: lxc/storage_bucket.go:732 lxc/storage_bucket.go:773
-#: lxc/storage_bucket.go:852 lxc/storage_bucket.go:958
-#: lxc/storage_bucket.go:1022 lxc/storage_bucket.go:1157
+#: lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189
+#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:383
+#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:536
+#: lxc/storage_bucket.go:630 lxc/storage_bucket.go:699
+#: lxc/storage_bucket.go:733 lxc/storage_bucket.go:774
+#: lxc/storage_bucket.go:853 lxc/storage_bucket.go:959
+#: lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158
 #: lxc/storage_volume.go:58 lxc/storage_volume.go:169 lxc/storage_volume.go:283
 #: lxc/storage_volume.go:390 lxc/storage_volume.go:605
 #: lxc/storage_volume.go:714 lxc/storage_volume.go:801
@@ -1741,8 +1741,8 @@ msgstr ""
 #: lxc/storage_volume.go:2064 lxc/storage_volume.go:2222
 #: lxc/storage_volume.go:2343 lxc/storage_volume.go:2405
 #: lxc/storage_volume.go:2541 lxc/storage_volume.go:2624
-#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:29
-#: lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
+#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:30
+#: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
@@ -1829,7 +1829,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:994
+#: lxc/file.go:995
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1895,7 +1895,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:74
+#: lxc/file.go:75
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1905,7 +1905,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:955 lxc/auth.go:956
+#: lxc/auth.go:956 lxc/auth.go:957
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1913,15 +1913,15 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:171 lxc/file.go:172
+#: lxc/file.go:172 lxc/file.go:173
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/auth.go:200 lxc/auth.go:201
+#: lxc/auth.go:201 lxc/auth.go:202
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1572 lxc/auth.go:1573
+#: lxc/auth.go:1573 lxc/auth.go:1574
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -1977,15 +1977,15 @@ msgstr ""
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:259 lxc/project.go:260
+#: lxc/project.go:260 lxc/project.go:261
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:248 lxc/storage_bucket.go:249
+#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:250
 msgid "Edit storage bucket configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:1021 lxc/storage_bucket.go:1022
+#: lxc/storage_bucket.go:1022 lxc/storage_bucket.go:1023
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
@@ -2002,7 +2002,7 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1147 lxc/list.go:622 lxc/storage_volume.go:1766
-#: lxc/warning.go:235
+#: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2057,7 +2057,7 @@ msgstr ""
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
-#: lxc/project.go:718 lxc/storage.go:812 lxc/storage_bucket.go:602
+#: lxc/project.go:719 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2155 lxc/storage_volume.go:2193
 #, c-format
 msgid "Error setting properties: %v"
@@ -2071,8 +2071,8 @@ msgstr ""
 #: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
-#: lxc/profile.go:981 lxc/project.go:712 lxc/storage.go:806
-#: lxc/storage_bucket.go:596 lxc/storage_volume.go:2149
+#: lxc/profile.go:981 lxc/project.go:713 lxc/storage.go:806
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2149
 #: lxc/storage_volume.go:2187
 #, c-format
 msgid "Error unsetting property: %v"
@@ -2092,7 +2092,7 @@ msgstr ""
 msgid "Evacuating cluster member: %s"
 msgstr ""
 
-#: lxc/monitor.go:50
+#: lxc/monitor.go:51
 msgid "Event type to listen for"
 msgstr ""
 
@@ -2179,16 +2179,16 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/warning.go:210
+#: lxc/warning.go:211
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1237
+#: lxc/file.go:1238
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1260
+#: lxc/file.go:1261
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2203,12 +2203,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1287
+#: lxc/file.go:1288
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1072
+#: lxc/file.go:1073
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2238,7 +2238,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1193
+#: lxc/file.go:1194
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2253,7 +2253,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1198
+#: lxc/file.go:1199
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2263,12 +2263,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1098
+#: lxc/file.go:1099
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1225
+#: lxc/file.go:1226
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2307,7 +2307,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1210
+#: lxc/file.go:1211
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2322,7 +2322,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:820
+#: lxc/file.go:821
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2337,7 +2337,7 @@ msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
 #: lxc/network.go:1044 lxc/network_acl.go:133 lxc/network_zone.go:124
-#: lxc/operation.go:136
+#: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
 
@@ -2402,21 +2402,21 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
+#: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:770 lxc/auth.go:1697
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1114 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:57
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
-#: lxc/operation.go:108 lxc/profile.go:707 lxc/project.go:472
-#: lxc/project.go:917 lxc/remote.go:690 lxc/storage.go:657
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:774
-#: lxc/storage_volume.go:1608 lxc/warning.go:93
+#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:473
+#: lxc/project.go:918 lxc/remote.go:690 lxc/storage.go:657
+#: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
+#: lxc/storage_volume.go:1608 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
-#: lxc/monitor.go:52
+#: lxc/monitor.go:53
 msgid "Format (json|pretty|yaml)"
 msgstr ""
 
@@ -2460,7 +2460,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:817 lxc/auth.go:1736
+#: lxc/auth.go:818 lxc/auth.go:1737
 msgid "GROUPS"
 msgstr ""
 
@@ -2476,7 +2476,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:914 lxc/project.go:915
+#: lxc/project.go:915 lxc/project.go:916
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2524,11 +2524,11 @@ msgstr ""
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:400
+#: lxc/project.go:401
 msgid "Get the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:385
+#: lxc/storage_bucket.go:386
 msgid "Get the key as a storage bucket property"
 msgstr ""
 
@@ -2588,11 +2588,11 @@ msgstr ""
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:395 lxc/project.go:396
+#: lxc/project.go:396 lxc/project.go:397
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:382
+#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:383
 msgid "Get values for storage bucket configuration keys"
 msgstr ""
 
@@ -2609,17 +2609,17 @@ msgstr ""
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: lxc/auth.go:136
+#: lxc/auth.go:137
 #, c-format
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:186
+#: lxc/auth.go:187
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:426 lxc/auth.go:1786
+#: lxc/auth.go:427 lxc/auth.go:1787
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2644,27 +2644,27 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1310
+#: lxc/file.go:1311
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1299
+#: lxc/file.go:1300
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1122
+#: lxc/file.go:1123
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1132
+#: lxc/file.go:1133
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:966 lxc/operation.go:170
+#: lxc/network.go:966 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2678,11 +2678,11 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:816
+#: lxc/auth.go:817
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:566
+#: lxc/project.go:567
 msgid "IMAGES"
 msgstr ""
 
@@ -2710,17 +2710,17 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1508
+#: lxc/auth.go:1509
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1558
+#: lxc/auth.go:1559
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
 
-#: lxc/rebuild.go:32
+#: lxc/rebuild.go:33
 msgid "If an instance is running, stop it and then rebuild it"
 msgstr ""
 
@@ -2841,7 +2841,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1233 lxc/auth.go:1234
+#: lxc/auth.go:1234 lxc/auth.go:1235
 msgid "Inspect permissions"
 msgstr ""
 
@@ -2849,11 +2849,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1124
+#: lxc/file.go:1125
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1301
+#: lxc/file.go:1302
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2871,7 +2871,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1044
+#: lxc/file.go:1045
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2880,7 +2880,7 @@ msgstr ""
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/rebuild.go:74
+#: lxc/rebuild.go:75
 #, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
@@ -2913,7 +2913,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/monitor.go:70
+#: lxc/monitor.go:71
 #, c-format
 msgid "Invalid format: %s"
 msgstr ""
@@ -2923,7 +2923,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1039
+#: lxc/file.go:1040
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2965,7 +2965,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:147
+#: lxc/file.go:148
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2981,12 +2981,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:313
+#: lxc/file.go:314
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:495
+#: lxc/file.go:496
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3000,7 +3000,7 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/warning.go:212
 msgid "LAST SEEN"
 msgstr ""
 
@@ -3008,7 +3008,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:984
+#: lxc/project.go:985
 msgid "LIMIT"
 msgstr ""
 
@@ -3017,8 +3017,8 @@ msgid "LISTEN ADDRESS"
 msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
-#: lxc/network_load_balancer.go:165 lxc/operation.go:177
-#: lxc/storage_bucket.go:516 lxc/storage_volume.go:1739 lxc/warning.go:220
+#: lxc/network_load_balancer.go:165 lxc/operation.go:178
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1739 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3092,7 +3092,7 @@ msgstr ""
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/warning.go:94
+#: lxc/warning.go:95
 msgid "List all warnings"
 msgstr ""
 
@@ -3136,19 +3136,19 @@ msgstr ""
 msgid "List available storage pools"
 msgstr ""
 
-#: lxc/operation.go:105 lxc/operation.go:106
+#: lxc/operation.go:106 lxc/operation.go:107
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:331 lxc/auth.go:332
+#: lxc/auth.go:332 lxc/auth.go:333
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:764 lxc/auth.go:765
+#: lxc/auth.go:765 lxc/auth.go:766
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1691 lxc/auth.go:1692
+#: lxc/auth.go:1692 lxc/auth.go:1693
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3297,11 +3297,11 @@ msgstr ""
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/operation.go:109
+#: lxc/operation.go:110
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1255 lxc/auth.go:1256
+#: lxc/auth.go:1256 lxc/auth.go:1257
 msgid "List permissions"
 msgstr ""
 
@@ -3309,15 +3309,15 @@ msgstr ""
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:469 lxc/project.go:470
+#: lxc/project.go:470 lxc/project.go:471
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:771 lxc/storage_bucket.go:773
+#: lxc/storage_bucket.go:772 lxc/storage_bucket.go:774
 msgid "List storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:456 lxc/storage_bucket.go:458
+#: lxc/storage_bucket.go:457 lxc/storage_bucket.go:459
 msgid "List storage buckets"
 msgstr ""
 
@@ -3353,11 +3353,11 @@ msgstr ""
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/warning.go:70
+#: lxc/warning.go:71
 msgid "List warnings"
 msgstr ""
 
-#: lxc/warning.go:71
+#: lxc/warning.go:72
 msgid ""
 "List warnings\n"
 "\n"
@@ -3380,7 +3380,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/operation.go:23 lxc/operation.go:24
+#: lxc/operation.go:24 lxc/operation.go:25
 msgid "List, show and delete background operations"
 msgstr ""
 
@@ -3389,7 +3389,7 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/monitor.go:79
+#: lxc/monitor.go:80
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
@@ -3493,23 +3493,23 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:82 lxc/file.go:83
+#: lxc/file.go:83 lxc/file.go:84
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1433 lxc/auth.go:1434
+#: lxc/auth.go:59 lxc/auth.go:60 lxc/auth.go:1434 lxc/auth.go:1435
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1083 lxc/auth.go:1084
+#: lxc/auth.go:1084 lxc/auth.go:1085
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:730 lxc/auth.go:731
+#: lxc/auth.go:731 lxc/auth.go:732
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1851 lxc/auth.go:1852
+#: lxc/auth.go:1852 lxc/auth.go:1853
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3600,7 +3600,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:492 lxc/auth.go:493
+#: lxc/auth.go:493 lxc/auth.go:494
 msgid "Manage permissions"
 msgstr ""
 
@@ -3608,23 +3608,23 @@ msgstr ""
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:28 lxc/project.go:29
+#: lxc/project.go:29 lxc/project.go:30
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:731
+#: lxc/storage_bucket.go:732
 msgid "Manage storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:732
+#: lxc/storage_bucket.go:733
 msgid "Manage storage bucket keys."
 msgstr ""
 
-#: lxc/storage_bucket.go:28
+#: lxc/storage_bucket.go:29
 msgid "Manage storage buckets"
 msgstr ""
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:30
 msgid "Manage storage buckets."
 msgstr ""
 
@@ -3652,11 +3652,11 @@ msgstr ""
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/auth.go:29 lxc/auth.go:30
+#: lxc/auth.go:30 lxc/auth.go:31
 msgid "Manage user authorization"
 msgstr ""
 
-#: lxc/warning.go:28 lxc/warning.go:29
+#: lxc/warning.go:29 lxc/warning.go:30
 msgid "Manage warnings"
 msgstr ""
 
@@ -3720,17 +3720,17 @@ msgstr ""
 msgid "Migration operation failure: %w"
 msgstr ""
 
-#: lxc/monitor.go:51
+#: lxc/monitor.go:52
 msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: lxc/storage_bucket.go:116 lxc/storage_bucket.go:216
-#: lxc/storage_bucket.go:292 lxc/storage_bucket.go:411
-#: lxc/storage_bucket.go:568 lxc/storage_bucket.go:660
-#: lxc/storage_bucket.go:802 lxc/storage_bucket.go:889
-#: lxc/storage_bucket.go:986 lxc/storage_bucket.go:1065
-#: lxc/storage_bucket.go:1188
+#: lxc/storage_bucket.go:117 lxc/storage_bucket.go:217
+#: lxc/storage_bucket.go:293 lxc/storage_bucket.go:412
+#: lxc/storage_bucket.go:569 lxc/storage_bucket.go:661
+#: lxc/storage_bucket.go:803 lxc/storage_bucket.go:890
+#: lxc/storage_bucket.go:987 lxc/storage_bucket.go:1066
+#: lxc/storage_bucket.go:1189
 msgid "Missing bucket name"
 msgstr ""
 
@@ -3749,20 +3749,20 @@ msgstr ""
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1825
+#: lxc/auth.go:123 lxc/auth.go:177 lxc/auth.go:255 lxc/auth.go:417
+#: lxc/auth.go:466 lxc/auth.go:541 lxc/auth.go:600 lxc/auth.go:1826
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:862 lxc/auth.go:1003 lxc/auth.go:1131 lxc/auth.go:1189
+#: lxc/auth.go:863 lxc/auth.go:1004 lxc/auth.go:1132 lxc/auth.go:1190
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1495 lxc/auth.go:1548 lxc/auth.go:1614 lxc/auth.go:1776
+#: lxc/auth.go:1496 lxc/auth.go:1549 lxc/auth.go:1615 lxc/auth.go:1777
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1899 lxc/auth.go:1952
+#: lxc/auth.go:1900 lxc/auth.go:1953
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -3770,12 +3770,12 @@ msgstr ""
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
 #: lxc/config_template.go:377 lxc/profile.go:141 lxc/profile.go:222
-#: lxc/profile.go:808 lxc/rebuild.go:60
+#: lxc/profile.go:808 lxc/rebuild.go:61
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/storage_bucket.go:893 lxc/storage_bucket.go:990
-#: lxc/storage_bucket.go:1069 lxc/storage_bucket.go:1192
+#: lxc/storage_bucket.go:894 lxc/storage_bucket.go:991
+#: lxc/storage_bucket.go:1070 lxc/storage_bucket.go:1193
 msgid "Missing key name"
 msgstr ""
 
@@ -3840,13 +3840,13 @@ msgid "Missing peer name"
 msgstr ""
 
 #: lxc/storage.go:235 lxc/storage.go:313 lxc/storage.go:431 lxc/storage.go:509
-#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:112
-#: lxc/storage_bucket.go:212 lxc/storage_bucket.go:288
-#: lxc/storage_bucket.go:407 lxc/storage_bucket.go:482
-#: lxc/storage_bucket.go:564 lxc/storage_bucket.go:656
-#: lxc/storage_bucket.go:798 lxc/storage_bucket.go:885
-#: lxc/storage_bucket.go:982 lxc/storage_bucket.go:1061
-#: lxc/storage_bucket.go:1184 lxc/storage_volume.go:209
+#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:113
+#: lxc/storage_bucket.go:213 lxc/storage_bucket.go:289
+#: lxc/storage_bucket.go:408 lxc/storage_bucket.go:483
+#: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
+#: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
+#: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
 #: lxc/storage_volume.go:323 lxc/storage_volume.go:643
 #: lxc/storage_volume.go:750 lxc/storage_volume.go:841
 #: lxc/storage_volume.go:939 lxc/storage_volume.go:1053
@@ -3861,9 +3861,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:404 lxc/project.go:146 lxc/project.go:226 lxc/project.go:316
-#: lxc/project.go:433 lxc/project.go:622 lxc/project.go:691 lxc/project.go:819
-#: lxc/project.go:948
+#: lxc/profile.go:404 lxc/project.go:147 lxc/project.go:227 lxc/project.go:317
+#: lxc/project.go:434 lxc/project.go:623 lxc/project.go:692 lxc/project.go:820
+#: lxc/project.go:949
 msgid "Missing project name"
 msgstr ""
 
@@ -3879,7 +3879,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:598
+#: lxc/file.go:599
 msgid "Missing target directory"
 msgstr ""
 
@@ -3901,11 +3901,11 @@ msgstr ""
 msgid "Model: %v"
 msgstr ""
 
-#: lxc/monitor.go:32
+#: lxc/monitor.go:33
 msgid "Monitor a local or remote LXD server"
 msgstr ""
 
-#: lxc/monitor.go:33
+#: lxc/monitor.go:34
 msgid ""
 "Monitor a local or remote LXD server\n"
 "\n"
@@ -3917,11 +3917,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:285
+#: lxc/file.go:286
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:985 lxc/file.go:986
+#: lxc/file.go:986 lxc/file.go:987
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3983,13 +3983,13 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:192
+#: lxc/auth.go:376 lxc/auth.go:816 lxc/auth.go:1736 lxc/cluster.go:192
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
-#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:565
-#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:511
-#: lxc/storage_bucket.go:831 lxc/storage_volume.go:1731
+#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:566
+#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1731
 msgid "NAME"
 msgstr ""
 
@@ -3997,11 +3997,11 @@ msgstr ""
 msgid "NAT"
 msgstr ""
 
-#: lxc/project.go:571
+#: lxc/project.go:572
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:570
+#: lxc/project.go:571
 msgid "NETWORKS"
 msgstr ""
 
@@ -4013,9 +4013,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/operation.go:154 lxc/project.go:523
-#: lxc/project.go:528 lxc/project.go:533 lxc/project.go:538 lxc/project.go:543
-#: lxc/project.go:548 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
+#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:524
+#: lxc/project.go:529 lxc/project.go:534 lxc/project.go:539 lxc/project.go:544
+#: lxc/project.go:549 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
 msgid "NO"
 msgstr ""
 
@@ -4260,7 +4260,7 @@ msgstr ""
 msgid "Only managed networks can be modified"
 msgstr ""
 
-#: lxc/operation.go:86
+#: lxc/operation.go:87
 #, c-format
 msgid "Operation %s deleted"
 msgstr ""
@@ -4307,11 +4307,11 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:567
+#: lxc/list.go:576 lxc/project.go:568
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:212
+#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4373,24 +4373,24 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1102
+#: lxc/file.go:1103
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:860
+#: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
-#: lxc/project.go:363 lxc/storage.go:360 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1151
+#: lxc/project.go:364 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1151
 #: lxc/storage_volume.go:1183
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
-#: lxc/monitor.go:48
+#: lxc/monitor.go:49
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
@@ -4476,17 +4476,17 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:172
+#: lxc/project.go:173
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:236
+#: lxc/project.go:237
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:637
+#: lxc/project.go:638
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -4607,20 +4607,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:241 lxc/file.go:242
+#: lxc/file.go:242 lxc/file.go:243
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:416 lxc/file.go:767
+#: lxc/file.go:417 lxc/file.go:768
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:466 lxc/file.go:467
+#: lxc/file.go:467 lxc/file.go:468
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:701 lxc/file.go:867
+#: lxc/file.go:702 lxc/file.go:868
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4633,11 +4633,11 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:983
+#: lxc/project.go:984
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/storage_bucket.go:833
+#: lxc/storage_bucket.go:834
 msgid "ROLE"
 msgstr ""
 
@@ -4650,15 +4650,15 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/rebuild.go:31
+#: lxc/rebuild.go:32
 msgid "Rebuild as an empty instance"
 msgstr ""
 
-#: lxc/rebuild.go:26
+#: lxc/rebuild.go:27
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:249 lxc/file.go:473
+#: lxc/file.go:250 lxc/file.go:474
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4685,7 +4685,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:882 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
+#: lxc/project.go:883 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
 #: lxc/remote.go:994
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4736,7 +4736,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1164 lxc/auth.go:1165
+#: lxc/auth.go:1165 lxc/auth.go:1166
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4772,7 +4772,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1927 lxc/auth.go:1928
+#: lxc/auth.go:1928 lxc/auth.go:1929
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4784,7 +4784,7 @@ msgstr ""
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:574 lxc/auth.go:575
+#: lxc/auth.go:575 lxc/auth.go:576
 msgid "Remove permissions from groups"
 msgstr ""
 
@@ -4829,11 +4829,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:391 lxc/auth.go:392
+#: lxc/auth.go:392 lxc/auth.go:393
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1751 lxc/auth.go:1752
+#: lxc/auth.go:1752 lxc/auth.go:1753
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -4853,7 +4853,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:589 lxc/project.go:590
+#: lxc/project.go:590 lxc/project.go:591
 msgid "Rename projects"
 msgstr ""
 
@@ -4951,7 +4951,7 @@ msgstr ""
 msgid "Revoke cluster member join token"
 msgstr ""
 
-#: lxc/storage_bucket.go:862
+#: lxc/storage_bucket.go:863
 msgid "Role (admin or read-only)"
 msgstr ""
 
@@ -4967,7 +4967,7 @@ msgstr ""
 msgid "Run against all projects"
 msgstr ""
 
-#: lxc/warning.go:213
+#: lxc/warning.go:214
 msgid "SEVERITY"
 msgstr ""
 
@@ -4987,12 +4987,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1231
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1231
+#: lxc/file.go:1232
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5006,11 +5006,11 @@ msgstr ""
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:173 lxc/warning.go:214
+#: lxc/operation.go:174 lxc/warning.go:215
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:569
+#: lxc/project.go:570
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5018,7 +5018,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:569
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -5026,11 +5026,11 @@ msgstr ""
 msgid "STP"
 msgstr ""
 
-#: lxc/storage_bucket.go:864
+#: lxc/storage_bucket.go:865
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:942
+#: lxc/storage_bucket.go:943
 #, c-format
 msgid "Secret key: %s"
 msgstr ""
@@ -5068,7 +5068,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:995
+#: lxc/file.go:996
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5206,11 +5206,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:654
+#: lxc/project.go:655
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:655
+#: lxc/project.go:656
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5219,11 +5219,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage_bucket.go:534
+#: lxc/storage_bucket.go:535
 msgid "Set storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:535
+#: lxc/storage_bucket.go:536
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -5262,15 +5262,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:476
+#: lxc/file.go:477
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:477
+#: lxc/file.go:478
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:475
+#: lxc/file.go:476
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5310,11 +5310,11 @@ msgstr ""
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 msgid "Set the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:542
+#: lxc/storage_bucket.go:543
 msgid "Set the key as a storage bucket property"
 msgstr ""
 
@@ -5330,7 +5330,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:993
+#: lxc/file.go:994
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5342,7 +5342,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1800 lxc/auth.go:1801
+#: lxc/auth.go:1801 lxc/auth.go:1802
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5358,11 +5358,11 @@ msgstr ""
 msgid "Show details of a cluster member"
 msgstr ""
 
-#: lxc/operation.go:192 lxc/operation.go:193
+#: lxc/operation.go:193 lxc/operation.go:194
 msgid "Show details on a background operation"
 msgstr ""
 
-#: lxc/monitor.go:49
+#: lxc/monitor.go:50
 msgid "Show events from all projects"
 msgstr ""
 
@@ -5370,11 +5370,11 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:440 lxc/auth.go:441
+#: lxc/auth.go:441 lxc/auth.go:442
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:832
+#: lxc/auth.go:833
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5455,15 +5455,15 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:786 lxc/project.go:787
+#: lxc/project.go:787 lxc/project.go:788
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage_bucket.go:628 lxc/storage_bucket.go:629
+#: lxc/storage_bucket.go:629 lxc/storage_bucket.go:630
 msgid "Show storage bucket configurations"
 msgstr ""
 
-#: lxc/storage_bucket.go:1156 lxc/storage_bucket.go:1157
+#: lxc/storage_bucket.go:1157 lxc/storage_bucket.go:1158
 msgid "Show storage bucket key configurations"
 msgstr ""
 
@@ -5479,7 +5479,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:895
+#: lxc/auth.go:896
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5529,7 +5529,7 @@ msgstr ""
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: lxc/warning.go:302 lxc/warning.go:303
+#: lxc/warning.go:303 lxc/warning.go:304
 msgid "Show warning"
 msgstr ""
 
@@ -5613,22 +5613,22 @@ msgstr ""
 msgid "Stopping the instance failed: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:166
+#: lxc/storage_bucket.go:167
 #, c-format
 msgid "Storage bucket %s created"
 msgstr ""
 
-#: lxc/storage_bucket.go:233
+#: lxc/storage_bucket.go:234
 #, c-format
 msgid "Storage bucket %s deleted"
 msgstr ""
 
-#: lxc/storage_bucket.go:940
+#: lxc/storage_bucket.go:941
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr ""
 
-#: lxc/storage_bucket.go:1006
+#: lxc/storage_bucket.go:1007
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr ""
@@ -5697,7 +5697,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:847 lxc/project.go:848
+#: lxc/project.go:848 lxc/project.go:849
 msgid "Switch the current project"
 msgstr ""
 
@@ -5713,10 +5713,10 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1139
+#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1139
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
-#: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:171
-#: lxc/storage_volume.go:1730 lxc/warning.go:215
+#: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
+#: lxc/storage_volume.go:1730 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
@@ -5724,11 +5724,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1032
+#: lxc/file.go:1033
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1026
+#: lxc/file.go:1027
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5856,12 +5856,12 @@ msgstr ""
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:446
+#: lxc/project.go:447
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
 
-#: lxc/storage_bucket.go:431
+#: lxc/storage_bucket.go:432
 #, c-format
 msgid "The property %q does not exist on the storage bucket %q: %v"
 msgstr ""
@@ -6046,7 +6046,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:961
+#: lxc/project.go:962
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6058,17 +6058,17 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:985 lxc/storage_volume.go:1735
+#: lxc/project.go:986 lxc/storage_volume.go:1735
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:573
+#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:574
 #: lxc/storage.go:724 lxc/storage_volume.go:1734
 msgid "USED BY"
 msgstr ""
 
-#: lxc/warning.go:216
+#: lxc/warning.go:217
 msgid "UUID"
 msgstr ""
 
@@ -6077,7 +6077,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:197
+#: lxc/file.go:198
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6091,13 +6091,13 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1253
+#: lxc/file.go:1254
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1153 lxc/list.go:631 lxc/storage_volume.go:1772
-#: lxc/warning.go:241
+#: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6107,7 +6107,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:807
+#: lxc/file.go:808
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6190,11 +6190,11 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:742 lxc/project.go:743
+#: lxc/project.go:743 lxc/project.go:744
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:697 lxc/storage_bucket.go:698
+#: lxc/storage_bucket.go:698 lxc/storage_bucket.go:699
 msgid "Unset storage bucket configuration keys"
 msgstr ""
 
@@ -6242,11 +6242,11 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:747
+#: lxc/project.go:748
 msgid "Unset the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:701
+#: lxc/storage_bucket.go:702
 msgid "Unset the key as a storage bucket property"
 msgstr ""
 
@@ -6325,7 +6325,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:71
+#: lxc/file.go:72
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6362,11 +6362,11 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:831
+#: lxc/auth.go:832
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:894
+#: lxc/auth.go:895
 msgid "View the current identity"
 msgstr ""
 
@@ -6397,15 +6397,15 @@ msgstr ""
 msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
-#: lxc/rebuild.go:27
+#: lxc/rebuild.go:28
 msgid ""
 "Wipe the instance root disk and re-initialize. The original image is used to "
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:156 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
+#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:526
+#: lxc/project.go:531 lxc/project.go:536 lxc/project.go:541 lxc/project.go:546
+#: lxc/project.go:551 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
 msgid "YES"
 msgstr ""
 
@@ -6425,7 +6425,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/rebuild.go:119
+#: lxc/rebuild.go:120
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
@@ -6437,12 +6437,12 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1689
+#: lxc/auth.go:330 lxc/auth.go:763 lxc/auth.go:894 lxc/auth.go:1690
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
-#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
+#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
-#: lxc/operation.go:103 lxc/profile.go:700 lxc/project.go:467
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:68
+#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:468
+#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6470,7 +6470,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1254
+#: lxc/auth.go:1255
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6531,11 +6531,11 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:830
+#: lxc/auth.go:831
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1926
+#: lxc/auth.go:1106 lxc/auth.go:1164 lxc/auth.go:1927
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6543,13 +6543,13 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:954 lxc/auth.go:1470 lxc/cluster_group.go:168
+#: lxc/auth.go:97 lxc/auth.go:150 lxc/auth.go:200 lxc/auth.go:440
+#: lxc/auth.go:955 lxc/auth.go:1471 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:514 lxc/auth.go:572
+#: lxc/auth.go:515 lxc/auth.go:573
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
@@ -6559,19 +6559,19 @@ msgstr ""
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:389
+#: lxc/auth.go:390
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1521 lxc/auth.go:1571 lxc/auth.go:1799
+#: lxc/auth.go:1522 lxc/auth.go:1572 lxc/auth.go:1800
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1873
+#: lxc/auth.go:1874
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1749
+#: lxc/auth.go:1750
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -6591,7 +6591,7 @@ msgstr ""
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
-#: lxc/rebuild.go:25
+#: lxc/rebuild.go:26
 msgid "[<remote>:]<image> [<remote>:]<instance>"
 msgstr ""
 
@@ -6674,20 +6674,20 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:170
+#: lxc/file.go:171
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:120
+#: lxc/file.go:121
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:240
+#: lxc/file.go:241
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:984
+#: lxc/file.go:985
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6838,12 +6838,12 @@ msgstr ""
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
-#: lxc/operation.go:53 lxc/operation.go:191
+#: lxc/operation.go:54 lxc/operation.go:192
 msgid "[<remote>:]<operation>"
 msgstr ""
 
 #: lxc/storage.go:200 lxc/storage.go:259 lxc/storage.go:473 lxc/storage.go:844
-#: lxc/storage_bucket.go:454
+#: lxc/storage_bucket.go:455
 msgid "[<remote>:]<pool>"
 msgstr ""
 
@@ -6851,22 +6851,22 @@ msgstr ""
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
-#: lxc/storage_bucket.go:185 lxc/storage_bucket.go:247
-#: lxc/storage_bucket.go:627 lxc/storage_bucket.go:769
+#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:248
+#: lxc/storage_bucket.go:628 lxc/storage_bucket.go:770
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
 
-#: lxc/storage_bucket.go:380 lxc/storage_bucket.go:696
-#: lxc/storage_bucket.go:850 lxc/storage_bucket.go:956
-#: lxc/storage_bucket.go:1020 lxc/storage_bucket.go:1155
+#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:697
+#: lxc/storage_bucket.go:851 lxc/storage_bucket.go:957
+#: lxc/storage_bucket.go:1021 lxc/storage_bucket.go:1156
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
 
-#: lxc/storage_bucket.go:533
+#: lxc/storage_bucket.go:534
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_bucket.go:81
+#: lxc/storage_bucket.go:82
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
 
@@ -6981,20 +6981,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:91 lxc/project.go:186 lxc/project.go:258 lxc/project.go:785
-#: lxc/project.go:846 lxc/project.go:913
+#: lxc/project.go:92 lxc/project.go:187 lxc/project.go:259 lxc/project.go:786
+#: lxc/project.go:847 lxc/project.go:914
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:394 lxc/project.go:741
+#: lxc/project.go:395 lxc/project.go:742
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:653
+#: lxc/project.go:654
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:587
+#: lxc/project.go:588
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7002,7 +7002,7 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:259 lxc/warning.go:301 lxc/warning.go:354
+#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
@@ -7058,7 +7058,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:555 lxc/remote.go:739
+#: lxc/project.go:556 lxc/remote.go:739
 msgid "current"
 msgstr ""
 
@@ -7105,20 +7105,20 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/auth.go:203
+#: lxc/auth.go:204
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:958
+#: lxc/auth.go:959
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1575
+#: lxc/auth.go:1576
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7196,20 +7196,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:988
+#: lxc/file.go:989
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:244
+#: lxc/file.go:245
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:470
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7291,7 +7291,7 @@ msgid ""
 "  List instances with their running state and user comment."
 msgstr ""
 
-#: lxc/monitor.go:37
+#: lxc/monitor.go:38
 msgid ""
 "lxc monitor --type=logging\n"
 "    Only show log messages.\n"
@@ -7367,7 +7367,7 @@ msgid ""
 "    Create record r1 for zone z1 with configuration from config.yaml"
 msgstr ""
 
-#: lxc/operation.go:195
+#: lxc/operation.go:196
 msgid ""
 "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Show details on that operation UUID"
@@ -7410,7 +7410,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:95
+#: lxc/project.go:96
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7418,7 +7418,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:262
+#: lxc/project.go:263
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7449,7 +7449,7 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:85
 msgid ""
 "lxc storage bucket create p1 b01\n"
 "\tCreate a new storage bucket name b01 in storage pool p1\n"
@@ -7459,19 +7459,19 @@ msgid ""
 "of config.yaml"
 msgstr ""
 
-#: lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:251
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1023
+#: lxc/storage_bucket.go:1024
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:854
 msgid ""
 "lxc storage bucket key create p1 b01 k1\n"
 "\tCreate a key called k1 for the bucket b01 in the pool p1.\n"
@@ -7481,14 +7481,14 @@ msgid ""
 "of config.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1158
+#: lxc/storage_bucket.go:1159
 msgid ""
 "lxc storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_bucket.go:630
+#: lxc/storage_bucket.go:631
 msgid ""
 "lxc storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
@@ -7558,16 +7558,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1142
+#: lxc/file.go:1143
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1101
+#: lxc/file.go:1102
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1054
+#: lxc/file.go:1055
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/th.po
+++ b/po/th.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-04 08:52-0600\n"
+"POT-Creation-Date: 2024-09-05 08:44-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: lxc/storage_bucket.go:260 lxc/storage_bucket.go:1033
+#: lxc/storage_bucket.go:261 lxc/storage_bucket.go:1034
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -130,7 +130,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:213
+#: lxc/auth.go:214
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -157,7 +157,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:968
+#: lxc/auth.go:969
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -178,7 +178,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1585
+#: lxc/auth.go:1586
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -388,7 +388,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:280
+#: lxc/project.go:281
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -430,12 +430,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:935
+#: lxc/file.go:936
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:825
+#: lxc/file.go:826
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -471,7 +471,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:142 lxc/rebuild.go:64
+#: lxc/init.go:142 lxc/rebuild.go:65
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -524,7 +524,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:465
+#: lxc/file.go:466
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -557,7 +557,7 @@ msgstr ""
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:813
+#: lxc/auth.go:814
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -565,11 +565,11 @@ msgstr ""
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/storage_bucket.go:863
+#: lxc/storage_bucket.go:864
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:941
+#: lxc/storage_bucket.go:942
 #, c-format
 msgid "Access key: %s"
 msgstr ""
@@ -578,7 +578,7 @@ msgstr ""
 msgid "Access the expanded configuration"
 msgstr ""
 
-#: lxc/warning.go:261 lxc/warning.go:262
+#: lxc/warning.go:262 lxc/warning.go:263
 msgid "Acknowledge warning"
 msgstr ""
 
@@ -595,11 +595,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1106 lxc/auth.go:1107
+#: lxc/auth.go:1107 lxc/auth.go:1108
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1874 lxc/auth.go:1875
+#: lxc/auth.go:1875 lxc/auth.go:1876
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -668,7 +668,7 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:515 lxc/auth.go:516
+#: lxc/auth.go:516 lxc/auth.go:517
 msgid "Add permissions to groups"
 msgstr ""
 
@@ -697,7 +697,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:169
+#: lxc/storage_bucket.go:170
 #, c-format
 msgid "Admin access key: %s"
 msgstr ""
@@ -707,7 +707,7 @@ msgstr ""
 msgid "Admin password (or token) for %s:"
 msgstr ""
 
-#: lxc/storage_bucket.go:170
+#: lxc/storage_bucket.go:171
 #, c-format
 msgid "Admin secret key: %s"
 msgstr ""
@@ -766,7 +766,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:342 lxc/rebuild.go:130
+#: lxc/init.go:342 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -866,12 +866,12 @@ msgstr ""
 
 #: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:318
 #: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
-#: lxc/network_zone.go:366 lxc/network_zone.go:1053 lxc/storage_bucket.go:141
+#: lxc/network_zone.go:366 lxc/network_zone.go:1053 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:159
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:160
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Bytes sent"
 msgstr ""
 
-#: lxc/operation.go:174
+#: lxc/operation.go:175
 msgid "CANCELABLE"
 msgstr ""
 
@@ -923,7 +923,7 @@ msgstr ""
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: lxc/warning.go:209
+#: lxc/warning.go:210
 msgid "COUNT"
 msgstr ""
 
@@ -949,7 +949,7 @@ msgstr ""
 msgid "CPUs (%s):"
 msgstr ""
 
-#: lxc/operation.go:175
+#: lxc/operation.go:176
 msgid "CREATED"
 msgstr ""
 
@@ -979,7 +979,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:340
+#: lxc/file.go:341
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1004,11 +1004,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:224
+#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:546
+#: lxc/file.go:547
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1017,7 +1017,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:160
+#: lxc/rebuild.go:161
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1140,13 +1140,13 @@ msgstr ""
 #: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
 #: lxc/network_load_balancer.go:1051 lxc/network_load_balancer.go:1125
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
-#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:90
-#: lxc/storage_bucket.go:190 lxc/storage_bucket.go:253
-#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:541
-#: lxc/storage_bucket.go:634 lxc/storage_bucket.go:700
-#: lxc/storage_bucket.go:775 lxc/storage_bucket.go:861
-#: lxc/storage_bucket.go:961 lxc/storage_bucket.go:1026
-#: lxc/storage_bucket.go:1162 lxc/storage_volume.go:394
+#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
+#: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
+#: lxc/storage_bucket.go:385 lxc/storage_bucket.go:542
+#: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
+#: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
+#: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
 #: lxc/storage_volume.go:612 lxc/storage_volume.go:717
 #: lxc/storage_volume.go:1005 lxc/storage_volume.go:1231
 #: lxc/storage_volume.go:1360 lxc/storage_volume.go:1848
@@ -1170,7 +1170,7 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1113 lxc/list.go:132 lxc/storage_volume.go:1589
-#: lxc/warning.go:92
+#: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
@@ -1198,7 +1198,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:100
+#: lxc/project.go:101
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1212,8 +1212,8 @@ msgstr ""
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
-#: lxc/project.go:362 lxc/storage.go:359 lxc/storage_bucket.go:348
-#: lxc/storage_bucket.go:1125 lxc/storage_volume.go:1150
+#: lxc/project.go:363 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1150
 #: lxc/storage_volume.go:1182
 #, c-format
 msgid "Config parsing error: %s"
@@ -1340,12 +1340,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:300 lxc/auth.go:1660
+#: lxc/auth.go:301 lxc/auth.go:1661
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1054
+#: lxc/auth.go:1055
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1394,15 +1394,15 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:248 lxc/file.go:474
+#: lxc/file.go:249 lxc/file.go:475
 msgid "Create any directories necessary"
 msgstr ""
 
-#: lxc/auth.go:97 lxc/auth.go:98
+#: lxc/auth.go:98 lxc/auth.go:99
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1471 lxc/auth.go:1472
+#: lxc/auth.go:1472 lxc/auth.go:1473
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1422,11 +1422,11 @@ msgstr ""
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_bucket.go:851 lxc/storage_bucket.go:852
+#: lxc/storage_bucket.go:852 lxc/storage_bucket.go:853
 msgid "Create key for a storage bucket"
 msgstr ""
 
-#: lxc/storage_bucket.go:82 lxc/storage_bucket.go:83
+#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
 msgid "Create new custom storage buckets"
 msgstr ""
 
@@ -1470,7 +1470,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:92 lxc/project.go:93
+#: lxc/project.go:93 lxc/project.go:94
 msgid "Create projects"
 msgstr ""
 
@@ -1505,13 +1505,13 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:376 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1135 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
-#: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:172
-#: lxc/profile.go:756 lxc/project.go:572 lxc/storage.go:723
-#: lxc/storage_bucket.go:512 lxc/storage_bucket.go:832
+#: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
+#: lxc/profile.go:756 lxc/project.go:573 lxc/storage.go:723
+#: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1732
 msgid "DESCRIPTION"
 msgstr ""
@@ -1536,7 +1536,7 @@ msgstr ""
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
-#: lxc/operation.go:55 lxc/operation.go:56
+#: lxc/operation.go:56 lxc/operation.go:57
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
@@ -1544,19 +1544,19 @@ msgstr ""
 msgid "Delete a cluster group"
 msgstr ""
 
-#: lxc/warning.go:360
+#: lxc/warning.go:361
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:122 lxc/file.go:123
+#: lxc/file.go:123 lxc/file.go:124
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/auth.go:151 lxc/auth.go:152
+#: lxc/auth.go:152 lxc/auth.go:153
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1523 lxc/auth.go:1524
+#: lxc/auth.go:1524 lxc/auth.go:1525
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1576,7 +1576,7 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/storage_bucket.go:957 lxc/storage_bucket.go:958
+#: lxc/storage_bucket.go:958 lxc/storage_bucket.go:959
 msgid "Delete key from a storage bucket"
 msgstr ""
 
@@ -1612,11 +1612,11 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:188 lxc/project.go:189
+#: lxc/project.go:189 lxc/project.go:190
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:187 lxc/storage_bucket.go:188
+#: lxc/storage_bucket.go:188 lxc/storage_bucket.go:189
 msgid "Delete storage buckets"
 msgstr ""
 
@@ -1628,20 +1628,20 @@ msgstr ""
 msgid "Delete storage volumes"
 msgstr ""
 
-#: lxc/warning.go:356 lxc/warning.go:357
+#: lxc/warning.go:357 lxc/warning.go:358
 msgid "Delete warning"
 msgstr ""
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:30 lxc/auth.go:59 lxc/auth.go:98
-#: lxc/auth.go:152 lxc/auth.go:201 lxc/auth.go:332 lxc/auth.go:392
-#: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
-#: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
-#: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
-#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1434 lxc/auth.go:1472
-#: lxc/auth.go:1524 lxc/auth.go:1573 lxc/auth.go:1692 lxc/auth.go:1752
-#: lxc/auth.go:1801 lxc/auth.go:1852 lxc/auth.go:1875 lxc/auth.go:1928
+#: lxc/alias.go:214 lxc/auth.go:31 lxc/auth.go:60 lxc/auth.go:99
+#: lxc/auth.go:153 lxc/auth.go:202 lxc/auth.go:333 lxc/auth.go:393
+#: lxc/auth.go:442 lxc/auth.go:494 lxc/auth.go:517 lxc/auth.go:576
+#: lxc/auth.go:732 lxc/auth.go:766 lxc/auth.go:833 lxc/auth.go:896
+#: lxc/auth.go:957 lxc/auth.go:1085 lxc/auth.go:1108 lxc/auth.go:1166
+#: lxc/auth.go:1235 lxc/auth.go:1257 lxc/auth.go:1435 lxc/auth.go:1473
+#: lxc/auth.go:1525 lxc/auth.go:1574 lxc/auth.go:1693 lxc/auth.go:1753
+#: lxc/auth.go:1802 lxc/auth.go:1853 lxc/auth.go:1876 lxc/auth.go:1929
 #: lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215 lxc/cluster.go:272
 #: lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:484 lxc/cluster.go:528
 #: lxc/cluster.go:586 lxc/cluster.go:677 lxc/cluster.go:770 lxc/cluster.go:893
@@ -1665,15 +1665,15 @@ msgstr ""
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:83 lxc/file.go:123 lxc/file.go:172
-#: lxc/file.go:242 lxc/file.go:467 lxc/file.go:986 lxc/image.go:38
+#: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
+#: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
 #: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
 #: lxc/image.go:697 lxc/image.go:946 lxc/image.go:1088 lxc/image.go:1415
 #: lxc/image.go:1506 lxc/image.go:1572 lxc/image.go:1636 lxc/image.go:1699
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:38 lxc/network.go:33
+#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33
 #: lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405
 #: lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793
 #: lxc/network.go:874 lxc/network.go:1005 lxc/network.go:1106
@@ -1707,27 +1707,27 @@ msgstr ""
 #: lxc/network_zone.go:909 lxc/network_zone.go:985 lxc/network_zone.go:1083
 #: lxc/network_zone.go:1172 lxc/network_zone.go:1219 lxc/network_zone.go:1349
 #: lxc/network_zone.go:1410 lxc/network_zone.go:1425 lxc/network_zone.go:1483
-#: lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:106
-#: lxc/operation.go:193 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
+#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
+#: lxc/operation.go:194 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
 #: lxc/profile.go:271 lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493
 #: lxc/profile.go:629 lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860
-#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:29
-#: lxc/project.go:93 lxc/project.go:189 lxc/project.go:260 lxc/project.go:396
-#: lxc/project.go:470 lxc/project.go:590 lxc/project.go:655 lxc/project.go:743
-#: lxc/project.go:787 lxc/project.go:848 lxc/project.go:915 lxc/publish.go:34
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:35 lxc/remote.go:91
+#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:30
+#: lxc/project.go:94 lxc/project.go:190 lxc/project.go:261 lxc/project.go:397
+#: lxc/project.go:471 lxc/project.go:591 lxc/project.go:656 lxc/project.go:744
+#: lxc/project.go:788 lxc/project.go:849 lxc/project.go:916 lxc/publish.go:34
+#: lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91
 #: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853
 #: lxc/remote.go:917 lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24
 #: lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203
 #: lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655
 #: lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940
-#: lxc/storage_bucket.go:29 lxc/storage_bucket.go:83 lxc/storage_bucket.go:188
-#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:382
-#: lxc/storage_bucket.go:458 lxc/storage_bucket.go:535
-#: lxc/storage_bucket.go:629 lxc/storage_bucket.go:698
-#: lxc/storage_bucket.go:732 lxc/storage_bucket.go:773
-#: lxc/storage_bucket.go:852 lxc/storage_bucket.go:958
-#: lxc/storage_bucket.go:1022 lxc/storage_bucket.go:1157
+#: lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189
+#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:383
+#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:536
+#: lxc/storage_bucket.go:630 lxc/storage_bucket.go:699
+#: lxc/storage_bucket.go:733 lxc/storage_bucket.go:774
+#: lxc/storage_bucket.go:853 lxc/storage_bucket.go:959
+#: lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158
 #: lxc/storage_volume.go:58 lxc/storage_volume.go:169 lxc/storage_volume.go:283
 #: lxc/storage_volume.go:390 lxc/storage_volume.go:605
 #: lxc/storage_volume.go:714 lxc/storage_volume.go:801
@@ -1738,8 +1738,8 @@ msgstr ""
 #: lxc/storage_volume.go:2064 lxc/storage_volume.go:2222
 #: lxc/storage_volume.go:2343 lxc/storage_volume.go:2405
 #: lxc/storage_volume.go:2541 lxc/storage_volume.go:2624
-#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:29
-#: lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
+#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:30
+#: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
@@ -1826,7 +1826,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:994
+#: lxc/file.go:995
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1892,7 +1892,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:74
+#: lxc/file.go:75
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1902,7 +1902,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:955 lxc/auth.go:956
+#: lxc/auth.go:956 lxc/auth.go:957
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1910,15 +1910,15 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:171 lxc/file.go:172
+#: lxc/file.go:172 lxc/file.go:173
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/auth.go:200 lxc/auth.go:201
+#: lxc/auth.go:201 lxc/auth.go:202
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1572 lxc/auth.go:1573
+#: lxc/auth.go:1573 lxc/auth.go:1574
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -1974,15 +1974,15 @@ msgstr ""
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:259 lxc/project.go:260
+#: lxc/project.go:260 lxc/project.go:261
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:248 lxc/storage_bucket.go:249
+#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:250
 msgid "Edit storage bucket configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:1021 lxc/storage_bucket.go:1022
+#: lxc/storage_bucket.go:1022 lxc/storage_bucket.go:1023
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
@@ -1999,7 +1999,7 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1147 lxc/list.go:622 lxc/storage_volume.go:1766
-#: lxc/warning.go:235
+#: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2054,7 +2054,7 @@ msgstr ""
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
-#: lxc/project.go:718 lxc/storage.go:812 lxc/storage_bucket.go:602
+#: lxc/project.go:719 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2155 lxc/storage_volume.go:2193
 #, c-format
 msgid "Error setting properties: %v"
@@ -2068,8 +2068,8 @@ msgstr ""
 #: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
-#: lxc/profile.go:981 lxc/project.go:712 lxc/storage.go:806
-#: lxc/storage_bucket.go:596 lxc/storage_volume.go:2149
+#: lxc/profile.go:981 lxc/project.go:713 lxc/storage.go:806
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2149
 #: lxc/storage_volume.go:2187
 #, c-format
 msgid "Error unsetting property: %v"
@@ -2089,7 +2089,7 @@ msgstr ""
 msgid "Evacuating cluster member: %s"
 msgstr ""
 
-#: lxc/monitor.go:50
+#: lxc/monitor.go:51
 msgid "Event type to listen for"
 msgstr ""
 
@@ -2176,16 +2176,16 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/warning.go:210
+#: lxc/warning.go:211
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1237
+#: lxc/file.go:1238
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1260
+#: lxc/file.go:1261
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2200,12 +2200,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1287
+#: lxc/file.go:1288
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1072
+#: lxc/file.go:1073
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2235,7 +2235,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1193
+#: lxc/file.go:1194
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2250,7 +2250,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1198
+#: lxc/file.go:1199
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2260,12 +2260,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1098
+#: lxc/file.go:1099
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1225
+#: lxc/file.go:1226
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2304,7 +2304,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1210
+#: lxc/file.go:1211
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2319,7 +2319,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:820
+#: lxc/file.go:821
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2334,7 +2334,7 @@ msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
 #: lxc/network.go:1044 lxc/network_acl.go:133 lxc/network_zone.go:124
-#: lxc/operation.go:136
+#: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
 
@@ -2399,21 +2399,21 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
+#: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:770 lxc/auth.go:1697
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1114 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:57
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
-#: lxc/operation.go:108 lxc/profile.go:707 lxc/project.go:472
-#: lxc/project.go:917 lxc/remote.go:690 lxc/storage.go:657
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:774
-#: lxc/storage_volume.go:1608 lxc/warning.go:93
+#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:473
+#: lxc/project.go:918 lxc/remote.go:690 lxc/storage.go:657
+#: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
+#: lxc/storage_volume.go:1608 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
-#: lxc/monitor.go:52
+#: lxc/monitor.go:53
 msgid "Format (json|pretty|yaml)"
 msgstr ""
 
@@ -2457,7 +2457,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:817 lxc/auth.go:1736
+#: lxc/auth.go:818 lxc/auth.go:1737
 msgid "GROUPS"
 msgstr ""
 
@@ -2473,7 +2473,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:914 lxc/project.go:915
+#: lxc/project.go:915 lxc/project.go:916
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2521,11 +2521,11 @@ msgstr ""
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:400
+#: lxc/project.go:401
 msgid "Get the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:385
+#: lxc/storage_bucket.go:386
 msgid "Get the key as a storage bucket property"
 msgstr ""
 
@@ -2585,11 +2585,11 @@ msgstr ""
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:395 lxc/project.go:396
+#: lxc/project.go:396 lxc/project.go:397
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:382
+#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:383
 msgid "Get values for storage bucket configuration keys"
 msgstr ""
 
@@ -2606,17 +2606,17 @@ msgstr ""
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: lxc/auth.go:136
+#: lxc/auth.go:137
 #, c-format
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:186
+#: lxc/auth.go:187
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:426 lxc/auth.go:1786
+#: lxc/auth.go:427 lxc/auth.go:1787
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2641,27 +2641,27 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1310
+#: lxc/file.go:1311
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1299
+#: lxc/file.go:1300
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1122
+#: lxc/file.go:1123
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1132
+#: lxc/file.go:1133
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:966 lxc/operation.go:170
+#: lxc/network.go:966 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2675,11 +2675,11 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:816
+#: lxc/auth.go:817
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:566
+#: lxc/project.go:567
 msgid "IMAGES"
 msgstr ""
 
@@ -2707,17 +2707,17 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1508
+#: lxc/auth.go:1509
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1558
+#: lxc/auth.go:1559
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
 
-#: lxc/rebuild.go:32
+#: lxc/rebuild.go:33
 msgid "If an instance is running, stop it and then rebuild it"
 msgstr ""
 
@@ -2838,7 +2838,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1233 lxc/auth.go:1234
+#: lxc/auth.go:1234 lxc/auth.go:1235
 msgid "Inspect permissions"
 msgstr ""
 
@@ -2846,11 +2846,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1124
+#: lxc/file.go:1125
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1301
+#: lxc/file.go:1302
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2868,7 +2868,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1044
+#: lxc/file.go:1045
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2877,7 +2877,7 @@ msgstr ""
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/rebuild.go:74
+#: lxc/rebuild.go:75
 #, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
@@ -2910,7 +2910,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/monitor.go:70
+#: lxc/monitor.go:71
 #, c-format
 msgid "Invalid format: %s"
 msgstr ""
@@ -2920,7 +2920,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1039
+#: lxc/file.go:1040
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2962,7 +2962,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:147
+#: lxc/file.go:148
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2978,12 +2978,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:313
+#: lxc/file.go:314
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:495
+#: lxc/file.go:496
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -2997,7 +2997,7 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/warning.go:212
 msgid "LAST SEEN"
 msgstr ""
 
@@ -3005,7 +3005,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:984
+#: lxc/project.go:985
 msgid "LIMIT"
 msgstr ""
 
@@ -3014,8 +3014,8 @@ msgid "LISTEN ADDRESS"
 msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
-#: lxc/network_load_balancer.go:165 lxc/operation.go:177
-#: lxc/storage_bucket.go:516 lxc/storage_volume.go:1739 lxc/warning.go:220
+#: lxc/network_load_balancer.go:165 lxc/operation.go:178
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1739 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3089,7 +3089,7 @@ msgstr ""
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/warning.go:94
+#: lxc/warning.go:95
 msgid "List all warnings"
 msgstr ""
 
@@ -3133,19 +3133,19 @@ msgstr ""
 msgid "List available storage pools"
 msgstr ""
 
-#: lxc/operation.go:105 lxc/operation.go:106
+#: lxc/operation.go:106 lxc/operation.go:107
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:331 lxc/auth.go:332
+#: lxc/auth.go:332 lxc/auth.go:333
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:764 lxc/auth.go:765
+#: lxc/auth.go:765 lxc/auth.go:766
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1691 lxc/auth.go:1692
+#: lxc/auth.go:1692 lxc/auth.go:1693
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3294,11 +3294,11 @@ msgstr ""
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/operation.go:109
+#: lxc/operation.go:110
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1255 lxc/auth.go:1256
+#: lxc/auth.go:1256 lxc/auth.go:1257
 msgid "List permissions"
 msgstr ""
 
@@ -3306,15 +3306,15 @@ msgstr ""
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:469 lxc/project.go:470
+#: lxc/project.go:470 lxc/project.go:471
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:771 lxc/storage_bucket.go:773
+#: lxc/storage_bucket.go:772 lxc/storage_bucket.go:774
 msgid "List storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:456 lxc/storage_bucket.go:458
+#: lxc/storage_bucket.go:457 lxc/storage_bucket.go:459
 msgid "List storage buckets"
 msgstr ""
 
@@ -3350,11 +3350,11 @@ msgstr ""
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/warning.go:70
+#: lxc/warning.go:71
 msgid "List warnings"
 msgstr ""
 
-#: lxc/warning.go:71
+#: lxc/warning.go:72
 msgid ""
 "List warnings\n"
 "\n"
@@ -3377,7 +3377,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/operation.go:23 lxc/operation.go:24
+#: lxc/operation.go:24 lxc/operation.go:25
 msgid "List, show and delete background operations"
 msgstr ""
 
@@ -3386,7 +3386,7 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/monitor.go:79
+#: lxc/monitor.go:80
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
@@ -3490,23 +3490,23 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:82 lxc/file.go:83
+#: lxc/file.go:83 lxc/file.go:84
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1433 lxc/auth.go:1434
+#: lxc/auth.go:59 lxc/auth.go:60 lxc/auth.go:1434 lxc/auth.go:1435
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1083 lxc/auth.go:1084
+#: lxc/auth.go:1084 lxc/auth.go:1085
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:730 lxc/auth.go:731
+#: lxc/auth.go:731 lxc/auth.go:732
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1851 lxc/auth.go:1852
+#: lxc/auth.go:1852 lxc/auth.go:1853
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3597,7 +3597,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:492 lxc/auth.go:493
+#: lxc/auth.go:493 lxc/auth.go:494
 msgid "Manage permissions"
 msgstr ""
 
@@ -3605,23 +3605,23 @@ msgstr ""
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:28 lxc/project.go:29
+#: lxc/project.go:29 lxc/project.go:30
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:731
+#: lxc/storage_bucket.go:732
 msgid "Manage storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:732
+#: lxc/storage_bucket.go:733
 msgid "Manage storage bucket keys."
 msgstr ""
 
-#: lxc/storage_bucket.go:28
+#: lxc/storage_bucket.go:29
 msgid "Manage storage buckets"
 msgstr ""
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:30
 msgid "Manage storage buckets."
 msgstr ""
 
@@ -3649,11 +3649,11 @@ msgstr ""
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/auth.go:29 lxc/auth.go:30
+#: lxc/auth.go:30 lxc/auth.go:31
 msgid "Manage user authorization"
 msgstr ""
 
-#: lxc/warning.go:28 lxc/warning.go:29
+#: lxc/warning.go:29 lxc/warning.go:30
 msgid "Manage warnings"
 msgstr ""
 
@@ -3717,17 +3717,17 @@ msgstr ""
 msgid "Migration operation failure: %w"
 msgstr ""
 
-#: lxc/monitor.go:51
+#: lxc/monitor.go:52
 msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: lxc/storage_bucket.go:116 lxc/storage_bucket.go:216
-#: lxc/storage_bucket.go:292 lxc/storage_bucket.go:411
-#: lxc/storage_bucket.go:568 lxc/storage_bucket.go:660
-#: lxc/storage_bucket.go:802 lxc/storage_bucket.go:889
-#: lxc/storage_bucket.go:986 lxc/storage_bucket.go:1065
-#: lxc/storage_bucket.go:1188
+#: lxc/storage_bucket.go:117 lxc/storage_bucket.go:217
+#: lxc/storage_bucket.go:293 lxc/storage_bucket.go:412
+#: lxc/storage_bucket.go:569 lxc/storage_bucket.go:661
+#: lxc/storage_bucket.go:803 lxc/storage_bucket.go:890
+#: lxc/storage_bucket.go:987 lxc/storage_bucket.go:1066
+#: lxc/storage_bucket.go:1189
 msgid "Missing bucket name"
 msgstr ""
 
@@ -3746,20 +3746,20 @@ msgstr ""
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1825
+#: lxc/auth.go:123 lxc/auth.go:177 lxc/auth.go:255 lxc/auth.go:417
+#: lxc/auth.go:466 lxc/auth.go:541 lxc/auth.go:600 lxc/auth.go:1826
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:862 lxc/auth.go:1003 lxc/auth.go:1131 lxc/auth.go:1189
+#: lxc/auth.go:863 lxc/auth.go:1004 lxc/auth.go:1132 lxc/auth.go:1190
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1495 lxc/auth.go:1548 lxc/auth.go:1614 lxc/auth.go:1776
+#: lxc/auth.go:1496 lxc/auth.go:1549 lxc/auth.go:1615 lxc/auth.go:1777
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1899 lxc/auth.go:1952
+#: lxc/auth.go:1900 lxc/auth.go:1953
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -3767,12 +3767,12 @@ msgstr ""
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
 #: lxc/config_template.go:377 lxc/profile.go:141 lxc/profile.go:222
-#: lxc/profile.go:808 lxc/rebuild.go:60
+#: lxc/profile.go:808 lxc/rebuild.go:61
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/storage_bucket.go:893 lxc/storage_bucket.go:990
-#: lxc/storage_bucket.go:1069 lxc/storage_bucket.go:1192
+#: lxc/storage_bucket.go:894 lxc/storage_bucket.go:991
+#: lxc/storage_bucket.go:1070 lxc/storage_bucket.go:1193
 msgid "Missing key name"
 msgstr ""
 
@@ -3837,13 +3837,13 @@ msgid "Missing peer name"
 msgstr ""
 
 #: lxc/storage.go:235 lxc/storage.go:313 lxc/storage.go:431 lxc/storage.go:509
-#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:112
-#: lxc/storage_bucket.go:212 lxc/storage_bucket.go:288
-#: lxc/storage_bucket.go:407 lxc/storage_bucket.go:482
-#: lxc/storage_bucket.go:564 lxc/storage_bucket.go:656
-#: lxc/storage_bucket.go:798 lxc/storage_bucket.go:885
-#: lxc/storage_bucket.go:982 lxc/storage_bucket.go:1061
-#: lxc/storage_bucket.go:1184 lxc/storage_volume.go:209
+#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:113
+#: lxc/storage_bucket.go:213 lxc/storage_bucket.go:289
+#: lxc/storage_bucket.go:408 lxc/storage_bucket.go:483
+#: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
+#: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
+#: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
 #: lxc/storage_volume.go:323 lxc/storage_volume.go:643
 #: lxc/storage_volume.go:750 lxc/storage_volume.go:841
 #: lxc/storage_volume.go:939 lxc/storage_volume.go:1053
@@ -3858,9 +3858,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:404 lxc/project.go:146 lxc/project.go:226 lxc/project.go:316
-#: lxc/project.go:433 lxc/project.go:622 lxc/project.go:691 lxc/project.go:819
-#: lxc/project.go:948
+#: lxc/profile.go:404 lxc/project.go:147 lxc/project.go:227 lxc/project.go:317
+#: lxc/project.go:434 lxc/project.go:623 lxc/project.go:692 lxc/project.go:820
+#: lxc/project.go:949
 msgid "Missing project name"
 msgstr ""
 
@@ -3876,7 +3876,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:598
+#: lxc/file.go:599
 msgid "Missing target directory"
 msgstr ""
 
@@ -3898,11 +3898,11 @@ msgstr ""
 msgid "Model: %v"
 msgstr ""
 
-#: lxc/monitor.go:32
+#: lxc/monitor.go:33
 msgid "Monitor a local or remote LXD server"
 msgstr ""
 
-#: lxc/monitor.go:33
+#: lxc/monitor.go:34
 msgid ""
 "Monitor a local or remote LXD server\n"
 "\n"
@@ -3914,11 +3914,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:285
+#: lxc/file.go:286
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:985 lxc/file.go:986
+#: lxc/file.go:986 lxc/file.go:987
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3980,13 +3980,13 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:192
+#: lxc/auth.go:376 lxc/auth.go:816 lxc/auth.go:1736 lxc/cluster.go:192
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
-#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:565
-#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:511
-#: lxc/storage_bucket.go:831 lxc/storage_volume.go:1731
+#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:566
+#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1731
 msgid "NAME"
 msgstr ""
 
@@ -3994,11 +3994,11 @@ msgstr ""
 msgid "NAT"
 msgstr ""
 
-#: lxc/project.go:571
+#: lxc/project.go:572
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:570
+#: lxc/project.go:571
 msgid "NETWORKS"
 msgstr ""
 
@@ -4010,9 +4010,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/operation.go:154 lxc/project.go:523
-#: lxc/project.go:528 lxc/project.go:533 lxc/project.go:538 lxc/project.go:543
-#: lxc/project.go:548 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
+#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:524
+#: lxc/project.go:529 lxc/project.go:534 lxc/project.go:539 lxc/project.go:544
+#: lxc/project.go:549 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
 msgid "NO"
 msgstr ""
 
@@ -4257,7 +4257,7 @@ msgstr ""
 msgid "Only managed networks can be modified"
 msgstr ""
 
-#: lxc/operation.go:86
+#: lxc/operation.go:87
 #, c-format
 msgid "Operation %s deleted"
 msgstr ""
@@ -4304,11 +4304,11 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:567
+#: lxc/list.go:576 lxc/project.go:568
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:212
+#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4370,24 +4370,24 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1102
+#: lxc/file.go:1103
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:860
+#: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
-#: lxc/project.go:363 lxc/storage.go:360 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1151
+#: lxc/project.go:364 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1151
 #: lxc/storage_volume.go:1183
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
-#: lxc/monitor.go:48
+#: lxc/monitor.go:49
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
@@ -4473,17 +4473,17 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:172
+#: lxc/project.go:173
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:236
+#: lxc/project.go:237
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:637
+#: lxc/project.go:638
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -4604,20 +4604,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:241 lxc/file.go:242
+#: lxc/file.go:242 lxc/file.go:243
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:416 lxc/file.go:767
+#: lxc/file.go:417 lxc/file.go:768
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:466 lxc/file.go:467
+#: lxc/file.go:467 lxc/file.go:468
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:701 lxc/file.go:867
+#: lxc/file.go:702 lxc/file.go:868
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4630,11 +4630,11 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:983
+#: lxc/project.go:984
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/storage_bucket.go:833
+#: lxc/storage_bucket.go:834
 msgid "ROLE"
 msgstr ""
 
@@ -4647,15 +4647,15 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/rebuild.go:31
+#: lxc/rebuild.go:32
 msgid "Rebuild as an empty instance"
 msgstr ""
 
-#: lxc/rebuild.go:26
+#: lxc/rebuild.go:27
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:249 lxc/file.go:473
+#: lxc/file.go:250 lxc/file.go:474
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4682,7 +4682,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:882 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
+#: lxc/project.go:883 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
 #: lxc/remote.go:994
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4733,7 +4733,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1164 lxc/auth.go:1165
+#: lxc/auth.go:1165 lxc/auth.go:1166
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4769,7 +4769,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1927 lxc/auth.go:1928
+#: lxc/auth.go:1928 lxc/auth.go:1929
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4781,7 +4781,7 @@ msgstr ""
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:574 lxc/auth.go:575
+#: lxc/auth.go:575 lxc/auth.go:576
 msgid "Remove permissions from groups"
 msgstr ""
 
@@ -4826,11 +4826,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:391 lxc/auth.go:392
+#: lxc/auth.go:392 lxc/auth.go:393
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1751 lxc/auth.go:1752
+#: lxc/auth.go:1752 lxc/auth.go:1753
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -4850,7 +4850,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:589 lxc/project.go:590
+#: lxc/project.go:590 lxc/project.go:591
 msgid "Rename projects"
 msgstr ""
 
@@ -4948,7 +4948,7 @@ msgstr ""
 msgid "Revoke cluster member join token"
 msgstr ""
 
-#: lxc/storage_bucket.go:862
+#: lxc/storage_bucket.go:863
 msgid "Role (admin or read-only)"
 msgstr ""
 
@@ -4964,7 +4964,7 @@ msgstr ""
 msgid "Run against all projects"
 msgstr ""
 
-#: lxc/warning.go:213
+#: lxc/warning.go:214
 msgid "SEVERITY"
 msgstr ""
 
@@ -4984,12 +4984,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1231
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1231
+#: lxc/file.go:1232
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5003,11 +5003,11 @@ msgstr ""
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:173 lxc/warning.go:214
+#: lxc/operation.go:174 lxc/warning.go:215
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:569
+#: lxc/project.go:570
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5015,7 +5015,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:569
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -5023,11 +5023,11 @@ msgstr ""
 msgid "STP"
 msgstr ""
 
-#: lxc/storage_bucket.go:864
+#: lxc/storage_bucket.go:865
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:942
+#: lxc/storage_bucket.go:943
 #, c-format
 msgid "Secret key: %s"
 msgstr ""
@@ -5065,7 +5065,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:995
+#: lxc/file.go:996
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5203,11 +5203,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:654
+#: lxc/project.go:655
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:655
+#: lxc/project.go:656
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5216,11 +5216,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage_bucket.go:534
+#: lxc/storage_bucket.go:535
 msgid "Set storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:535
+#: lxc/storage_bucket.go:536
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -5259,15 +5259,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:476
+#: lxc/file.go:477
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:477
+#: lxc/file.go:478
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:475
+#: lxc/file.go:476
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5307,11 +5307,11 @@ msgstr ""
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 msgid "Set the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:542
+#: lxc/storage_bucket.go:543
 msgid "Set the key as a storage bucket property"
 msgstr ""
 
@@ -5327,7 +5327,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:993
+#: lxc/file.go:994
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5339,7 +5339,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1800 lxc/auth.go:1801
+#: lxc/auth.go:1801 lxc/auth.go:1802
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5355,11 +5355,11 @@ msgstr ""
 msgid "Show details of a cluster member"
 msgstr ""
 
-#: lxc/operation.go:192 lxc/operation.go:193
+#: lxc/operation.go:193 lxc/operation.go:194
 msgid "Show details on a background operation"
 msgstr ""
 
-#: lxc/monitor.go:49
+#: lxc/monitor.go:50
 msgid "Show events from all projects"
 msgstr ""
 
@@ -5367,11 +5367,11 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:440 lxc/auth.go:441
+#: lxc/auth.go:441 lxc/auth.go:442
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:832
+#: lxc/auth.go:833
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5452,15 +5452,15 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:786 lxc/project.go:787
+#: lxc/project.go:787 lxc/project.go:788
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage_bucket.go:628 lxc/storage_bucket.go:629
+#: lxc/storage_bucket.go:629 lxc/storage_bucket.go:630
 msgid "Show storage bucket configurations"
 msgstr ""
 
-#: lxc/storage_bucket.go:1156 lxc/storage_bucket.go:1157
+#: lxc/storage_bucket.go:1157 lxc/storage_bucket.go:1158
 msgid "Show storage bucket key configurations"
 msgstr ""
 
@@ -5476,7 +5476,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:895
+#: lxc/auth.go:896
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5526,7 +5526,7 @@ msgstr ""
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: lxc/warning.go:302 lxc/warning.go:303
+#: lxc/warning.go:303 lxc/warning.go:304
 msgid "Show warning"
 msgstr ""
 
@@ -5610,22 +5610,22 @@ msgstr ""
 msgid "Stopping the instance failed: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:166
+#: lxc/storage_bucket.go:167
 #, c-format
 msgid "Storage bucket %s created"
 msgstr ""
 
-#: lxc/storage_bucket.go:233
+#: lxc/storage_bucket.go:234
 #, c-format
 msgid "Storage bucket %s deleted"
 msgstr ""
 
-#: lxc/storage_bucket.go:940
+#: lxc/storage_bucket.go:941
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr ""
 
-#: lxc/storage_bucket.go:1006
+#: lxc/storage_bucket.go:1007
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr ""
@@ -5694,7 +5694,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:847 lxc/project.go:848
+#: lxc/project.go:848 lxc/project.go:849
 msgid "Switch the current project"
 msgstr ""
 
@@ -5710,10 +5710,10 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1139
+#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1139
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
-#: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:171
-#: lxc/storage_volume.go:1730 lxc/warning.go:215
+#: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
+#: lxc/storage_volume.go:1730 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
@@ -5721,11 +5721,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1032
+#: lxc/file.go:1033
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1026
+#: lxc/file.go:1027
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5853,12 +5853,12 @@ msgstr ""
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:446
+#: lxc/project.go:447
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
 
-#: lxc/storage_bucket.go:431
+#: lxc/storage_bucket.go:432
 #, c-format
 msgid "The property %q does not exist on the storage bucket %q: %v"
 msgstr ""
@@ -6043,7 +6043,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:961
+#: lxc/project.go:962
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6055,17 +6055,17 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:985 lxc/storage_volume.go:1735
+#: lxc/project.go:986 lxc/storage_volume.go:1735
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:573
+#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:574
 #: lxc/storage.go:724 lxc/storage_volume.go:1734
 msgid "USED BY"
 msgstr ""
 
-#: lxc/warning.go:216
+#: lxc/warning.go:217
 msgid "UUID"
 msgstr ""
 
@@ -6074,7 +6074,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:197
+#: lxc/file.go:198
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6088,13 +6088,13 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1253
+#: lxc/file.go:1254
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1153 lxc/list.go:631 lxc/storage_volume.go:1772
-#: lxc/warning.go:241
+#: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6104,7 +6104,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:807
+#: lxc/file.go:808
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6187,11 +6187,11 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:742 lxc/project.go:743
+#: lxc/project.go:743 lxc/project.go:744
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:697 lxc/storage_bucket.go:698
+#: lxc/storage_bucket.go:698 lxc/storage_bucket.go:699
 msgid "Unset storage bucket configuration keys"
 msgstr ""
 
@@ -6239,11 +6239,11 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:747
+#: lxc/project.go:748
 msgid "Unset the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:701
+#: lxc/storage_bucket.go:702
 msgid "Unset the key as a storage bucket property"
 msgstr ""
 
@@ -6322,7 +6322,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:71
+#: lxc/file.go:72
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6359,11 +6359,11 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:831
+#: lxc/auth.go:832
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:894
+#: lxc/auth.go:895
 msgid "View the current identity"
 msgstr ""
 
@@ -6394,15 +6394,15 @@ msgstr ""
 msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
-#: lxc/rebuild.go:27
+#: lxc/rebuild.go:28
 msgid ""
 "Wipe the instance root disk and re-initialize. The original image is used to "
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:156 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
+#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:526
+#: lxc/project.go:531 lxc/project.go:536 lxc/project.go:541 lxc/project.go:546
+#: lxc/project.go:551 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
 msgid "YES"
 msgstr ""
 
@@ -6422,7 +6422,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/rebuild.go:119
+#: lxc/rebuild.go:120
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
@@ -6434,12 +6434,12 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1689
+#: lxc/auth.go:330 lxc/auth.go:763 lxc/auth.go:894 lxc/auth.go:1690
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
-#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
+#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
-#: lxc/operation.go:103 lxc/profile.go:700 lxc/project.go:467
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:68
+#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:468
+#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6467,7 +6467,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1254
+#: lxc/auth.go:1255
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6528,11 +6528,11 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:830
+#: lxc/auth.go:831
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1926
+#: lxc/auth.go:1106 lxc/auth.go:1164 lxc/auth.go:1927
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6540,13 +6540,13 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:954 lxc/auth.go:1470 lxc/cluster_group.go:168
+#: lxc/auth.go:97 lxc/auth.go:150 lxc/auth.go:200 lxc/auth.go:440
+#: lxc/auth.go:955 lxc/auth.go:1471 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:514 lxc/auth.go:572
+#: lxc/auth.go:515 lxc/auth.go:573
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
@@ -6556,19 +6556,19 @@ msgstr ""
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:389
+#: lxc/auth.go:390
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1521 lxc/auth.go:1571 lxc/auth.go:1799
+#: lxc/auth.go:1522 lxc/auth.go:1572 lxc/auth.go:1800
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1873
+#: lxc/auth.go:1874
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1749
+#: lxc/auth.go:1750
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -6588,7 +6588,7 @@ msgstr ""
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
-#: lxc/rebuild.go:25
+#: lxc/rebuild.go:26
 msgid "[<remote>:]<image> [<remote>:]<instance>"
 msgstr ""
 
@@ -6671,20 +6671,20 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:170
+#: lxc/file.go:171
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:120
+#: lxc/file.go:121
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:240
+#: lxc/file.go:241
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:984
+#: lxc/file.go:985
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6835,12 +6835,12 @@ msgstr ""
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
-#: lxc/operation.go:53 lxc/operation.go:191
+#: lxc/operation.go:54 lxc/operation.go:192
 msgid "[<remote>:]<operation>"
 msgstr ""
 
 #: lxc/storage.go:200 lxc/storage.go:259 lxc/storage.go:473 lxc/storage.go:844
-#: lxc/storage_bucket.go:454
+#: lxc/storage_bucket.go:455
 msgid "[<remote>:]<pool>"
 msgstr ""
 
@@ -6848,22 +6848,22 @@ msgstr ""
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
-#: lxc/storage_bucket.go:185 lxc/storage_bucket.go:247
-#: lxc/storage_bucket.go:627 lxc/storage_bucket.go:769
+#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:248
+#: lxc/storage_bucket.go:628 lxc/storage_bucket.go:770
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
 
-#: lxc/storage_bucket.go:380 lxc/storage_bucket.go:696
-#: lxc/storage_bucket.go:850 lxc/storage_bucket.go:956
-#: lxc/storage_bucket.go:1020 lxc/storage_bucket.go:1155
+#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:697
+#: lxc/storage_bucket.go:851 lxc/storage_bucket.go:957
+#: lxc/storage_bucket.go:1021 lxc/storage_bucket.go:1156
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
 
-#: lxc/storage_bucket.go:533
+#: lxc/storage_bucket.go:534
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_bucket.go:81
+#: lxc/storage_bucket.go:82
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
 
@@ -6978,20 +6978,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:91 lxc/project.go:186 lxc/project.go:258 lxc/project.go:785
-#: lxc/project.go:846 lxc/project.go:913
+#: lxc/project.go:92 lxc/project.go:187 lxc/project.go:259 lxc/project.go:786
+#: lxc/project.go:847 lxc/project.go:914
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:394 lxc/project.go:741
+#: lxc/project.go:395 lxc/project.go:742
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:653
+#: lxc/project.go:654
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:587
+#: lxc/project.go:588
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -6999,7 +6999,7 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:259 lxc/warning.go:301 lxc/warning.go:354
+#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
@@ -7055,7 +7055,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:555 lxc/remote.go:739
+#: lxc/project.go:556 lxc/remote.go:739
 msgid "current"
 msgstr ""
 
@@ -7102,20 +7102,20 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/auth.go:203
+#: lxc/auth.go:204
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:958
+#: lxc/auth.go:959
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1575
+#: lxc/auth.go:1576
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7193,20 +7193,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:988
+#: lxc/file.go:989
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:244
+#: lxc/file.go:245
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:470
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7288,7 +7288,7 @@ msgid ""
 "  List instances with their running state and user comment."
 msgstr ""
 
-#: lxc/monitor.go:37
+#: lxc/monitor.go:38
 msgid ""
 "lxc monitor --type=logging\n"
 "    Only show log messages.\n"
@@ -7364,7 +7364,7 @@ msgid ""
 "    Create record r1 for zone z1 with configuration from config.yaml"
 msgstr ""
 
-#: lxc/operation.go:195
+#: lxc/operation.go:196
 msgid ""
 "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Show details on that operation UUID"
@@ -7407,7 +7407,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:95
+#: lxc/project.go:96
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7415,7 +7415,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:262
+#: lxc/project.go:263
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7446,7 +7446,7 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:85
 msgid ""
 "lxc storage bucket create p1 b01\n"
 "\tCreate a new storage bucket name b01 in storage pool p1\n"
@@ -7456,19 +7456,19 @@ msgid ""
 "of config.yaml"
 msgstr ""
 
-#: lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:251
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1023
+#: lxc/storage_bucket.go:1024
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:854
 msgid ""
 "lxc storage bucket key create p1 b01 k1\n"
 "\tCreate a key called k1 for the bucket b01 in the pool p1.\n"
@@ -7478,14 +7478,14 @@ msgid ""
 "of config.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1158
+#: lxc/storage_bucket.go:1159
 msgid ""
 "lxc storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_bucket.go:630
+#: lxc/storage_bucket.go:631
 msgid ""
 "lxc storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
@@ -7555,16 +7555,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1142
+#: lxc/file.go:1143
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1101
+#: lxc/file.go:1102
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1054
+#: lxc/file.go:1055
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-04 08:52-0600\n"
+"POT-Creation-Date: 2024-09-05 08:44-0400\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Turkish <https://hosted.weblate.org/projects/linux-containers/"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: lxc/storage_bucket.go:260 lxc/storage_bucket.go:1033
+#: lxc/storage_bucket.go:261 lxc/storage_bucket.go:1034
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -133,7 +133,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:213
+#: lxc/auth.go:214
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -160,7 +160,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:968
+#: lxc/auth.go:969
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -181,7 +181,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1585
+#: lxc/auth.go:1586
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -391,7 +391,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:280
+#: lxc/project.go:281
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -433,12 +433,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:935
+#: lxc/file.go:936
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:825
+#: lxc/file.go:826
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -474,7 +474,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:142 lxc/rebuild.go:64
+#: lxc/init.go:142 lxc/rebuild.go:65
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -527,7 +527,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:465
+#: lxc/file.go:466
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -560,7 +560,7 @@ msgstr ""
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:813
+#: lxc/auth.go:814
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -568,11 +568,11 @@ msgstr ""
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/storage_bucket.go:863
+#: lxc/storage_bucket.go:864
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:941
+#: lxc/storage_bucket.go:942
 #, c-format
 msgid "Access key: %s"
 msgstr ""
@@ -581,7 +581,7 @@ msgstr ""
 msgid "Access the expanded configuration"
 msgstr ""
 
-#: lxc/warning.go:261 lxc/warning.go:262
+#: lxc/warning.go:262 lxc/warning.go:263
 msgid "Acknowledge warning"
 msgstr ""
 
@@ -598,11 +598,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1106 lxc/auth.go:1107
+#: lxc/auth.go:1107 lxc/auth.go:1108
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1874 lxc/auth.go:1875
+#: lxc/auth.go:1875 lxc/auth.go:1876
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -671,7 +671,7 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:515 lxc/auth.go:516
+#: lxc/auth.go:516 lxc/auth.go:517
 msgid "Add permissions to groups"
 msgstr ""
 
@@ -700,7 +700,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:169
+#: lxc/storage_bucket.go:170
 #, c-format
 msgid "Admin access key: %s"
 msgstr ""
@@ -710,7 +710,7 @@ msgstr ""
 msgid "Admin password (or token) for %s:"
 msgstr ""
 
-#: lxc/storage_bucket.go:170
+#: lxc/storage_bucket.go:171
 #, c-format
 msgid "Admin secret key: %s"
 msgstr ""
@@ -769,7 +769,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:342 lxc/rebuild.go:130
+#: lxc/init.go:342 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -869,12 +869,12 @@ msgstr ""
 
 #: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:318
 #: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
-#: lxc/network_zone.go:366 lxc/network_zone.go:1053 lxc/storage_bucket.go:141
+#: lxc/network_zone.go:366 lxc/network_zone.go:1053 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:159
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:160
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -914,7 +914,7 @@ msgstr ""
 msgid "Bytes sent"
 msgstr ""
 
-#: lxc/operation.go:174
+#: lxc/operation.go:175
 msgid "CANCELABLE"
 msgstr ""
 
@@ -926,7 +926,7 @@ msgstr ""
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: lxc/warning.go:209
+#: lxc/warning.go:210
 msgid "COUNT"
 msgstr ""
 
@@ -952,7 +952,7 @@ msgstr ""
 msgid "CPUs (%s):"
 msgstr ""
 
-#: lxc/operation.go:175
+#: lxc/operation.go:176
 msgid "CREATED"
 msgstr ""
 
@@ -982,7 +982,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:340
+#: lxc/file.go:341
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1007,11 +1007,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:224
+#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:546
+#: lxc/file.go:547
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1020,7 +1020,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:160
+#: lxc/rebuild.go:161
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1143,13 +1143,13 @@ msgstr ""
 #: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
 #: lxc/network_load_balancer.go:1051 lxc/network_load_balancer.go:1125
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
-#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:90
-#: lxc/storage_bucket.go:190 lxc/storage_bucket.go:253
-#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:541
-#: lxc/storage_bucket.go:634 lxc/storage_bucket.go:700
-#: lxc/storage_bucket.go:775 lxc/storage_bucket.go:861
-#: lxc/storage_bucket.go:961 lxc/storage_bucket.go:1026
-#: lxc/storage_bucket.go:1162 lxc/storage_volume.go:394
+#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
+#: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
+#: lxc/storage_bucket.go:385 lxc/storage_bucket.go:542
+#: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
+#: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
+#: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
 #: lxc/storage_volume.go:612 lxc/storage_volume.go:717
 #: lxc/storage_volume.go:1005 lxc/storage_volume.go:1231
 #: lxc/storage_volume.go:1360 lxc/storage_volume.go:1848
@@ -1173,7 +1173,7 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1113 lxc/list.go:132 lxc/storage_volume.go:1589
-#: lxc/warning.go:92
+#: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
@@ -1201,7 +1201,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:100
+#: lxc/project.go:101
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1215,8 +1215,8 @@ msgstr ""
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
-#: lxc/project.go:362 lxc/storage.go:359 lxc/storage_bucket.go:348
-#: lxc/storage_bucket.go:1125 lxc/storage_volume.go:1150
+#: lxc/project.go:363 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1150
 #: lxc/storage_volume.go:1182
 #, c-format
 msgid "Config parsing error: %s"
@@ -1343,12 +1343,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:300 lxc/auth.go:1660
+#: lxc/auth.go:301 lxc/auth.go:1661
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1054
+#: lxc/auth.go:1055
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1397,15 +1397,15 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:248 lxc/file.go:474
+#: lxc/file.go:249 lxc/file.go:475
 msgid "Create any directories necessary"
 msgstr ""
 
-#: lxc/auth.go:97 lxc/auth.go:98
+#: lxc/auth.go:98 lxc/auth.go:99
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1471 lxc/auth.go:1472
+#: lxc/auth.go:1472 lxc/auth.go:1473
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1425,11 +1425,11 @@ msgstr ""
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_bucket.go:851 lxc/storage_bucket.go:852
+#: lxc/storage_bucket.go:852 lxc/storage_bucket.go:853
 msgid "Create key for a storage bucket"
 msgstr ""
 
-#: lxc/storage_bucket.go:82 lxc/storage_bucket.go:83
+#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
 msgid "Create new custom storage buckets"
 msgstr ""
 
@@ -1473,7 +1473,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:92 lxc/project.go:93
+#: lxc/project.go:93 lxc/project.go:94
 msgid "Create projects"
 msgstr ""
 
@@ -1508,13 +1508,13 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:376 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1135 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
-#: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:172
-#: lxc/profile.go:756 lxc/project.go:572 lxc/storage.go:723
-#: lxc/storage_bucket.go:512 lxc/storage_bucket.go:832
+#: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
+#: lxc/profile.go:756 lxc/project.go:573 lxc/storage.go:723
+#: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1732
 msgid "DESCRIPTION"
 msgstr ""
@@ -1539,7 +1539,7 @@ msgstr ""
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
-#: lxc/operation.go:55 lxc/operation.go:56
+#: lxc/operation.go:56 lxc/operation.go:57
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
@@ -1547,19 +1547,19 @@ msgstr ""
 msgid "Delete a cluster group"
 msgstr ""
 
-#: lxc/warning.go:360
+#: lxc/warning.go:361
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:122 lxc/file.go:123
+#: lxc/file.go:123 lxc/file.go:124
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/auth.go:151 lxc/auth.go:152
+#: lxc/auth.go:152 lxc/auth.go:153
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1523 lxc/auth.go:1524
+#: lxc/auth.go:1524 lxc/auth.go:1525
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1579,7 +1579,7 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/storage_bucket.go:957 lxc/storage_bucket.go:958
+#: lxc/storage_bucket.go:958 lxc/storage_bucket.go:959
 msgid "Delete key from a storage bucket"
 msgstr ""
 
@@ -1615,11 +1615,11 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:188 lxc/project.go:189
+#: lxc/project.go:189 lxc/project.go:190
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:187 lxc/storage_bucket.go:188
+#: lxc/storage_bucket.go:188 lxc/storage_bucket.go:189
 msgid "Delete storage buckets"
 msgstr ""
 
@@ -1631,20 +1631,20 @@ msgstr ""
 msgid "Delete storage volumes"
 msgstr ""
 
-#: lxc/warning.go:356 lxc/warning.go:357
+#: lxc/warning.go:357 lxc/warning.go:358
 msgid "Delete warning"
 msgstr ""
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:30 lxc/auth.go:59 lxc/auth.go:98
-#: lxc/auth.go:152 lxc/auth.go:201 lxc/auth.go:332 lxc/auth.go:392
-#: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
-#: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
-#: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
-#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1434 lxc/auth.go:1472
-#: lxc/auth.go:1524 lxc/auth.go:1573 lxc/auth.go:1692 lxc/auth.go:1752
-#: lxc/auth.go:1801 lxc/auth.go:1852 lxc/auth.go:1875 lxc/auth.go:1928
+#: lxc/alias.go:214 lxc/auth.go:31 lxc/auth.go:60 lxc/auth.go:99
+#: lxc/auth.go:153 lxc/auth.go:202 lxc/auth.go:333 lxc/auth.go:393
+#: lxc/auth.go:442 lxc/auth.go:494 lxc/auth.go:517 lxc/auth.go:576
+#: lxc/auth.go:732 lxc/auth.go:766 lxc/auth.go:833 lxc/auth.go:896
+#: lxc/auth.go:957 lxc/auth.go:1085 lxc/auth.go:1108 lxc/auth.go:1166
+#: lxc/auth.go:1235 lxc/auth.go:1257 lxc/auth.go:1435 lxc/auth.go:1473
+#: lxc/auth.go:1525 lxc/auth.go:1574 lxc/auth.go:1693 lxc/auth.go:1753
+#: lxc/auth.go:1802 lxc/auth.go:1853 lxc/auth.go:1876 lxc/auth.go:1929
 #: lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215 lxc/cluster.go:272
 #: lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:484 lxc/cluster.go:528
 #: lxc/cluster.go:586 lxc/cluster.go:677 lxc/cluster.go:770 lxc/cluster.go:893
@@ -1668,15 +1668,15 @@ msgstr ""
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:83 lxc/file.go:123 lxc/file.go:172
-#: lxc/file.go:242 lxc/file.go:467 lxc/file.go:986 lxc/image.go:38
+#: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
+#: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
 #: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
 #: lxc/image.go:697 lxc/image.go:946 lxc/image.go:1088 lxc/image.go:1415
 #: lxc/image.go:1506 lxc/image.go:1572 lxc/image.go:1636 lxc/image.go:1699
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:38 lxc/network.go:33
+#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33
 #: lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405
 #: lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793
 #: lxc/network.go:874 lxc/network.go:1005 lxc/network.go:1106
@@ -1710,27 +1710,27 @@ msgstr ""
 #: lxc/network_zone.go:909 lxc/network_zone.go:985 lxc/network_zone.go:1083
 #: lxc/network_zone.go:1172 lxc/network_zone.go:1219 lxc/network_zone.go:1349
 #: lxc/network_zone.go:1410 lxc/network_zone.go:1425 lxc/network_zone.go:1483
-#: lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:106
-#: lxc/operation.go:193 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
+#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
+#: lxc/operation.go:194 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
 #: lxc/profile.go:271 lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493
 #: lxc/profile.go:629 lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860
-#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:29
-#: lxc/project.go:93 lxc/project.go:189 lxc/project.go:260 lxc/project.go:396
-#: lxc/project.go:470 lxc/project.go:590 lxc/project.go:655 lxc/project.go:743
-#: lxc/project.go:787 lxc/project.go:848 lxc/project.go:915 lxc/publish.go:34
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:35 lxc/remote.go:91
+#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:30
+#: lxc/project.go:94 lxc/project.go:190 lxc/project.go:261 lxc/project.go:397
+#: lxc/project.go:471 lxc/project.go:591 lxc/project.go:656 lxc/project.go:744
+#: lxc/project.go:788 lxc/project.go:849 lxc/project.go:916 lxc/publish.go:34
+#: lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91
 #: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853
 #: lxc/remote.go:917 lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24
 #: lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203
 #: lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655
 #: lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940
-#: lxc/storage_bucket.go:29 lxc/storage_bucket.go:83 lxc/storage_bucket.go:188
-#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:382
-#: lxc/storage_bucket.go:458 lxc/storage_bucket.go:535
-#: lxc/storage_bucket.go:629 lxc/storage_bucket.go:698
-#: lxc/storage_bucket.go:732 lxc/storage_bucket.go:773
-#: lxc/storage_bucket.go:852 lxc/storage_bucket.go:958
-#: lxc/storage_bucket.go:1022 lxc/storage_bucket.go:1157
+#: lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189
+#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:383
+#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:536
+#: lxc/storage_bucket.go:630 lxc/storage_bucket.go:699
+#: lxc/storage_bucket.go:733 lxc/storage_bucket.go:774
+#: lxc/storage_bucket.go:853 lxc/storage_bucket.go:959
+#: lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158
 #: lxc/storage_volume.go:58 lxc/storage_volume.go:169 lxc/storage_volume.go:283
 #: lxc/storage_volume.go:390 lxc/storage_volume.go:605
 #: lxc/storage_volume.go:714 lxc/storage_volume.go:801
@@ -1741,8 +1741,8 @@ msgstr ""
 #: lxc/storage_volume.go:2064 lxc/storage_volume.go:2222
 #: lxc/storage_volume.go:2343 lxc/storage_volume.go:2405
 #: lxc/storage_volume.go:2541 lxc/storage_volume.go:2624
-#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:29
-#: lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
+#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:30
+#: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
@@ -1829,7 +1829,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:994
+#: lxc/file.go:995
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1895,7 +1895,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:74
+#: lxc/file.go:75
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1905,7 +1905,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:955 lxc/auth.go:956
+#: lxc/auth.go:956 lxc/auth.go:957
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1913,15 +1913,15 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:171 lxc/file.go:172
+#: lxc/file.go:172 lxc/file.go:173
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/auth.go:200 lxc/auth.go:201
+#: lxc/auth.go:201 lxc/auth.go:202
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1572 lxc/auth.go:1573
+#: lxc/auth.go:1573 lxc/auth.go:1574
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -1977,15 +1977,15 @@ msgstr ""
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:259 lxc/project.go:260
+#: lxc/project.go:260 lxc/project.go:261
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:248 lxc/storage_bucket.go:249
+#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:250
 msgid "Edit storage bucket configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:1021 lxc/storage_bucket.go:1022
+#: lxc/storage_bucket.go:1022 lxc/storage_bucket.go:1023
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
@@ -2002,7 +2002,7 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1147 lxc/list.go:622 lxc/storage_volume.go:1766
-#: lxc/warning.go:235
+#: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2057,7 +2057,7 @@ msgstr ""
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
-#: lxc/project.go:718 lxc/storage.go:812 lxc/storage_bucket.go:602
+#: lxc/project.go:719 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2155 lxc/storage_volume.go:2193
 #, c-format
 msgid "Error setting properties: %v"
@@ -2071,8 +2071,8 @@ msgstr ""
 #: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
-#: lxc/profile.go:981 lxc/project.go:712 lxc/storage.go:806
-#: lxc/storage_bucket.go:596 lxc/storage_volume.go:2149
+#: lxc/profile.go:981 lxc/project.go:713 lxc/storage.go:806
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2149
 #: lxc/storage_volume.go:2187
 #, c-format
 msgid "Error unsetting property: %v"
@@ -2092,7 +2092,7 @@ msgstr ""
 msgid "Evacuating cluster member: %s"
 msgstr ""
 
-#: lxc/monitor.go:50
+#: lxc/monitor.go:51
 msgid "Event type to listen for"
 msgstr ""
 
@@ -2179,16 +2179,16 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/warning.go:210
+#: lxc/warning.go:211
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1237
+#: lxc/file.go:1238
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1260
+#: lxc/file.go:1261
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2203,12 +2203,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1287
+#: lxc/file.go:1288
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1072
+#: lxc/file.go:1073
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2238,7 +2238,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1193
+#: lxc/file.go:1194
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2253,7 +2253,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1198
+#: lxc/file.go:1199
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2263,12 +2263,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1098
+#: lxc/file.go:1099
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1225
+#: lxc/file.go:1226
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2307,7 +2307,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1210
+#: lxc/file.go:1211
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2322,7 +2322,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:820
+#: lxc/file.go:821
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2337,7 +2337,7 @@ msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
 #: lxc/network.go:1044 lxc/network_acl.go:133 lxc/network_zone.go:124
-#: lxc/operation.go:136
+#: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
 
@@ -2402,21 +2402,21 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
+#: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:770 lxc/auth.go:1697
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1114 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:57
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
-#: lxc/operation.go:108 lxc/profile.go:707 lxc/project.go:472
-#: lxc/project.go:917 lxc/remote.go:690 lxc/storage.go:657
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:774
-#: lxc/storage_volume.go:1608 lxc/warning.go:93
+#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:473
+#: lxc/project.go:918 lxc/remote.go:690 lxc/storage.go:657
+#: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
+#: lxc/storage_volume.go:1608 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
-#: lxc/monitor.go:52
+#: lxc/monitor.go:53
 msgid "Format (json|pretty|yaml)"
 msgstr ""
 
@@ -2460,7 +2460,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:817 lxc/auth.go:1736
+#: lxc/auth.go:818 lxc/auth.go:1737
 msgid "GROUPS"
 msgstr ""
 
@@ -2476,7 +2476,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:914 lxc/project.go:915
+#: lxc/project.go:915 lxc/project.go:916
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2524,11 +2524,11 @@ msgstr ""
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:400
+#: lxc/project.go:401
 msgid "Get the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:385
+#: lxc/storage_bucket.go:386
 msgid "Get the key as a storage bucket property"
 msgstr ""
 
@@ -2588,11 +2588,11 @@ msgstr ""
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:395 lxc/project.go:396
+#: lxc/project.go:396 lxc/project.go:397
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:382
+#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:383
 msgid "Get values for storage bucket configuration keys"
 msgstr ""
 
@@ -2609,17 +2609,17 @@ msgstr ""
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: lxc/auth.go:136
+#: lxc/auth.go:137
 #, c-format
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:186
+#: lxc/auth.go:187
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:426 lxc/auth.go:1786
+#: lxc/auth.go:427 lxc/auth.go:1787
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2644,27 +2644,27 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1310
+#: lxc/file.go:1311
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1299
+#: lxc/file.go:1300
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1122
+#: lxc/file.go:1123
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1132
+#: lxc/file.go:1133
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:966 lxc/operation.go:170
+#: lxc/network.go:966 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2678,11 +2678,11 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:816
+#: lxc/auth.go:817
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:566
+#: lxc/project.go:567
 msgid "IMAGES"
 msgstr ""
 
@@ -2710,17 +2710,17 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1508
+#: lxc/auth.go:1509
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1558
+#: lxc/auth.go:1559
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
 
-#: lxc/rebuild.go:32
+#: lxc/rebuild.go:33
 msgid "If an instance is running, stop it and then rebuild it"
 msgstr ""
 
@@ -2841,7 +2841,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1233 lxc/auth.go:1234
+#: lxc/auth.go:1234 lxc/auth.go:1235
 msgid "Inspect permissions"
 msgstr ""
 
@@ -2849,11 +2849,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1124
+#: lxc/file.go:1125
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1301
+#: lxc/file.go:1302
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2871,7 +2871,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1044
+#: lxc/file.go:1045
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2880,7 +2880,7 @@ msgstr ""
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/rebuild.go:74
+#: lxc/rebuild.go:75
 #, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
@@ -2913,7 +2913,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/monitor.go:70
+#: lxc/monitor.go:71
 #, c-format
 msgid "Invalid format: %s"
 msgstr ""
@@ -2923,7 +2923,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1039
+#: lxc/file.go:1040
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2965,7 +2965,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:147
+#: lxc/file.go:148
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2981,12 +2981,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:313
+#: lxc/file.go:314
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:495
+#: lxc/file.go:496
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3000,7 +3000,7 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/warning.go:212
 msgid "LAST SEEN"
 msgstr ""
 
@@ -3008,7 +3008,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:984
+#: lxc/project.go:985
 msgid "LIMIT"
 msgstr ""
 
@@ -3017,8 +3017,8 @@ msgid "LISTEN ADDRESS"
 msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
-#: lxc/network_load_balancer.go:165 lxc/operation.go:177
-#: lxc/storage_bucket.go:516 lxc/storage_volume.go:1739 lxc/warning.go:220
+#: lxc/network_load_balancer.go:165 lxc/operation.go:178
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1739 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3092,7 +3092,7 @@ msgstr ""
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/warning.go:94
+#: lxc/warning.go:95
 msgid "List all warnings"
 msgstr ""
 
@@ -3136,19 +3136,19 @@ msgstr ""
 msgid "List available storage pools"
 msgstr ""
 
-#: lxc/operation.go:105 lxc/operation.go:106
+#: lxc/operation.go:106 lxc/operation.go:107
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:331 lxc/auth.go:332
+#: lxc/auth.go:332 lxc/auth.go:333
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:764 lxc/auth.go:765
+#: lxc/auth.go:765 lxc/auth.go:766
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1691 lxc/auth.go:1692
+#: lxc/auth.go:1692 lxc/auth.go:1693
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3297,11 +3297,11 @@ msgstr ""
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/operation.go:109
+#: lxc/operation.go:110
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1255 lxc/auth.go:1256
+#: lxc/auth.go:1256 lxc/auth.go:1257
 msgid "List permissions"
 msgstr ""
 
@@ -3309,15 +3309,15 @@ msgstr ""
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:469 lxc/project.go:470
+#: lxc/project.go:470 lxc/project.go:471
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:771 lxc/storage_bucket.go:773
+#: lxc/storage_bucket.go:772 lxc/storage_bucket.go:774
 msgid "List storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:456 lxc/storage_bucket.go:458
+#: lxc/storage_bucket.go:457 lxc/storage_bucket.go:459
 msgid "List storage buckets"
 msgstr ""
 
@@ -3353,11 +3353,11 @@ msgstr ""
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/warning.go:70
+#: lxc/warning.go:71
 msgid "List warnings"
 msgstr ""
 
-#: lxc/warning.go:71
+#: lxc/warning.go:72
 msgid ""
 "List warnings\n"
 "\n"
@@ -3380,7 +3380,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/operation.go:23 lxc/operation.go:24
+#: lxc/operation.go:24 lxc/operation.go:25
 msgid "List, show and delete background operations"
 msgstr ""
 
@@ -3389,7 +3389,7 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/monitor.go:79
+#: lxc/monitor.go:80
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
@@ -3493,23 +3493,23 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:82 lxc/file.go:83
+#: lxc/file.go:83 lxc/file.go:84
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1433 lxc/auth.go:1434
+#: lxc/auth.go:59 lxc/auth.go:60 lxc/auth.go:1434 lxc/auth.go:1435
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1083 lxc/auth.go:1084
+#: lxc/auth.go:1084 lxc/auth.go:1085
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:730 lxc/auth.go:731
+#: lxc/auth.go:731 lxc/auth.go:732
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1851 lxc/auth.go:1852
+#: lxc/auth.go:1852 lxc/auth.go:1853
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3600,7 +3600,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:492 lxc/auth.go:493
+#: lxc/auth.go:493 lxc/auth.go:494
 msgid "Manage permissions"
 msgstr ""
 
@@ -3608,23 +3608,23 @@ msgstr ""
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:28 lxc/project.go:29
+#: lxc/project.go:29 lxc/project.go:30
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:731
+#: lxc/storage_bucket.go:732
 msgid "Manage storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:732
+#: lxc/storage_bucket.go:733
 msgid "Manage storage bucket keys."
 msgstr ""
 
-#: lxc/storage_bucket.go:28
+#: lxc/storage_bucket.go:29
 msgid "Manage storage buckets"
 msgstr ""
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:30
 msgid "Manage storage buckets."
 msgstr ""
 
@@ -3652,11 +3652,11 @@ msgstr ""
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/auth.go:29 lxc/auth.go:30
+#: lxc/auth.go:30 lxc/auth.go:31
 msgid "Manage user authorization"
 msgstr ""
 
-#: lxc/warning.go:28 lxc/warning.go:29
+#: lxc/warning.go:29 lxc/warning.go:30
 msgid "Manage warnings"
 msgstr ""
 
@@ -3720,17 +3720,17 @@ msgstr ""
 msgid "Migration operation failure: %w"
 msgstr ""
 
-#: lxc/monitor.go:51
+#: lxc/monitor.go:52
 msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: lxc/storage_bucket.go:116 lxc/storage_bucket.go:216
-#: lxc/storage_bucket.go:292 lxc/storage_bucket.go:411
-#: lxc/storage_bucket.go:568 lxc/storage_bucket.go:660
-#: lxc/storage_bucket.go:802 lxc/storage_bucket.go:889
-#: lxc/storage_bucket.go:986 lxc/storage_bucket.go:1065
-#: lxc/storage_bucket.go:1188
+#: lxc/storage_bucket.go:117 lxc/storage_bucket.go:217
+#: lxc/storage_bucket.go:293 lxc/storage_bucket.go:412
+#: lxc/storage_bucket.go:569 lxc/storage_bucket.go:661
+#: lxc/storage_bucket.go:803 lxc/storage_bucket.go:890
+#: lxc/storage_bucket.go:987 lxc/storage_bucket.go:1066
+#: lxc/storage_bucket.go:1189
 msgid "Missing bucket name"
 msgstr ""
 
@@ -3749,20 +3749,20 @@ msgstr ""
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1825
+#: lxc/auth.go:123 lxc/auth.go:177 lxc/auth.go:255 lxc/auth.go:417
+#: lxc/auth.go:466 lxc/auth.go:541 lxc/auth.go:600 lxc/auth.go:1826
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:862 lxc/auth.go:1003 lxc/auth.go:1131 lxc/auth.go:1189
+#: lxc/auth.go:863 lxc/auth.go:1004 lxc/auth.go:1132 lxc/auth.go:1190
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1495 lxc/auth.go:1548 lxc/auth.go:1614 lxc/auth.go:1776
+#: lxc/auth.go:1496 lxc/auth.go:1549 lxc/auth.go:1615 lxc/auth.go:1777
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1899 lxc/auth.go:1952
+#: lxc/auth.go:1900 lxc/auth.go:1953
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -3770,12 +3770,12 @@ msgstr ""
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
 #: lxc/config_template.go:377 lxc/profile.go:141 lxc/profile.go:222
-#: lxc/profile.go:808 lxc/rebuild.go:60
+#: lxc/profile.go:808 lxc/rebuild.go:61
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/storage_bucket.go:893 lxc/storage_bucket.go:990
-#: lxc/storage_bucket.go:1069 lxc/storage_bucket.go:1192
+#: lxc/storage_bucket.go:894 lxc/storage_bucket.go:991
+#: lxc/storage_bucket.go:1070 lxc/storage_bucket.go:1193
 msgid "Missing key name"
 msgstr ""
 
@@ -3840,13 +3840,13 @@ msgid "Missing peer name"
 msgstr ""
 
 #: lxc/storage.go:235 lxc/storage.go:313 lxc/storage.go:431 lxc/storage.go:509
-#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:112
-#: lxc/storage_bucket.go:212 lxc/storage_bucket.go:288
-#: lxc/storage_bucket.go:407 lxc/storage_bucket.go:482
-#: lxc/storage_bucket.go:564 lxc/storage_bucket.go:656
-#: lxc/storage_bucket.go:798 lxc/storage_bucket.go:885
-#: lxc/storage_bucket.go:982 lxc/storage_bucket.go:1061
-#: lxc/storage_bucket.go:1184 lxc/storage_volume.go:209
+#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:113
+#: lxc/storage_bucket.go:213 lxc/storage_bucket.go:289
+#: lxc/storage_bucket.go:408 lxc/storage_bucket.go:483
+#: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
+#: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
+#: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
 #: lxc/storage_volume.go:323 lxc/storage_volume.go:643
 #: lxc/storage_volume.go:750 lxc/storage_volume.go:841
 #: lxc/storage_volume.go:939 lxc/storage_volume.go:1053
@@ -3861,9 +3861,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:404 lxc/project.go:146 lxc/project.go:226 lxc/project.go:316
-#: lxc/project.go:433 lxc/project.go:622 lxc/project.go:691 lxc/project.go:819
-#: lxc/project.go:948
+#: lxc/profile.go:404 lxc/project.go:147 lxc/project.go:227 lxc/project.go:317
+#: lxc/project.go:434 lxc/project.go:623 lxc/project.go:692 lxc/project.go:820
+#: lxc/project.go:949
 msgid "Missing project name"
 msgstr ""
 
@@ -3879,7 +3879,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:598
+#: lxc/file.go:599
 msgid "Missing target directory"
 msgstr ""
 
@@ -3901,11 +3901,11 @@ msgstr ""
 msgid "Model: %v"
 msgstr ""
 
-#: lxc/monitor.go:32
+#: lxc/monitor.go:33
 msgid "Monitor a local or remote LXD server"
 msgstr ""
 
-#: lxc/monitor.go:33
+#: lxc/monitor.go:34
 msgid ""
 "Monitor a local or remote LXD server\n"
 "\n"
@@ -3917,11 +3917,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:285
+#: lxc/file.go:286
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:985 lxc/file.go:986
+#: lxc/file.go:986 lxc/file.go:987
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3983,13 +3983,13 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:192
+#: lxc/auth.go:376 lxc/auth.go:816 lxc/auth.go:1736 lxc/cluster.go:192
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
-#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:565
-#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:511
-#: lxc/storage_bucket.go:831 lxc/storage_volume.go:1731
+#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:566
+#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1731
 msgid "NAME"
 msgstr ""
 
@@ -3997,11 +3997,11 @@ msgstr ""
 msgid "NAT"
 msgstr ""
 
-#: lxc/project.go:571
+#: lxc/project.go:572
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:570
+#: lxc/project.go:571
 msgid "NETWORKS"
 msgstr ""
 
@@ -4013,9 +4013,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/operation.go:154 lxc/project.go:523
-#: lxc/project.go:528 lxc/project.go:533 lxc/project.go:538 lxc/project.go:543
-#: lxc/project.go:548 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
+#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:524
+#: lxc/project.go:529 lxc/project.go:534 lxc/project.go:539 lxc/project.go:544
+#: lxc/project.go:549 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
 msgid "NO"
 msgstr ""
 
@@ -4260,7 +4260,7 @@ msgstr ""
 msgid "Only managed networks can be modified"
 msgstr ""
 
-#: lxc/operation.go:86
+#: lxc/operation.go:87
 #, c-format
 msgid "Operation %s deleted"
 msgstr ""
@@ -4307,11 +4307,11 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:567
+#: lxc/list.go:576 lxc/project.go:568
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:212
+#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4373,24 +4373,24 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1102
+#: lxc/file.go:1103
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:860
+#: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
-#: lxc/project.go:363 lxc/storage.go:360 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1151
+#: lxc/project.go:364 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1151
 #: lxc/storage_volume.go:1183
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
-#: lxc/monitor.go:48
+#: lxc/monitor.go:49
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
@@ -4476,17 +4476,17 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:172
+#: lxc/project.go:173
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:236
+#: lxc/project.go:237
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:637
+#: lxc/project.go:638
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -4607,20 +4607,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:241 lxc/file.go:242
+#: lxc/file.go:242 lxc/file.go:243
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:416 lxc/file.go:767
+#: lxc/file.go:417 lxc/file.go:768
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:466 lxc/file.go:467
+#: lxc/file.go:467 lxc/file.go:468
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:701 lxc/file.go:867
+#: lxc/file.go:702 lxc/file.go:868
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4633,11 +4633,11 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:983
+#: lxc/project.go:984
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/storage_bucket.go:833
+#: lxc/storage_bucket.go:834
 msgid "ROLE"
 msgstr ""
 
@@ -4650,15 +4650,15 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/rebuild.go:31
+#: lxc/rebuild.go:32
 msgid "Rebuild as an empty instance"
 msgstr ""
 
-#: lxc/rebuild.go:26
+#: lxc/rebuild.go:27
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:249 lxc/file.go:473
+#: lxc/file.go:250 lxc/file.go:474
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4685,7 +4685,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:882 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
+#: lxc/project.go:883 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
 #: lxc/remote.go:994
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4736,7 +4736,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1164 lxc/auth.go:1165
+#: lxc/auth.go:1165 lxc/auth.go:1166
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4772,7 +4772,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1927 lxc/auth.go:1928
+#: lxc/auth.go:1928 lxc/auth.go:1929
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4784,7 +4784,7 @@ msgstr ""
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:574 lxc/auth.go:575
+#: lxc/auth.go:575 lxc/auth.go:576
 msgid "Remove permissions from groups"
 msgstr ""
 
@@ -4829,11 +4829,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:391 lxc/auth.go:392
+#: lxc/auth.go:392 lxc/auth.go:393
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1751 lxc/auth.go:1752
+#: lxc/auth.go:1752 lxc/auth.go:1753
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -4853,7 +4853,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:589 lxc/project.go:590
+#: lxc/project.go:590 lxc/project.go:591
 msgid "Rename projects"
 msgstr ""
 
@@ -4951,7 +4951,7 @@ msgstr ""
 msgid "Revoke cluster member join token"
 msgstr ""
 
-#: lxc/storage_bucket.go:862
+#: lxc/storage_bucket.go:863
 msgid "Role (admin or read-only)"
 msgstr ""
 
@@ -4967,7 +4967,7 @@ msgstr ""
 msgid "Run against all projects"
 msgstr ""
 
-#: lxc/warning.go:213
+#: lxc/warning.go:214
 msgid "SEVERITY"
 msgstr ""
 
@@ -4987,12 +4987,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1231
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1231
+#: lxc/file.go:1232
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5006,11 +5006,11 @@ msgstr ""
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:173 lxc/warning.go:214
+#: lxc/operation.go:174 lxc/warning.go:215
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:569
+#: lxc/project.go:570
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5018,7 +5018,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:569
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -5026,11 +5026,11 @@ msgstr ""
 msgid "STP"
 msgstr ""
 
-#: lxc/storage_bucket.go:864
+#: lxc/storage_bucket.go:865
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:942
+#: lxc/storage_bucket.go:943
 #, c-format
 msgid "Secret key: %s"
 msgstr ""
@@ -5068,7 +5068,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:995
+#: lxc/file.go:996
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5206,11 +5206,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:654
+#: lxc/project.go:655
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:655
+#: lxc/project.go:656
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5219,11 +5219,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage_bucket.go:534
+#: lxc/storage_bucket.go:535
 msgid "Set storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:535
+#: lxc/storage_bucket.go:536
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -5262,15 +5262,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:476
+#: lxc/file.go:477
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:477
+#: lxc/file.go:478
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:475
+#: lxc/file.go:476
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5310,11 +5310,11 @@ msgstr ""
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 msgid "Set the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:542
+#: lxc/storage_bucket.go:543
 msgid "Set the key as a storage bucket property"
 msgstr ""
 
@@ -5330,7 +5330,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:993
+#: lxc/file.go:994
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5342,7 +5342,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1800 lxc/auth.go:1801
+#: lxc/auth.go:1801 lxc/auth.go:1802
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5358,11 +5358,11 @@ msgstr ""
 msgid "Show details of a cluster member"
 msgstr ""
 
-#: lxc/operation.go:192 lxc/operation.go:193
+#: lxc/operation.go:193 lxc/operation.go:194
 msgid "Show details on a background operation"
 msgstr ""
 
-#: lxc/monitor.go:49
+#: lxc/monitor.go:50
 msgid "Show events from all projects"
 msgstr ""
 
@@ -5370,11 +5370,11 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:440 lxc/auth.go:441
+#: lxc/auth.go:441 lxc/auth.go:442
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:832
+#: lxc/auth.go:833
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5455,15 +5455,15 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:786 lxc/project.go:787
+#: lxc/project.go:787 lxc/project.go:788
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage_bucket.go:628 lxc/storage_bucket.go:629
+#: lxc/storage_bucket.go:629 lxc/storage_bucket.go:630
 msgid "Show storage bucket configurations"
 msgstr ""
 
-#: lxc/storage_bucket.go:1156 lxc/storage_bucket.go:1157
+#: lxc/storage_bucket.go:1157 lxc/storage_bucket.go:1158
 msgid "Show storage bucket key configurations"
 msgstr ""
 
@@ -5479,7 +5479,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:895
+#: lxc/auth.go:896
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5529,7 +5529,7 @@ msgstr ""
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: lxc/warning.go:302 lxc/warning.go:303
+#: lxc/warning.go:303 lxc/warning.go:304
 msgid "Show warning"
 msgstr ""
 
@@ -5613,22 +5613,22 @@ msgstr ""
 msgid "Stopping the instance failed: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:166
+#: lxc/storage_bucket.go:167
 #, c-format
 msgid "Storage bucket %s created"
 msgstr ""
 
-#: lxc/storage_bucket.go:233
+#: lxc/storage_bucket.go:234
 #, c-format
 msgid "Storage bucket %s deleted"
 msgstr ""
 
-#: lxc/storage_bucket.go:940
+#: lxc/storage_bucket.go:941
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr ""
 
-#: lxc/storage_bucket.go:1006
+#: lxc/storage_bucket.go:1007
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr ""
@@ -5697,7 +5697,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:847 lxc/project.go:848
+#: lxc/project.go:848 lxc/project.go:849
 msgid "Switch the current project"
 msgstr ""
 
@@ -5713,10 +5713,10 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1139
+#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1139
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
-#: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:171
-#: lxc/storage_volume.go:1730 lxc/warning.go:215
+#: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
+#: lxc/storage_volume.go:1730 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
@@ -5724,11 +5724,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1032
+#: lxc/file.go:1033
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1026
+#: lxc/file.go:1027
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5856,12 +5856,12 @@ msgstr ""
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:446
+#: lxc/project.go:447
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
 
-#: lxc/storage_bucket.go:431
+#: lxc/storage_bucket.go:432
 #, c-format
 msgid "The property %q does not exist on the storage bucket %q: %v"
 msgstr ""
@@ -6046,7 +6046,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:961
+#: lxc/project.go:962
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6058,17 +6058,17 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:985 lxc/storage_volume.go:1735
+#: lxc/project.go:986 lxc/storage_volume.go:1735
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:573
+#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:574
 #: lxc/storage.go:724 lxc/storage_volume.go:1734
 msgid "USED BY"
 msgstr ""
 
-#: lxc/warning.go:216
+#: lxc/warning.go:217
 msgid "UUID"
 msgstr ""
 
@@ -6077,7 +6077,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:197
+#: lxc/file.go:198
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6091,13 +6091,13 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1253
+#: lxc/file.go:1254
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1153 lxc/list.go:631 lxc/storage_volume.go:1772
-#: lxc/warning.go:241
+#: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6107,7 +6107,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:807
+#: lxc/file.go:808
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6190,11 +6190,11 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:742 lxc/project.go:743
+#: lxc/project.go:743 lxc/project.go:744
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:697 lxc/storage_bucket.go:698
+#: lxc/storage_bucket.go:698 lxc/storage_bucket.go:699
 msgid "Unset storage bucket configuration keys"
 msgstr ""
 
@@ -6242,11 +6242,11 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:747
+#: lxc/project.go:748
 msgid "Unset the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:701
+#: lxc/storage_bucket.go:702
 msgid "Unset the key as a storage bucket property"
 msgstr ""
 
@@ -6325,7 +6325,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:71
+#: lxc/file.go:72
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6362,11 +6362,11 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:831
+#: lxc/auth.go:832
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:894
+#: lxc/auth.go:895
 msgid "View the current identity"
 msgstr ""
 
@@ -6397,15 +6397,15 @@ msgstr ""
 msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
-#: lxc/rebuild.go:27
+#: lxc/rebuild.go:28
 msgid ""
 "Wipe the instance root disk and re-initialize. The original image is used to "
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:156 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
+#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:526
+#: lxc/project.go:531 lxc/project.go:536 lxc/project.go:541 lxc/project.go:546
+#: lxc/project.go:551 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
 msgid "YES"
 msgstr ""
 
@@ -6425,7 +6425,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/rebuild.go:119
+#: lxc/rebuild.go:120
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
@@ -6437,12 +6437,12 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1689
+#: lxc/auth.go:330 lxc/auth.go:763 lxc/auth.go:894 lxc/auth.go:1690
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
-#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
+#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
-#: lxc/operation.go:103 lxc/profile.go:700 lxc/project.go:467
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:68
+#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:468
+#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6470,7 +6470,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1254
+#: lxc/auth.go:1255
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6531,11 +6531,11 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:830
+#: lxc/auth.go:831
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1926
+#: lxc/auth.go:1106 lxc/auth.go:1164 lxc/auth.go:1927
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6543,13 +6543,13 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:954 lxc/auth.go:1470 lxc/cluster_group.go:168
+#: lxc/auth.go:97 lxc/auth.go:150 lxc/auth.go:200 lxc/auth.go:440
+#: lxc/auth.go:955 lxc/auth.go:1471 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:514 lxc/auth.go:572
+#: lxc/auth.go:515 lxc/auth.go:573
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
@@ -6559,19 +6559,19 @@ msgstr ""
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:389
+#: lxc/auth.go:390
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1521 lxc/auth.go:1571 lxc/auth.go:1799
+#: lxc/auth.go:1522 lxc/auth.go:1572 lxc/auth.go:1800
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1873
+#: lxc/auth.go:1874
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1749
+#: lxc/auth.go:1750
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -6591,7 +6591,7 @@ msgstr ""
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
-#: lxc/rebuild.go:25
+#: lxc/rebuild.go:26
 msgid "[<remote>:]<image> [<remote>:]<instance>"
 msgstr ""
 
@@ -6674,20 +6674,20 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:170
+#: lxc/file.go:171
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:120
+#: lxc/file.go:121
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:240
+#: lxc/file.go:241
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:984
+#: lxc/file.go:985
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6838,12 +6838,12 @@ msgstr ""
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
-#: lxc/operation.go:53 lxc/operation.go:191
+#: lxc/operation.go:54 lxc/operation.go:192
 msgid "[<remote>:]<operation>"
 msgstr ""
 
 #: lxc/storage.go:200 lxc/storage.go:259 lxc/storage.go:473 lxc/storage.go:844
-#: lxc/storage_bucket.go:454
+#: lxc/storage_bucket.go:455
 msgid "[<remote>:]<pool>"
 msgstr ""
 
@@ -6851,22 +6851,22 @@ msgstr ""
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
-#: lxc/storage_bucket.go:185 lxc/storage_bucket.go:247
-#: lxc/storage_bucket.go:627 lxc/storage_bucket.go:769
+#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:248
+#: lxc/storage_bucket.go:628 lxc/storage_bucket.go:770
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
 
-#: lxc/storage_bucket.go:380 lxc/storage_bucket.go:696
-#: lxc/storage_bucket.go:850 lxc/storage_bucket.go:956
-#: lxc/storage_bucket.go:1020 lxc/storage_bucket.go:1155
+#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:697
+#: lxc/storage_bucket.go:851 lxc/storage_bucket.go:957
+#: lxc/storage_bucket.go:1021 lxc/storage_bucket.go:1156
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
 
-#: lxc/storage_bucket.go:533
+#: lxc/storage_bucket.go:534
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_bucket.go:81
+#: lxc/storage_bucket.go:82
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
 
@@ -6981,20 +6981,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:91 lxc/project.go:186 lxc/project.go:258 lxc/project.go:785
-#: lxc/project.go:846 lxc/project.go:913
+#: lxc/project.go:92 lxc/project.go:187 lxc/project.go:259 lxc/project.go:786
+#: lxc/project.go:847 lxc/project.go:914
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:394 lxc/project.go:741
+#: lxc/project.go:395 lxc/project.go:742
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:653
+#: lxc/project.go:654
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:587
+#: lxc/project.go:588
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7002,7 +7002,7 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:259 lxc/warning.go:301 lxc/warning.go:354
+#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
@@ -7058,7 +7058,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:555 lxc/remote.go:739
+#: lxc/project.go:556 lxc/remote.go:739
 msgid "current"
 msgstr ""
 
@@ -7105,20 +7105,20 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/auth.go:203
+#: lxc/auth.go:204
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:958
+#: lxc/auth.go:959
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1575
+#: lxc/auth.go:1576
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7196,20 +7196,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:988
+#: lxc/file.go:989
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:244
+#: lxc/file.go:245
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:470
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7291,7 +7291,7 @@ msgid ""
 "  List instances with their running state and user comment."
 msgstr ""
 
-#: lxc/monitor.go:37
+#: lxc/monitor.go:38
 msgid ""
 "lxc monitor --type=logging\n"
 "    Only show log messages.\n"
@@ -7367,7 +7367,7 @@ msgid ""
 "    Create record r1 for zone z1 with configuration from config.yaml"
 msgstr ""
 
-#: lxc/operation.go:195
+#: lxc/operation.go:196
 msgid ""
 "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Show details on that operation UUID"
@@ -7410,7 +7410,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:95
+#: lxc/project.go:96
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7418,7 +7418,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:262
+#: lxc/project.go:263
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7449,7 +7449,7 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:85
 msgid ""
 "lxc storage bucket create p1 b01\n"
 "\tCreate a new storage bucket name b01 in storage pool p1\n"
@@ -7459,19 +7459,19 @@ msgid ""
 "of config.yaml"
 msgstr ""
 
-#: lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:251
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1023
+#: lxc/storage_bucket.go:1024
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:854
 msgid ""
 "lxc storage bucket key create p1 b01 k1\n"
 "\tCreate a key called k1 for the bucket b01 in the pool p1.\n"
@@ -7481,14 +7481,14 @@ msgid ""
 "of config.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1158
+#: lxc/storage_bucket.go:1159
 msgid ""
 "lxc storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_bucket.go:630
+#: lxc/storage_bucket.go:631
 msgid ""
 "lxc storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
@@ -7558,16 +7558,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1142
+#: lxc/file.go:1143
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1101
+#: lxc/file.go:1102
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1054
+#: lxc/file.go:1055
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/tzm.po
+++ b/po/tzm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-04 08:52-0600\n"
+"POT-Creation-Date: 2024-09-05 08:44-0400\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Tamazight (Central Atlas) <https://hosted.weblate.org/"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n >= 2 && (n < 11 || n > 99);\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: lxc/storage_bucket.go:260 lxc/storage_bucket.go:1033
+#: lxc/storage_bucket.go:261 lxc/storage_bucket.go:1034
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -133,7 +133,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:213
+#: lxc/auth.go:214
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -160,7 +160,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:968
+#: lxc/auth.go:969
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -181,7 +181,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1585
+#: lxc/auth.go:1586
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -391,7 +391,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:280
+#: lxc/project.go:281
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -433,12 +433,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:935
+#: lxc/file.go:936
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:825
+#: lxc/file.go:826
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -474,7 +474,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:142 lxc/rebuild.go:64
+#: lxc/init.go:142 lxc/rebuild.go:65
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -527,7 +527,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:465
+#: lxc/file.go:466
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -560,7 +560,7 @@ msgstr ""
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:813
+#: lxc/auth.go:814
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -568,11 +568,11 @@ msgstr ""
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/storage_bucket.go:863
+#: lxc/storage_bucket.go:864
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:941
+#: lxc/storage_bucket.go:942
 #, c-format
 msgid "Access key: %s"
 msgstr ""
@@ -581,7 +581,7 @@ msgstr ""
 msgid "Access the expanded configuration"
 msgstr ""
 
-#: lxc/warning.go:261 lxc/warning.go:262
+#: lxc/warning.go:262 lxc/warning.go:263
 msgid "Acknowledge warning"
 msgstr ""
 
@@ -598,11 +598,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1106 lxc/auth.go:1107
+#: lxc/auth.go:1107 lxc/auth.go:1108
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1874 lxc/auth.go:1875
+#: lxc/auth.go:1875 lxc/auth.go:1876
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -671,7 +671,7 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:515 lxc/auth.go:516
+#: lxc/auth.go:516 lxc/auth.go:517
 msgid "Add permissions to groups"
 msgstr ""
 
@@ -700,7 +700,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:169
+#: lxc/storage_bucket.go:170
 #, c-format
 msgid "Admin access key: %s"
 msgstr ""
@@ -710,7 +710,7 @@ msgstr ""
 msgid "Admin password (or token) for %s:"
 msgstr ""
 
-#: lxc/storage_bucket.go:170
+#: lxc/storage_bucket.go:171
 #, c-format
 msgid "Admin secret key: %s"
 msgstr ""
@@ -769,7 +769,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:342 lxc/rebuild.go:130
+#: lxc/init.go:342 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -869,12 +869,12 @@ msgstr ""
 
 #: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:318
 #: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
-#: lxc/network_zone.go:366 lxc/network_zone.go:1053 lxc/storage_bucket.go:141
+#: lxc/network_zone.go:366 lxc/network_zone.go:1053 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:159
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:160
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -914,7 +914,7 @@ msgstr ""
 msgid "Bytes sent"
 msgstr ""
 
-#: lxc/operation.go:174
+#: lxc/operation.go:175
 msgid "CANCELABLE"
 msgstr ""
 
@@ -926,7 +926,7 @@ msgstr ""
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: lxc/warning.go:209
+#: lxc/warning.go:210
 msgid "COUNT"
 msgstr ""
 
@@ -952,7 +952,7 @@ msgstr ""
 msgid "CPUs (%s):"
 msgstr ""
 
-#: lxc/operation.go:175
+#: lxc/operation.go:176
 msgid "CREATED"
 msgstr ""
 
@@ -982,7 +982,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:340
+#: lxc/file.go:341
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1007,11 +1007,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:224
+#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:546
+#: lxc/file.go:547
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1020,7 +1020,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:160
+#: lxc/rebuild.go:161
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1143,13 +1143,13 @@ msgstr ""
 #: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
 #: lxc/network_load_balancer.go:1051 lxc/network_load_balancer.go:1125
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
-#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:90
-#: lxc/storage_bucket.go:190 lxc/storage_bucket.go:253
-#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:541
-#: lxc/storage_bucket.go:634 lxc/storage_bucket.go:700
-#: lxc/storage_bucket.go:775 lxc/storage_bucket.go:861
-#: lxc/storage_bucket.go:961 lxc/storage_bucket.go:1026
-#: lxc/storage_bucket.go:1162 lxc/storage_volume.go:394
+#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
+#: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
+#: lxc/storage_bucket.go:385 lxc/storage_bucket.go:542
+#: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
+#: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
+#: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
 #: lxc/storage_volume.go:612 lxc/storage_volume.go:717
 #: lxc/storage_volume.go:1005 lxc/storage_volume.go:1231
 #: lxc/storage_volume.go:1360 lxc/storage_volume.go:1848
@@ -1173,7 +1173,7 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1113 lxc/list.go:132 lxc/storage_volume.go:1589
-#: lxc/warning.go:92
+#: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
@@ -1201,7 +1201,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:100
+#: lxc/project.go:101
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1215,8 +1215,8 @@ msgstr ""
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
-#: lxc/project.go:362 lxc/storage.go:359 lxc/storage_bucket.go:348
-#: lxc/storage_bucket.go:1125 lxc/storage_volume.go:1150
+#: lxc/project.go:363 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1150
 #: lxc/storage_volume.go:1182
 #, c-format
 msgid "Config parsing error: %s"
@@ -1343,12 +1343,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:300 lxc/auth.go:1660
+#: lxc/auth.go:301 lxc/auth.go:1661
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1054
+#: lxc/auth.go:1055
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1397,15 +1397,15 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:248 lxc/file.go:474
+#: lxc/file.go:249 lxc/file.go:475
 msgid "Create any directories necessary"
 msgstr ""
 
-#: lxc/auth.go:97 lxc/auth.go:98
+#: lxc/auth.go:98 lxc/auth.go:99
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1471 lxc/auth.go:1472
+#: lxc/auth.go:1472 lxc/auth.go:1473
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1425,11 +1425,11 @@ msgstr ""
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_bucket.go:851 lxc/storage_bucket.go:852
+#: lxc/storage_bucket.go:852 lxc/storage_bucket.go:853
 msgid "Create key for a storage bucket"
 msgstr ""
 
-#: lxc/storage_bucket.go:82 lxc/storage_bucket.go:83
+#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
 msgid "Create new custom storage buckets"
 msgstr ""
 
@@ -1473,7 +1473,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:92 lxc/project.go:93
+#: lxc/project.go:93 lxc/project.go:94
 msgid "Create projects"
 msgstr ""
 
@@ -1508,13 +1508,13 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:376 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1135 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
-#: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:172
-#: lxc/profile.go:756 lxc/project.go:572 lxc/storage.go:723
-#: lxc/storage_bucket.go:512 lxc/storage_bucket.go:832
+#: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
+#: lxc/profile.go:756 lxc/project.go:573 lxc/storage.go:723
+#: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1732
 msgid "DESCRIPTION"
 msgstr ""
@@ -1539,7 +1539,7 @@ msgstr ""
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
-#: lxc/operation.go:55 lxc/operation.go:56
+#: lxc/operation.go:56 lxc/operation.go:57
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
@@ -1547,19 +1547,19 @@ msgstr ""
 msgid "Delete a cluster group"
 msgstr ""
 
-#: lxc/warning.go:360
+#: lxc/warning.go:361
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:122 lxc/file.go:123
+#: lxc/file.go:123 lxc/file.go:124
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/auth.go:151 lxc/auth.go:152
+#: lxc/auth.go:152 lxc/auth.go:153
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1523 lxc/auth.go:1524
+#: lxc/auth.go:1524 lxc/auth.go:1525
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1579,7 +1579,7 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/storage_bucket.go:957 lxc/storage_bucket.go:958
+#: lxc/storage_bucket.go:958 lxc/storage_bucket.go:959
 msgid "Delete key from a storage bucket"
 msgstr ""
 
@@ -1615,11 +1615,11 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:188 lxc/project.go:189
+#: lxc/project.go:189 lxc/project.go:190
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:187 lxc/storage_bucket.go:188
+#: lxc/storage_bucket.go:188 lxc/storage_bucket.go:189
 msgid "Delete storage buckets"
 msgstr ""
 
@@ -1631,20 +1631,20 @@ msgstr ""
 msgid "Delete storage volumes"
 msgstr ""
 
-#: lxc/warning.go:356 lxc/warning.go:357
+#: lxc/warning.go:357 lxc/warning.go:358
 msgid "Delete warning"
 msgstr ""
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:30 lxc/auth.go:59 lxc/auth.go:98
-#: lxc/auth.go:152 lxc/auth.go:201 lxc/auth.go:332 lxc/auth.go:392
-#: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
-#: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
-#: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
-#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1434 lxc/auth.go:1472
-#: lxc/auth.go:1524 lxc/auth.go:1573 lxc/auth.go:1692 lxc/auth.go:1752
-#: lxc/auth.go:1801 lxc/auth.go:1852 lxc/auth.go:1875 lxc/auth.go:1928
+#: lxc/alias.go:214 lxc/auth.go:31 lxc/auth.go:60 lxc/auth.go:99
+#: lxc/auth.go:153 lxc/auth.go:202 lxc/auth.go:333 lxc/auth.go:393
+#: lxc/auth.go:442 lxc/auth.go:494 lxc/auth.go:517 lxc/auth.go:576
+#: lxc/auth.go:732 lxc/auth.go:766 lxc/auth.go:833 lxc/auth.go:896
+#: lxc/auth.go:957 lxc/auth.go:1085 lxc/auth.go:1108 lxc/auth.go:1166
+#: lxc/auth.go:1235 lxc/auth.go:1257 lxc/auth.go:1435 lxc/auth.go:1473
+#: lxc/auth.go:1525 lxc/auth.go:1574 lxc/auth.go:1693 lxc/auth.go:1753
+#: lxc/auth.go:1802 lxc/auth.go:1853 lxc/auth.go:1876 lxc/auth.go:1929
 #: lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215 lxc/cluster.go:272
 #: lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:484 lxc/cluster.go:528
 #: lxc/cluster.go:586 lxc/cluster.go:677 lxc/cluster.go:770 lxc/cluster.go:893
@@ -1668,15 +1668,15 @@ msgstr ""
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:83 lxc/file.go:123 lxc/file.go:172
-#: lxc/file.go:242 lxc/file.go:467 lxc/file.go:986 lxc/image.go:38
+#: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
+#: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
 #: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
 #: lxc/image.go:697 lxc/image.go:946 lxc/image.go:1088 lxc/image.go:1415
 #: lxc/image.go:1506 lxc/image.go:1572 lxc/image.go:1636 lxc/image.go:1699
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:38 lxc/network.go:33
+#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33
 #: lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405
 #: lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793
 #: lxc/network.go:874 lxc/network.go:1005 lxc/network.go:1106
@@ -1710,27 +1710,27 @@ msgstr ""
 #: lxc/network_zone.go:909 lxc/network_zone.go:985 lxc/network_zone.go:1083
 #: lxc/network_zone.go:1172 lxc/network_zone.go:1219 lxc/network_zone.go:1349
 #: lxc/network_zone.go:1410 lxc/network_zone.go:1425 lxc/network_zone.go:1483
-#: lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:106
-#: lxc/operation.go:193 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
+#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
+#: lxc/operation.go:194 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
 #: lxc/profile.go:271 lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493
 #: lxc/profile.go:629 lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860
-#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:29
-#: lxc/project.go:93 lxc/project.go:189 lxc/project.go:260 lxc/project.go:396
-#: lxc/project.go:470 lxc/project.go:590 lxc/project.go:655 lxc/project.go:743
-#: lxc/project.go:787 lxc/project.go:848 lxc/project.go:915 lxc/publish.go:34
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:35 lxc/remote.go:91
+#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:30
+#: lxc/project.go:94 lxc/project.go:190 lxc/project.go:261 lxc/project.go:397
+#: lxc/project.go:471 lxc/project.go:591 lxc/project.go:656 lxc/project.go:744
+#: lxc/project.go:788 lxc/project.go:849 lxc/project.go:916 lxc/publish.go:34
+#: lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91
 #: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853
 #: lxc/remote.go:917 lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24
 #: lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203
 #: lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655
 #: lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940
-#: lxc/storage_bucket.go:29 lxc/storage_bucket.go:83 lxc/storage_bucket.go:188
-#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:382
-#: lxc/storage_bucket.go:458 lxc/storage_bucket.go:535
-#: lxc/storage_bucket.go:629 lxc/storage_bucket.go:698
-#: lxc/storage_bucket.go:732 lxc/storage_bucket.go:773
-#: lxc/storage_bucket.go:852 lxc/storage_bucket.go:958
-#: lxc/storage_bucket.go:1022 lxc/storage_bucket.go:1157
+#: lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189
+#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:383
+#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:536
+#: lxc/storage_bucket.go:630 lxc/storage_bucket.go:699
+#: lxc/storage_bucket.go:733 lxc/storage_bucket.go:774
+#: lxc/storage_bucket.go:853 lxc/storage_bucket.go:959
+#: lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158
 #: lxc/storage_volume.go:58 lxc/storage_volume.go:169 lxc/storage_volume.go:283
 #: lxc/storage_volume.go:390 lxc/storage_volume.go:605
 #: lxc/storage_volume.go:714 lxc/storage_volume.go:801
@@ -1741,8 +1741,8 @@ msgstr ""
 #: lxc/storage_volume.go:2064 lxc/storage_volume.go:2222
 #: lxc/storage_volume.go:2343 lxc/storage_volume.go:2405
 #: lxc/storage_volume.go:2541 lxc/storage_volume.go:2624
-#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:29
-#: lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
+#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:30
+#: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
@@ -1829,7 +1829,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:994
+#: lxc/file.go:995
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1895,7 +1895,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:74
+#: lxc/file.go:75
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1905,7 +1905,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:955 lxc/auth.go:956
+#: lxc/auth.go:956 lxc/auth.go:957
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1913,15 +1913,15 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:171 lxc/file.go:172
+#: lxc/file.go:172 lxc/file.go:173
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/auth.go:200 lxc/auth.go:201
+#: lxc/auth.go:201 lxc/auth.go:202
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1572 lxc/auth.go:1573
+#: lxc/auth.go:1573 lxc/auth.go:1574
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -1977,15 +1977,15 @@ msgstr ""
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:259 lxc/project.go:260
+#: lxc/project.go:260 lxc/project.go:261
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:248 lxc/storage_bucket.go:249
+#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:250
 msgid "Edit storage bucket configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:1021 lxc/storage_bucket.go:1022
+#: lxc/storage_bucket.go:1022 lxc/storage_bucket.go:1023
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
@@ -2002,7 +2002,7 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1147 lxc/list.go:622 lxc/storage_volume.go:1766
-#: lxc/warning.go:235
+#: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2057,7 +2057,7 @@ msgstr ""
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
-#: lxc/project.go:718 lxc/storage.go:812 lxc/storage_bucket.go:602
+#: lxc/project.go:719 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2155 lxc/storage_volume.go:2193
 #, c-format
 msgid "Error setting properties: %v"
@@ -2071,8 +2071,8 @@ msgstr ""
 #: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
-#: lxc/profile.go:981 lxc/project.go:712 lxc/storage.go:806
-#: lxc/storage_bucket.go:596 lxc/storage_volume.go:2149
+#: lxc/profile.go:981 lxc/project.go:713 lxc/storage.go:806
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2149
 #: lxc/storage_volume.go:2187
 #, c-format
 msgid "Error unsetting property: %v"
@@ -2092,7 +2092,7 @@ msgstr ""
 msgid "Evacuating cluster member: %s"
 msgstr ""
 
-#: lxc/monitor.go:50
+#: lxc/monitor.go:51
 msgid "Event type to listen for"
 msgstr ""
 
@@ -2179,16 +2179,16 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/warning.go:210
+#: lxc/warning.go:211
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1237
+#: lxc/file.go:1238
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1260
+#: lxc/file.go:1261
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2203,12 +2203,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1287
+#: lxc/file.go:1288
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1072
+#: lxc/file.go:1073
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2238,7 +2238,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1193
+#: lxc/file.go:1194
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2253,7 +2253,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1198
+#: lxc/file.go:1199
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2263,12 +2263,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1098
+#: lxc/file.go:1099
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1225
+#: lxc/file.go:1226
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2307,7 +2307,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1210
+#: lxc/file.go:1211
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2322,7 +2322,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:820
+#: lxc/file.go:821
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2337,7 +2337,7 @@ msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
 #: lxc/network.go:1044 lxc/network_acl.go:133 lxc/network_zone.go:124
-#: lxc/operation.go:136
+#: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
 
@@ -2402,21 +2402,21 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
+#: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:770 lxc/auth.go:1697
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1114 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:57
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
-#: lxc/operation.go:108 lxc/profile.go:707 lxc/project.go:472
-#: lxc/project.go:917 lxc/remote.go:690 lxc/storage.go:657
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:774
-#: lxc/storage_volume.go:1608 lxc/warning.go:93
+#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:473
+#: lxc/project.go:918 lxc/remote.go:690 lxc/storage.go:657
+#: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
+#: lxc/storage_volume.go:1608 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
-#: lxc/monitor.go:52
+#: lxc/monitor.go:53
 msgid "Format (json|pretty|yaml)"
 msgstr ""
 
@@ -2460,7 +2460,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:817 lxc/auth.go:1736
+#: lxc/auth.go:818 lxc/auth.go:1737
 msgid "GROUPS"
 msgstr ""
 
@@ -2476,7 +2476,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:914 lxc/project.go:915
+#: lxc/project.go:915 lxc/project.go:916
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2524,11 +2524,11 @@ msgstr ""
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:400
+#: lxc/project.go:401
 msgid "Get the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:385
+#: lxc/storage_bucket.go:386
 msgid "Get the key as a storage bucket property"
 msgstr ""
 
@@ -2588,11 +2588,11 @@ msgstr ""
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:395 lxc/project.go:396
+#: lxc/project.go:396 lxc/project.go:397
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:382
+#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:383
 msgid "Get values for storage bucket configuration keys"
 msgstr ""
 
@@ -2609,17 +2609,17 @@ msgstr ""
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: lxc/auth.go:136
+#: lxc/auth.go:137
 #, c-format
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:186
+#: lxc/auth.go:187
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:426 lxc/auth.go:1786
+#: lxc/auth.go:427 lxc/auth.go:1787
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2644,27 +2644,27 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1310
+#: lxc/file.go:1311
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1299
+#: lxc/file.go:1300
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1122
+#: lxc/file.go:1123
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1132
+#: lxc/file.go:1133
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:966 lxc/operation.go:170
+#: lxc/network.go:966 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2678,11 +2678,11 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:816
+#: lxc/auth.go:817
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:566
+#: lxc/project.go:567
 msgid "IMAGES"
 msgstr ""
 
@@ -2710,17 +2710,17 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1508
+#: lxc/auth.go:1509
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1558
+#: lxc/auth.go:1559
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
 
-#: lxc/rebuild.go:32
+#: lxc/rebuild.go:33
 msgid "If an instance is running, stop it and then rebuild it"
 msgstr ""
 
@@ -2841,7 +2841,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1233 lxc/auth.go:1234
+#: lxc/auth.go:1234 lxc/auth.go:1235
 msgid "Inspect permissions"
 msgstr ""
 
@@ -2849,11 +2849,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1124
+#: lxc/file.go:1125
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1301
+#: lxc/file.go:1302
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2871,7 +2871,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1044
+#: lxc/file.go:1045
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2880,7 +2880,7 @@ msgstr ""
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/rebuild.go:74
+#: lxc/rebuild.go:75
 #, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
@@ -2913,7 +2913,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/monitor.go:70
+#: lxc/monitor.go:71
 #, c-format
 msgid "Invalid format: %s"
 msgstr ""
@@ -2923,7 +2923,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1039
+#: lxc/file.go:1040
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2965,7 +2965,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:147
+#: lxc/file.go:148
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2981,12 +2981,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:313
+#: lxc/file.go:314
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:495
+#: lxc/file.go:496
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3000,7 +3000,7 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/warning.go:212
 msgid "LAST SEEN"
 msgstr ""
 
@@ -3008,7 +3008,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:984
+#: lxc/project.go:985
 msgid "LIMIT"
 msgstr ""
 
@@ -3017,8 +3017,8 @@ msgid "LISTEN ADDRESS"
 msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
-#: lxc/network_load_balancer.go:165 lxc/operation.go:177
-#: lxc/storage_bucket.go:516 lxc/storage_volume.go:1739 lxc/warning.go:220
+#: lxc/network_load_balancer.go:165 lxc/operation.go:178
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1739 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3092,7 +3092,7 @@ msgstr ""
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/warning.go:94
+#: lxc/warning.go:95
 msgid "List all warnings"
 msgstr ""
 
@@ -3136,19 +3136,19 @@ msgstr ""
 msgid "List available storage pools"
 msgstr ""
 
-#: lxc/operation.go:105 lxc/operation.go:106
+#: lxc/operation.go:106 lxc/operation.go:107
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:331 lxc/auth.go:332
+#: lxc/auth.go:332 lxc/auth.go:333
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:764 lxc/auth.go:765
+#: lxc/auth.go:765 lxc/auth.go:766
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1691 lxc/auth.go:1692
+#: lxc/auth.go:1692 lxc/auth.go:1693
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3297,11 +3297,11 @@ msgstr ""
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/operation.go:109
+#: lxc/operation.go:110
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1255 lxc/auth.go:1256
+#: lxc/auth.go:1256 lxc/auth.go:1257
 msgid "List permissions"
 msgstr ""
 
@@ -3309,15 +3309,15 @@ msgstr ""
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:469 lxc/project.go:470
+#: lxc/project.go:470 lxc/project.go:471
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:771 lxc/storage_bucket.go:773
+#: lxc/storage_bucket.go:772 lxc/storage_bucket.go:774
 msgid "List storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:456 lxc/storage_bucket.go:458
+#: lxc/storage_bucket.go:457 lxc/storage_bucket.go:459
 msgid "List storage buckets"
 msgstr ""
 
@@ -3353,11 +3353,11 @@ msgstr ""
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/warning.go:70
+#: lxc/warning.go:71
 msgid "List warnings"
 msgstr ""
 
-#: lxc/warning.go:71
+#: lxc/warning.go:72
 msgid ""
 "List warnings\n"
 "\n"
@@ -3380,7 +3380,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/operation.go:23 lxc/operation.go:24
+#: lxc/operation.go:24 lxc/operation.go:25
 msgid "List, show and delete background operations"
 msgstr ""
 
@@ -3389,7 +3389,7 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/monitor.go:79
+#: lxc/monitor.go:80
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
@@ -3493,23 +3493,23 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:82 lxc/file.go:83
+#: lxc/file.go:83 lxc/file.go:84
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1433 lxc/auth.go:1434
+#: lxc/auth.go:59 lxc/auth.go:60 lxc/auth.go:1434 lxc/auth.go:1435
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1083 lxc/auth.go:1084
+#: lxc/auth.go:1084 lxc/auth.go:1085
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:730 lxc/auth.go:731
+#: lxc/auth.go:731 lxc/auth.go:732
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1851 lxc/auth.go:1852
+#: lxc/auth.go:1852 lxc/auth.go:1853
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3600,7 +3600,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:492 lxc/auth.go:493
+#: lxc/auth.go:493 lxc/auth.go:494
 msgid "Manage permissions"
 msgstr ""
 
@@ -3608,23 +3608,23 @@ msgstr ""
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:28 lxc/project.go:29
+#: lxc/project.go:29 lxc/project.go:30
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:731
+#: lxc/storage_bucket.go:732
 msgid "Manage storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:732
+#: lxc/storage_bucket.go:733
 msgid "Manage storage bucket keys."
 msgstr ""
 
-#: lxc/storage_bucket.go:28
+#: lxc/storage_bucket.go:29
 msgid "Manage storage buckets"
 msgstr ""
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:30
 msgid "Manage storage buckets."
 msgstr ""
 
@@ -3652,11 +3652,11 @@ msgstr ""
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/auth.go:29 lxc/auth.go:30
+#: lxc/auth.go:30 lxc/auth.go:31
 msgid "Manage user authorization"
 msgstr ""
 
-#: lxc/warning.go:28 lxc/warning.go:29
+#: lxc/warning.go:29 lxc/warning.go:30
 msgid "Manage warnings"
 msgstr ""
 
@@ -3720,17 +3720,17 @@ msgstr ""
 msgid "Migration operation failure: %w"
 msgstr ""
 
-#: lxc/monitor.go:51
+#: lxc/monitor.go:52
 msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: lxc/storage_bucket.go:116 lxc/storage_bucket.go:216
-#: lxc/storage_bucket.go:292 lxc/storage_bucket.go:411
-#: lxc/storage_bucket.go:568 lxc/storage_bucket.go:660
-#: lxc/storage_bucket.go:802 lxc/storage_bucket.go:889
-#: lxc/storage_bucket.go:986 lxc/storage_bucket.go:1065
-#: lxc/storage_bucket.go:1188
+#: lxc/storage_bucket.go:117 lxc/storage_bucket.go:217
+#: lxc/storage_bucket.go:293 lxc/storage_bucket.go:412
+#: lxc/storage_bucket.go:569 lxc/storage_bucket.go:661
+#: lxc/storage_bucket.go:803 lxc/storage_bucket.go:890
+#: lxc/storage_bucket.go:987 lxc/storage_bucket.go:1066
+#: lxc/storage_bucket.go:1189
 msgid "Missing bucket name"
 msgstr ""
 
@@ -3749,20 +3749,20 @@ msgstr ""
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1825
+#: lxc/auth.go:123 lxc/auth.go:177 lxc/auth.go:255 lxc/auth.go:417
+#: lxc/auth.go:466 lxc/auth.go:541 lxc/auth.go:600 lxc/auth.go:1826
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:862 lxc/auth.go:1003 lxc/auth.go:1131 lxc/auth.go:1189
+#: lxc/auth.go:863 lxc/auth.go:1004 lxc/auth.go:1132 lxc/auth.go:1190
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1495 lxc/auth.go:1548 lxc/auth.go:1614 lxc/auth.go:1776
+#: lxc/auth.go:1496 lxc/auth.go:1549 lxc/auth.go:1615 lxc/auth.go:1777
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1899 lxc/auth.go:1952
+#: lxc/auth.go:1900 lxc/auth.go:1953
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -3770,12 +3770,12 @@ msgstr ""
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
 #: lxc/config_template.go:377 lxc/profile.go:141 lxc/profile.go:222
-#: lxc/profile.go:808 lxc/rebuild.go:60
+#: lxc/profile.go:808 lxc/rebuild.go:61
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/storage_bucket.go:893 lxc/storage_bucket.go:990
-#: lxc/storage_bucket.go:1069 lxc/storage_bucket.go:1192
+#: lxc/storage_bucket.go:894 lxc/storage_bucket.go:991
+#: lxc/storage_bucket.go:1070 lxc/storage_bucket.go:1193
 msgid "Missing key name"
 msgstr ""
 
@@ -3840,13 +3840,13 @@ msgid "Missing peer name"
 msgstr ""
 
 #: lxc/storage.go:235 lxc/storage.go:313 lxc/storage.go:431 lxc/storage.go:509
-#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:112
-#: lxc/storage_bucket.go:212 lxc/storage_bucket.go:288
-#: lxc/storage_bucket.go:407 lxc/storage_bucket.go:482
-#: lxc/storage_bucket.go:564 lxc/storage_bucket.go:656
-#: lxc/storage_bucket.go:798 lxc/storage_bucket.go:885
-#: lxc/storage_bucket.go:982 lxc/storage_bucket.go:1061
-#: lxc/storage_bucket.go:1184 lxc/storage_volume.go:209
+#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:113
+#: lxc/storage_bucket.go:213 lxc/storage_bucket.go:289
+#: lxc/storage_bucket.go:408 lxc/storage_bucket.go:483
+#: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
+#: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
+#: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
 #: lxc/storage_volume.go:323 lxc/storage_volume.go:643
 #: lxc/storage_volume.go:750 lxc/storage_volume.go:841
 #: lxc/storage_volume.go:939 lxc/storage_volume.go:1053
@@ -3861,9 +3861,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:404 lxc/project.go:146 lxc/project.go:226 lxc/project.go:316
-#: lxc/project.go:433 lxc/project.go:622 lxc/project.go:691 lxc/project.go:819
-#: lxc/project.go:948
+#: lxc/profile.go:404 lxc/project.go:147 lxc/project.go:227 lxc/project.go:317
+#: lxc/project.go:434 lxc/project.go:623 lxc/project.go:692 lxc/project.go:820
+#: lxc/project.go:949
 msgid "Missing project name"
 msgstr ""
 
@@ -3879,7 +3879,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:598
+#: lxc/file.go:599
 msgid "Missing target directory"
 msgstr ""
 
@@ -3901,11 +3901,11 @@ msgstr ""
 msgid "Model: %v"
 msgstr ""
 
-#: lxc/monitor.go:32
+#: lxc/monitor.go:33
 msgid "Monitor a local or remote LXD server"
 msgstr ""
 
-#: lxc/monitor.go:33
+#: lxc/monitor.go:34
 msgid ""
 "Monitor a local or remote LXD server\n"
 "\n"
@@ -3917,11 +3917,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:285
+#: lxc/file.go:286
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:985 lxc/file.go:986
+#: lxc/file.go:986 lxc/file.go:987
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3983,13 +3983,13 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:192
+#: lxc/auth.go:376 lxc/auth.go:816 lxc/auth.go:1736 lxc/cluster.go:192
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
-#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:565
-#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:511
-#: lxc/storage_bucket.go:831 lxc/storage_volume.go:1731
+#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:566
+#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1731
 msgid "NAME"
 msgstr ""
 
@@ -3997,11 +3997,11 @@ msgstr ""
 msgid "NAT"
 msgstr ""
 
-#: lxc/project.go:571
+#: lxc/project.go:572
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:570
+#: lxc/project.go:571
 msgid "NETWORKS"
 msgstr ""
 
@@ -4013,9 +4013,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/operation.go:154 lxc/project.go:523
-#: lxc/project.go:528 lxc/project.go:533 lxc/project.go:538 lxc/project.go:543
-#: lxc/project.go:548 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
+#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:524
+#: lxc/project.go:529 lxc/project.go:534 lxc/project.go:539 lxc/project.go:544
+#: lxc/project.go:549 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
 msgid "NO"
 msgstr ""
 
@@ -4260,7 +4260,7 @@ msgstr ""
 msgid "Only managed networks can be modified"
 msgstr ""
 
-#: lxc/operation.go:86
+#: lxc/operation.go:87
 #, c-format
 msgid "Operation %s deleted"
 msgstr ""
@@ -4307,11 +4307,11 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:567
+#: lxc/list.go:576 lxc/project.go:568
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:212
+#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4373,24 +4373,24 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1102
+#: lxc/file.go:1103
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:860
+#: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
-#: lxc/project.go:363 lxc/storage.go:360 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1151
+#: lxc/project.go:364 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1151
 #: lxc/storage_volume.go:1183
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
-#: lxc/monitor.go:48
+#: lxc/monitor.go:49
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
@@ -4476,17 +4476,17 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:172
+#: lxc/project.go:173
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:236
+#: lxc/project.go:237
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:637
+#: lxc/project.go:638
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -4607,20 +4607,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:241 lxc/file.go:242
+#: lxc/file.go:242 lxc/file.go:243
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:416 lxc/file.go:767
+#: lxc/file.go:417 lxc/file.go:768
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:466 lxc/file.go:467
+#: lxc/file.go:467 lxc/file.go:468
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:701 lxc/file.go:867
+#: lxc/file.go:702 lxc/file.go:868
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4633,11 +4633,11 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:983
+#: lxc/project.go:984
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/storage_bucket.go:833
+#: lxc/storage_bucket.go:834
 msgid "ROLE"
 msgstr ""
 
@@ -4650,15 +4650,15 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/rebuild.go:31
+#: lxc/rebuild.go:32
 msgid "Rebuild as an empty instance"
 msgstr ""
 
-#: lxc/rebuild.go:26
+#: lxc/rebuild.go:27
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:249 lxc/file.go:473
+#: lxc/file.go:250 lxc/file.go:474
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4685,7 +4685,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:882 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
+#: lxc/project.go:883 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
 #: lxc/remote.go:994
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4736,7 +4736,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1164 lxc/auth.go:1165
+#: lxc/auth.go:1165 lxc/auth.go:1166
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4772,7 +4772,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1927 lxc/auth.go:1928
+#: lxc/auth.go:1928 lxc/auth.go:1929
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4784,7 +4784,7 @@ msgstr ""
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:574 lxc/auth.go:575
+#: lxc/auth.go:575 lxc/auth.go:576
 msgid "Remove permissions from groups"
 msgstr ""
 
@@ -4829,11 +4829,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:391 lxc/auth.go:392
+#: lxc/auth.go:392 lxc/auth.go:393
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1751 lxc/auth.go:1752
+#: lxc/auth.go:1752 lxc/auth.go:1753
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -4853,7 +4853,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:589 lxc/project.go:590
+#: lxc/project.go:590 lxc/project.go:591
 msgid "Rename projects"
 msgstr ""
 
@@ -4951,7 +4951,7 @@ msgstr ""
 msgid "Revoke cluster member join token"
 msgstr ""
 
-#: lxc/storage_bucket.go:862
+#: lxc/storage_bucket.go:863
 msgid "Role (admin or read-only)"
 msgstr ""
 
@@ -4967,7 +4967,7 @@ msgstr ""
 msgid "Run against all projects"
 msgstr ""
 
-#: lxc/warning.go:213
+#: lxc/warning.go:214
 msgid "SEVERITY"
 msgstr ""
 
@@ -4987,12 +4987,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1231
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1231
+#: lxc/file.go:1232
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5006,11 +5006,11 @@ msgstr ""
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:173 lxc/warning.go:214
+#: lxc/operation.go:174 lxc/warning.go:215
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:569
+#: lxc/project.go:570
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5018,7 +5018,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:569
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -5026,11 +5026,11 @@ msgstr ""
 msgid "STP"
 msgstr ""
 
-#: lxc/storage_bucket.go:864
+#: lxc/storage_bucket.go:865
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:942
+#: lxc/storage_bucket.go:943
 #, c-format
 msgid "Secret key: %s"
 msgstr ""
@@ -5068,7 +5068,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:995
+#: lxc/file.go:996
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5206,11 +5206,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:654
+#: lxc/project.go:655
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:655
+#: lxc/project.go:656
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5219,11 +5219,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage_bucket.go:534
+#: lxc/storage_bucket.go:535
 msgid "Set storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:535
+#: lxc/storage_bucket.go:536
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -5262,15 +5262,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:476
+#: lxc/file.go:477
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:477
+#: lxc/file.go:478
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:475
+#: lxc/file.go:476
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5310,11 +5310,11 @@ msgstr ""
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 msgid "Set the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:542
+#: lxc/storage_bucket.go:543
 msgid "Set the key as a storage bucket property"
 msgstr ""
 
@@ -5330,7 +5330,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:993
+#: lxc/file.go:994
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5342,7 +5342,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1800 lxc/auth.go:1801
+#: lxc/auth.go:1801 lxc/auth.go:1802
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5358,11 +5358,11 @@ msgstr ""
 msgid "Show details of a cluster member"
 msgstr ""
 
-#: lxc/operation.go:192 lxc/operation.go:193
+#: lxc/operation.go:193 lxc/operation.go:194
 msgid "Show details on a background operation"
 msgstr ""
 
-#: lxc/monitor.go:49
+#: lxc/monitor.go:50
 msgid "Show events from all projects"
 msgstr ""
 
@@ -5370,11 +5370,11 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:440 lxc/auth.go:441
+#: lxc/auth.go:441 lxc/auth.go:442
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:832
+#: lxc/auth.go:833
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5455,15 +5455,15 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:786 lxc/project.go:787
+#: lxc/project.go:787 lxc/project.go:788
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage_bucket.go:628 lxc/storage_bucket.go:629
+#: lxc/storage_bucket.go:629 lxc/storage_bucket.go:630
 msgid "Show storage bucket configurations"
 msgstr ""
 
-#: lxc/storage_bucket.go:1156 lxc/storage_bucket.go:1157
+#: lxc/storage_bucket.go:1157 lxc/storage_bucket.go:1158
 msgid "Show storage bucket key configurations"
 msgstr ""
 
@@ -5479,7 +5479,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:895
+#: lxc/auth.go:896
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5529,7 +5529,7 @@ msgstr ""
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: lxc/warning.go:302 lxc/warning.go:303
+#: lxc/warning.go:303 lxc/warning.go:304
 msgid "Show warning"
 msgstr ""
 
@@ -5613,22 +5613,22 @@ msgstr ""
 msgid "Stopping the instance failed: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:166
+#: lxc/storage_bucket.go:167
 #, c-format
 msgid "Storage bucket %s created"
 msgstr ""
 
-#: lxc/storage_bucket.go:233
+#: lxc/storage_bucket.go:234
 #, c-format
 msgid "Storage bucket %s deleted"
 msgstr ""
 
-#: lxc/storage_bucket.go:940
+#: lxc/storage_bucket.go:941
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr ""
 
-#: lxc/storage_bucket.go:1006
+#: lxc/storage_bucket.go:1007
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr ""
@@ -5697,7 +5697,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:847 lxc/project.go:848
+#: lxc/project.go:848 lxc/project.go:849
 msgid "Switch the current project"
 msgstr ""
 
@@ -5713,10 +5713,10 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1139
+#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1139
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
-#: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:171
-#: lxc/storage_volume.go:1730 lxc/warning.go:215
+#: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
+#: lxc/storage_volume.go:1730 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
@@ -5724,11 +5724,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1032
+#: lxc/file.go:1033
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1026
+#: lxc/file.go:1027
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5856,12 +5856,12 @@ msgstr ""
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:446
+#: lxc/project.go:447
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
 
-#: lxc/storage_bucket.go:431
+#: lxc/storage_bucket.go:432
 #, c-format
 msgid "The property %q does not exist on the storage bucket %q: %v"
 msgstr ""
@@ -6046,7 +6046,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:961
+#: lxc/project.go:962
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6058,17 +6058,17 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:985 lxc/storage_volume.go:1735
+#: lxc/project.go:986 lxc/storage_volume.go:1735
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:573
+#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:574
 #: lxc/storage.go:724 lxc/storage_volume.go:1734
 msgid "USED BY"
 msgstr ""
 
-#: lxc/warning.go:216
+#: lxc/warning.go:217
 msgid "UUID"
 msgstr ""
 
@@ -6077,7 +6077,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:197
+#: lxc/file.go:198
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6091,13 +6091,13 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1253
+#: lxc/file.go:1254
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1153 lxc/list.go:631 lxc/storage_volume.go:1772
-#: lxc/warning.go:241
+#: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6107,7 +6107,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:807
+#: lxc/file.go:808
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6190,11 +6190,11 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:742 lxc/project.go:743
+#: lxc/project.go:743 lxc/project.go:744
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:697 lxc/storage_bucket.go:698
+#: lxc/storage_bucket.go:698 lxc/storage_bucket.go:699
 msgid "Unset storage bucket configuration keys"
 msgstr ""
 
@@ -6242,11 +6242,11 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:747
+#: lxc/project.go:748
 msgid "Unset the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:701
+#: lxc/storage_bucket.go:702
 msgid "Unset the key as a storage bucket property"
 msgstr ""
 
@@ -6325,7 +6325,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:71
+#: lxc/file.go:72
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6362,11 +6362,11 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:831
+#: lxc/auth.go:832
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:894
+#: lxc/auth.go:895
 msgid "View the current identity"
 msgstr ""
 
@@ -6397,15 +6397,15 @@ msgstr ""
 msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
-#: lxc/rebuild.go:27
+#: lxc/rebuild.go:28
 msgid ""
 "Wipe the instance root disk and re-initialize. The original image is used to "
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:156 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
+#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:526
+#: lxc/project.go:531 lxc/project.go:536 lxc/project.go:541 lxc/project.go:546
+#: lxc/project.go:551 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
 msgid "YES"
 msgstr ""
 
@@ -6425,7 +6425,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/rebuild.go:119
+#: lxc/rebuild.go:120
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
@@ -6437,12 +6437,12 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1689
+#: lxc/auth.go:330 lxc/auth.go:763 lxc/auth.go:894 lxc/auth.go:1690
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
-#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
+#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
-#: lxc/operation.go:103 lxc/profile.go:700 lxc/project.go:467
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:68
+#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:468
+#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6470,7 +6470,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1254
+#: lxc/auth.go:1255
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6531,11 +6531,11 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:830
+#: lxc/auth.go:831
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1926
+#: lxc/auth.go:1106 lxc/auth.go:1164 lxc/auth.go:1927
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6543,13 +6543,13 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:954 lxc/auth.go:1470 lxc/cluster_group.go:168
+#: lxc/auth.go:97 lxc/auth.go:150 lxc/auth.go:200 lxc/auth.go:440
+#: lxc/auth.go:955 lxc/auth.go:1471 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:514 lxc/auth.go:572
+#: lxc/auth.go:515 lxc/auth.go:573
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
@@ -6559,19 +6559,19 @@ msgstr ""
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:389
+#: lxc/auth.go:390
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1521 lxc/auth.go:1571 lxc/auth.go:1799
+#: lxc/auth.go:1522 lxc/auth.go:1572 lxc/auth.go:1800
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1873
+#: lxc/auth.go:1874
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1749
+#: lxc/auth.go:1750
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -6591,7 +6591,7 @@ msgstr ""
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
-#: lxc/rebuild.go:25
+#: lxc/rebuild.go:26
 msgid "[<remote>:]<image> [<remote>:]<instance>"
 msgstr ""
 
@@ -6674,20 +6674,20 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:170
+#: lxc/file.go:171
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:120
+#: lxc/file.go:121
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:240
+#: lxc/file.go:241
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:984
+#: lxc/file.go:985
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6838,12 +6838,12 @@ msgstr ""
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
-#: lxc/operation.go:53 lxc/operation.go:191
+#: lxc/operation.go:54 lxc/operation.go:192
 msgid "[<remote>:]<operation>"
 msgstr ""
 
 #: lxc/storage.go:200 lxc/storage.go:259 lxc/storage.go:473 lxc/storage.go:844
-#: lxc/storage_bucket.go:454
+#: lxc/storage_bucket.go:455
 msgid "[<remote>:]<pool>"
 msgstr ""
 
@@ -6851,22 +6851,22 @@ msgstr ""
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
-#: lxc/storage_bucket.go:185 lxc/storage_bucket.go:247
-#: lxc/storage_bucket.go:627 lxc/storage_bucket.go:769
+#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:248
+#: lxc/storage_bucket.go:628 lxc/storage_bucket.go:770
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
 
-#: lxc/storage_bucket.go:380 lxc/storage_bucket.go:696
-#: lxc/storage_bucket.go:850 lxc/storage_bucket.go:956
-#: lxc/storage_bucket.go:1020 lxc/storage_bucket.go:1155
+#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:697
+#: lxc/storage_bucket.go:851 lxc/storage_bucket.go:957
+#: lxc/storage_bucket.go:1021 lxc/storage_bucket.go:1156
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
 
-#: lxc/storage_bucket.go:533
+#: lxc/storage_bucket.go:534
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_bucket.go:81
+#: lxc/storage_bucket.go:82
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
 
@@ -6981,20 +6981,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:91 lxc/project.go:186 lxc/project.go:258 lxc/project.go:785
-#: lxc/project.go:846 lxc/project.go:913
+#: lxc/project.go:92 lxc/project.go:187 lxc/project.go:259 lxc/project.go:786
+#: lxc/project.go:847 lxc/project.go:914
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:394 lxc/project.go:741
+#: lxc/project.go:395 lxc/project.go:742
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:653
+#: lxc/project.go:654
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:587
+#: lxc/project.go:588
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7002,7 +7002,7 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:259 lxc/warning.go:301 lxc/warning.go:354
+#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
@@ -7058,7 +7058,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:555 lxc/remote.go:739
+#: lxc/project.go:556 lxc/remote.go:739
 msgid "current"
 msgstr ""
 
@@ -7105,20 +7105,20 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/auth.go:203
+#: lxc/auth.go:204
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:958
+#: lxc/auth.go:959
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1575
+#: lxc/auth.go:1576
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7196,20 +7196,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:988
+#: lxc/file.go:989
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:244
+#: lxc/file.go:245
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:470
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7291,7 +7291,7 @@ msgid ""
 "  List instances with their running state and user comment."
 msgstr ""
 
-#: lxc/monitor.go:37
+#: lxc/monitor.go:38
 msgid ""
 "lxc monitor --type=logging\n"
 "    Only show log messages.\n"
@@ -7367,7 +7367,7 @@ msgid ""
 "    Create record r1 for zone z1 with configuration from config.yaml"
 msgstr ""
 
-#: lxc/operation.go:195
+#: lxc/operation.go:196
 msgid ""
 "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Show details on that operation UUID"
@@ -7410,7 +7410,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:95
+#: lxc/project.go:96
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7418,7 +7418,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:262
+#: lxc/project.go:263
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7449,7 +7449,7 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:85
 msgid ""
 "lxc storage bucket create p1 b01\n"
 "\tCreate a new storage bucket name b01 in storage pool p1\n"
@@ -7459,19 +7459,19 @@ msgid ""
 "of config.yaml"
 msgstr ""
 
-#: lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:251
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1023
+#: lxc/storage_bucket.go:1024
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:854
 msgid ""
 "lxc storage bucket key create p1 b01 k1\n"
 "\tCreate a key called k1 for the bucket b01 in the pool p1.\n"
@@ -7481,14 +7481,14 @@ msgid ""
 "of config.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1158
+#: lxc/storage_bucket.go:1159
 msgid ""
 "lxc storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_bucket.go:630
+#: lxc/storage_bucket.go:631
 msgid ""
 "lxc storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
@@ -7558,16 +7558,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1142
+#: lxc/file.go:1143
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1101
+#: lxc/file.go:1102
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1054
+#: lxc/file.go:1055
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/ug.po
+++ b/po/ug.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-04 08:52-0600\n"
+"POT-Creation-Date: 2024-09-05 08:44-0400\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Uyghur <https://hosted.weblate.org/projects/linux-containers/"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: lxc/storage_bucket.go:260 lxc/storage_bucket.go:1033
+#: lxc/storage_bucket.go:261 lxc/storage_bucket.go:1034
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -133,7 +133,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:213
+#: lxc/auth.go:214
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -160,7 +160,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:968
+#: lxc/auth.go:969
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -181,7 +181,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1585
+#: lxc/auth.go:1586
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -391,7 +391,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:280
+#: lxc/project.go:281
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -433,12 +433,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:935
+#: lxc/file.go:936
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:825
+#: lxc/file.go:826
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -474,7 +474,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:142 lxc/rebuild.go:64
+#: lxc/init.go:142 lxc/rebuild.go:65
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -527,7 +527,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:465
+#: lxc/file.go:466
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -560,7 +560,7 @@ msgstr ""
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:813
+#: lxc/auth.go:814
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -568,11 +568,11 @@ msgstr ""
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/storage_bucket.go:863
+#: lxc/storage_bucket.go:864
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:941
+#: lxc/storage_bucket.go:942
 #, c-format
 msgid "Access key: %s"
 msgstr ""
@@ -581,7 +581,7 @@ msgstr ""
 msgid "Access the expanded configuration"
 msgstr ""
 
-#: lxc/warning.go:261 lxc/warning.go:262
+#: lxc/warning.go:262 lxc/warning.go:263
 msgid "Acknowledge warning"
 msgstr ""
 
@@ -598,11 +598,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1106 lxc/auth.go:1107
+#: lxc/auth.go:1107 lxc/auth.go:1108
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1874 lxc/auth.go:1875
+#: lxc/auth.go:1875 lxc/auth.go:1876
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -671,7 +671,7 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:515 lxc/auth.go:516
+#: lxc/auth.go:516 lxc/auth.go:517
 msgid "Add permissions to groups"
 msgstr ""
 
@@ -700,7 +700,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:169
+#: lxc/storage_bucket.go:170
 #, c-format
 msgid "Admin access key: %s"
 msgstr ""
@@ -710,7 +710,7 @@ msgstr ""
 msgid "Admin password (or token) for %s:"
 msgstr ""
 
-#: lxc/storage_bucket.go:170
+#: lxc/storage_bucket.go:171
 #, c-format
 msgid "Admin secret key: %s"
 msgstr ""
@@ -769,7 +769,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:342 lxc/rebuild.go:130
+#: lxc/init.go:342 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -869,12 +869,12 @@ msgstr ""
 
 #: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:318
 #: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
-#: lxc/network_zone.go:366 lxc/network_zone.go:1053 lxc/storage_bucket.go:141
+#: lxc/network_zone.go:366 lxc/network_zone.go:1053 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:159
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:160
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -914,7 +914,7 @@ msgstr ""
 msgid "Bytes sent"
 msgstr ""
 
-#: lxc/operation.go:174
+#: lxc/operation.go:175
 msgid "CANCELABLE"
 msgstr ""
 
@@ -926,7 +926,7 @@ msgstr ""
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: lxc/warning.go:209
+#: lxc/warning.go:210
 msgid "COUNT"
 msgstr ""
 
@@ -952,7 +952,7 @@ msgstr ""
 msgid "CPUs (%s):"
 msgstr ""
 
-#: lxc/operation.go:175
+#: lxc/operation.go:176
 msgid "CREATED"
 msgstr ""
 
@@ -982,7 +982,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:340
+#: lxc/file.go:341
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1007,11 +1007,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:224
+#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:546
+#: lxc/file.go:547
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1020,7 +1020,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:160
+#: lxc/rebuild.go:161
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1143,13 +1143,13 @@ msgstr ""
 #: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
 #: lxc/network_load_balancer.go:1051 lxc/network_load_balancer.go:1125
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
-#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:90
-#: lxc/storage_bucket.go:190 lxc/storage_bucket.go:253
-#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:541
-#: lxc/storage_bucket.go:634 lxc/storage_bucket.go:700
-#: lxc/storage_bucket.go:775 lxc/storage_bucket.go:861
-#: lxc/storage_bucket.go:961 lxc/storage_bucket.go:1026
-#: lxc/storage_bucket.go:1162 lxc/storage_volume.go:394
+#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
+#: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
+#: lxc/storage_bucket.go:385 lxc/storage_bucket.go:542
+#: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
+#: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
+#: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
 #: lxc/storage_volume.go:612 lxc/storage_volume.go:717
 #: lxc/storage_volume.go:1005 lxc/storage_volume.go:1231
 #: lxc/storage_volume.go:1360 lxc/storage_volume.go:1848
@@ -1173,7 +1173,7 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1113 lxc/list.go:132 lxc/storage_volume.go:1589
-#: lxc/warning.go:92
+#: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
@@ -1201,7 +1201,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:100
+#: lxc/project.go:101
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1215,8 +1215,8 @@ msgstr ""
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
-#: lxc/project.go:362 lxc/storage.go:359 lxc/storage_bucket.go:348
-#: lxc/storage_bucket.go:1125 lxc/storage_volume.go:1150
+#: lxc/project.go:363 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1150
 #: lxc/storage_volume.go:1182
 #, c-format
 msgid "Config parsing error: %s"
@@ -1343,12 +1343,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:300 lxc/auth.go:1660
+#: lxc/auth.go:301 lxc/auth.go:1661
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1054
+#: lxc/auth.go:1055
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1397,15 +1397,15 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:248 lxc/file.go:474
+#: lxc/file.go:249 lxc/file.go:475
 msgid "Create any directories necessary"
 msgstr ""
 
-#: lxc/auth.go:97 lxc/auth.go:98
+#: lxc/auth.go:98 lxc/auth.go:99
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1471 lxc/auth.go:1472
+#: lxc/auth.go:1472 lxc/auth.go:1473
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1425,11 +1425,11 @@ msgstr ""
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_bucket.go:851 lxc/storage_bucket.go:852
+#: lxc/storage_bucket.go:852 lxc/storage_bucket.go:853
 msgid "Create key for a storage bucket"
 msgstr ""
 
-#: lxc/storage_bucket.go:82 lxc/storage_bucket.go:83
+#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
 msgid "Create new custom storage buckets"
 msgstr ""
 
@@ -1473,7 +1473,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:92 lxc/project.go:93
+#: lxc/project.go:93 lxc/project.go:94
 msgid "Create projects"
 msgstr ""
 
@@ -1508,13 +1508,13 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:376 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1135 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
-#: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:172
-#: lxc/profile.go:756 lxc/project.go:572 lxc/storage.go:723
-#: lxc/storage_bucket.go:512 lxc/storage_bucket.go:832
+#: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
+#: lxc/profile.go:756 lxc/project.go:573 lxc/storage.go:723
+#: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1732
 msgid "DESCRIPTION"
 msgstr ""
@@ -1539,7 +1539,7 @@ msgstr ""
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
-#: lxc/operation.go:55 lxc/operation.go:56
+#: lxc/operation.go:56 lxc/operation.go:57
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
@@ -1547,19 +1547,19 @@ msgstr ""
 msgid "Delete a cluster group"
 msgstr ""
 
-#: lxc/warning.go:360
+#: lxc/warning.go:361
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:122 lxc/file.go:123
+#: lxc/file.go:123 lxc/file.go:124
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/auth.go:151 lxc/auth.go:152
+#: lxc/auth.go:152 lxc/auth.go:153
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1523 lxc/auth.go:1524
+#: lxc/auth.go:1524 lxc/auth.go:1525
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1579,7 +1579,7 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/storage_bucket.go:957 lxc/storage_bucket.go:958
+#: lxc/storage_bucket.go:958 lxc/storage_bucket.go:959
 msgid "Delete key from a storage bucket"
 msgstr ""
 
@@ -1615,11 +1615,11 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:188 lxc/project.go:189
+#: lxc/project.go:189 lxc/project.go:190
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:187 lxc/storage_bucket.go:188
+#: lxc/storage_bucket.go:188 lxc/storage_bucket.go:189
 msgid "Delete storage buckets"
 msgstr ""
 
@@ -1631,20 +1631,20 @@ msgstr ""
 msgid "Delete storage volumes"
 msgstr ""
 
-#: lxc/warning.go:356 lxc/warning.go:357
+#: lxc/warning.go:357 lxc/warning.go:358
 msgid "Delete warning"
 msgstr ""
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:30 lxc/auth.go:59 lxc/auth.go:98
-#: lxc/auth.go:152 lxc/auth.go:201 lxc/auth.go:332 lxc/auth.go:392
-#: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
-#: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
-#: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
-#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1434 lxc/auth.go:1472
-#: lxc/auth.go:1524 lxc/auth.go:1573 lxc/auth.go:1692 lxc/auth.go:1752
-#: lxc/auth.go:1801 lxc/auth.go:1852 lxc/auth.go:1875 lxc/auth.go:1928
+#: lxc/alias.go:214 lxc/auth.go:31 lxc/auth.go:60 lxc/auth.go:99
+#: lxc/auth.go:153 lxc/auth.go:202 lxc/auth.go:333 lxc/auth.go:393
+#: lxc/auth.go:442 lxc/auth.go:494 lxc/auth.go:517 lxc/auth.go:576
+#: lxc/auth.go:732 lxc/auth.go:766 lxc/auth.go:833 lxc/auth.go:896
+#: lxc/auth.go:957 lxc/auth.go:1085 lxc/auth.go:1108 lxc/auth.go:1166
+#: lxc/auth.go:1235 lxc/auth.go:1257 lxc/auth.go:1435 lxc/auth.go:1473
+#: lxc/auth.go:1525 lxc/auth.go:1574 lxc/auth.go:1693 lxc/auth.go:1753
+#: lxc/auth.go:1802 lxc/auth.go:1853 lxc/auth.go:1876 lxc/auth.go:1929
 #: lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215 lxc/cluster.go:272
 #: lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:484 lxc/cluster.go:528
 #: lxc/cluster.go:586 lxc/cluster.go:677 lxc/cluster.go:770 lxc/cluster.go:893
@@ -1668,15 +1668,15 @@ msgstr ""
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:83 lxc/file.go:123 lxc/file.go:172
-#: lxc/file.go:242 lxc/file.go:467 lxc/file.go:986 lxc/image.go:38
+#: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
+#: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
 #: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
 #: lxc/image.go:697 lxc/image.go:946 lxc/image.go:1088 lxc/image.go:1415
 #: lxc/image.go:1506 lxc/image.go:1572 lxc/image.go:1636 lxc/image.go:1699
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:38 lxc/network.go:33
+#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33
 #: lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405
 #: lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793
 #: lxc/network.go:874 lxc/network.go:1005 lxc/network.go:1106
@@ -1710,27 +1710,27 @@ msgstr ""
 #: lxc/network_zone.go:909 lxc/network_zone.go:985 lxc/network_zone.go:1083
 #: lxc/network_zone.go:1172 lxc/network_zone.go:1219 lxc/network_zone.go:1349
 #: lxc/network_zone.go:1410 lxc/network_zone.go:1425 lxc/network_zone.go:1483
-#: lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:106
-#: lxc/operation.go:193 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
+#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
+#: lxc/operation.go:194 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
 #: lxc/profile.go:271 lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493
 #: lxc/profile.go:629 lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860
-#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:29
-#: lxc/project.go:93 lxc/project.go:189 lxc/project.go:260 lxc/project.go:396
-#: lxc/project.go:470 lxc/project.go:590 lxc/project.go:655 lxc/project.go:743
-#: lxc/project.go:787 lxc/project.go:848 lxc/project.go:915 lxc/publish.go:34
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:35 lxc/remote.go:91
+#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:30
+#: lxc/project.go:94 lxc/project.go:190 lxc/project.go:261 lxc/project.go:397
+#: lxc/project.go:471 lxc/project.go:591 lxc/project.go:656 lxc/project.go:744
+#: lxc/project.go:788 lxc/project.go:849 lxc/project.go:916 lxc/publish.go:34
+#: lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91
 #: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853
 #: lxc/remote.go:917 lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24
 #: lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203
 #: lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655
 #: lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940
-#: lxc/storage_bucket.go:29 lxc/storage_bucket.go:83 lxc/storage_bucket.go:188
-#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:382
-#: lxc/storage_bucket.go:458 lxc/storage_bucket.go:535
-#: lxc/storage_bucket.go:629 lxc/storage_bucket.go:698
-#: lxc/storage_bucket.go:732 lxc/storage_bucket.go:773
-#: lxc/storage_bucket.go:852 lxc/storage_bucket.go:958
-#: lxc/storage_bucket.go:1022 lxc/storage_bucket.go:1157
+#: lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189
+#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:383
+#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:536
+#: lxc/storage_bucket.go:630 lxc/storage_bucket.go:699
+#: lxc/storage_bucket.go:733 lxc/storage_bucket.go:774
+#: lxc/storage_bucket.go:853 lxc/storage_bucket.go:959
+#: lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158
 #: lxc/storage_volume.go:58 lxc/storage_volume.go:169 lxc/storage_volume.go:283
 #: lxc/storage_volume.go:390 lxc/storage_volume.go:605
 #: lxc/storage_volume.go:714 lxc/storage_volume.go:801
@@ -1741,8 +1741,8 @@ msgstr ""
 #: lxc/storage_volume.go:2064 lxc/storage_volume.go:2222
 #: lxc/storage_volume.go:2343 lxc/storage_volume.go:2405
 #: lxc/storage_volume.go:2541 lxc/storage_volume.go:2624
-#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:29
-#: lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
+#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:30
+#: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
@@ -1829,7 +1829,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:994
+#: lxc/file.go:995
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1895,7 +1895,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:74
+#: lxc/file.go:75
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1905,7 +1905,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:955 lxc/auth.go:956
+#: lxc/auth.go:956 lxc/auth.go:957
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1913,15 +1913,15 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:171 lxc/file.go:172
+#: lxc/file.go:172 lxc/file.go:173
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/auth.go:200 lxc/auth.go:201
+#: lxc/auth.go:201 lxc/auth.go:202
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1572 lxc/auth.go:1573
+#: lxc/auth.go:1573 lxc/auth.go:1574
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -1977,15 +1977,15 @@ msgstr ""
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:259 lxc/project.go:260
+#: lxc/project.go:260 lxc/project.go:261
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:248 lxc/storage_bucket.go:249
+#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:250
 msgid "Edit storage bucket configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:1021 lxc/storage_bucket.go:1022
+#: lxc/storage_bucket.go:1022 lxc/storage_bucket.go:1023
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
@@ -2002,7 +2002,7 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1147 lxc/list.go:622 lxc/storage_volume.go:1766
-#: lxc/warning.go:235
+#: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2057,7 +2057,7 @@ msgstr ""
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
-#: lxc/project.go:718 lxc/storage.go:812 lxc/storage_bucket.go:602
+#: lxc/project.go:719 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2155 lxc/storage_volume.go:2193
 #, c-format
 msgid "Error setting properties: %v"
@@ -2071,8 +2071,8 @@ msgstr ""
 #: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
-#: lxc/profile.go:981 lxc/project.go:712 lxc/storage.go:806
-#: lxc/storage_bucket.go:596 lxc/storage_volume.go:2149
+#: lxc/profile.go:981 lxc/project.go:713 lxc/storage.go:806
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2149
 #: lxc/storage_volume.go:2187
 #, c-format
 msgid "Error unsetting property: %v"
@@ -2092,7 +2092,7 @@ msgstr ""
 msgid "Evacuating cluster member: %s"
 msgstr ""
 
-#: lxc/monitor.go:50
+#: lxc/monitor.go:51
 msgid "Event type to listen for"
 msgstr ""
 
@@ -2179,16 +2179,16 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/warning.go:210
+#: lxc/warning.go:211
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1237
+#: lxc/file.go:1238
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1260
+#: lxc/file.go:1261
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2203,12 +2203,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1287
+#: lxc/file.go:1288
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1072
+#: lxc/file.go:1073
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2238,7 +2238,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1193
+#: lxc/file.go:1194
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2253,7 +2253,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1198
+#: lxc/file.go:1199
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2263,12 +2263,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1098
+#: lxc/file.go:1099
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1225
+#: lxc/file.go:1226
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2307,7 +2307,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1210
+#: lxc/file.go:1211
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2322,7 +2322,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:820
+#: lxc/file.go:821
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2337,7 +2337,7 @@ msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
 #: lxc/network.go:1044 lxc/network_acl.go:133 lxc/network_zone.go:124
-#: lxc/operation.go:136
+#: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
 
@@ -2402,21 +2402,21 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
+#: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:770 lxc/auth.go:1697
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1114 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:57
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
-#: lxc/operation.go:108 lxc/profile.go:707 lxc/project.go:472
-#: lxc/project.go:917 lxc/remote.go:690 lxc/storage.go:657
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:774
-#: lxc/storage_volume.go:1608 lxc/warning.go:93
+#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:473
+#: lxc/project.go:918 lxc/remote.go:690 lxc/storage.go:657
+#: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
+#: lxc/storage_volume.go:1608 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
-#: lxc/monitor.go:52
+#: lxc/monitor.go:53
 msgid "Format (json|pretty|yaml)"
 msgstr ""
 
@@ -2460,7 +2460,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:817 lxc/auth.go:1736
+#: lxc/auth.go:818 lxc/auth.go:1737
 msgid "GROUPS"
 msgstr ""
 
@@ -2476,7 +2476,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:914 lxc/project.go:915
+#: lxc/project.go:915 lxc/project.go:916
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2524,11 +2524,11 @@ msgstr ""
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:400
+#: lxc/project.go:401
 msgid "Get the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:385
+#: lxc/storage_bucket.go:386
 msgid "Get the key as a storage bucket property"
 msgstr ""
 
@@ -2588,11 +2588,11 @@ msgstr ""
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:395 lxc/project.go:396
+#: lxc/project.go:396 lxc/project.go:397
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:382
+#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:383
 msgid "Get values for storage bucket configuration keys"
 msgstr ""
 
@@ -2609,17 +2609,17 @@ msgstr ""
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: lxc/auth.go:136
+#: lxc/auth.go:137
 #, c-format
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:186
+#: lxc/auth.go:187
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:426 lxc/auth.go:1786
+#: lxc/auth.go:427 lxc/auth.go:1787
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2644,27 +2644,27 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1310
+#: lxc/file.go:1311
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1299
+#: lxc/file.go:1300
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1122
+#: lxc/file.go:1123
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1132
+#: lxc/file.go:1133
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:966 lxc/operation.go:170
+#: lxc/network.go:966 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2678,11 +2678,11 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:816
+#: lxc/auth.go:817
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:566
+#: lxc/project.go:567
 msgid "IMAGES"
 msgstr ""
 
@@ -2710,17 +2710,17 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1508
+#: lxc/auth.go:1509
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1558
+#: lxc/auth.go:1559
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
 
-#: lxc/rebuild.go:32
+#: lxc/rebuild.go:33
 msgid "If an instance is running, stop it and then rebuild it"
 msgstr ""
 
@@ -2841,7 +2841,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1233 lxc/auth.go:1234
+#: lxc/auth.go:1234 lxc/auth.go:1235
 msgid "Inspect permissions"
 msgstr ""
 
@@ -2849,11 +2849,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1124
+#: lxc/file.go:1125
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1301
+#: lxc/file.go:1302
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2871,7 +2871,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1044
+#: lxc/file.go:1045
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2880,7 +2880,7 @@ msgstr ""
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/rebuild.go:74
+#: lxc/rebuild.go:75
 #, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
@@ -2913,7 +2913,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/monitor.go:70
+#: lxc/monitor.go:71
 #, c-format
 msgid "Invalid format: %s"
 msgstr ""
@@ -2923,7 +2923,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1039
+#: lxc/file.go:1040
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2965,7 +2965,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:147
+#: lxc/file.go:148
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2981,12 +2981,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:313
+#: lxc/file.go:314
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:495
+#: lxc/file.go:496
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3000,7 +3000,7 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/warning.go:212
 msgid "LAST SEEN"
 msgstr ""
 
@@ -3008,7 +3008,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:984
+#: lxc/project.go:985
 msgid "LIMIT"
 msgstr ""
 
@@ -3017,8 +3017,8 @@ msgid "LISTEN ADDRESS"
 msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
-#: lxc/network_load_balancer.go:165 lxc/operation.go:177
-#: lxc/storage_bucket.go:516 lxc/storage_volume.go:1739 lxc/warning.go:220
+#: lxc/network_load_balancer.go:165 lxc/operation.go:178
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1739 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3092,7 +3092,7 @@ msgstr ""
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/warning.go:94
+#: lxc/warning.go:95
 msgid "List all warnings"
 msgstr ""
 
@@ -3136,19 +3136,19 @@ msgstr ""
 msgid "List available storage pools"
 msgstr ""
 
-#: lxc/operation.go:105 lxc/operation.go:106
+#: lxc/operation.go:106 lxc/operation.go:107
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:331 lxc/auth.go:332
+#: lxc/auth.go:332 lxc/auth.go:333
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:764 lxc/auth.go:765
+#: lxc/auth.go:765 lxc/auth.go:766
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1691 lxc/auth.go:1692
+#: lxc/auth.go:1692 lxc/auth.go:1693
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3297,11 +3297,11 @@ msgstr ""
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/operation.go:109
+#: lxc/operation.go:110
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1255 lxc/auth.go:1256
+#: lxc/auth.go:1256 lxc/auth.go:1257
 msgid "List permissions"
 msgstr ""
 
@@ -3309,15 +3309,15 @@ msgstr ""
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:469 lxc/project.go:470
+#: lxc/project.go:470 lxc/project.go:471
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:771 lxc/storage_bucket.go:773
+#: lxc/storage_bucket.go:772 lxc/storage_bucket.go:774
 msgid "List storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:456 lxc/storage_bucket.go:458
+#: lxc/storage_bucket.go:457 lxc/storage_bucket.go:459
 msgid "List storage buckets"
 msgstr ""
 
@@ -3353,11 +3353,11 @@ msgstr ""
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/warning.go:70
+#: lxc/warning.go:71
 msgid "List warnings"
 msgstr ""
 
-#: lxc/warning.go:71
+#: lxc/warning.go:72
 msgid ""
 "List warnings\n"
 "\n"
@@ -3380,7 +3380,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/operation.go:23 lxc/operation.go:24
+#: lxc/operation.go:24 lxc/operation.go:25
 msgid "List, show and delete background operations"
 msgstr ""
 
@@ -3389,7 +3389,7 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/monitor.go:79
+#: lxc/monitor.go:80
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
@@ -3493,23 +3493,23 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:82 lxc/file.go:83
+#: lxc/file.go:83 lxc/file.go:84
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1433 lxc/auth.go:1434
+#: lxc/auth.go:59 lxc/auth.go:60 lxc/auth.go:1434 lxc/auth.go:1435
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1083 lxc/auth.go:1084
+#: lxc/auth.go:1084 lxc/auth.go:1085
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:730 lxc/auth.go:731
+#: lxc/auth.go:731 lxc/auth.go:732
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1851 lxc/auth.go:1852
+#: lxc/auth.go:1852 lxc/auth.go:1853
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3600,7 +3600,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:492 lxc/auth.go:493
+#: lxc/auth.go:493 lxc/auth.go:494
 msgid "Manage permissions"
 msgstr ""
 
@@ -3608,23 +3608,23 @@ msgstr ""
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:28 lxc/project.go:29
+#: lxc/project.go:29 lxc/project.go:30
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:731
+#: lxc/storage_bucket.go:732
 msgid "Manage storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:732
+#: lxc/storage_bucket.go:733
 msgid "Manage storage bucket keys."
 msgstr ""
 
-#: lxc/storage_bucket.go:28
+#: lxc/storage_bucket.go:29
 msgid "Manage storage buckets"
 msgstr ""
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:30
 msgid "Manage storage buckets."
 msgstr ""
 
@@ -3652,11 +3652,11 @@ msgstr ""
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/auth.go:29 lxc/auth.go:30
+#: lxc/auth.go:30 lxc/auth.go:31
 msgid "Manage user authorization"
 msgstr ""
 
-#: lxc/warning.go:28 lxc/warning.go:29
+#: lxc/warning.go:29 lxc/warning.go:30
 msgid "Manage warnings"
 msgstr ""
 
@@ -3720,17 +3720,17 @@ msgstr ""
 msgid "Migration operation failure: %w"
 msgstr ""
 
-#: lxc/monitor.go:51
+#: lxc/monitor.go:52
 msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: lxc/storage_bucket.go:116 lxc/storage_bucket.go:216
-#: lxc/storage_bucket.go:292 lxc/storage_bucket.go:411
-#: lxc/storage_bucket.go:568 lxc/storage_bucket.go:660
-#: lxc/storage_bucket.go:802 lxc/storage_bucket.go:889
-#: lxc/storage_bucket.go:986 lxc/storage_bucket.go:1065
-#: lxc/storage_bucket.go:1188
+#: lxc/storage_bucket.go:117 lxc/storage_bucket.go:217
+#: lxc/storage_bucket.go:293 lxc/storage_bucket.go:412
+#: lxc/storage_bucket.go:569 lxc/storage_bucket.go:661
+#: lxc/storage_bucket.go:803 lxc/storage_bucket.go:890
+#: lxc/storage_bucket.go:987 lxc/storage_bucket.go:1066
+#: lxc/storage_bucket.go:1189
 msgid "Missing bucket name"
 msgstr ""
 
@@ -3749,20 +3749,20 @@ msgstr ""
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1825
+#: lxc/auth.go:123 lxc/auth.go:177 lxc/auth.go:255 lxc/auth.go:417
+#: lxc/auth.go:466 lxc/auth.go:541 lxc/auth.go:600 lxc/auth.go:1826
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:862 lxc/auth.go:1003 lxc/auth.go:1131 lxc/auth.go:1189
+#: lxc/auth.go:863 lxc/auth.go:1004 lxc/auth.go:1132 lxc/auth.go:1190
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1495 lxc/auth.go:1548 lxc/auth.go:1614 lxc/auth.go:1776
+#: lxc/auth.go:1496 lxc/auth.go:1549 lxc/auth.go:1615 lxc/auth.go:1777
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1899 lxc/auth.go:1952
+#: lxc/auth.go:1900 lxc/auth.go:1953
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -3770,12 +3770,12 @@ msgstr ""
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
 #: lxc/config_template.go:377 lxc/profile.go:141 lxc/profile.go:222
-#: lxc/profile.go:808 lxc/rebuild.go:60
+#: lxc/profile.go:808 lxc/rebuild.go:61
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/storage_bucket.go:893 lxc/storage_bucket.go:990
-#: lxc/storage_bucket.go:1069 lxc/storage_bucket.go:1192
+#: lxc/storage_bucket.go:894 lxc/storage_bucket.go:991
+#: lxc/storage_bucket.go:1070 lxc/storage_bucket.go:1193
 msgid "Missing key name"
 msgstr ""
 
@@ -3840,13 +3840,13 @@ msgid "Missing peer name"
 msgstr ""
 
 #: lxc/storage.go:235 lxc/storage.go:313 lxc/storage.go:431 lxc/storage.go:509
-#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:112
-#: lxc/storage_bucket.go:212 lxc/storage_bucket.go:288
-#: lxc/storage_bucket.go:407 lxc/storage_bucket.go:482
-#: lxc/storage_bucket.go:564 lxc/storage_bucket.go:656
-#: lxc/storage_bucket.go:798 lxc/storage_bucket.go:885
-#: lxc/storage_bucket.go:982 lxc/storage_bucket.go:1061
-#: lxc/storage_bucket.go:1184 lxc/storage_volume.go:209
+#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:113
+#: lxc/storage_bucket.go:213 lxc/storage_bucket.go:289
+#: lxc/storage_bucket.go:408 lxc/storage_bucket.go:483
+#: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
+#: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
+#: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
 #: lxc/storage_volume.go:323 lxc/storage_volume.go:643
 #: lxc/storage_volume.go:750 lxc/storage_volume.go:841
 #: lxc/storage_volume.go:939 lxc/storage_volume.go:1053
@@ -3861,9 +3861,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:404 lxc/project.go:146 lxc/project.go:226 lxc/project.go:316
-#: lxc/project.go:433 lxc/project.go:622 lxc/project.go:691 lxc/project.go:819
-#: lxc/project.go:948
+#: lxc/profile.go:404 lxc/project.go:147 lxc/project.go:227 lxc/project.go:317
+#: lxc/project.go:434 lxc/project.go:623 lxc/project.go:692 lxc/project.go:820
+#: lxc/project.go:949
 msgid "Missing project name"
 msgstr ""
 
@@ -3879,7 +3879,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:598
+#: lxc/file.go:599
 msgid "Missing target directory"
 msgstr ""
 
@@ -3901,11 +3901,11 @@ msgstr ""
 msgid "Model: %v"
 msgstr ""
 
-#: lxc/monitor.go:32
+#: lxc/monitor.go:33
 msgid "Monitor a local or remote LXD server"
 msgstr ""
 
-#: lxc/monitor.go:33
+#: lxc/monitor.go:34
 msgid ""
 "Monitor a local or remote LXD server\n"
 "\n"
@@ -3917,11 +3917,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:285
+#: lxc/file.go:286
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:985 lxc/file.go:986
+#: lxc/file.go:986 lxc/file.go:987
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3983,13 +3983,13 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:192
+#: lxc/auth.go:376 lxc/auth.go:816 lxc/auth.go:1736 lxc/cluster.go:192
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
-#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:565
-#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:511
-#: lxc/storage_bucket.go:831 lxc/storage_volume.go:1731
+#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:566
+#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1731
 msgid "NAME"
 msgstr ""
 
@@ -3997,11 +3997,11 @@ msgstr ""
 msgid "NAT"
 msgstr ""
 
-#: lxc/project.go:571
+#: lxc/project.go:572
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:570
+#: lxc/project.go:571
 msgid "NETWORKS"
 msgstr ""
 
@@ -4013,9 +4013,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/operation.go:154 lxc/project.go:523
-#: lxc/project.go:528 lxc/project.go:533 lxc/project.go:538 lxc/project.go:543
-#: lxc/project.go:548 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
+#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:524
+#: lxc/project.go:529 lxc/project.go:534 lxc/project.go:539 lxc/project.go:544
+#: lxc/project.go:549 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
 msgid "NO"
 msgstr ""
 
@@ -4260,7 +4260,7 @@ msgstr ""
 msgid "Only managed networks can be modified"
 msgstr ""
 
-#: lxc/operation.go:86
+#: lxc/operation.go:87
 #, c-format
 msgid "Operation %s deleted"
 msgstr ""
@@ -4307,11 +4307,11 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:567
+#: lxc/list.go:576 lxc/project.go:568
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:212
+#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4373,24 +4373,24 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1102
+#: lxc/file.go:1103
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:860
+#: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
-#: lxc/project.go:363 lxc/storage.go:360 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1151
+#: lxc/project.go:364 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1151
 #: lxc/storage_volume.go:1183
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
-#: lxc/monitor.go:48
+#: lxc/monitor.go:49
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
@@ -4476,17 +4476,17 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:172
+#: lxc/project.go:173
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:236
+#: lxc/project.go:237
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:637
+#: lxc/project.go:638
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -4607,20 +4607,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:241 lxc/file.go:242
+#: lxc/file.go:242 lxc/file.go:243
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:416 lxc/file.go:767
+#: lxc/file.go:417 lxc/file.go:768
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:466 lxc/file.go:467
+#: lxc/file.go:467 lxc/file.go:468
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:701 lxc/file.go:867
+#: lxc/file.go:702 lxc/file.go:868
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4633,11 +4633,11 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:983
+#: lxc/project.go:984
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/storage_bucket.go:833
+#: lxc/storage_bucket.go:834
 msgid "ROLE"
 msgstr ""
 
@@ -4650,15 +4650,15 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/rebuild.go:31
+#: lxc/rebuild.go:32
 msgid "Rebuild as an empty instance"
 msgstr ""
 
-#: lxc/rebuild.go:26
+#: lxc/rebuild.go:27
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:249 lxc/file.go:473
+#: lxc/file.go:250 lxc/file.go:474
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4685,7 +4685,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:882 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
+#: lxc/project.go:883 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
 #: lxc/remote.go:994
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4736,7 +4736,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1164 lxc/auth.go:1165
+#: lxc/auth.go:1165 lxc/auth.go:1166
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4772,7 +4772,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1927 lxc/auth.go:1928
+#: lxc/auth.go:1928 lxc/auth.go:1929
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4784,7 +4784,7 @@ msgstr ""
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:574 lxc/auth.go:575
+#: lxc/auth.go:575 lxc/auth.go:576
 msgid "Remove permissions from groups"
 msgstr ""
 
@@ -4829,11 +4829,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:391 lxc/auth.go:392
+#: lxc/auth.go:392 lxc/auth.go:393
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1751 lxc/auth.go:1752
+#: lxc/auth.go:1752 lxc/auth.go:1753
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -4853,7 +4853,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:589 lxc/project.go:590
+#: lxc/project.go:590 lxc/project.go:591
 msgid "Rename projects"
 msgstr ""
 
@@ -4951,7 +4951,7 @@ msgstr ""
 msgid "Revoke cluster member join token"
 msgstr ""
 
-#: lxc/storage_bucket.go:862
+#: lxc/storage_bucket.go:863
 msgid "Role (admin or read-only)"
 msgstr ""
 
@@ -4967,7 +4967,7 @@ msgstr ""
 msgid "Run against all projects"
 msgstr ""
 
-#: lxc/warning.go:213
+#: lxc/warning.go:214
 msgid "SEVERITY"
 msgstr ""
 
@@ -4987,12 +4987,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1231
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1231
+#: lxc/file.go:1232
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5006,11 +5006,11 @@ msgstr ""
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:173 lxc/warning.go:214
+#: lxc/operation.go:174 lxc/warning.go:215
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:569
+#: lxc/project.go:570
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5018,7 +5018,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:569
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -5026,11 +5026,11 @@ msgstr ""
 msgid "STP"
 msgstr ""
 
-#: lxc/storage_bucket.go:864
+#: lxc/storage_bucket.go:865
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:942
+#: lxc/storage_bucket.go:943
 #, c-format
 msgid "Secret key: %s"
 msgstr ""
@@ -5068,7 +5068,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:995
+#: lxc/file.go:996
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5206,11 +5206,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:654
+#: lxc/project.go:655
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:655
+#: lxc/project.go:656
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5219,11 +5219,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage_bucket.go:534
+#: lxc/storage_bucket.go:535
 msgid "Set storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:535
+#: lxc/storage_bucket.go:536
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -5262,15 +5262,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:476
+#: lxc/file.go:477
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:477
+#: lxc/file.go:478
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:475
+#: lxc/file.go:476
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5310,11 +5310,11 @@ msgstr ""
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 msgid "Set the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:542
+#: lxc/storage_bucket.go:543
 msgid "Set the key as a storage bucket property"
 msgstr ""
 
@@ -5330,7 +5330,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:993
+#: lxc/file.go:994
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5342,7 +5342,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1800 lxc/auth.go:1801
+#: lxc/auth.go:1801 lxc/auth.go:1802
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5358,11 +5358,11 @@ msgstr ""
 msgid "Show details of a cluster member"
 msgstr ""
 
-#: lxc/operation.go:192 lxc/operation.go:193
+#: lxc/operation.go:193 lxc/operation.go:194
 msgid "Show details on a background operation"
 msgstr ""
 
-#: lxc/monitor.go:49
+#: lxc/monitor.go:50
 msgid "Show events from all projects"
 msgstr ""
 
@@ -5370,11 +5370,11 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:440 lxc/auth.go:441
+#: lxc/auth.go:441 lxc/auth.go:442
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:832
+#: lxc/auth.go:833
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5455,15 +5455,15 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:786 lxc/project.go:787
+#: lxc/project.go:787 lxc/project.go:788
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage_bucket.go:628 lxc/storage_bucket.go:629
+#: lxc/storage_bucket.go:629 lxc/storage_bucket.go:630
 msgid "Show storage bucket configurations"
 msgstr ""
 
-#: lxc/storage_bucket.go:1156 lxc/storage_bucket.go:1157
+#: lxc/storage_bucket.go:1157 lxc/storage_bucket.go:1158
 msgid "Show storage bucket key configurations"
 msgstr ""
 
@@ -5479,7 +5479,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:895
+#: lxc/auth.go:896
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5529,7 +5529,7 @@ msgstr ""
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: lxc/warning.go:302 lxc/warning.go:303
+#: lxc/warning.go:303 lxc/warning.go:304
 msgid "Show warning"
 msgstr ""
 
@@ -5613,22 +5613,22 @@ msgstr ""
 msgid "Stopping the instance failed: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:166
+#: lxc/storage_bucket.go:167
 #, c-format
 msgid "Storage bucket %s created"
 msgstr ""
 
-#: lxc/storage_bucket.go:233
+#: lxc/storage_bucket.go:234
 #, c-format
 msgid "Storage bucket %s deleted"
 msgstr ""
 
-#: lxc/storage_bucket.go:940
+#: lxc/storage_bucket.go:941
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr ""
 
-#: lxc/storage_bucket.go:1006
+#: lxc/storage_bucket.go:1007
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr ""
@@ -5697,7 +5697,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:847 lxc/project.go:848
+#: lxc/project.go:848 lxc/project.go:849
 msgid "Switch the current project"
 msgstr ""
 
@@ -5713,10 +5713,10 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1139
+#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1139
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
-#: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:171
-#: lxc/storage_volume.go:1730 lxc/warning.go:215
+#: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
+#: lxc/storage_volume.go:1730 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
@@ -5724,11 +5724,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1032
+#: lxc/file.go:1033
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1026
+#: lxc/file.go:1027
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5856,12 +5856,12 @@ msgstr ""
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:446
+#: lxc/project.go:447
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
 
-#: lxc/storage_bucket.go:431
+#: lxc/storage_bucket.go:432
 #, c-format
 msgid "The property %q does not exist on the storage bucket %q: %v"
 msgstr ""
@@ -6046,7 +6046,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:961
+#: lxc/project.go:962
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6058,17 +6058,17 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:985 lxc/storage_volume.go:1735
+#: lxc/project.go:986 lxc/storage_volume.go:1735
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:573
+#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:574
 #: lxc/storage.go:724 lxc/storage_volume.go:1734
 msgid "USED BY"
 msgstr ""
 
-#: lxc/warning.go:216
+#: lxc/warning.go:217
 msgid "UUID"
 msgstr ""
 
@@ -6077,7 +6077,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:197
+#: lxc/file.go:198
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6091,13 +6091,13 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1253
+#: lxc/file.go:1254
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1153 lxc/list.go:631 lxc/storage_volume.go:1772
-#: lxc/warning.go:241
+#: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6107,7 +6107,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:807
+#: lxc/file.go:808
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6190,11 +6190,11 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:742 lxc/project.go:743
+#: lxc/project.go:743 lxc/project.go:744
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:697 lxc/storage_bucket.go:698
+#: lxc/storage_bucket.go:698 lxc/storage_bucket.go:699
 msgid "Unset storage bucket configuration keys"
 msgstr ""
 
@@ -6242,11 +6242,11 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:747
+#: lxc/project.go:748
 msgid "Unset the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:701
+#: lxc/storage_bucket.go:702
 msgid "Unset the key as a storage bucket property"
 msgstr ""
 
@@ -6325,7 +6325,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:71
+#: lxc/file.go:72
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6362,11 +6362,11 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:831
+#: lxc/auth.go:832
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:894
+#: lxc/auth.go:895
 msgid "View the current identity"
 msgstr ""
 
@@ -6397,15 +6397,15 @@ msgstr ""
 msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
-#: lxc/rebuild.go:27
+#: lxc/rebuild.go:28
 msgid ""
 "Wipe the instance root disk and re-initialize. The original image is used to "
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:156 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
+#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:526
+#: lxc/project.go:531 lxc/project.go:536 lxc/project.go:541 lxc/project.go:546
+#: lxc/project.go:551 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
 msgid "YES"
 msgstr ""
 
@@ -6425,7 +6425,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/rebuild.go:119
+#: lxc/rebuild.go:120
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
@@ -6437,12 +6437,12 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1689
+#: lxc/auth.go:330 lxc/auth.go:763 lxc/auth.go:894 lxc/auth.go:1690
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
-#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
+#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
-#: lxc/operation.go:103 lxc/profile.go:700 lxc/project.go:467
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:68
+#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:468
+#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6470,7 +6470,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1254
+#: lxc/auth.go:1255
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6531,11 +6531,11 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:830
+#: lxc/auth.go:831
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1926
+#: lxc/auth.go:1106 lxc/auth.go:1164 lxc/auth.go:1927
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6543,13 +6543,13 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:954 lxc/auth.go:1470 lxc/cluster_group.go:168
+#: lxc/auth.go:97 lxc/auth.go:150 lxc/auth.go:200 lxc/auth.go:440
+#: lxc/auth.go:955 lxc/auth.go:1471 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:514 lxc/auth.go:572
+#: lxc/auth.go:515 lxc/auth.go:573
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
@@ -6559,19 +6559,19 @@ msgstr ""
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:389
+#: lxc/auth.go:390
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1521 lxc/auth.go:1571 lxc/auth.go:1799
+#: lxc/auth.go:1522 lxc/auth.go:1572 lxc/auth.go:1800
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1873
+#: lxc/auth.go:1874
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1749
+#: lxc/auth.go:1750
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -6591,7 +6591,7 @@ msgstr ""
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
-#: lxc/rebuild.go:25
+#: lxc/rebuild.go:26
 msgid "[<remote>:]<image> [<remote>:]<instance>"
 msgstr ""
 
@@ -6674,20 +6674,20 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:170
+#: lxc/file.go:171
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:120
+#: lxc/file.go:121
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:240
+#: lxc/file.go:241
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:984
+#: lxc/file.go:985
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6838,12 +6838,12 @@ msgstr ""
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
-#: lxc/operation.go:53 lxc/operation.go:191
+#: lxc/operation.go:54 lxc/operation.go:192
 msgid "[<remote>:]<operation>"
 msgstr ""
 
 #: lxc/storage.go:200 lxc/storage.go:259 lxc/storage.go:473 lxc/storage.go:844
-#: lxc/storage_bucket.go:454
+#: lxc/storage_bucket.go:455
 msgid "[<remote>:]<pool>"
 msgstr ""
 
@@ -6851,22 +6851,22 @@ msgstr ""
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
-#: lxc/storage_bucket.go:185 lxc/storage_bucket.go:247
-#: lxc/storage_bucket.go:627 lxc/storage_bucket.go:769
+#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:248
+#: lxc/storage_bucket.go:628 lxc/storage_bucket.go:770
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
 
-#: lxc/storage_bucket.go:380 lxc/storage_bucket.go:696
-#: lxc/storage_bucket.go:850 lxc/storage_bucket.go:956
-#: lxc/storage_bucket.go:1020 lxc/storage_bucket.go:1155
+#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:697
+#: lxc/storage_bucket.go:851 lxc/storage_bucket.go:957
+#: lxc/storage_bucket.go:1021 lxc/storage_bucket.go:1156
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
 
-#: lxc/storage_bucket.go:533
+#: lxc/storage_bucket.go:534
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_bucket.go:81
+#: lxc/storage_bucket.go:82
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
 
@@ -6981,20 +6981,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:91 lxc/project.go:186 lxc/project.go:258 lxc/project.go:785
-#: lxc/project.go:846 lxc/project.go:913
+#: lxc/project.go:92 lxc/project.go:187 lxc/project.go:259 lxc/project.go:786
+#: lxc/project.go:847 lxc/project.go:914
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:394 lxc/project.go:741
+#: lxc/project.go:395 lxc/project.go:742
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:653
+#: lxc/project.go:654
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:587
+#: lxc/project.go:588
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7002,7 +7002,7 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:259 lxc/warning.go:301 lxc/warning.go:354
+#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
@@ -7058,7 +7058,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:555 lxc/remote.go:739
+#: lxc/project.go:556 lxc/remote.go:739
 msgid "current"
 msgstr ""
 
@@ -7105,20 +7105,20 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/auth.go:203
+#: lxc/auth.go:204
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:958
+#: lxc/auth.go:959
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1575
+#: lxc/auth.go:1576
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7196,20 +7196,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:988
+#: lxc/file.go:989
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:244
+#: lxc/file.go:245
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:470
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7291,7 +7291,7 @@ msgid ""
 "  List instances with their running state and user comment."
 msgstr ""
 
-#: lxc/monitor.go:37
+#: lxc/monitor.go:38
 msgid ""
 "lxc monitor --type=logging\n"
 "    Only show log messages.\n"
@@ -7367,7 +7367,7 @@ msgid ""
 "    Create record r1 for zone z1 with configuration from config.yaml"
 msgstr ""
 
-#: lxc/operation.go:195
+#: lxc/operation.go:196
 msgid ""
 "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Show details on that operation UUID"
@@ -7410,7 +7410,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:95
+#: lxc/project.go:96
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7418,7 +7418,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:262
+#: lxc/project.go:263
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7449,7 +7449,7 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:85
 msgid ""
 "lxc storage bucket create p1 b01\n"
 "\tCreate a new storage bucket name b01 in storage pool p1\n"
@@ -7459,19 +7459,19 @@ msgid ""
 "of config.yaml"
 msgstr ""
 
-#: lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:251
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1023
+#: lxc/storage_bucket.go:1024
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:854
 msgid ""
 "lxc storage bucket key create p1 b01 k1\n"
 "\tCreate a key called k1 for the bucket b01 in the pool p1.\n"
@@ -7481,14 +7481,14 @@ msgid ""
 "of config.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1158
+#: lxc/storage_bucket.go:1159
 msgid ""
 "lxc storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_bucket.go:630
+#: lxc/storage_bucket.go:631
 msgid ""
 "lxc storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
@@ -7558,16 +7558,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1142
+#: lxc/file.go:1143
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1101
+#: lxc/file.go:1102
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1054
+#: lxc/file.go:1055
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-04 08:52-0600\n"
+"POT-Creation-Date: 2024-09-05 08:44-0400\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Ukrainian <https://hosted.weblate.org/projects/linux-"
@@ -20,7 +20,7 @@ msgstr ""
 "n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: lxc/storage_bucket.go:260 lxc/storage_bucket.go:1033
+#: lxc/storage_bucket.go:261 lxc/storage_bucket.go:1034
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -134,7 +134,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:213
+#: lxc/auth.go:214
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -161,7 +161,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:968
+#: lxc/auth.go:969
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -182,7 +182,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1585
+#: lxc/auth.go:1586
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -392,7 +392,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:280
+#: lxc/project.go:281
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -434,12 +434,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:935
+#: lxc/file.go:936
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:825
+#: lxc/file.go:826
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -475,7 +475,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:142 lxc/rebuild.go:64
+#: lxc/init.go:142 lxc/rebuild.go:65
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -528,7 +528,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:465
+#: lxc/file.go:466
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -561,7 +561,7 @@ msgstr ""
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:813
+#: lxc/auth.go:814
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -569,11 +569,11 @@ msgstr ""
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/storage_bucket.go:863
+#: lxc/storage_bucket.go:864
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:941
+#: lxc/storage_bucket.go:942
 #, c-format
 msgid "Access key: %s"
 msgstr ""
@@ -582,7 +582,7 @@ msgstr ""
 msgid "Access the expanded configuration"
 msgstr ""
 
-#: lxc/warning.go:261 lxc/warning.go:262
+#: lxc/warning.go:262 lxc/warning.go:263
 msgid "Acknowledge warning"
 msgstr ""
 
@@ -599,11 +599,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1106 lxc/auth.go:1107
+#: lxc/auth.go:1107 lxc/auth.go:1108
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1874 lxc/auth.go:1875
+#: lxc/auth.go:1875 lxc/auth.go:1876
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -672,7 +672,7 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:515 lxc/auth.go:516
+#: lxc/auth.go:516 lxc/auth.go:517
 msgid "Add permissions to groups"
 msgstr ""
 
@@ -701,7 +701,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:169
+#: lxc/storage_bucket.go:170
 #, c-format
 msgid "Admin access key: %s"
 msgstr ""
@@ -711,7 +711,7 @@ msgstr ""
 msgid "Admin password (or token) for %s:"
 msgstr ""
 
-#: lxc/storage_bucket.go:170
+#: lxc/storage_bucket.go:171
 #, c-format
 msgid "Admin secret key: %s"
 msgstr ""
@@ -770,7 +770,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:342 lxc/rebuild.go:130
+#: lxc/init.go:342 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -870,12 +870,12 @@ msgstr ""
 
 #: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:318
 #: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
-#: lxc/network_zone.go:366 lxc/network_zone.go:1053 lxc/storage_bucket.go:141
+#: lxc/network_zone.go:366 lxc/network_zone.go:1053 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:159
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:160
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -915,7 +915,7 @@ msgstr ""
 msgid "Bytes sent"
 msgstr ""
 
-#: lxc/operation.go:174
+#: lxc/operation.go:175
 msgid "CANCELABLE"
 msgstr ""
 
@@ -927,7 +927,7 @@ msgstr ""
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: lxc/warning.go:209
+#: lxc/warning.go:210
 msgid "COUNT"
 msgstr ""
 
@@ -953,7 +953,7 @@ msgstr ""
 msgid "CPUs (%s):"
 msgstr ""
 
-#: lxc/operation.go:175
+#: lxc/operation.go:176
 msgid "CREATED"
 msgstr ""
 
@@ -983,7 +983,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:340
+#: lxc/file.go:341
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1008,11 +1008,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:224
+#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:546
+#: lxc/file.go:547
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1021,7 +1021,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:160
+#: lxc/rebuild.go:161
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1144,13 +1144,13 @@ msgstr ""
 #: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
 #: lxc/network_load_balancer.go:1051 lxc/network_load_balancer.go:1125
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
-#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:90
-#: lxc/storage_bucket.go:190 lxc/storage_bucket.go:253
-#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:541
-#: lxc/storage_bucket.go:634 lxc/storage_bucket.go:700
-#: lxc/storage_bucket.go:775 lxc/storage_bucket.go:861
-#: lxc/storage_bucket.go:961 lxc/storage_bucket.go:1026
-#: lxc/storage_bucket.go:1162 lxc/storage_volume.go:394
+#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
+#: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
+#: lxc/storage_bucket.go:385 lxc/storage_bucket.go:542
+#: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
+#: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
+#: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
 #: lxc/storage_volume.go:612 lxc/storage_volume.go:717
 #: lxc/storage_volume.go:1005 lxc/storage_volume.go:1231
 #: lxc/storage_volume.go:1360 lxc/storage_volume.go:1848
@@ -1174,7 +1174,7 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1113 lxc/list.go:132 lxc/storage_volume.go:1589
-#: lxc/warning.go:92
+#: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
@@ -1202,7 +1202,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:100
+#: lxc/project.go:101
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1216,8 +1216,8 @@ msgstr ""
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
-#: lxc/project.go:362 lxc/storage.go:359 lxc/storage_bucket.go:348
-#: lxc/storage_bucket.go:1125 lxc/storage_volume.go:1150
+#: lxc/project.go:363 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1150
 #: lxc/storage_volume.go:1182
 #, c-format
 msgid "Config parsing error: %s"
@@ -1344,12 +1344,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:300 lxc/auth.go:1660
+#: lxc/auth.go:301 lxc/auth.go:1661
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1054
+#: lxc/auth.go:1055
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1398,15 +1398,15 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:248 lxc/file.go:474
+#: lxc/file.go:249 lxc/file.go:475
 msgid "Create any directories necessary"
 msgstr ""
 
-#: lxc/auth.go:97 lxc/auth.go:98
+#: lxc/auth.go:98 lxc/auth.go:99
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1471 lxc/auth.go:1472
+#: lxc/auth.go:1472 lxc/auth.go:1473
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1426,11 +1426,11 @@ msgstr ""
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_bucket.go:851 lxc/storage_bucket.go:852
+#: lxc/storage_bucket.go:852 lxc/storage_bucket.go:853
 msgid "Create key for a storage bucket"
 msgstr ""
 
-#: lxc/storage_bucket.go:82 lxc/storage_bucket.go:83
+#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
 msgid "Create new custom storage buckets"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:92 lxc/project.go:93
+#: lxc/project.go:93 lxc/project.go:94
 msgid "Create projects"
 msgstr ""
 
@@ -1509,13 +1509,13 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:376 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1135 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
-#: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:172
-#: lxc/profile.go:756 lxc/project.go:572 lxc/storage.go:723
-#: lxc/storage_bucket.go:512 lxc/storage_bucket.go:832
+#: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
+#: lxc/profile.go:756 lxc/project.go:573 lxc/storage.go:723
+#: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1732
 msgid "DESCRIPTION"
 msgstr ""
@@ -1540,7 +1540,7 @@ msgstr ""
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
-#: lxc/operation.go:55 lxc/operation.go:56
+#: lxc/operation.go:56 lxc/operation.go:57
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
@@ -1548,19 +1548,19 @@ msgstr ""
 msgid "Delete a cluster group"
 msgstr ""
 
-#: lxc/warning.go:360
+#: lxc/warning.go:361
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:122 lxc/file.go:123
+#: lxc/file.go:123 lxc/file.go:124
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/auth.go:151 lxc/auth.go:152
+#: lxc/auth.go:152 lxc/auth.go:153
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1523 lxc/auth.go:1524
+#: lxc/auth.go:1524 lxc/auth.go:1525
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1580,7 +1580,7 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/storage_bucket.go:957 lxc/storage_bucket.go:958
+#: lxc/storage_bucket.go:958 lxc/storage_bucket.go:959
 msgid "Delete key from a storage bucket"
 msgstr ""
 
@@ -1616,11 +1616,11 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:188 lxc/project.go:189
+#: lxc/project.go:189 lxc/project.go:190
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:187 lxc/storage_bucket.go:188
+#: lxc/storage_bucket.go:188 lxc/storage_bucket.go:189
 msgid "Delete storage buckets"
 msgstr ""
 
@@ -1632,20 +1632,20 @@ msgstr ""
 msgid "Delete storage volumes"
 msgstr ""
 
-#: lxc/warning.go:356 lxc/warning.go:357
+#: lxc/warning.go:357 lxc/warning.go:358
 msgid "Delete warning"
 msgstr ""
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:30 lxc/auth.go:59 lxc/auth.go:98
-#: lxc/auth.go:152 lxc/auth.go:201 lxc/auth.go:332 lxc/auth.go:392
-#: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
-#: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
-#: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
-#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1434 lxc/auth.go:1472
-#: lxc/auth.go:1524 lxc/auth.go:1573 lxc/auth.go:1692 lxc/auth.go:1752
-#: lxc/auth.go:1801 lxc/auth.go:1852 lxc/auth.go:1875 lxc/auth.go:1928
+#: lxc/alias.go:214 lxc/auth.go:31 lxc/auth.go:60 lxc/auth.go:99
+#: lxc/auth.go:153 lxc/auth.go:202 lxc/auth.go:333 lxc/auth.go:393
+#: lxc/auth.go:442 lxc/auth.go:494 lxc/auth.go:517 lxc/auth.go:576
+#: lxc/auth.go:732 lxc/auth.go:766 lxc/auth.go:833 lxc/auth.go:896
+#: lxc/auth.go:957 lxc/auth.go:1085 lxc/auth.go:1108 lxc/auth.go:1166
+#: lxc/auth.go:1235 lxc/auth.go:1257 lxc/auth.go:1435 lxc/auth.go:1473
+#: lxc/auth.go:1525 lxc/auth.go:1574 lxc/auth.go:1693 lxc/auth.go:1753
+#: lxc/auth.go:1802 lxc/auth.go:1853 lxc/auth.go:1876 lxc/auth.go:1929
 #: lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215 lxc/cluster.go:272
 #: lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:484 lxc/cluster.go:528
 #: lxc/cluster.go:586 lxc/cluster.go:677 lxc/cluster.go:770 lxc/cluster.go:893
@@ -1669,15 +1669,15 @@ msgstr ""
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:83 lxc/file.go:123 lxc/file.go:172
-#: lxc/file.go:242 lxc/file.go:467 lxc/file.go:986 lxc/image.go:38
+#: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
+#: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
 #: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
 #: lxc/image.go:697 lxc/image.go:946 lxc/image.go:1088 lxc/image.go:1415
 #: lxc/image.go:1506 lxc/image.go:1572 lxc/image.go:1636 lxc/image.go:1699
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:38 lxc/network.go:33
+#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33
 #: lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405
 #: lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793
 #: lxc/network.go:874 lxc/network.go:1005 lxc/network.go:1106
@@ -1711,27 +1711,27 @@ msgstr ""
 #: lxc/network_zone.go:909 lxc/network_zone.go:985 lxc/network_zone.go:1083
 #: lxc/network_zone.go:1172 lxc/network_zone.go:1219 lxc/network_zone.go:1349
 #: lxc/network_zone.go:1410 lxc/network_zone.go:1425 lxc/network_zone.go:1483
-#: lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:106
-#: lxc/operation.go:193 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
+#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
+#: lxc/operation.go:194 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
 #: lxc/profile.go:271 lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493
 #: lxc/profile.go:629 lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860
-#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:29
-#: lxc/project.go:93 lxc/project.go:189 lxc/project.go:260 lxc/project.go:396
-#: lxc/project.go:470 lxc/project.go:590 lxc/project.go:655 lxc/project.go:743
-#: lxc/project.go:787 lxc/project.go:848 lxc/project.go:915 lxc/publish.go:34
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:35 lxc/remote.go:91
+#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:30
+#: lxc/project.go:94 lxc/project.go:190 lxc/project.go:261 lxc/project.go:397
+#: lxc/project.go:471 lxc/project.go:591 lxc/project.go:656 lxc/project.go:744
+#: lxc/project.go:788 lxc/project.go:849 lxc/project.go:916 lxc/publish.go:34
+#: lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91
 #: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853
 #: lxc/remote.go:917 lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24
 #: lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203
 #: lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655
 #: lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940
-#: lxc/storage_bucket.go:29 lxc/storage_bucket.go:83 lxc/storage_bucket.go:188
-#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:382
-#: lxc/storage_bucket.go:458 lxc/storage_bucket.go:535
-#: lxc/storage_bucket.go:629 lxc/storage_bucket.go:698
-#: lxc/storage_bucket.go:732 lxc/storage_bucket.go:773
-#: lxc/storage_bucket.go:852 lxc/storage_bucket.go:958
-#: lxc/storage_bucket.go:1022 lxc/storage_bucket.go:1157
+#: lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189
+#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:383
+#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:536
+#: lxc/storage_bucket.go:630 lxc/storage_bucket.go:699
+#: lxc/storage_bucket.go:733 lxc/storage_bucket.go:774
+#: lxc/storage_bucket.go:853 lxc/storage_bucket.go:959
+#: lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158
 #: lxc/storage_volume.go:58 lxc/storage_volume.go:169 lxc/storage_volume.go:283
 #: lxc/storage_volume.go:390 lxc/storage_volume.go:605
 #: lxc/storage_volume.go:714 lxc/storage_volume.go:801
@@ -1742,8 +1742,8 @@ msgstr ""
 #: lxc/storage_volume.go:2064 lxc/storage_volume.go:2222
 #: lxc/storage_volume.go:2343 lxc/storage_volume.go:2405
 #: lxc/storage_volume.go:2541 lxc/storage_volume.go:2624
-#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:29
-#: lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
+#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:30
+#: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
@@ -1830,7 +1830,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:994
+#: lxc/file.go:995
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1896,7 +1896,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:74
+#: lxc/file.go:75
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1906,7 +1906,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:955 lxc/auth.go:956
+#: lxc/auth.go:956 lxc/auth.go:957
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1914,15 +1914,15 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:171 lxc/file.go:172
+#: lxc/file.go:172 lxc/file.go:173
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/auth.go:200 lxc/auth.go:201
+#: lxc/auth.go:201 lxc/auth.go:202
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1572 lxc/auth.go:1573
+#: lxc/auth.go:1573 lxc/auth.go:1574
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -1978,15 +1978,15 @@ msgstr ""
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:259 lxc/project.go:260
+#: lxc/project.go:260 lxc/project.go:261
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:248 lxc/storage_bucket.go:249
+#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:250
 msgid "Edit storage bucket configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:1021 lxc/storage_bucket.go:1022
+#: lxc/storage_bucket.go:1022 lxc/storage_bucket.go:1023
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
@@ -2003,7 +2003,7 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1147 lxc/list.go:622 lxc/storage_volume.go:1766
-#: lxc/warning.go:235
+#: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2058,7 +2058,7 @@ msgstr ""
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
-#: lxc/project.go:718 lxc/storage.go:812 lxc/storage_bucket.go:602
+#: lxc/project.go:719 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2155 lxc/storage_volume.go:2193
 #, c-format
 msgid "Error setting properties: %v"
@@ -2072,8 +2072,8 @@ msgstr ""
 #: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
-#: lxc/profile.go:981 lxc/project.go:712 lxc/storage.go:806
-#: lxc/storage_bucket.go:596 lxc/storage_volume.go:2149
+#: lxc/profile.go:981 lxc/project.go:713 lxc/storage.go:806
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2149
 #: lxc/storage_volume.go:2187
 #, c-format
 msgid "Error unsetting property: %v"
@@ -2093,7 +2093,7 @@ msgstr ""
 msgid "Evacuating cluster member: %s"
 msgstr ""
 
-#: lxc/monitor.go:50
+#: lxc/monitor.go:51
 msgid "Event type to listen for"
 msgstr ""
 
@@ -2180,16 +2180,16 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/warning.go:210
+#: lxc/warning.go:211
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1237
+#: lxc/file.go:1238
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1260
+#: lxc/file.go:1261
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2204,12 +2204,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1287
+#: lxc/file.go:1288
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1072
+#: lxc/file.go:1073
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2239,7 +2239,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1193
+#: lxc/file.go:1194
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2254,7 +2254,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1198
+#: lxc/file.go:1199
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2264,12 +2264,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1098
+#: lxc/file.go:1099
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1225
+#: lxc/file.go:1226
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2308,7 +2308,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1210
+#: lxc/file.go:1211
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2323,7 +2323,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:820
+#: lxc/file.go:821
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2338,7 +2338,7 @@ msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
 #: lxc/network.go:1044 lxc/network_acl.go:133 lxc/network_zone.go:124
-#: lxc/operation.go:136
+#: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
 
@@ -2403,21 +2403,21 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
+#: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:770 lxc/auth.go:1697
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1114 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:57
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
-#: lxc/operation.go:108 lxc/profile.go:707 lxc/project.go:472
-#: lxc/project.go:917 lxc/remote.go:690 lxc/storage.go:657
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:774
-#: lxc/storage_volume.go:1608 lxc/warning.go:93
+#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:473
+#: lxc/project.go:918 lxc/remote.go:690 lxc/storage.go:657
+#: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
+#: lxc/storage_volume.go:1608 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
-#: lxc/monitor.go:52
+#: lxc/monitor.go:53
 msgid "Format (json|pretty|yaml)"
 msgstr ""
 
@@ -2461,7 +2461,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:817 lxc/auth.go:1736
+#: lxc/auth.go:818 lxc/auth.go:1737
 msgid "GROUPS"
 msgstr ""
 
@@ -2477,7 +2477,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:914 lxc/project.go:915
+#: lxc/project.go:915 lxc/project.go:916
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2525,11 +2525,11 @@ msgstr ""
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:400
+#: lxc/project.go:401
 msgid "Get the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:385
+#: lxc/storage_bucket.go:386
 msgid "Get the key as a storage bucket property"
 msgstr ""
 
@@ -2589,11 +2589,11 @@ msgstr ""
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:395 lxc/project.go:396
+#: lxc/project.go:396 lxc/project.go:397
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:382
+#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:383
 msgid "Get values for storage bucket configuration keys"
 msgstr ""
 
@@ -2610,17 +2610,17 @@ msgstr ""
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: lxc/auth.go:136
+#: lxc/auth.go:137
 #, c-format
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:186
+#: lxc/auth.go:187
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:426 lxc/auth.go:1786
+#: lxc/auth.go:427 lxc/auth.go:1787
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2645,27 +2645,27 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1310
+#: lxc/file.go:1311
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1299
+#: lxc/file.go:1300
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1122
+#: lxc/file.go:1123
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1132
+#: lxc/file.go:1133
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:966 lxc/operation.go:170
+#: lxc/network.go:966 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2679,11 +2679,11 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:816
+#: lxc/auth.go:817
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:566
+#: lxc/project.go:567
 msgid "IMAGES"
 msgstr ""
 
@@ -2711,17 +2711,17 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1508
+#: lxc/auth.go:1509
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1558
+#: lxc/auth.go:1559
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
 
-#: lxc/rebuild.go:32
+#: lxc/rebuild.go:33
 msgid "If an instance is running, stop it and then rebuild it"
 msgstr ""
 
@@ -2842,7 +2842,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1233 lxc/auth.go:1234
+#: lxc/auth.go:1234 lxc/auth.go:1235
 msgid "Inspect permissions"
 msgstr ""
 
@@ -2850,11 +2850,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1124
+#: lxc/file.go:1125
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1301
+#: lxc/file.go:1302
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2872,7 +2872,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1044
+#: lxc/file.go:1045
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2881,7 +2881,7 @@ msgstr ""
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/rebuild.go:74
+#: lxc/rebuild.go:75
 #, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
@@ -2914,7 +2914,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/monitor.go:70
+#: lxc/monitor.go:71
 #, c-format
 msgid "Invalid format: %s"
 msgstr ""
@@ -2924,7 +2924,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1039
+#: lxc/file.go:1040
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2966,7 +2966,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:147
+#: lxc/file.go:148
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2982,12 +2982,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:313
+#: lxc/file.go:314
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:495
+#: lxc/file.go:496
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3001,7 +3001,7 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/warning.go:212
 msgid "LAST SEEN"
 msgstr ""
 
@@ -3009,7 +3009,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:984
+#: lxc/project.go:985
 msgid "LIMIT"
 msgstr ""
 
@@ -3018,8 +3018,8 @@ msgid "LISTEN ADDRESS"
 msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
-#: lxc/network_load_balancer.go:165 lxc/operation.go:177
-#: lxc/storage_bucket.go:516 lxc/storage_volume.go:1739 lxc/warning.go:220
+#: lxc/network_load_balancer.go:165 lxc/operation.go:178
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1739 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3093,7 +3093,7 @@ msgstr ""
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/warning.go:94
+#: lxc/warning.go:95
 msgid "List all warnings"
 msgstr ""
 
@@ -3137,19 +3137,19 @@ msgstr ""
 msgid "List available storage pools"
 msgstr ""
 
-#: lxc/operation.go:105 lxc/operation.go:106
+#: lxc/operation.go:106 lxc/operation.go:107
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:331 lxc/auth.go:332
+#: lxc/auth.go:332 lxc/auth.go:333
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:764 lxc/auth.go:765
+#: lxc/auth.go:765 lxc/auth.go:766
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1691 lxc/auth.go:1692
+#: lxc/auth.go:1692 lxc/auth.go:1693
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3298,11 +3298,11 @@ msgstr ""
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/operation.go:109
+#: lxc/operation.go:110
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1255 lxc/auth.go:1256
+#: lxc/auth.go:1256 lxc/auth.go:1257
 msgid "List permissions"
 msgstr ""
 
@@ -3310,15 +3310,15 @@ msgstr ""
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:469 lxc/project.go:470
+#: lxc/project.go:470 lxc/project.go:471
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:771 lxc/storage_bucket.go:773
+#: lxc/storage_bucket.go:772 lxc/storage_bucket.go:774
 msgid "List storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:456 lxc/storage_bucket.go:458
+#: lxc/storage_bucket.go:457 lxc/storage_bucket.go:459
 msgid "List storage buckets"
 msgstr ""
 
@@ -3354,11 +3354,11 @@ msgstr ""
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/warning.go:70
+#: lxc/warning.go:71
 msgid "List warnings"
 msgstr ""
 
-#: lxc/warning.go:71
+#: lxc/warning.go:72
 msgid ""
 "List warnings\n"
 "\n"
@@ -3381,7 +3381,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/operation.go:23 lxc/operation.go:24
+#: lxc/operation.go:24 lxc/operation.go:25
 msgid "List, show and delete background operations"
 msgstr ""
 
@@ -3390,7 +3390,7 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/monitor.go:79
+#: lxc/monitor.go:80
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
@@ -3494,23 +3494,23 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:82 lxc/file.go:83
+#: lxc/file.go:83 lxc/file.go:84
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1433 lxc/auth.go:1434
+#: lxc/auth.go:59 lxc/auth.go:60 lxc/auth.go:1434 lxc/auth.go:1435
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1083 lxc/auth.go:1084
+#: lxc/auth.go:1084 lxc/auth.go:1085
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:730 lxc/auth.go:731
+#: lxc/auth.go:731 lxc/auth.go:732
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1851 lxc/auth.go:1852
+#: lxc/auth.go:1852 lxc/auth.go:1853
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3601,7 +3601,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:492 lxc/auth.go:493
+#: lxc/auth.go:493 lxc/auth.go:494
 msgid "Manage permissions"
 msgstr ""
 
@@ -3609,23 +3609,23 @@ msgstr ""
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:28 lxc/project.go:29
+#: lxc/project.go:29 lxc/project.go:30
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:731
+#: lxc/storage_bucket.go:732
 msgid "Manage storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:732
+#: lxc/storage_bucket.go:733
 msgid "Manage storage bucket keys."
 msgstr ""
 
-#: lxc/storage_bucket.go:28
+#: lxc/storage_bucket.go:29
 msgid "Manage storage buckets"
 msgstr ""
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:30
 msgid "Manage storage buckets."
 msgstr ""
 
@@ -3653,11 +3653,11 @@ msgstr ""
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/auth.go:29 lxc/auth.go:30
+#: lxc/auth.go:30 lxc/auth.go:31
 msgid "Manage user authorization"
 msgstr ""
 
-#: lxc/warning.go:28 lxc/warning.go:29
+#: lxc/warning.go:29 lxc/warning.go:30
 msgid "Manage warnings"
 msgstr ""
 
@@ -3721,17 +3721,17 @@ msgstr ""
 msgid "Migration operation failure: %w"
 msgstr ""
 
-#: lxc/monitor.go:51
+#: lxc/monitor.go:52
 msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: lxc/storage_bucket.go:116 lxc/storage_bucket.go:216
-#: lxc/storage_bucket.go:292 lxc/storage_bucket.go:411
-#: lxc/storage_bucket.go:568 lxc/storage_bucket.go:660
-#: lxc/storage_bucket.go:802 lxc/storage_bucket.go:889
-#: lxc/storage_bucket.go:986 lxc/storage_bucket.go:1065
-#: lxc/storage_bucket.go:1188
+#: lxc/storage_bucket.go:117 lxc/storage_bucket.go:217
+#: lxc/storage_bucket.go:293 lxc/storage_bucket.go:412
+#: lxc/storage_bucket.go:569 lxc/storage_bucket.go:661
+#: lxc/storage_bucket.go:803 lxc/storage_bucket.go:890
+#: lxc/storage_bucket.go:987 lxc/storage_bucket.go:1066
+#: lxc/storage_bucket.go:1189
 msgid "Missing bucket name"
 msgstr ""
 
@@ -3750,20 +3750,20 @@ msgstr ""
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1825
+#: lxc/auth.go:123 lxc/auth.go:177 lxc/auth.go:255 lxc/auth.go:417
+#: lxc/auth.go:466 lxc/auth.go:541 lxc/auth.go:600 lxc/auth.go:1826
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:862 lxc/auth.go:1003 lxc/auth.go:1131 lxc/auth.go:1189
+#: lxc/auth.go:863 lxc/auth.go:1004 lxc/auth.go:1132 lxc/auth.go:1190
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1495 lxc/auth.go:1548 lxc/auth.go:1614 lxc/auth.go:1776
+#: lxc/auth.go:1496 lxc/auth.go:1549 lxc/auth.go:1615 lxc/auth.go:1777
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1899 lxc/auth.go:1952
+#: lxc/auth.go:1900 lxc/auth.go:1953
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -3771,12 +3771,12 @@ msgstr ""
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
 #: lxc/config_template.go:377 lxc/profile.go:141 lxc/profile.go:222
-#: lxc/profile.go:808 lxc/rebuild.go:60
+#: lxc/profile.go:808 lxc/rebuild.go:61
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/storage_bucket.go:893 lxc/storage_bucket.go:990
-#: lxc/storage_bucket.go:1069 lxc/storage_bucket.go:1192
+#: lxc/storage_bucket.go:894 lxc/storage_bucket.go:991
+#: lxc/storage_bucket.go:1070 lxc/storage_bucket.go:1193
 msgid "Missing key name"
 msgstr ""
 
@@ -3841,13 +3841,13 @@ msgid "Missing peer name"
 msgstr ""
 
 #: lxc/storage.go:235 lxc/storage.go:313 lxc/storage.go:431 lxc/storage.go:509
-#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:112
-#: lxc/storage_bucket.go:212 lxc/storage_bucket.go:288
-#: lxc/storage_bucket.go:407 lxc/storage_bucket.go:482
-#: lxc/storage_bucket.go:564 lxc/storage_bucket.go:656
-#: lxc/storage_bucket.go:798 lxc/storage_bucket.go:885
-#: lxc/storage_bucket.go:982 lxc/storage_bucket.go:1061
-#: lxc/storage_bucket.go:1184 lxc/storage_volume.go:209
+#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:113
+#: lxc/storage_bucket.go:213 lxc/storage_bucket.go:289
+#: lxc/storage_bucket.go:408 lxc/storage_bucket.go:483
+#: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
+#: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
+#: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
 #: lxc/storage_volume.go:323 lxc/storage_volume.go:643
 #: lxc/storage_volume.go:750 lxc/storage_volume.go:841
 #: lxc/storage_volume.go:939 lxc/storage_volume.go:1053
@@ -3862,9 +3862,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:404 lxc/project.go:146 lxc/project.go:226 lxc/project.go:316
-#: lxc/project.go:433 lxc/project.go:622 lxc/project.go:691 lxc/project.go:819
-#: lxc/project.go:948
+#: lxc/profile.go:404 lxc/project.go:147 lxc/project.go:227 lxc/project.go:317
+#: lxc/project.go:434 lxc/project.go:623 lxc/project.go:692 lxc/project.go:820
+#: lxc/project.go:949
 msgid "Missing project name"
 msgstr ""
 
@@ -3880,7 +3880,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:598
+#: lxc/file.go:599
 msgid "Missing target directory"
 msgstr ""
 
@@ -3902,11 +3902,11 @@ msgstr ""
 msgid "Model: %v"
 msgstr ""
 
-#: lxc/monitor.go:32
+#: lxc/monitor.go:33
 msgid "Monitor a local or remote LXD server"
 msgstr ""
 
-#: lxc/monitor.go:33
+#: lxc/monitor.go:34
 msgid ""
 "Monitor a local or remote LXD server\n"
 "\n"
@@ -3918,11 +3918,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:285
+#: lxc/file.go:286
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:985 lxc/file.go:986
+#: lxc/file.go:986 lxc/file.go:987
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3984,13 +3984,13 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:192
+#: lxc/auth.go:376 lxc/auth.go:816 lxc/auth.go:1736 lxc/cluster.go:192
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
-#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:565
-#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:511
-#: lxc/storage_bucket.go:831 lxc/storage_volume.go:1731
+#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:566
+#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1731
 msgid "NAME"
 msgstr ""
 
@@ -3998,11 +3998,11 @@ msgstr ""
 msgid "NAT"
 msgstr ""
 
-#: lxc/project.go:571
+#: lxc/project.go:572
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:570
+#: lxc/project.go:571
 msgid "NETWORKS"
 msgstr ""
 
@@ -4014,9 +4014,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/operation.go:154 lxc/project.go:523
-#: lxc/project.go:528 lxc/project.go:533 lxc/project.go:538 lxc/project.go:543
-#: lxc/project.go:548 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
+#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:524
+#: lxc/project.go:529 lxc/project.go:534 lxc/project.go:539 lxc/project.go:544
+#: lxc/project.go:549 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
 msgid "NO"
 msgstr ""
 
@@ -4261,7 +4261,7 @@ msgstr ""
 msgid "Only managed networks can be modified"
 msgstr ""
 
-#: lxc/operation.go:86
+#: lxc/operation.go:87
 #, c-format
 msgid "Operation %s deleted"
 msgstr ""
@@ -4308,11 +4308,11 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:567
+#: lxc/list.go:576 lxc/project.go:568
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:212
+#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4374,24 +4374,24 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1102
+#: lxc/file.go:1103
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:860
+#: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
-#: lxc/project.go:363 lxc/storage.go:360 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1151
+#: lxc/project.go:364 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1151
 #: lxc/storage_volume.go:1183
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
-#: lxc/monitor.go:48
+#: lxc/monitor.go:49
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
@@ -4477,17 +4477,17 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:172
+#: lxc/project.go:173
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:236
+#: lxc/project.go:237
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:637
+#: lxc/project.go:638
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -4608,20 +4608,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:241 lxc/file.go:242
+#: lxc/file.go:242 lxc/file.go:243
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:416 lxc/file.go:767
+#: lxc/file.go:417 lxc/file.go:768
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:466 lxc/file.go:467
+#: lxc/file.go:467 lxc/file.go:468
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:701 lxc/file.go:867
+#: lxc/file.go:702 lxc/file.go:868
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4634,11 +4634,11 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:983
+#: lxc/project.go:984
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/storage_bucket.go:833
+#: lxc/storage_bucket.go:834
 msgid "ROLE"
 msgstr ""
 
@@ -4651,15 +4651,15 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/rebuild.go:31
+#: lxc/rebuild.go:32
 msgid "Rebuild as an empty instance"
 msgstr ""
 
-#: lxc/rebuild.go:26
+#: lxc/rebuild.go:27
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:249 lxc/file.go:473
+#: lxc/file.go:250 lxc/file.go:474
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4686,7 +4686,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:882 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
+#: lxc/project.go:883 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
 #: lxc/remote.go:994
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4737,7 +4737,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1164 lxc/auth.go:1165
+#: lxc/auth.go:1165 lxc/auth.go:1166
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4773,7 +4773,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1927 lxc/auth.go:1928
+#: lxc/auth.go:1928 lxc/auth.go:1929
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4785,7 +4785,7 @@ msgstr ""
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:574 lxc/auth.go:575
+#: lxc/auth.go:575 lxc/auth.go:576
 msgid "Remove permissions from groups"
 msgstr ""
 
@@ -4830,11 +4830,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:391 lxc/auth.go:392
+#: lxc/auth.go:392 lxc/auth.go:393
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1751 lxc/auth.go:1752
+#: lxc/auth.go:1752 lxc/auth.go:1753
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -4854,7 +4854,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:589 lxc/project.go:590
+#: lxc/project.go:590 lxc/project.go:591
 msgid "Rename projects"
 msgstr ""
 
@@ -4952,7 +4952,7 @@ msgstr ""
 msgid "Revoke cluster member join token"
 msgstr ""
 
-#: lxc/storage_bucket.go:862
+#: lxc/storage_bucket.go:863
 msgid "Role (admin or read-only)"
 msgstr ""
 
@@ -4968,7 +4968,7 @@ msgstr ""
 msgid "Run against all projects"
 msgstr ""
 
-#: lxc/warning.go:213
+#: lxc/warning.go:214
 msgid "SEVERITY"
 msgstr ""
 
@@ -4988,12 +4988,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1231
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1231
+#: lxc/file.go:1232
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5007,11 +5007,11 @@ msgstr ""
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:173 lxc/warning.go:214
+#: lxc/operation.go:174 lxc/warning.go:215
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:569
+#: lxc/project.go:570
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5019,7 +5019,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:569
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -5027,11 +5027,11 @@ msgstr ""
 msgid "STP"
 msgstr ""
 
-#: lxc/storage_bucket.go:864
+#: lxc/storage_bucket.go:865
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:942
+#: lxc/storage_bucket.go:943
 #, c-format
 msgid "Secret key: %s"
 msgstr ""
@@ -5069,7 +5069,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:995
+#: lxc/file.go:996
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5207,11 +5207,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:654
+#: lxc/project.go:655
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:655
+#: lxc/project.go:656
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5220,11 +5220,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage_bucket.go:534
+#: lxc/storage_bucket.go:535
 msgid "Set storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:535
+#: lxc/storage_bucket.go:536
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -5263,15 +5263,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:476
+#: lxc/file.go:477
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:477
+#: lxc/file.go:478
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:475
+#: lxc/file.go:476
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5311,11 +5311,11 @@ msgstr ""
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 msgid "Set the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:542
+#: lxc/storage_bucket.go:543
 msgid "Set the key as a storage bucket property"
 msgstr ""
 
@@ -5331,7 +5331,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:993
+#: lxc/file.go:994
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5343,7 +5343,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1800 lxc/auth.go:1801
+#: lxc/auth.go:1801 lxc/auth.go:1802
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5359,11 +5359,11 @@ msgstr ""
 msgid "Show details of a cluster member"
 msgstr ""
 
-#: lxc/operation.go:192 lxc/operation.go:193
+#: lxc/operation.go:193 lxc/operation.go:194
 msgid "Show details on a background operation"
 msgstr ""
 
-#: lxc/monitor.go:49
+#: lxc/monitor.go:50
 msgid "Show events from all projects"
 msgstr ""
 
@@ -5371,11 +5371,11 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:440 lxc/auth.go:441
+#: lxc/auth.go:441 lxc/auth.go:442
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:832
+#: lxc/auth.go:833
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5456,15 +5456,15 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:786 lxc/project.go:787
+#: lxc/project.go:787 lxc/project.go:788
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage_bucket.go:628 lxc/storage_bucket.go:629
+#: lxc/storage_bucket.go:629 lxc/storage_bucket.go:630
 msgid "Show storage bucket configurations"
 msgstr ""
 
-#: lxc/storage_bucket.go:1156 lxc/storage_bucket.go:1157
+#: lxc/storage_bucket.go:1157 lxc/storage_bucket.go:1158
 msgid "Show storage bucket key configurations"
 msgstr ""
 
@@ -5480,7 +5480,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:895
+#: lxc/auth.go:896
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5530,7 +5530,7 @@ msgstr ""
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: lxc/warning.go:302 lxc/warning.go:303
+#: lxc/warning.go:303 lxc/warning.go:304
 msgid "Show warning"
 msgstr ""
 
@@ -5614,22 +5614,22 @@ msgstr ""
 msgid "Stopping the instance failed: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:166
+#: lxc/storage_bucket.go:167
 #, c-format
 msgid "Storage bucket %s created"
 msgstr ""
 
-#: lxc/storage_bucket.go:233
+#: lxc/storage_bucket.go:234
 #, c-format
 msgid "Storage bucket %s deleted"
 msgstr ""
 
-#: lxc/storage_bucket.go:940
+#: lxc/storage_bucket.go:941
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr ""
 
-#: lxc/storage_bucket.go:1006
+#: lxc/storage_bucket.go:1007
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr ""
@@ -5698,7 +5698,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:847 lxc/project.go:848
+#: lxc/project.go:848 lxc/project.go:849
 msgid "Switch the current project"
 msgstr ""
 
@@ -5714,10 +5714,10 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1139
+#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1139
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
-#: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:171
-#: lxc/storage_volume.go:1730 lxc/warning.go:215
+#: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
+#: lxc/storage_volume.go:1730 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
@@ -5725,11 +5725,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1032
+#: lxc/file.go:1033
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1026
+#: lxc/file.go:1027
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5857,12 +5857,12 @@ msgstr ""
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:446
+#: lxc/project.go:447
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
 
-#: lxc/storage_bucket.go:431
+#: lxc/storage_bucket.go:432
 #, c-format
 msgid "The property %q does not exist on the storage bucket %q: %v"
 msgstr ""
@@ -6047,7 +6047,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:961
+#: lxc/project.go:962
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6059,17 +6059,17 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:985 lxc/storage_volume.go:1735
+#: lxc/project.go:986 lxc/storage_volume.go:1735
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:573
+#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:574
 #: lxc/storage.go:724 lxc/storage_volume.go:1734
 msgid "USED BY"
 msgstr ""
 
-#: lxc/warning.go:216
+#: lxc/warning.go:217
 msgid "UUID"
 msgstr ""
 
@@ -6078,7 +6078,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:197
+#: lxc/file.go:198
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6092,13 +6092,13 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1253
+#: lxc/file.go:1254
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1153 lxc/list.go:631 lxc/storage_volume.go:1772
-#: lxc/warning.go:241
+#: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6108,7 +6108,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:807
+#: lxc/file.go:808
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6191,11 +6191,11 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:742 lxc/project.go:743
+#: lxc/project.go:743 lxc/project.go:744
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:697 lxc/storage_bucket.go:698
+#: lxc/storage_bucket.go:698 lxc/storage_bucket.go:699
 msgid "Unset storage bucket configuration keys"
 msgstr ""
 
@@ -6243,11 +6243,11 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:747
+#: lxc/project.go:748
 msgid "Unset the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:701
+#: lxc/storage_bucket.go:702
 msgid "Unset the key as a storage bucket property"
 msgstr ""
 
@@ -6326,7 +6326,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:71
+#: lxc/file.go:72
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6363,11 +6363,11 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:831
+#: lxc/auth.go:832
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:894
+#: lxc/auth.go:895
 msgid "View the current identity"
 msgstr ""
 
@@ -6398,15 +6398,15 @@ msgstr ""
 msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
-#: lxc/rebuild.go:27
+#: lxc/rebuild.go:28
 msgid ""
 "Wipe the instance root disk and re-initialize. The original image is used to "
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:156 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
+#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:526
+#: lxc/project.go:531 lxc/project.go:536 lxc/project.go:541 lxc/project.go:546
+#: lxc/project.go:551 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
 msgid "YES"
 msgstr ""
 
@@ -6426,7 +6426,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/rebuild.go:119
+#: lxc/rebuild.go:120
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
@@ -6438,12 +6438,12 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1689
+#: lxc/auth.go:330 lxc/auth.go:763 lxc/auth.go:894 lxc/auth.go:1690
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
-#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
+#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
-#: lxc/operation.go:103 lxc/profile.go:700 lxc/project.go:467
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:68
+#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:468
+#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6471,7 +6471,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1254
+#: lxc/auth.go:1255
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6532,11 +6532,11 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:830
+#: lxc/auth.go:831
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1926
+#: lxc/auth.go:1106 lxc/auth.go:1164 lxc/auth.go:1927
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6544,13 +6544,13 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:954 lxc/auth.go:1470 lxc/cluster_group.go:168
+#: lxc/auth.go:97 lxc/auth.go:150 lxc/auth.go:200 lxc/auth.go:440
+#: lxc/auth.go:955 lxc/auth.go:1471 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:514 lxc/auth.go:572
+#: lxc/auth.go:515 lxc/auth.go:573
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
@@ -6560,19 +6560,19 @@ msgstr ""
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:389
+#: lxc/auth.go:390
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1521 lxc/auth.go:1571 lxc/auth.go:1799
+#: lxc/auth.go:1522 lxc/auth.go:1572 lxc/auth.go:1800
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1873
+#: lxc/auth.go:1874
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1749
+#: lxc/auth.go:1750
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -6592,7 +6592,7 @@ msgstr ""
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
-#: lxc/rebuild.go:25
+#: lxc/rebuild.go:26
 msgid "[<remote>:]<image> [<remote>:]<instance>"
 msgstr ""
 
@@ -6675,20 +6675,20 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:170
+#: lxc/file.go:171
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:120
+#: lxc/file.go:121
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:240
+#: lxc/file.go:241
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:984
+#: lxc/file.go:985
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6839,12 +6839,12 @@ msgstr ""
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
-#: lxc/operation.go:53 lxc/operation.go:191
+#: lxc/operation.go:54 lxc/operation.go:192
 msgid "[<remote>:]<operation>"
 msgstr ""
 
 #: lxc/storage.go:200 lxc/storage.go:259 lxc/storage.go:473 lxc/storage.go:844
-#: lxc/storage_bucket.go:454
+#: lxc/storage_bucket.go:455
 msgid "[<remote>:]<pool>"
 msgstr ""
 
@@ -6852,22 +6852,22 @@ msgstr ""
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
-#: lxc/storage_bucket.go:185 lxc/storage_bucket.go:247
-#: lxc/storage_bucket.go:627 lxc/storage_bucket.go:769
+#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:248
+#: lxc/storage_bucket.go:628 lxc/storage_bucket.go:770
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
 
-#: lxc/storage_bucket.go:380 lxc/storage_bucket.go:696
-#: lxc/storage_bucket.go:850 lxc/storage_bucket.go:956
-#: lxc/storage_bucket.go:1020 lxc/storage_bucket.go:1155
+#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:697
+#: lxc/storage_bucket.go:851 lxc/storage_bucket.go:957
+#: lxc/storage_bucket.go:1021 lxc/storage_bucket.go:1156
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
 
-#: lxc/storage_bucket.go:533
+#: lxc/storage_bucket.go:534
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_bucket.go:81
+#: lxc/storage_bucket.go:82
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
 
@@ -6982,20 +6982,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:91 lxc/project.go:186 lxc/project.go:258 lxc/project.go:785
-#: lxc/project.go:846 lxc/project.go:913
+#: lxc/project.go:92 lxc/project.go:187 lxc/project.go:259 lxc/project.go:786
+#: lxc/project.go:847 lxc/project.go:914
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:394 lxc/project.go:741
+#: lxc/project.go:395 lxc/project.go:742
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:653
+#: lxc/project.go:654
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:587
+#: lxc/project.go:588
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7003,7 +7003,7 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:259 lxc/warning.go:301 lxc/warning.go:354
+#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
@@ -7059,7 +7059,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:555 lxc/remote.go:739
+#: lxc/project.go:556 lxc/remote.go:739
 msgid "current"
 msgstr ""
 
@@ -7106,20 +7106,20 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/auth.go:203
+#: lxc/auth.go:204
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:958
+#: lxc/auth.go:959
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1575
+#: lxc/auth.go:1576
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7197,20 +7197,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:988
+#: lxc/file.go:989
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:244
+#: lxc/file.go:245
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:470
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7292,7 +7292,7 @@ msgid ""
 "  List instances with their running state and user comment."
 msgstr ""
 
-#: lxc/monitor.go:37
+#: lxc/monitor.go:38
 msgid ""
 "lxc monitor --type=logging\n"
 "    Only show log messages.\n"
@@ -7368,7 +7368,7 @@ msgid ""
 "    Create record r1 for zone z1 with configuration from config.yaml"
 msgstr ""
 
-#: lxc/operation.go:195
+#: lxc/operation.go:196
 msgid ""
 "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Show details on that operation UUID"
@@ -7411,7 +7411,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:95
+#: lxc/project.go:96
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7419,7 +7419,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:262
+#: lxc/project.go:263
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7450,7 +7450,7 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:85
 msgid ""
 "lxc storage bucket create p1 b01\n"
 "\tCreate a new storage bucket name b01 in storage pool p1\n"
@@ -7460,19 +7460,19 @@ msgid ""
 "of config.yaml"
 msgstr ""
 
-#: lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:251
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1023
+#: lxc/storage_bucket.go:1024
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:854
 msgid ""
 "lxc storage bucket key create p1 b01 k1\n"
 "\tCreate a key called k1 for the bucket b01 in the pool p1.\n"
@@ -7482,14 +7482,14 @@ msgid ""
 "of config.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1158
+#: lxc/storage_bucket.go:1159
 msgid ""
 "lxc storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_bucket.go:630
+#: lxc/storage_bucket.go:631
 msgid ""
 "lxc storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
@@ -7559,16 +7559,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1142
+#: lxc/file.go:1143
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1101
+#: lxc/file.go:1102
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1054
+#: lxc/file.go:1055
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-04 08:52-0600\n"
+"POT-Creation-Date: 2024-09-05 08:44-0400\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: 0x0916 <w@laoqinren.net>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: lxc/storage_bucket.go:260 lxc/storage_bucket.go:1033
+#: lxc/storage_bucket.go:261 lxc/storage_bucket.go:1034
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
@@ -207,7 +207,7 @@ msgstr ""
 "###\n"
 "### Note that the name is shown but cannot be changed"
 
-#: lxc/auth.go:213
+#: lxc/auth.go:214
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -234,7 +234,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:968
+#: lxc/auth.go:969
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -255,7 +255,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1585
+#: lxc/auth.go:1586
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
@@ -534,7 +534,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:280
+#: lxc/project.go:281
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the project.\n"
@@ -594,12 +594,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:935
+#: lxc/file.go:936
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s 不是一个目录"
 
-#: lxc/file.go:825
+#: lxc/file.go:826
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -635,7 +635,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:142 lxc/rebuild.go:64
+#: lxc/init.go:142 lxc/rebuild.go:65
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -688,7 +688,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:465
+#: lxc/file.go:466
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -721,7 +721,7 @@ msgstr ""
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:813
+#: lxc/auth.go:814
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -729,11 +729,11 @@ msgstr ""
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/storage_bucket.go:863
+#: lxc/storage_bucket.go:864
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:941
+#: lxc/storage_bucket.go:942
 #, c-format
 msgid "Access key: %s"
 msgstr ""
@@ -742,7 +742,7 @@ msgstr ""
 msgid "Access the expanded configuration"
 msgstr ""
 
-#: lxc/warning.go:261 lxc/warning.go:262
+#: lxc/warning.go:262 lxc/warning.go:263
 msgid "Acknowledge warning"
 msgstr ""
 
@@ -759,11 +759,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1106 lxc/auth.go:1107
+#: lxc/auth.go:1107 lxc/auth.go:1108
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1874 lxc/auth.go:1875
+#: lxc/auth.go:1875 lxc/auth.go:1876
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -832,7 +832,7 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:515 lxc/auth.go:516
+#: lxc/auth.go:516 lxc/auth.go:517
 msgid "Add permissions to groups"
 msgstr ""
 
@@ -861,7 +861,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:169
+#: lxc/storage_bucket.go:170
 #, c-format
 msgid "Admin access key: %s"
 msgstr ""
@@ -871,7 +871,7 @@ msgstr ""
 msgid "Admin password (or token) for %s:"
 msgstr ""
 
-#: lxc/storage_bucket.go:170
+#: lxc/storage_bucket.go:171
 #, c-format
 msgid "Admin secret key: %s"
 msgstr ""
@@ -930,7 +930,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:342 lxc/rebuild.go:130
+#: lxc/init.go:342 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -1030,12 +1030,12 @@ msgstr ""
 
 #: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:318
 #: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
-#: lxc/network_zone.go:366 lxc/network_zone.go:1053 lxc/storage_bucket.go:141
+#: lxc/network_zone.go:366 lxc/network_zone.go:1053 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:159
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:160
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1075,7 +1075,7 @@ msgstr ""
 msgid "Bytes sent"
 msgstr ""
 
-#: lxc/operation.go:174
+#: lxc/operation.go:175
 msgid "CANCELABLE"
 msgstr ""
 
@@ -1087,7 +1087,7 @@ msgstr ""
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: lxc/warning.go:209
+#: lxc/warning.go:210
 msgid "COUNT"
 msgstr ""
 
@@ -1113,7 +1113,7 @@ msgstr ""
 msgid "CPUs (%s):"
 msgstr ""
 
-#: lxc/operation.go:175
+#: lxc/operation.go:176
 msgid "CREATED"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:340
+#: lxc/file.go:341
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1168,11 +1168,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:224
+#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:546
+#: lxc/file.go:547
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1181,7 +1181,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:160
+#: lxc/rebuild.go:161
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1304,13 +1304,13 @@ msgstr ""
 #: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
 #: lxc/network_load_balancer.go:1051 lxc/network_load_balancer.go:1125
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
-#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:90
-#: lxc/storage_bucket.go:190 lxc/storage_bucket.go:253
-#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:541
-#: lxc/storage_bucket.go:634 lxc/storage_bucket.go:700
-#: lxc/storage_bucket.go:775 lxc/storage_bucket.go:861
-#: lxc/storage_bucket.go:961 lxc/storage_bucket.go:1026
-#: lxc/storage_bucket.go:1162 lxc/storage_volume.go:394
+#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
+#: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
+#: lxc/storage_bucket.go:385 lxc/storage_bucket.go:542
+#: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
+#: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
+#: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
 #: lxc/storage_volume.go:612 lxc/storage_volume.go:717
 #: lxc/storage_volume.go:1005 lxc/storage_volume.go:1231
 #: lxc/storage_volume.go:1360 lxc/storage_volume.go:1848
@@ -1334,7 +1334,7 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1113 lxc/list.go:132 lxc/storage_volume.go:1589
-#: lxc/warning.go:92
+#: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
@@ -1362,7 +1362,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:100
+#: lxc/project.go:101
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1376,8 +1376,8 @@ msgstr ""
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
-#: lxc/project.go:362 lxc/storage.go:359 lxc/storage_bucket.go:348
-#: lxc/storage_bucket.go:1125 lxc/storage_volume.go:1150
+#: lxc/project.go:363 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1150
 #: lxc/storage_volume.go:1182
 #, c-format
 msgid "Config parsing error: %s"
@@ -1504,12 +1504,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:300 lxc/auth.go:1660
+#: lxc/auth.go:301 lxc/auth.go:1661
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1054
+#: lxc/auth.go:1055
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1558,15 +1558,15 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:248 lxc/file.go:474
+#: lxc/file.go:249 lxc/file.go:475
 msgid "Create any directories necessary"
 msgstr ""
 
-#: lxc/auth.go:97 lxc/auth.go:98
+#: lxc/auth.go:98 lxc/auth.go:99
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1471 lxc/auth.go:1472
+#: lxc/auth.go:1472 lxc/auth.go:1473
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1586,11 +1586,11 @@ msgstr ""
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_bucket.go:851 lxc/storage_bucket.go:852
+#: lxc/storage_bucket.go:852 lxc/storage_bucket.go:853
 msgid "Create key for a storage bucket"
 msgstr ""
 
-#: lxc/storage_bucket.go:82 lxc/storage_bucket.go:83
+#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
 msgid "Create new custom storage buckets"
 msgstr ""
 
@@ -1634,7 +1634,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:92 lxc/project.go:93
+#: lxc/project.go:93 lxc/project.go:94
 msgid "Create projects"
 msgstr ""
 
@@ -1669,13 +1669,13 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:376 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1135 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
-#: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:172
-#: lxc/profile.go:756 lxc/project.go:572 lxc/storage.go:723
-#: lxc/storage_bucket.go:512 lxc/storage_bucket.go:832
+#: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
+#: lxc/profile.go:756 lxc/project.go:573 lxc/storage.go:723
+#: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1732
 msgid "DESCRIPTION"
 msgstr ""
@@ -1700,7 +1700,7 @@ msgstr ""
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
-#: lxc/operation.go:55 lxc/operation.go:56
+#: lxc/operation.go:56 lxc/operation.go:57
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
@@ -1708,19 +1708,19 @@ msgstr ""
 msgid "Delete a cluster group"
 msgstr ""
 
-#: lxc/warning.go:360
+#: lxc/warning.go:361
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:122 lxc/file.go:123
+#: lxc/file.go:123 lxc/file.go:124
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/auth.go:151 lxc/auth.go:152
+#: lxc/auth.go:152 lxc/auth.go:153
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1523 lxc/auth.go:1524
+#: lxc/auth.go:1524 lxc/auth.go:1525
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1740,7 +1740,7 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/storage_bucket.go:957 lxc/storage_bucket.go:958
+#: lxc/storage_bucket.go:958 lxc/storage_bucket.go:959
 msgid "Delete key from a storage bucket"
 msgstr ""
 
@@ -1776,11 +1776,11 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:188 lxc/project.go:189
+#: lxc/project.go:189 lxc/project.go:190
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:187 lxc/storage_bucket.go:188
+#: lxc/storage_bucket.go:188 lxc/storage_bucket.go:189
 msgid "Delete storage buckets"
 msgstr ""
 
@@ -1792,20 +1792,20 @@ msgstr ""
 msgid "Delete storage volumes"
 msgstr ""
 
-#: lxc/warning.go:356 lxc/warning.go:357
+#: lxc/warning.go:357 lxc/warning.go:358
 msgid "Delete warning"
 msgstr ""
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:30 lxc/auth.go:59 lxc/auth.go:98
-#: lxc/auth.go:152 lxc/auth.go:201 lxc/auth.go:332 lxc/auth.go:392
-#: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
-#: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
-#: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
-#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1434 lxc/auth.go:1472
-#: lxc/auth.go:1524 lxc/auth.go:1573 lxc/auth.go:1692 lxc/auth.go:1752
-#: lxc/auth.go:1801 lxc/auth.go:1852 lxc/auth.go:1875 lxc/auth.go:1928
+#: lxc/alias.go:214 lxc/auth.go:31 lxc/auth.go:60 lxc/auth.go:99
+#: lxc/auth.go:153 lxc/auth.go:202 lxc/auth.go:333 lxc/auth.go:393
+#: lxc/auth.go:442 lxc/auth.go:494 lxc/auth.go:517 lxc/auth.go:576
+#: lxc/auth.go:732 lxc/auth.go:766 lxc/auth.go:833 lxc/auth.go:896
+#: lxc/auth.go:957 lxc/auth.go:1085 lxc/auth.go:1108 lxc/auth.go:1166
+#: lxc/auth.go:1235 lxc/auth.go:1257 lxc/auth.go:1435 lxc/auth.go:1473
+#: lxc/auth.go:1525 lxc/auth.go:1574 lxc/auth.go:1693 lxc/auth.go:1753
+#: lxc/auth.go:1802 lxc/auth.go:1853 lxc/auth.go:1876 lxc/auth.go:1929
 #: lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215 lxc/cluster.go:272
 #: lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:484 lxc/cluster.go:528
 #: lxc/cluster.go:586 lxc/cluster.go:677 lxc/cluster.go:770 lxc/cluster.go:893
@@ -1829,15 +1829,15 @@ msgstr ""
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:83 lxc/file.go:123 lxc/file.go:172
-#: lxc/file.go:242 lxc/file.go:467 lxc/file.go:986 lxc/image.go:38
+#: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
+#: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
 #: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
 #: lxc/image.go:697 lxc/image.go:946 lxc/image.go:1088 lxc/image.go:1415
 #: lxc/image.go:1506 lxc/image.go:1572 lxc/image.go:1636 lxc/image.go:1699
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:38 lxc/network.go:33
+#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33
 #: lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405
 #: lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793
 #: lxc/network.go:874 lxc/network.go:1005 lxc/network.go:1106
@@ -1871,27 +1871,27 @@ msgstr ""
 #: lxc/network_zone.go:909 lxc/network_zone.go:985 lxc/network_zone.go:1083
 #: lxc/network_zone.go:1172 lxc/network_zone.go:1219 lxc/network_zone.go:1349
 #: lxc/network_zone.go:1410 lxc/network_zone.go:1425 lxc/network_zone.go:1483
-#: lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:106
-#: lxc/operation.go:193 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
+#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
+#: lxc/operation.go:194 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
 #: lxc/profile.go:271 lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493
 #: lxc/profile.go:629 lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860
-#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:29
-#: lxc/project.go:93 lxc/project.go:189 lxc/project.go:260 lxc/project.go:396
-#: lxc/project.go:470 lxc/project.go:590 lxc/project.go:655 lxc/project.go:743
-#: lxc/project.go:787 lxc/project.go:848 lxc/project.go:915 lxc/publish.go:34
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:35 lxc/remote.go:91
+#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:30
+#: lxc/project.go:94 lxc/project.go:190 lxc/project.go:261 lxc/project.go:397
+#: lxc/project.go:471 lxc/project.go:591 lxc/project.go:656 lxc/project.go:744
+#: lxc/project.go:788 lxc/project.go:849 lxc/project.go:916 lxc/publish.go:34
+#: lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91
 #: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853
 #: lxc/remote.go:917 lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24
 #: lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203
 #: lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655
 #: lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940
-#: lxc/storage_bucket.go:29 lxc/storage_bucket.go:83 lxc/storage_bucket.go:188
-#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:382
-#: lxc/storage_bucket.go:458 lxc/storage_bucket.go:535
-#: lxc/storage_bucket.go:629 lxc/storage_bucket.go:698
-#: lxc/storage_bucket.go:732 lxc/storage_bucket.go:773
-#: lxc/storage_bucket.go:852 lxc/storage_bucket.go:958
-#: lxc/storage_bucket.go:1022 lxc/storage_bucket.go:1157
+#: lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189
+#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:383
+#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:536
+#: lxc/storage_bucket.go:630 lxc/storage_bucket.go:699
+#: lxc/storage_bucket.go:733 lxc/storage_bucket.go:774
+#: lxc/storage_bucket.go:853 lxc/storage_bucket.go:959
+#: lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158
 #: lxc/storage_volume.go:58 lxc/storage_volume.go:169 lxc/storage_volume.go:283
 #: lxc/storage_volume.go:390 lxc/storage_volume.go:605
 #: lxc/storage_volume.go:714 lxc/storage_volume.go:801
@@ -1902,8 +1902,8 @@ msgstr ""
 #: lxc/storage_volume.go:2064 lxc/storage_volume.go:2222
 #: lxc/storage_volume.go:2343 lxc/storage_volume.go:2405
 #: lxc/storage_volume.go:2541 lxc/storage_volume.go:2624
-#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:29
-#: lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
+#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:30
+#: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
@@ -1990,7 +1990,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:994
+#: lxc/file.go:995
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2056,7 +2056,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:74
+#: lxc/file.go:75
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -2066,7 +2066,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:955 lxc/auth.go:956
+#: lxc/auth.go:956 lxc/auth.go:957
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -2074,15 +2074,15 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:171 lxc/file.go:172
+#: lxc/file.go:172 lxc/file.go:173
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/auth.go:200 lxc/auth.go:201
+#: lxc/auth.go:201 lxc/auth.go:202
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1572 lxc/auth.go:1573
+#: lxc/auth.go:1573 lxc/auth.go:1574
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2138,15 +2138,15 @@ msgstr ""
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:259 lxc/project.go:260
+#: lxc/project.go:260 lxc/project.go:261
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:248 lxc/storage_bucket.go:249
+#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:250
 msgid "Edit storage bucket configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:1021 lxc/storage_bucket.go:1022
+#: lxc/storage_bucket.go:1022 lxc/storage_bucket.go:1023
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
@@ -2163,7 +2163,7 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1147 lxc/list.go:622 lxc/storage_volume.go:1766
-#: lxc/warning.go:235
+#: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2218,7 +2218,7 @@ msgstr ""
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
-#: lxc/project.go:718 lxc/storage.go:812 lxc/storage_bucket.go:602
+#: lxc/project.go:719 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2155 lxc/storage_volume.go:2193
 #, c-format
 msgid "Error setting properties: %v"
@@ -2232,8 +2232,8 @@ msgstr ""
 #: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
-#: lxc/profile.go:981 lxc/project.go:712 lxc/storage.go:806
-#: lxc/storage_bucket.go:596 lxc/storage_volume.go:2149
+#: lxc/profile.go:981 lxc/project.go:713 lxc/storage.go:806
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2149
 #: lxc/storage_volume.go:2187
 #, c-format
 msgid "Error unsetting property: %v"
@@ -2253,7 +2253,7 @@ msgstr ""
 msgid "Evacuating cluster member: %s"
 msgstr ""
 
-#: lxc/monitor.go:50
+#: lxc/monitor.go:51
 msgid "Event type to listen for"
 msgstr ""
 
@@ -2340,16 +2340,16 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/warning.go:210
+#: lxc/warning.go:211
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1237
+#: lxc/file.go:1238
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1260
+#: lxc/file.go:1261
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2364,12 +2364,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1287
+#: lxc/file.go:1288
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1072
+#: lxc/file.go:1073
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2399,7 +2399,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1193
+#: lxc/file.go:1194
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2414,7 +2414,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1198
+#: lxc/file.go:1199
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2424,12 +2424,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1098
+#: lxc/file.go:1099
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1225
+#: lxc/file.go:1226
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2468,7 +2468,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1210
+#: lxc/file.go:1211
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2483,7 +2483,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:820
+#: lxc/file.go:821
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2498,7 +2498,7 @@ msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
 #: lxc/network.go:1044 lxc/network_acl.go:133 lxc/network_zone.go:124
-#: lxc/operation.go:136
+#: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
 
@@ -2563,21 +2563,21 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
+#: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:770 lxc/auth.go:1697
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1114 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:57
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
-#: lxc/operation.go:108 lxc/profile.go:707 lxc/project.go:472
-#: lxc/project.go:917 lxc/remote.go:690 lxc/storage.go:657
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:774
-#: lxc/storage_volume.go:1608 lxc/warning.go:93
+#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:473
+#: lxc/project.go:918 lxc/remote.go:690 lxc/storage.go:657
+#: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
+#: lxc/storage_volume.go:1608 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
-#: lxc/monitor.go:52
+#: lxc/monitor.go:53
 msgid "Format (json|pretty|yaml)"
 msgstr ""
 
@@ -2621,7 +2621,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:817 lxc/auth.go:1736
+#: lxc/auth.go:818 lxc/auth.go:1737
 msgid "GROUPS"
 msgstr ""
 
@@ -2637,7 +2637,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:914 lxc/project.go:915
+#: lxc/project.go:915 lxc/project.go:916
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2685,11 +2685,11 @@ msgstr ""
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:400
+#: lxc/project.go:401
 msgid "Get the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:385
+#: lxc/storage_bucket.go:386
 msgid "Get the key as a storage bucket property"
 msgstr ""
 
@@ -2749,11 +2749,11 @@ msgstr ""
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:395 lxc/project.go:396
+#: lxc/project.go:396 lxc/project.go:397
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:382
+#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:383
 msgid "Get values for storage bucket configuration keys"
 msgstr ""
 
@@ -2770,17 +2770,17 @@ msgstr ""
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: lxc/auth.go:136
+#: lxc/auth.go:137
 #, c-format
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:186
+#: lxc/auth.go:187
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:426 lxc/auth.go:1786
+#: lxc/auth.go:427 lxc/auth.go:1787
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2805,27 +2805,27 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1310
+#: lxc/file.go:1311
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1299
+#: lxc/file.go:1300
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1122
+#: lxc/file.go:1123
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1132
+#: lxc/file.go:1133
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:966 lxc/operation.go:170
+#: lxc/network.go:966 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2839,11 +2839,11 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:816
+#: lxc/auth.go:817
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:566
+#: lxc/project.go:567
 msgid "IMAGES"
 msgstr ""
 
@@ -2871,17 +2871,17 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1508
+#: lxc/auth.go:1509
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1558
+#: lxc/auth.go:1559
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
 
-#: lxc/rebuild.go:32
+#: lxc/rebuild.go:33
 msgid "If an instance is running, stop it and then rebuild it"
 msgstr ""
 
@@ -3002,7 +3002,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1233 lxc/auth.go:1234
+#: lxc/auth.go:1234 lxc/auth.go:1235
 msgid "Inspect permissions"
 msgstr ""
 
@@ -3010,11 +3010,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1124
+#: lxc/file.go:1125
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1301
+#: lxc/file.go:1302
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3032,7 +3032,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1044
+#: lxc/file.go:1045
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3041,7 +3041,7 @@ msgstr ""
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/rebuild.go:74
+#: lxc/rebuild.go:75
 #, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
@@ -3074,7 +3074,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/monitor.go:70
+#: lxc/monitor.go:71
 #, c-format
 msgid "Invalid format: %s"
 msgstr ""
@@ -3084,7 +3084,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1039
+#: lxc/file.go:1040
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3126,7 +3126,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:147
+#: lxc/file.go:148
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -3142,12 +3142,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:313
+#: lxc/file.go:314
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:495
+#: lxc/file.go:496
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3161,7 +3161,7 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/warning.go:212
 msgid "LAST SEEN"
 msgstr ""
 
@@ -3169,7 +3169,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:984
+#: lxc/project.go:985
 msgid "LIMIT"
 msgstr ""
 
@@ -3178,8 +3178,8 @@ msgid "LISTEN ADDRESS"
 msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
-#: lxc/network_load_balancer.go:165 lxc/operation.go:177
-#: lxc/storage_bucket.go:516 lxc/storage_volume.go:1739 lxc/warning.go:220
+#: lxc/network_load_balancer.go:165 lxc/operation.go:178
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1739 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3253,7 +3253,7 @@ msgstr ""
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/warning.go:94
+#: lxc/warning.go:95
 msgid "List all warnings"
 msgstr ""
 
@@ -3297,19 +3297,19 @@ msgstr ""
 msgid "List available storage pools"
 msgstr ""
 
-#: lxc/operation.go:105 lxc/operation.go:106
+#: lxc/operation.go:106 lxc/operation.go:107
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:331 lxc/auth.go:332
+#: lxc/auth.go:332 lxc/auth.go:333
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:764 lxc/auth.go:765
+#: lxc/auth.go:765 lxc/auth.go:766
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1691 lxc/auth.go:1692
+#: lxc/auth.go:1692 lxc/auth.go:1693
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3458,11 +3458,11 @@ msgstr ""
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/operation.go:109
+#: lxc/operation.go:110
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1255 lxc/auth.go:1256
+#: lxc/auth.go:1256 lxc/auth.go:1257
 msgid "List permissions"
 msgstr ""
 
@@ -3470,15 +3470,15 @@ msgstr ""
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:469 lxc/project.go:470
+#: lxc/project.go:470 lxc/project.go:471
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:771 lxc/storage_bucket.go:773
+#: lxc/storage_bucket.go:772 lxc/storage_bucket.go:774
 msgid "List storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:456 lxc/storage_bucket.go:458
+#: lxc/storage_bucket.go:457 lxc/storage_bucket.go:459
 msgid "List storage buckets"
 msgstr ""
 
@@ -3514,11 +3514,11 @@ msgstr ""
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/warning.go:70
+#: lxc/warning.go:71
 msgid "List warnings"
 msgstr ""
 
-#: lxc/warning.go:71
+#: lxc/warning.go:72
 msgid ""
 "List warnings\n"
 "\n"
@@ -3541,7 +3541,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/operation.go:23 lxc/operation.go:24
+#: lxc/operation.go:24 lxc/operation.go:25
 msgid "List, show and delete background operations"
 msgstr ""
 
@@ -3550,7 +3550,7 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/monitor.go:79
+#: lxc/monitor.go:80
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
@@ -3654,23 +3654,23 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:82 lxc/file.go:83
+#: lxc/file.go:83 lxc/file.go:84
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1433 lxc/auth.go:1434
+#: lxc/auth.go:59 lxc/auth.go:60 lxc/auth.go:1434 lxc/auth.go:1435
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1083 lxc/auth.go:1084
+#: lxc/auth.go:1084 lxc/auth.go:1085
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:730 lxc/auth.go:731
+#: lxc/auth.go:731 lxc/auth.go:732
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1851 lxc/auth.go:1852
+#: lxc/auth.go:1852 lxc/auth.go:1853
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3761,7 +3761,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:492 lxc/auth.go:493
+#: lxc/auth.go:493 lxc/auth.go:494
 msgid "Manage permissions"
 msgstr ""
 
@@ -3769,23 +3769,23 @@ msgstr ""
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:28 lxc/project.go:29
+#: lxc/project.go:29 lxc/project.go:30
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:731
+#: lxc/storage_bucket.go:732
 msgid "Manage storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:732
+#: lxc/storage_bucket.go:733
 msgid "Manage storage bucket keys."
 msgstr ""
 
-#: lxc/storage_bucket.go:28
+#: lxc/storage_bucket.go:29
 msgid "Manage storage buckets"
 msgstr ""
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:30
 msgid "Manage storage buckets."
 msgstr ""
 
@@ -3813,11 +3813,11 @@ msgstr ""
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/auth.go:29 lxc/auth.go:30
+#: lxc/auth.go:30 lxc/auth.go:31
 msgid "Manage user authorization"
 msgstr ""
 
-#: lxc/warning.go:28 lxc/warning.go:29
+#: lxc/warning.go:29 lxc/warning.go:30
 msgid "Manage warnings"
 msgstr ""
 
@@ -3881,17 +3881,17 @@ msgstr ""
 msgid "Migration operation failure: %w"
 msgstr ""
 
-#: lxc/monitor.go:51
+#: lxc/monitor.go:52
 msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: lxc/storage_bucket.go:116 lxc/storage_bucket.go:216
-#: lxc/storage_bucket.go:292 lxc/storage_bucket.go:411
-#: lxc/storage_bucket.go:568 lxc/storage_bucket.go:660
-#: lxc/storage_bucket.go:802 lxc/storage_bucket.go:889
-#: lxc/storage_bucket.go:986 lxc/storage_bucket.go:1065
-#: lxc/storage_bucket.go:1188
+#: lxc/storage_bucket.go:117 lxc/storage_bucket.go:217
+#: lxc/storage_bucket.go:293 lxc/storage_bucket.go:412
+#: lxc/storage_bucket.go:569 lxc/storage_bucket.go:661
+#: lxc/storage_bucket.go:803 lxc/storage_bucket.go:890
+#: lxc/storage_bucket.go:987 lxc/storage_bucket.go:1066
+#: lxc/storage_bucket.go:1189
 msgid "Missing bucket name"
 msgstr ""
 
@@ -3910,20 +3910,20 @@ msgstr ""
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1825
+#: lxc/auth.go:123 lxc/auth.go:177 lxc/auth.go:255 lxc/auth.go:417
+#: lxc/auth.go:466 lxc/auth.go:541 lxc/auth.go:600 lxc/auth.go:1826
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:862 lxc/auth.go:1003 lxc/auth.go:1131 lxc/auth.go:1189
+#: lxc/auth.go:863 lxc/auth.go:1004 lxc/auth.go:1132 lxc/auth.go:1190
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1495 lxc/auth.go:1548 lxc/auth.go:1614 lxc/auth.go:1776
+#: lxc/auth.go:1496 lxc/auth.go:1549 lxc/auth.go:1615 lxc/auth.go:1777
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1899 lxc/auth.go:1952
+#: lxc/auth.go:1900 lxc/auth.go:1953
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -3931,12 +3931,12 @@ msgstr ""
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
 #: lxc/config_template.go:377 lxc/profile.go:141 lxc/profile.go:222
-#: lxc/profile.go:808 lxc/rebuild.go:60
+#: lxc/profile.go:808 lxc/rebuild.go:61
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/storage_bucket.go:893 lxc/storage_bucket.go:990
-#: lxc/storage_bucket.go:1069 lxc/storage_bucket.go:1192
+#: lxc/storage_bucket.go:894 lxc/storage_bucket.go:991
+#: lxc/storage_bucket.go:1070 lxc/storage_bucket.go:1193
 msgid "Missing key name"
 msgstr ""
 
@@ -4001,13 +4001,13 @@ msgid "Missing peer name"
 msgstr ""
 
 #: lxc/storage.go:235 lxc/storage.go:313 lxc/storage.go:431 lxc/storage.go:509
-#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:112
-#: lxc/storage_bucket.go:212 lxc/storage_bucket.go:288
-#: lxc/storage_bucket.go:407 lxc/storage_bucket.go:482
-#: lxc/storage_bucket.go:564 lxc/storage_bucket.go:656
-#: lxc/storage_bucket.go:798 lxc/storage_bucket.go:885
-#: lxc/storage_bucket.go:982 lxc/storage_bucket.go:1061
-#: lxc/storage_bucket.go:1184 lxc/storage_volume.go:209
+#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:113
+#: lxc/storage_bucket.go:213 lxc/storage_bucket.go:289
+#: lxc/storage_bucket.go:408 lxc/storage_bucket.go:483
+#: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
+#: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
+#: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
 #: lxc/storage_volume.go:323 lxc/storage_volume.go:643
 #: lxc/storage_volume.go:750 lxc/storage_volume.go:841
 #: lxc/storage_volume.go:939 lxc/storage_volume.go:1053
@@ -4022,9 +4022,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:404 lxc/project.go:146 lxc/project.go:226 lxc/project.go:316
-#: lxc/project.go:433 lxc/project.go:622 lxc/project.go:691 lxc/project.go:819
-#: lxc/project.go:948
+#: lxc/profile.go:404 lxc/project.go:147 lxc/project.go:227 lxc/project.go:317
+#: lxc/project.go:434 lxc/project.go:623 lxc/project.go:692 lxc/project.go:820
+#: lxc/project.go:949
 msgid "Missing project name"
 msgstr ""
 
@@ -4040,7 +4040,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:598
+#: lxc/file.go:599
 msgid "Missing target directory"
 msgstr ""
 
@@ -4062,11 +4062,11 @@ msgstr ""
 msgid "Model: %v"
 msgstr ""
 
-#: lxc/monitor.go:32
+#: lxc/monitor.go:33
 msgid "Monitor a local or remote LXD server"
 msgstr ""
 
-#: lxc/monitor.go:33
+#: lxc/monitor.go:34
 msgid ""
 "Monitor a local or remote LXD server\n"
 "\n"
@@ -4078,11 +4078,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:285
+#: lxc/file.go:286
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:985 lxc/file.go:986
+#: lxc/file.go:986 lxc/file.go:987
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4144,13 +4144,13 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:192
+#: lxc/auth.go:376 lxc/auth.go:816 lxc/auth.go:1736 lxc/cluster.go:192
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
-#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:565
-#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:511
-#: lxc/storage_bucket.go:831 lxc/storage_volume.go:1731
+#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:566
+#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1731
 msgid "NAME"
 msgstr ""
 
@@ -4158,11 +4158,11 @@ msgstr ""
 msgid "NAT"
 msgstr ""
 
-#: lxc/project.go:571
+#: lxc/project.go:572
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:570
+#: lxc/project.go:571
 msgid "NETWORKS"
 msgstr ""
 
@@ -4174,9 +4174,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/operation.go:154 lxc/project.go:523
-#: lxc/project.go:528 lxc/project.go:533 lxc/project.go:538 lxc/project.go:543
-#: lxc/project.go:548 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
+#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:524
+#: lxc/project.go:529 lxc/project.go:534 lxc/project.go:539 lxc/project.go:544
+#: lxc/project.go:549 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
 msgid "NO"
 msgstr ""
 
@@ -4421,7 +4421,7 @@ msgstr ""
 msgid "Only managed networks can be modified"
 msgstr ""
 
-#: lxc/operation.go:86
+#: lxc/operation.go:87
 #, c-format
 msgid "Operation %s deleted"
 msgstr ""
@@ -4468,11 +4468,11 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:567
+#: lxc/list.go:576 lxc/project.go:568
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:212
+#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4534,24 +4534,24 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1102
+#: lxc/file.go:1103
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:860
+#: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
-#: lxc/project.go:363 lxc/storage.go:360 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1151
+#: lxc/project.go:364 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1151
 #: lxc/storage_volume.go:1183
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
-#: lxc/monitor.go:48
+#: lxc/monitor.go:49
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
@@ -4637,17 +4637,17 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:172
+#: lxc/project.go:173
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:236
+#: lxc/project.go:237
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:637
+#: lxc/project.go:638
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -4768,20 +4768,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:241 lxc/file.go:242
+#: lxc/file.go:242 lxc/file.go:243
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:416 lxc/file.go:767
+#: lxc/file.go:417 lxc/file.go:768
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:466 lxc/file.go:467
+#: lxc/file.go:467 lxc/file.go:468
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:701 lxc/file.go:867
+#: lxc/file.go:702 lxc/file.go:868
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4794,11 +4794,11 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:983
+#: lxc/project.go:984
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/storage_bucket.go:833
+#: lxc/storage_bucket.go:834
 msgid "ROLE"
 msgstr ""
 
@@ -4811,15 +4811,15 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/rebuild.go:31
+#: lxc/rebuild.go:32
 msgid "Rebuild as an empty instance"
 msgstr ""
 
-#: lxc/rebuild.go:26
+#: lxc/rebuild.go:27
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:249 lxc/file.go:473
+#: lxc/file.go:250 lxc/file.go:474
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4846,7 +4846,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:882 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
+#: lxc/project.go:883 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
 #: lxc/remote.go:994
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4897,7 +4897,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1164 lxc/auth.go:1165
+#: lxc/auth.go:1165 lxc/auth.go:1166
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4933,7 +4933,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1927 lxc/auth.go:1928
+#: lxc/auth.go:1928 lxc/auth.go:1929
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4945,7 +4945,7 @@ msgstr ""
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:574 lxc/auth.go:575
+#: lxc/auth.go:575 lxc/auth.go:576
 msgid "Remove permissions from groups"
 msgstr ""
 
@@ -4990,11 +4990,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:391 lxc/auth.go:392
+#: lxc/auth.go:392 lxc/auth.go:393
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1751 lxc/auth.go:1752
+#: lxc/auth.go:1752 lxc/auth.go:1753
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5014,7 +5014,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:589 lxc/project.go:590
+#: lxc/project.go:590 lxc/project.go:591
 msgid "Rename projects"
 msgstr ""
 
@@ -5112,7 +5112,7 @@ msgstr ""
 msgid "Revoke cluster member join token"
 msgstr ""
 
-#: lxc/storage_bucket.go:862
+#: lxc/storage_bucket.go:863
 msgid "Role (admin or read-only)"
 msgstr ""
 
@@ -5128,7 +5128,7 @@ msgstr ""
 msgid "Run against all projects"
 msgstr ""
 
-#: lxc/warning.go:213
+#: lxc/warning.go:214
 msgid "SEVERITY"
 msgstr ""
 
@@ -5148,12 +5148,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1231
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1231
+#: lxc/file.go:1232
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5167,11 +5167,11 @@ msgstr ""
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:173 lxc/warning.go:214
+#: lxc/operation.go:174 lxc/warning.go:215
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:569
+#: lxc/project.go:570
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5179,7 +5179,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:569
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -5187,11 +5187,11 @@ msgstr ""
 msgid "STP"
 msgstr ""
 
-#: lxc/storage_bucket.go:864
+#: lxc/storage_bucket.go:865
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:942
+#: lxc/storage_bucket.go:943
 #, c-format
 msgid "Secret key: %s"
 msgstr ""
@@ -5229,7 +5229,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:995
+#: lxc/file.go:996
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5367,11 +5367,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:654
+#: lxc/project.go:655
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:655
+#: lxc/project.go:656
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5380,11 +5380,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage_bucket.go:534
+#: lxc/storage_bucket.go:535
 msgid "Set storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:535
+#: lxc/storage_bucket.go:536
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -5423,15 +5423,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:476
+#: lxc/file.go:477
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:477
+#: lxc/file.go:478
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:475
+#: lxc/file.go:476
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5471,11 +5471,11 @@ msgstr ""
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 msgid "Set the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:542
+#: lxc/storage_bucket.go:543
 msgid "Set the key as a storage bucket property"
 msgstr ""
 
@@ -5491,7 +5491,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:993
+#: lxc/file.go:994
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5503,7 +5503,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1800 lxc/auth.go:1801
+#: lxc/auth.go:1801 lxc/auth.go:1802
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5519,11 +5519,11 @@ msgstr ""
 msgid "Show details of a cluster member"
 msgstr ""
 
-#: lxc/operation.go:192 lxc/operation.go:193
+#: lxc/operation.go:193 lxc/operation.go:194
 msgid "Show details on a background operation"
 msgstr ""
 
-#: lxc/monitor.go:49
+#: lxc/monitor.go:50
 msgid "Show events from all projects"
 msgstr ""
 
@@ -5531,11 +5531,11 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:440 lxc/auth.go:441
+#: lxc/auth.go:441 lxc/auth.go:442
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:832
+#: lxc/auth.go:833
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5616,15 +5616,15 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:786 lxc/project.go:787
+#: lxc/project.go:787 lxc/project.go:788
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage_bucket.go:628 lxc/storage_bucket.go:629
+#: lxc/storage_bucket.go:629 lxc/storage_bucket.go:630
 msgid "Show storage bucket configurations"
 msgstr ""
 
-#: lxc/storage_bucket.go:1156 lxc/storage_bucket.go:1157
+#: lxc/storage_bucket.go:1157 lxc/storage_bucket.go:1158
 msgid "Show storage bucket key configurations"
 msgstr ""
 
@@ -5640,7 +5640,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:895
+#: lxc/auth.go:896
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5690,7 +5690,7 @@ msgstr ""
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: lxc/warning.go:302 lxc/warning.go:303
+#: lxc/warning.go:303 lxc/warning.go:304
 msgid "Show warning"
 msgstr ""
 
@@ -5774,22 +5774,22 @@ msgstr ""
 msgid "Stopping the instance failed: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:166
+#: lxc/storage_bucket.go:167
 #, c-format
 msgid "Storage bucket %s created"
 msgstr ""
 
-#: lxc/storage_bucket.go:233
+#: lxc/storage_bucket.go:234
 #, c-format
 msgid "Storage bucket %s deleted"
 msgstr ""
 
-#: lxc/storage_bucket.go:940
+#: lxc/storage_bucket.go:941
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr ""
 
-#: lxc/storage_bucket.go:1006
+#: lxc/storage_bucket.go:1007
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr ""
@@ -5858,7 +5858,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:847 lxc/project.go:848
+#: lxc/project.go:848 lxc/project.go:849
 msgid "Switch the current project"
 msgstr ""
 
@@ -5874,10 +5874,10 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1139
+#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1139
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
-#: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:171
-#: lxc/storage_volume.go:1730 lxc/warning.go:215
+#: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
+#: lxc/storage_volume.go:1730 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
@@ -5885,11 +5885,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1032
+#: lxc/file.go:1033
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1026
+#: lxc/file.go:1027
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -6017,12 +6017,12 @@ msgstr ""
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:446
+#: lxc/project.go:447
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
 
-#: lxc/storage_bucket.go:431
+#: lxc/storage_bucket.go:432
 #, c-format
 msgid "The property %q does not exist on the storage bucket %q: %v"
 msgstr ""
@@ -6207,7 +6207,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:961
+#: lxc/project.go:962
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6219,17 +6219,17 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:985 lxc/storage_volume.go:1735
+#: lxc/project.go:986 lxc/storage_volume.go:1735
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:573
+#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:574
 #: lxc/storage.go:724 lxc/storage_volume.go:1734
 msgid "USED BY"
 msgstr ""
 
-#: lxc/warning.go:216
+#: lxc/warning.go:217
 msgid "UUID"
 msgstr ""
 
@@ -6238,7 +6238,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:197
+#: lxc/file.go:198
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6252,13 +6252,13 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1253
+#: lxc/file.go:1254
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1153 lxc/list.go:631 lxc/storage_volume.go:1772
-#: lxc/warning.go:241
+#: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6268,7 +6268,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:807
+#: lxc/file.go:808
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6351,11 +6351,11 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:742 lxc/project.go:743
+#: lxc/project.go:743 lxc/project.go:744
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:697 lxc/storage_bucket.go:698
+#: lxc/storage_bucket.go:698 lxc/storage_bucket.go:699
 msgid "Unset storage bucket configuration keys"
 msgstr ""
 
@@ -6403,11 +6403,11 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:747
+#: lxc/project.go:748
 msgid "Unset the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:701
+#: lxc/storage_bucket.go:702
 msgid "Unset the key as a storage bucket property"
 msgstr ""
 
@@ -6486,7 +6486,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:71
+#: lxc/file.go:72
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6523,11 +6523,11 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:831
+#: lxc/auth.go:832
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:894
+#: lxc/auth.go:895
 msgid "View the current identity"
 msgstr ""
 
@@ -6558,15 +6558,15 @@ msgstr ""
 msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
-#: lxc/rebuild.go:27
+#: lxc/rebuild.go:28
 msgid ""
 "Wipe the instance root disk and re-initialize. The original image is used to "
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:156 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
+#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:526
+#: lxc/project.go:531 lxc/project.go:536 lxc/project.go:541 lxc/project.go:546
+#: lxc/project.go:551 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
 msgid "YES"
 msgstr ""
 
@@ -6586,7 +6586,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/rebuild.go:119
+#: lxc/rebuild.go:120
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
@@ -6598,12 +6598,12 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1689
+#: lxc/auth.go:330 lxc/auth.go:763 lxc/auth.go:894 lxc/auth.go:1690
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
-#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
+#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
-#: lxc/operation.go:103 lxc/profile.go:700 lxc/project.go:467
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:68
+#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:468
+#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6631,7 +6631,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1254
+#: lxc/auth.go:1255
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6692,11 +6692,11 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:830
+#: lxc/auth.go:831
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1926
+#: lxc/auth.go:1106 lxc/auth.go:1164 lxc/auth.go:1927
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6704,13 +6704,13 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:954 lxc/auth.go:1470 lxc/cluster_group.go:168
+#: lxc/auth.go:97 lxc/auth.go:150 lxc/auth.go:200 lxc/auth.go:440
+#: lxc/auth.go:955 lxc/auth.go:1471 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:514 lxc/auth.go:572
+#: lxc/auth.go:515 lxc/auth.go:573
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
@@ -6720,19 +6720,19 @@ msgstr ""
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:389
+#: lxc/auth.go:390
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1521 lxc/auth.go:1571 lxc/auth.go:1799
+#: lxc/auth.go:1522 lxc/auth.go:1572 lxc/auth.go:1800
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1873
+#: lxc/auth.go:1874
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1749
+#: lxc/auth.go:1750
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -6752,7 +6752,7 @@ msgstr ""
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
-#: lxc/rebuild.go:25
+#: lxc/rebuild.go:26
 msgid "[<remote>:]<image> [<remote>:]<instance>"
 msgstr ""
 
@@ -6835,20 +6835,20 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:170
+#: lxc/file.go:171
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:120
+#: lxc/file.go:121
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:240
+#: lxc/file.go:241
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:984
+#: lxc/file.go:985
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6999,12 +6999,12 @@ msgstr ""
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
-#: lxc/operation.go:53 lxc/operation.go:191
+#: lxc/operation.go:54 lxc/operation.go:192
 msgid "[<remote>:]<operation>"
 msgstr ""
 
 #: lxc/storage.go:200 lxc/storage.go:259 lxc/storage.go:473 lxc/storage.go:844
-#: lxc/storage_bucket.go:454
+#: lxc/storage_bucket.go:455
 msgid "[<remote>:]<pool>"
 msgstr ""
 
@@ -7012,22 +7012,22 @@ msgstr ""
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
-#: lxc/storage_bucket.go:185 lxc/storage_bucket.go:247
-#: lxc/storage_bucket.go:627 lxc/storage_bucket.go:769
+#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:248
+#: lxc/storage_bucket.go:628 lxc/storage_bucket.go:770
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
 
-#: lxc/storage_bucket.go:380 lxc/storage_bucket.go:696
-#: lxc/storage_bucket.go:850 lxc/storage_bucket.go:956
-#: lxc/storage_bucket.go:1020 lxc/storage_bucket.go:1155
+#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:697
+#: lxc/storage_bucket.go:851 lxc/storage_bucket.go:957
+#: lxc/storage_bucket.go:1021 lxc/storage_bucket.go:1156
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
 
-#: lxc/storage_bucket.go:533
+#: lxc/storage_bucket.go:534
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_bucket.go:81
+#: lxc/storage_bucket.go:82
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
 
@@ -7142,20 +7142,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:91 lxc/project.go:186 lxc/project.go:258 lxc/project.go:785
-#: lxc/project.go:846 lxc/project.go:913
+#: lxc/project.go:92 lxc/project.go:187 lxc/project.go:259 lxc/project.go:786
+#: lxc/project.go:847 lxc/project.go:914
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:394 lxc/project.go:741
+#: lxc/project.go:395 lxc/project.go:742
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:653
+#: lxc/project.go:654
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:587
+#: lxc/project.go:588
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7163,7 +7163,7 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:259 lxc/warning.go:301 lxc/warning.go:354
+#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
@@ -7219,7 +7219,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:555 lxc/remote.go:739
+#: lxc/project.go:556 lxc/remote.go:739
 msgid "current"
 msgstr ""
 
@@ -7266,20 +7266,20 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/auth.go:203
+#: lxc/auth.go:204
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:958
+#: lxc/auth.go:959
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1575
+#: lxc/auth.go:1576
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7357,20 +7357,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:988
+#: lxc/file.go:989
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:244
+#: lxc/file.go:245
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:470
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7452,7 +7452,7 @@ msgid ""
 "  List instances with their running state and user comment."
 msgstr ""
 
-#: lxc/monitor.go:37
+#: lxc/monitor.go:38
 msgid ""
 "lxc monitor --type=logging\n"
 "    Only show log messages.\n"
@@ -7528,7 +7528,7 @@ msgid ""
 "    Create record r1 for zone z1 with configuration from config.yaml"
 msgstr ""
 
-#: lxc/operation.go:195
+#: lxc/operation.go:196
 msgid ""
 "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Show details on that operation UUID"
@@ -7571,7 +7571,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:95
+#: lxc/project.go:96
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7579,7 +7579,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:262
+#: lxc/project.go:263
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7610,7 +7610,7 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:85
 msgid ""
 "lxc storage bucket create p1 b01\n"
 "\tCreate a new storage bucket name b01 in storage pool p1\n"
@@ -7620,19 +7620,19 @@ msgid ""
 "of config.yaml"
 msgstr ""
 
-#: lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:251
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1023
+#: lxc/storage_bucket.go:1024
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:854
 msgid ""
 "lxc storage bucket key create p1 b01 k1\n"
 "\tCreate a key called k1 for the bucket b01 in the pool p1.\n"
@@ -7642,14 +7642,14 @@ msgid ""
 "of config.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1158
+#: lxc/storage_bucket.go:1159
 msgid ""
 "lxc storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_bucket.go:630
+#: lxc/storage_bucket.go:631
 msgid ""
 "lxc storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
@@ -7719,16 +7719,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1142
+#: lxc/file.go:1143
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1101
+#: lxc/file.go:1102
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1054
+#: lxc/file.go:1055
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/zh_Hant.po
+++ b/po/zh_Hant.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-04 08:52-0600\n"
+"POT-Creation-Date: 2024-09-05 08:44-0400\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Chinese (Traditional) <https://hosted.weblate.org/projects/"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: lxc/storage_bucket.go:260 lxc/storage_bucket.go:1033
+#: lxc/storage_bucket.go:261 lxc/storage_bucket.go:1034
 msgid ""
 "### This is a YAML representation of a storage bucket.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -133,7 +133,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:213
+#: lxc/auth.go:214
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -160,7 +160,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:968
+#: lxc/auth.go:969
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -181,7 +181,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1585
+#: lxc/auth.go:1586
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -391,7 +391,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:280
+#: lxc/project.go:281
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -433,12 +433,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:935
+#: lxc/file.go:936
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:825
+#: lxc/file.go:826
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -474,7 +474,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:142 lxc/rebuild.go:64
+#: lxc/init.go:142 lxc/rebuild.go:65
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -527,7 +527,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:465
+#: lxc/file.go:466
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -560,7 +560,7 @@ msgstr ""
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:813
+#: lxc/auth.go:814
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -568,11 +568,11 @@ msgstr ""
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/storage_bucket.go:863
+#: lxc/storage_bucket.go:864
 msgid "Access key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:941
+#: lxc/storage_bucket.go:942
 #, c-format
 msgid "Access key: %s"
 msgstr ""
@@ -581,7 +581,7 @@ msgstr ""
 msgid "Access the expanded configuration"
 msgstr ""
 
-#: lxc/warning.go:261 lxc/warning.go:262
+#: lxc/warning.go:262 lxc/warning.go:263
 msgid "Acknowledge warning"
 msgstr ""
 
@@ -598,11 +598,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1106 lxc/auth.go:1107
+#: lxc/auth.go:1107 lxc/auth.go:1108
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1874 lxc/auth.go:1875
+#: lxc/auth.go:1875 lxc/auth.go:1876
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -671,7 +671,7 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:515 lxc/auth.go:516
+#: lxc/auth.go:516 lxc/auth.go:517
 msgid "Add permissions to groups"
 msgstr ""
 
@@ -700,7 +700,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:169
+#: lxc/storage_bucket.go:170
 #, c-format
 msgid "Admin access key: %s"
 msgstr ""
@@ -710,7 +710,7 @@ msgstr ""
 msgid "Admin password (or token) for %s:"
 msgstr ""
 
-#: lxc/storage_bucket.go:170
+#: lxc/storage_bucket.go:171
 #, c-format
 msgid "Admin secret key: %s"
 msgstr ""
@@ -769,7 +769,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:342 lxc/rebuild.go:130
+#: lxc/init.go:342 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -869,12 +869,12 @@ msgstr ""
 
 #: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:318
 #: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
-#: lxc/network_zone.go:366 lxc/network_zone.go:1053 lxc/storage_bucket.go:141
+#: lxc/network_zone.go:366 lxc/network_zone.go:1053 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:159
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:160
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -914,7 +914,7 @@ msgstr ""
 msgid "Bytes sent"
 msgstr ""
 
-#: lxc/operation.go:174
+#: lxc/operation.go:175
 msgid "CANCELABLE"
 msgstr ""
 
@@ -926,7 +926,7 @@ msgstr ""
 msgid "CONTENT-TYPE"
 msgstr ""
 
-#: lxc/warning.go:209
+#: lxc/warning.go:210
 msgid "COUNT"
 msgstr ""
 
@@ -952,7 +952,7 @@ msgstr ""
 msgid "CPUs (%s):"
 msgstr ""
 
-#: lxc/operation.go:175
+#: lxc/operation.go:176
 msgid "CREATED"
 msgstr ""
 
@@ -982,7 +982,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:340
+#: lxc/file.go:341
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1007,11 +1007,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:224
+#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:546
+#: lxc/file.go:547
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1020,7 +1020,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:160
+#: lxc/rebuild.go:161
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1143,13 +1143,13 @@ msgstr ""
 #: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
 #: lxc/network_load_balancer.go:1051 lxc/network_load_balancer.go:1125
 #: lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748
-#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:90
-#: lxc/storage_bucket.go:190 lxc/storage_bucket.go:253
-#: lxc/storage_bucket.go:384 lxc/storage_bucket.go:541
-#: lxc/storage_bucket.go:634 lxc/storage_bucket.go:700
-#: lxc/storage_bucket.go:775 lxc/storage_bucket.go:861
-#: lxc/storage_bucket.go:961 lxc/storage_bucket.go:1026
-#: lxc/storage_bucket.go:1162 lxc/storage_volume.go:394
+#: lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91
+#: lxc/storage_bucket.go:191 lxc/storage_bucket.go:254
+#: lxc/storage_bucket.go:385 lxc/storage_bucket.go:542
+#: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
+#: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
+#: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
 #: lxc/storage_volume.go:612 lxc/storage_volume.go:717
 #: lxc/storage_volume.go:1005 lxc/storage_volume.go:1231
 #: lxc/storage_volume.go:1360 lxc/storage_volume.go:1848
@@ -1173,7 +1173,7 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1113 lxc/list.go:132 lxc/storage_volume.go:1589
-#: lxc/warning.go:92
+#: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
@@ -1201,7 +1201,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:100
+#: lxc/project.go:101
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1215,8 +1215,8 @@ msgstr ""
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
-#: lxc/project.go:362 lxc/storage.go:359 lxc/storage_bucket.go:348
-#: lxc/storage_bucket.go:1125 lxc/storage_volume.go:1150
+#: lxc/project.go:363 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1150
 #: lxc/storage_volume.go:1182
 #, c-format
 msgid "Config parsing error: %s"
@@ -1343,12 +1343,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:300 lxc/auth.go:1660
+#: lxc/auth.go:301 lxc/auth.go:1661
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1054
+#: lxc/auth.go:1055
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1397,15 +1397,15 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:248 lxc/file.go:474
+#: lxc/file.go:249 lxc/file.go:475
 msgid "Create any directories necessary"
 msgstr ""
 
-#: lxc/auth.go:97 lxc/auth.go:98
+#: lxc/auth.go:98 lxc/auth.go:99
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1471 lxc/auth.go:1472
+#: lxc/auth.go:1472 lxc/auth.go:1473
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1425,11 +1425,11 @@ msgstr ""
 msgid "Create instances from images"
 msgstr ""
 
-#: lxc/storage_bucket.go:851 lxc/storage_bucket.go:852
+#: lxc/storage_bucket.go:852 lxc/storage_bucket.go:853
 msgid "Create key for a storage bucket"
 msgstr ""
 
-#: lxc/storage_bucket.go:82 lxc/storage_bucket.go:83
+#: lxc/storage_bucket.go:83 lxc/storage_bucket.go:84
 msgid "Create new custom storage buckets"
 msgstr ""
 
@@ -1473,7 +1473,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:92 lxc/project.go:93
+#: lxc/project.go:93 lxc/project.go:94
 msgid "Create projects"
 msgstr ""
 
@@ -1508,13 +1508,13 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:376 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1135 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
-#: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:172
-#: lxc/profile.go:756 lxc/project.go:572 lxc/storage.go:723
-#: lxc/storage_bucket.go:512 lxc/storage_bucket.go:832
+#: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
+#: lxc/profile.go:756 lxc/project.go:573 lxc/storage.go:723
+#: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1732
 msgid "DESCRIPTION"
 msgstr ""
@@ -1539,7 +1539,7 @@ msgstr ""
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
-#: lxc/operation.go:55 lxc/operation.go:56
+#: lxc/operation.go:56 lxc/operation.go:57
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
@@ -1547,19 +1547,19 @@ msgstr ""
 msgid "Delete a cluster group"
 msgstr ""
 
-#: lxc/warning.go:360
+#: lxc/warning.go:361
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:122 lxc/file.go:123
+#: lxc/file.go:123 lxc/file.go:124
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/auth.go:151 lxc/auth.go:152
+#: lxc/auth.go:152 lxc/auth.go:153
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1523 lxc/auth.go:1524
+#: lxc/auth.go:1524 lxc/auth.go:1525
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1579,7 +1579,7 @@ msgstr ""
 msgid "Delete instances and snapshots"
 msgstr ""
 
-#: lxc/storage_bucket.go:957 lxc/storage_bucket.go:958
+#: lxc/storage_bucket.go:958 lxc/storage_bucket.go:959
 msgid "Delete key from a storage bucket"
 msgstr ""
 
@@ -1615,11 +1615,11 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:188 lxc/project.go:189
+#: lxc/project.go:189 lxc/project.go:190
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:187 lxc/storage_bucket.go:188
+#: lxc/storage_bucket.go:188 lxc/storage_bucket.go:189
 msgid "Delete storage buckets"
 msgstr ""
 
@@ -1631,20 +1631,20 @@ msgstr ""
 msgid "Delete storage volumes"
 msgstr ""
 
-#: lxc/warning.go:356 lxc/warning.go:357
+#: lxc/warning.go:357 lxc/warning.go:358
 msgid "Delete warning"
 msgstr ""
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:30 lxc/auth.go:59 lxc/auth.go:98
-#: lxc/auth.go:152 lxc/auth.go:201 lxc/auth.go:332 lxc/auth.go:392
-#: lxc/auth.go:441 lxc/auth.go:493 lxc/auth.go:516 lxc/auth.go:575
-#: lxc/auth.go:731 lxc/auth.go:765 lxc/auth.go:832 lxc/auth.go:895
-#: lxc/auth.go:956 lxc/auth.go:1084 lxc/auth.go:1107 lxc/auth.go:1165
-#: lxc/auth.go:1234 lxc/auth.go:1256 lxc/auth.go:1434 lxc/auth.go:1472
-#: lxc/auth.go:1524 lxc/auth.go:1573 lxc/auth.go:1692 lxc/auth.go:1752
-#: lxc/auth.go:1801 lxc/auth.go:1852 lxc/auth.go:1875 lxc/auth.go:1928
+#: lxc/alias.go:214 lxc/auth.go:31 lxc/auth.go:60 lxc/auth.go:99
+#: lxc/auth.go:153 lxc/auth.go:202 lxc/auth.go:333 lxc/auth.go:393
+#: lxc/auth.go:442 lxc/auth.go:494 lxc/auth.go:517 lxc/auth.go:576
+#: lxc/auth.go:732 lxc/auth.go:766 lxc/auth.go:833 lxc/auth.go:896
+#: lxc/auth.go:957 lxc/auth.go:1085 lxc/auth.go:1108 lxc/auth.go:1166
+#: lxc/auth.go:1235 lxc/auth.go:1257 lxc/auth.go:1435 lxc/auth.go:1473
+#: lxc/auth.go:1525 lxc/auth.go:1574 lxc/auth.go:1693 lxc/auth.go:1753
+#: lxc/auth.go:1802 lxc/auth.go:1853 lxc/auth.go:1876 lxc/auth.go:1929
 #: lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215 lxc/cluster.go:272
 #: lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:484 lxc/cluster.go:528
 #: lxc/cluster.go:586 lxc/cluster.go:677 lxc/cluster.go:770 lxc/cluster.go:893
@@ -1668,15 +1668,15 @@ msgstr ""
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:83 lxc/file.go:123 lxc/file.go:172
-#: lxc/file.go:242 lxc/file.go:467 lxc/file.go:986 lxc/image.go:38
+#: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
+#: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
 #: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
 #: lxc/image.go:697 lxc/image.go:946 lxc/image.go:1088 lxc/image.go:1415
 #: lxc/image.go:1506 lxc/image.go:1572 lxc/image.go:1636 lxc/image.go:1699
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:38 lxc/network.go:33
+#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33
 #: lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405
 #: lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793
 #: lxc/network.go:874 lxc/network.go:1005 lxc/network.go:1106
@@ -1710,27 +1710,27 @@ msgstr ""
 #: lxc/network_zone.go:909 lxc/network_zone.go:985 lxc/network_zone.go:1083
 #: lxc/network_zone.go:1172 lxc/network_zone.go:1219 lxc/network_zone.go:1349
 #: lxc/network_zone.go:1410 lxc/network_zone.go:1425 lxc/network_zone.go:1483
-#: lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:106
-#: lxc/operation.go:193 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
+#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
+#: lxc/operation.go:194 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
 #: lxc/profile.go:271 lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493
 #: lxc/profile.go:629 lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860
-#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:29
-#: lxc/project.go:93 lxc/project.go:189 lxc/project.go:260 lxc/project.go:396
-#: lxc/project.go:470 lxc/project.go:590 lxc/project.go:655 lxc/project.go:743
-#: lxc/project.go:787 lxc/project.go:848 lxc/project.go:915 lxc/publish.go:34
-#: lxc/query.go:34 lxc/rebuild.go:27 lxc/remote.go:35 lxc/remote.go:91
+#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:30
+#: lxc/project.go:94 lxc/project.go:190 lxc/project.go:261 lxc/project.go:397
+#: lxc/project.go:471 lxc/project.go:591 lxc/project.go:656 lxc/project.go:744
+#: lxc/project.go:788 lxc/project.go:849 lxc/project.go:916 lxc/publish.go:34
+#: lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91
 #: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853
 #: lxc/remote.go:917 lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24
 #: lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203
 #: lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655
 #: lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940
-#: lxc/storage_bucket.go:29 lxc/storage_bucket.go:83 lxc/storage_bucket.go:188
-#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:382
-#: lxc/storage_bucket.go:458 lxc/storage_bucket.go:535
-#: lxc/storage_bucket.go:629 lxc/storage_bucket.go:698
-#: lxc/storage_bucket.go:732 lxc/storage_bucket.go:773
-#: lxc/storage_bucket.go:852 lxc/storage_bucket.go:958
-#: lxc/storage_bucket.go:1022 lxc/storage_bucket.go:1157
+#: lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189
+#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:383
+#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:536
+#: lxc/storage_bucket.go:630 lxc/storage_bucket.go:699
+#: lxc/storage_bucket.go:733 lxc/storage_bucket.go:774
+#: lxc/storage_bucket.go:853 lxc/storage_bucket.go:959
+#: lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158
 #: lxc/storage_volume.go:58 lxc/storage_volume.go:169 lxc/storage_volume.go:283
 #: lxc/storage_volume.go:390 lxc/storage_volume.go:605
 #: lxc/storage_volume.go:714 lxc/storage_volume.go:801
@@ -1741,8 +1741,8 @@ msgstr ""
 #: lxc/storage_volume.go:2064 lxc/storage_volume.go:2222
 #: lxc/storage_volume.go:2343 lxc/storage_volume.go:2405
 #: lxc/storage_volume.go:2541 lxc/storage_volume.go:2624
-#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:29
-#: lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
+#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:30
+#: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
@@ -1829,7 +1829,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:994
+#: lxc/file.go:995
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1895,7 +1895,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:74
+#: lxc/file.go:75
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1905,7 +1905,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:955 lxc/auth.go:956
+#: lxc/auth.go:956 lxc/auth.go:957
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1913,15 +1913,15 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:171 lxc/file.go:172
+#: lxc/file.go:172 lxc/file.go:173
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/auth.go:200 lxc/auth.go:201
+#: lxc/auth.go:201 lxc/auth.go:202
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1572 lxc/auth.go:1573
+#: lxc/auth.go:1573 lxc/auth.go:1574
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -1977,15 +1977,15 @@ msgstr ""
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:259 lxc/project.go:260
+#: lxc/project.go:260 lxc/project.go:261
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:248 lxc/storage_bucket.go:249
+#: lxc/storage_bucket.go:249 lxc/storage_bucket.go:250
 msgid "Edit storage bucket configurations as YAML"
 msgstr ""
 
-#: lxc/storage_bucket.go:1021 lxc/storage_bucket.go:1022
+#: lxc/storage_bucket.go:1022 lxc/storage_bucket.go:1023
 msgid "Edit storage bucket key as YAML"
 msgstr ""
 
@@ -2002,7 +2002,7 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1147 lxc/list.go:622 lxc/storage_volume.go:1766
-#: lxc/warning.go:235
+#: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2057,7 +2057,7 @@ msgstr ""
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
-#: lxc/project.go:718 lxc/storage.go:812 lxc/storage_bucket.go:602
+#: lxc/project.go:719 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2155 lxc/storage_volume.go:2193
 #, c-format
 msgid "Error setting properties: %v"
@@ -2071,8 +2071,8 @@ msgstr ""
 #: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
-#: lxc/profile.go:981 lxc/project.go:712 lxc/storage.go:806
-#: lxc/storage_bucket.go:596 lxc/storage_volume.go:2149
+#: lxc/profile.go:981 lxc/project.go:713 lxc/storage.go:806
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2149
 #: lxc/storage_volume.go:2187
 #, c-format
 msgid "Error unsetting property: %v"
@@ -2092,7 +2092,7 @@ msgstr ""
 msgid "Evacuating cluster member: %s"
 msgstr ""
 
-#: lxc/monitor.go:50
+#: lxc/monitor.go:51
 msgid "Event type to listen for"
 msgstr ""
 
@@ -2179,16 +2179,16 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/warning.go:210
+#: lxc/warning.go:211
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1237
+#: lxc/file.go:1238
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1260
+#: lxc/file.go:1261
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2203,12 +2203,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1287
+#: lxc/file.go:1288
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1072
+#: lxc/file.go:1073
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2238,7 +2238,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1193
+#: lxc/file.go:1194
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2253,7 +2253,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1198
+#: lxc/file.go:1199
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2263,12 +2263,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1098
+#: lxc/file.go:1099
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1225
+#: lxc/file.go:1226
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2307,7 +2307,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1210
+#: lxc/file.go:1211
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2322,7 +2322,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:820
+#: lxc/file.go:821
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2337,7 +2337,7 @@ msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
 #: lxc/network.go:1044 lxc/network_acl.go:133 lxc/network_zone.go:124
-#: lxc/operation.go:136
+#: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
 
@@ -2402,21 +2402,21 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:336 lxc/auth.go:769 lxc/auth.go:1696
+#: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:770 lxc/auth.go:1697
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1114 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:57
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
-#: lxc/operation.go:108 lxc/profile.go:707 lxc/project.go:472
-#: lxc/project.go:917 lxc/remote.go:690 lxc/storage.go:657
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:774
-#: lxc/storage_volume.go:1608 lxc/warning.go:93
+#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:473
+#: lxc/project.go:918 lxc/remote.go:690 lxc/storage.go:657
+#: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
+#: lxc/storage_volume.go:1608 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
-#: lxc/monitor.go:52
+#: lxc/monitor.go:53
 msgid "Format (json|pretty|yaml)"
 msgstr ""
 
@@ -2460,7 +2460,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:817 lxc/auth.go:1736
+#: lxc/auth.go:818 lxc/auth.go:1737
 msgid "GROUPS"
 msgstr ""
 
@@ -2476,7 +2476,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:914 lxc/project.go:915
+#: lxc/project.go:915 lxc/project.go:916
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2524,11 +2524,11 @@ msgstr ""
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:400
+#: lxc/project.go:401
 msgid "Get the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:385
+#: lxc/storage_bucket.go:386
 msgid "Get the key as a storage bucket property"
 msgstr ""
 
@@ -2588,11 +2588,11 @@ msgstr ""
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:395 lxc/project.go:396
+#: lxc/project.go:396 lxc/project.go:397
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:382
+#: lxc/storage_bucket.go:382 lxc/storage_bucket.go:383
 msgid "Get values for storage bucket configuration keys"
 msgstr ""
 
@@ -2609,17 +2609,17 @@ msgstr ""
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: lxc/auth.go:136
+#: lxc/auth.go:137
 #, c-format
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:186
+#: lxc/auth.go:187
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:426 lxc/auth.go:1786
+#: lxc/auth.go:427 lxc/auth.go:1787
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2644,27 +2644,27 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1310
+#: lxc/file.go:1311
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1299
+#: lxc/file.go:1300
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1122
+#: lxc/file.go:1123
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1132
+#: lxc/file.go:1133
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
 
-#: lxc/network.go:966 lxc/operation.go:170
+#: lxc/network.go:966 lxc/operation.go:171
 msgid "ID"
 msgstr ""
 
@@ -2678,11 +2678,11 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:816
+#: lxc/auth.go:817
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:566
+#: lxc/project.go:567
 msgid "IMAGES"
 msgstr ""
 
@@ -2710,17 +2710,17 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1508
+#: lxc/auth.go:1509
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1558
+#: lxc/auth.go:1559
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
 
-#: lxc/rebuild.go:32
+#: lxc/rebuild.go:33
 msgid "If an instance is running, stop it and then rebuild it"
 msgstr ""
 
@@ -2841,7 +2841,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1233 lxc/auth.go:1234
+#: lxc/auth.go:1234 lxc/auth.go:1235
 msgid "Inspect permissions"
 msgstr ""
 
@@ -2849,11 +2849,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1124
+#: lxc/file.go:1125
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1301
+#: lxc/file.go:1302
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2871,7 +2871,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1044
+#: lxc/file.go:1045
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2880,7 +2880,7 @@ msgstr ""
 msgid "Instance published with fingerprint: %s"
 msgstr ""
 
-#: lxc/rebuild.go:74
+#: lxc/rebuild.go:75
 #, c-format
 msgid "Instance snapshots cannot be rebuilt: %s"
 msgstr ""
@@ -2913,7 +2913,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/monitor.go:70
+#: lxc/monitor.go:71
 #, c-format
 msgid "Invalid format: %s"
 msgstr ""
@@ -2923,7 +2923,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1039
+#: lxc/file.go:1040
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2965,7 +2965,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:147
+#: lxc/file.go:148
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2981,12 +2981,12 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:313
+#: lxc/file.go:314
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:495
+#: lxc/file.go:496
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3000,7 +3000,7 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/warning.go:211
+#: lxc/warning.go:212
 msgid "LAST SEEN"
 msgstr ""
 
@@ -3008,7 +3008,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:984
+#: lxc/project.go:985
 msgid "LIMIT"
 msgstr ""
 
@@ -3017,8 +3017,8 @@ msgid "LISTEN ADDRESS"
 msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
-#: lxc/network_load_balancer.go:165 lxc/operation.go:177
-#: lxc/storage_bucket.go:516 lxc/storage_volume.go:1739 lxc/warning.go:220
+#: lxc/network_load_balancer.go:165 lxc/operation.go:178
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1739 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3092,7 +3092,7 @@ msgstr ""
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/warning.go:94
+#: lxc/warning.go:95
 msgid "List all warnings"
 msgstr ""
 
@@ -3136,19 +3136,19 @@ msgstr ""
 msgid "List available storage pools"
 msgstr ""
 
-#: lxc/operation.go:105 lxc/operation.go:106
+#: lxc/operation.go:106 lxc/operation.go:107
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:331 lxc/auth.go:332
+#: lxc/auth.go:332 lxc/auth.go:333
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:764 lxc/auth.go:765
+#: lxc/auth.go:765 lxc/auth.go:766
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1691 lxc/auth.go:1692
+#: lxc/auth.go:1692 lxc/auth.go:1693
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3297,11 +3297,11 @@ msgstr ""
 msgid "List of projects to restrict the certificate to"
 msgstr ""
 
-#: lxc/operation.go:109
+#: lxc/operation.go:110
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1255 lxc/auth.go:1256
+#: lxc/auth.go:1256 lxc/auth.go:1257
 msgid "List permissions"
 msgstr ""
 
@@ -3309,15 +3309,15 @@ msgstr ""
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:469 lxc/project.go:470
+#: lxc/project.go:470 lxc/project.go:471
 msgid "List projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:771 lxc/storage_bucket.go:773
+#: lxc/storage_bucket.go:772 lxc/storage_bucket.go:774
 msgid "List storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:456 lxc/storage_bucket.go:458
+#: lxc/storage_bucket.go:457 lxc/storage_bucket.go:459
 msgid "List storage buckets"
 msgstr ""
 
@@ -3353,11 +3353,11 @@ msgstr ""
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/warning.go:70
+#: lxc/warning.go:71
 msgid "List warnings"
 msgstr ""
 
-#: lxc/warning.go:71
+#: lxc/warning.go:72
 msgid ""
 "List warnings\n"
 "\n"
@@ -3380,7 +3380,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/operation.go:23 lxc/operation.go:24
+#: lxc/operation.go:24 lxc/operation.go:25
 msgid "List, show and delete background operations"
 msgstr ""
 
@@ -3389,7 +3389,7 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/monitor.go:79
+#: lxc/monitor.go:80
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
@@ -3493,23 +3493,23 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:82 lxc/file.go:83
+#: lxc/file.go:83 lxc/file.go:84
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:58 lxc/auth.go:59 lxc/auth.go:1433 lxc/auth.go:1434
+#: lxc/auth.go:59 lxc/auth.go:60 lxc/auth.go:1434 lxc/auth.go:1435
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1083 lxc/auth.go:1084
+#: lxc/auth.go:1084 lxc/auth.go:1085
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:730 lxc/auth.go:731
+#: lxc/auth.go:731 lxc/auth.go:732
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1851 lxc/auth.go:1852
+#: lxc/auth.go:1852 lxc/auth.go:1853
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3600,7 +3600,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:492 lxc/auth.go:493
+#: lxc/auth.go:493 lxc/auth.go:494
 msgid "Manage permissions"
 msgstr ""
 
@@ -3608,23 +3608,23 @@ msgstr ""
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:28 lxc/project.go:29
+#: lxc/project.go:29 lxc/project.go:30
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage_bucket.go:731
+#: lxc/storage_bucket.go:732
 msgid "Manage storage bucket keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:732
+#: lxc/storage_bucket.go:733
 msgid "Manage storage bucket keys."
 msgstr ""
 
-#: lxc/storage_bucket.go:28
+#: lxc/storage_bucket.go:29
 msgid "Manage storage buckets"
 msgstr ""
 
-#: lxc/storage_bucket.go:29
+#: lxc/storage_bucket.go:30
 msgid "Manage storage buckets."
 msgstr ""
 
@@ -3652,11 +3652,11 @@ msgstr ""
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/auth.go:29 lxc/auth.go:30
+#: lxc/auth.go:30 lxc/auth.go:31
 msgid "Manage user authorization"
 msgstr ""
 
-#: lxc/warning.go:28 lxc/warning.go:29
+#: lxc/warning.go:29 lxc/warning.go:30
 msgid "Manage warnings"
 msgstr ""
 
@@ -3720,17 +3720,17 @@ msgstr ""
 msgid "Migration operation failure: %w"
 msgstr ""
 
-#: lxc/monitor.go:51
+#: lxc/monitor.go:52
 msgid ""
 "Minimum level for log messages (only available when using pretty format)"
 msgstr ""
 
-#: lxc/storage_bucket.go:116 lxc/storage_bucket.go:216
-#: lxc/storage_bucket.go:292 lxc/storage_bucket.go:411
-#: lxc/storage_bucket.go:568 lxc/storage_bucket.go:660
-#: lxc/storage_bucket.go:802 lxc/storage_bucket.go:889
-#: lxc/storage_bucket.go:986 lxc/storage_bucket.go:1065
-#: lxc/storage_bucket.go:1188
+#: lxc/storage_bucket.go:117 lxc/storage_bucket.go:217
+#: lxc/storage_bucket.go:293 lxc/storage_bucket.go:412
+#: lxc/storage_bucket.go:569 lxc/storage_bucket.go:661
+#: lxc/storage_bucket.go:803 lxc/storage_bucket.go:890
+#: lxc/storage_bucket.go:987 lxc/storage_bucket.go:1066
+#: lxc/storage_bucket.go:1189
 msgid "Missing bucket name"
 msgstr ""
 
@@ -3749,20 +3749,20 @@ msgstr ""
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:122 lxc/auth.go:176 lxc/auth.go:254 lxc/auth.go:416
-#: lxc/auth.go:465 lxc/auth.go:540 lxc/auth.go:599 lxc/auth.go:1825
+#: lxc/auth.go:123 lxc/auth.go:177 lxc/auth.go:255 lxc/auth.go:417
+#: lxc/auth.go:466 lxc/auth.go:541 lxc/auth.go:600 lxc/auth.go:1826
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:862 lxc/auth.go:1003 lxc/auth.go:1131 lxc/auth.go:1189
+#: lxc/auth.go:863 lxc/auth.go:1004 lxc/auth.go:1132 lxc/auth.go:1190
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1495 lxc/auth.go:1548 lxc/auth.go:1614 lxc/auth.go:1776
+#: lxc/auth.go:1496 lxc/auth.go:1549 lxc/auth.go:1615 lxc/auth.go:1777
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1899 lxc/auth.go:1952
+#: lxc/auth.go:1900 lxc/auth.go:1953
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -3770,12 +3770,12 @@ msgstr ""
 #: lxc/config_template.go:100 lxc/config_template.go:155
 #: lxc/config_template.go:209 lxc/config_template.go:306
 #: lxc/config_template.go:377 lxc/profile.go:141 lxc/profile.go:222
-#: lxc/profile.go:808 lxc/rebuild.go:60
+#: lxc/profile.go:808 lxc/rebuild.go:61
 msgid "Missing instance name"
 msgstr ""
 
-#: lxc/storage_bucket.go:893 lxc/storage_bucket.go:990
-#: lxc/storage_bucket.go:1069 lxc/storage_bucket.go:1192
+#: lxc/storage_bucket.go:894 lxc/storage_bucket.go:991
+#: lxc/storage_bucket.go:1070 lxc/storage_bucket.go:1193
 msgid "Missing key name"
 msgstr ""
 
@@ -3840,13 +3840,13 @@ msgid "Missing peer name"
 msgstr ""
 
 #: lxc/storage.go:235 lxc/storage.go:313 lxc/storage.go:431 lxc/storage.go:509
-#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:112
-#: lxc/storage_bucket.go:212 lxc/storage_bucket.go:288
-#: lxc/storage_bucket.go:407 lxc/storage_bucket.go:482
-#: lxc/storage_bucket.go:564 lxc/storage_bucket.go:656
-#: lxc/storage_bucket.go:798 lxc/storage_bucket.go:885
-#: lxc/storage_bucket.go:982 lxc/storage_bucket.go:1061
-#: lxc/storage_bucket.go:1184 lxc/storage_volume.go:209
+#: lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:113
+#: lxc/storage_bucket.go:213 lxc/storage_bucket.go:289
+#: lxc/storage_bucket.go:408 lxc/storage_bucket.go:483
+#: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
+#: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
+#: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
 #: lxc/storage_volume.go:323 lxc/storage_volume.go:643
 #: lxc/storage_volume.go:750 lxc/storage_volume.go:841
 #: lxc/storage_volume.go:939 lxc/storage_volume.go:1053
@@ -3861,9 +3861,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:404 lxc/project.go:146 lxc/project.go:226 lxc/project.go:316
-#: lxc/project.go:433 lxc/project.go:622 lxc/project.go:691 lxc/project.go:819
-#: lxc/project.go:948
+#: lxc/profile.go:404 lxc/project.go:147 lxc/project.go:227 lxc/project.go:317
+#: lxc/project.go:434 lxc/project.go:623 lxc/project.go:692 lxc/project.go:820
+#: lxc/project.go:949
 msgid "Missing project name"
 msgstr ""
 
@@ -3879,7 +3879,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:598
+#: lxc/file.go:599
 msgid "Missing target directory"
 msgstr ""
 
@@ -3901,11 +3901,11 @@ msgstr ""
 msgid "Model: %v"
 msgstr ""
 
-#: lxc/monitor.go:32
+#: lxc/monitor.go:33
 msgid "Monitor a local or remote LXD server"
 msgstr ""
 
-#: lxc/monitor.go:33
+#: lxc/monitor.go:34
 msgid ""
 "Monitor a local or remote LXD server\n"
 "\n"
@@ -3917,11 +3917,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:285
+#: lxc/file.go:286
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:985 lxc/file.go:986
+#: lxc/file.go:986 lxc/file.go:987
 msgid "Mount files from instances"
 msgstr ""
 
@@ -3983,13 +3983,13 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:375 lxc/auth.go:815 lxc/auth.go:1735 lxc/cluster.go:192
+#: lxc/auth.go:376 lxc/auth.go:816 lxc/auth.go:1736 lxc/cluster.go:192
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
-#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:565
-#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:511
-#: lxc/storage_bucket.go:831 lxc/storage_volume.go:1731
+#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:566
+#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1731
 msgid "NAME"
 msgstr ""
 
@@ -3997,11 +3997,11 @@ msgstr ""
 msgid "NAT"
 msgstr ""
 
-#: lxc/project.go:571
+#: lxc/project.go:572
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:570
+#: lxc/project.go:571
 msgid "NETWORKS"
 msgstr ""
 
@@ -4013,9 +4013,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/operation.go:154 lxc/project.go:523
-#: lxc/project.go:528 lxc/project.go:533 lxc/project.go:538 lxc/project.go:543
-#: lxc/project.go:548 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
+#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:524
+#: lxc/project.go:529 lxc/project.go:534 lxc/project.go:539 lxc/project.go:544
+#: lxc/project.go:549 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
 msgid "NO"
 msgstr ""
 
@@ -4260,7 +4260,7 @@ msgstr ""
 msgid "Only managed networks can be modified"
 msgstr ""
 
-#: lxc/operation.go:86
+#: lxc/operation.go:87
 #, c-format
 msgid "Operation %s deleted"
 msgstr ""
@@ -4307,11 +4307,11 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:567
+#: lxc/list.go:576 lxc/project.go:568
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:212
+#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4373,24 +4373,24 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1102
+#: lxc/file.go:1103
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:1055 lxc/auth.go:1661 lxc/cluster.go:860
+#: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
-#: lxc/project.go:363 lxc/storage.go:360 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1151
+#: lxc/project.go:364 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1151
 #: lxc/storage_volume.go:1183
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
-#: lxc/monitor.go:48
+#: lxc/monitor.go:49
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
@@ -4476,17 +4476,17 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:172
+#: lxc/project.go:173
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:236
+#: lxc/project.go:237
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:637
+#: lxc/project.go:638
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -4607,20 +4607,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:241 lxc/file.go:242
+#: lxc/file.go:242 lxc/file.go:243
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:416 lxc/file.go:767
+#: lxc/file.go:417 lxc/file.go:768
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:466 lxc/file.go:467
+#: lxc/file.go:467 lxc/file.go:468
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:701 lxc/file.go:867
+#: lxc/file.go:702 lxc/file.go:868
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4633,11 +4633,11 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:983
+#: lxc/project.go:984
 msgid "RESOURCE"
 msgstr ""
 
-#: lxc/storage_bucket.go:833
+#: lxc/storage_bucket.go:834
 msgid "ROLE"
 msgstr ""
 
@@ -4650,15 +4650,15 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/rebuild.go:31
+#: lxc/rebuild.go:32
 msgid "Rebuild as an empty instance"
 msgstr ""
 
-#: lxc/rebuild.go:26
+#: lxc/rebuild.go:27
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:249 lxc/file.go:473
+#: lxc/file.go:250 lxc/file.go:474
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4685,7 +4685,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:882 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
+#: lxc/project.go:883 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
 #: lxc/remote.go:994
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4736,7 +4736,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1164 lxc/auth.go:1165
+#: lxc/auth.go:1165 lxc/auth.go:1166
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4772,7 +4772,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1927 lxc/auth.go:1928
+#: lxc/auth.go:1928 lxc/auth.go:1929
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4784,7 +4784,7 @@ msgstr ""
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:574 lxc/auth.go:575
+#: lxc/auth.go:575 lxc/auth.go:576
 msgid "Remove permissions from groups"
 msgstr ""
 
@@ -4829,11 +4829,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:391 lxc/auth.go:392
+#: lxc/auth.go:392 lxc/auth.go:393
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1751 lxc/auth.go:1752
+#: lxc/auth.go:1752 lxc/auth.go:1753
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -4853,7 +4853,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:589 lxc/project.go:590
+#: lxc/project.go:590 lxc/project.go:591
 msgid "Rename projects"
 msgstr ""
 
@@ -4951,7 +4951,7 @@ msgstr ""
 msgid "Revoke cluster member join token"
 msgstr ""
 
-#: lxc/storage_bucket.go:862
+#: lxc/storage_bucket.go:863
 msgid "Role (admin or read-only)"
 msgstr ""
 
@@ -4967,7 +4967,7 @@ msgstr ""
 msgid "Run against all projects"
 msgstr ""
 
-#: lxc/warning.go:213
+#: lxc/warning.go:214
 msgid "SEVERITY"
 msgstr ""
 
@@ -4987,12 +4987,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1231
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1231
+#: lxc/file.go:1232
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5006,11 +5006,11 @@ msgstr ""
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:173 lxc/warning.go:214
+#: lxc/operation.go:174 lxc/warning.go:215
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:569
+#: lxc/project.go:570
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5018,7 +5018,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:569
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -5026,11 +5026,11 @@ msgstr ""
 msgid "STP"
 msgstr ""
 
-#: lxc/storage_bucket.go:864
+#: lxc/storage_bucket.go:865
 msgid "Secret key (auto-generated if empty)"
 msgstr ""
 
-#: lxc/storage_bucket.go:942
+#: lxc/storage_bucket.go:943
 #, c-format
 msgid "Secret key: %s"
 msgstr ""
@@ -5068,7 +5068,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:995
+#: lxc/file.go:996
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5206,11 +5206,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:654
+#: lxc/project.go:655
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:655
+#: lxc/project.go:656
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5219,11 +5219,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage_bucket.go:534
+#: lxc/storage_bucket.go:535
 msgid "Set storage bucket configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:535
+#: lxc/storage_bucket.go:536
 msgid ""
 "Set storage bucket configuration keys\n"
 "\n"
@@ -5262,15 +5262,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:476
+#: lxc/file.go:477
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:477
+#: lxc/file.go:478
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:475
+#: lxc/file.go:476
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5310,11 +5310,11 @@ msgstr ""
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:662
+#: lxc/project.go:663
 msgid "Set the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:542
+#: lxc/storage_bucket.go:543
 msgid "Set the key as a storage bucket property"
 msgstr ""
 
@@ -5330,7 +5330,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:993
+#: lxc/file.go:994
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5342,7 +5342,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1800 lxc/auth.go:1801
+#: lxc/auth.go:1801 lxc/auth.go:1802
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5358,11 +5358,11 @@ msgstr ""
 msgid "Show details of a cluster member"
 msgstr ""
 
-#: lxc/operation.go:192 lxc/operation.go:193
+#: lxc/operation.go:193 lxc/operation.go:194
 msgid "Show details on a background operation"
 msgstr ""
 
-#: lxc/monitor.go:49
+#: lxc/monitor.go:50
 msgid "Show events from all projects"
 msgstr ""
 
@@ -5370,11 +5370,11 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:440 lxc/auth.go:441
+#: lxc/auth.go:441 lxc/auth.go:442
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:832
+#: lxc/auth.go:833
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5455,15 +5455,15 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:786 lxc/project.go:787
+#: lxc/project.go:787 lxc/project.go:788
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage_bucket.go:628 lxc/storage_bucket.go:629
+#: lxc/storage_bucket.go:629 lxc/storage_bucket.go:630
 msgid "Show storage bucket configurations"
 msgstr ""
 
-#: lxc/storage_bucket.go:1156 lxc/storage_bucket.go:1157
+#: lxc/storage_bucket.go:1157 lxc/storage_bucket.go:1158
 msgid "Show storage bucket key configurations"
 msgstr ""
 
@@ -5479,7 +5479,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:895
+#: lxc/auth.go:896
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5529,7 +5529,7 @@ msgstr ""
 msgid "Show useful information about storage pools"
 msgstr ""
 
-#: lxc/warning.go:302 lxc/warning.go:303
+#: lxc/warning.go:303 lxc/warning.go:304
 msgid "Show warning"
 msgstr ""
 
@@ -5613,22 +5613,22 @@ msgstr ""
 msgid "Stopping the instance failed: %s"
 msgstr ""
 
-#: lxc/storage_bucket.go:166
+#: lxc/storage_bucket.go:167
 #, c-format
 msgid "Storage bucket %s created"
 msgstr ""
 
-#: lxc/storage_bucket.go:233
+#: lxc/storage_bucket.go:234
 #, c-format
 msgid "Storage bucket %s deleted"
 msgstr ""
 
-#: lxc/storage_bucket.go:940
+#: lxc/storage_bucket.go:941
 #, c-format
 msgid "Storage bucket key %s added"
 msgstr ""
 
-#: lxc/storage_bucket.go:1006
+#: lxc/storage_bucket.go:1007
 #, c-format
 msgid "Storage bucket key %s removed"
 msgstr ""
@@ -5697,7 +5697,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:847 lxc/project.go:848
+#: lxc/project.go:848 lxc/project.go:849
 msgid "Switch the current project"
 msgstr ""
 
@@ -5713,10 +5713,10 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:814 lxc/config_trust.go:408 lxc/image.go:1139
+#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1139
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
-#: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:171
-#: lxc/storage_volume.go:1730 lxc/warning.go:215
+#: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
+#: lxc/storage_volume.go:1730 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
@@ -5724,11 +5724,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1032
+#: lxc/file.go:1033
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1026
+#: lxc/file.go:1027
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5856,12 +5856,12 @@ msgstr ""
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:446
+#: lxc/project.go:447
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
 
-#: lxc/storage_bucket.go:431
+#: lxc/storage_bucket.go:432
 #, c-format
 msgid "The property %q does not exist on the storage bucket %q: %v"
 msgstr ""
@@ -6046,7 +6046,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:961
+#: lxc/project.go:962
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6058,17 +6058,17 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:985 lxc/storage_volume.go:1735
+#: lxc/project.go:986 lxc/storage_volume.go:1735
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:573
+#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:574
 #: lxc/storage.go:724 lxc/storage_volume.go:1734
 msgid "USED BY"
 msgstr ""
 
-#: lxc/warning.go:216
+#: lxc/warning.go:217
 msgid "UUID"
 msgstr ""
 
@@ -6077,7 +6077,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:197
+#: lxc/file.go:198
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6091,13 +6091,13 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1253
+#: lxc/file.go:1254
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1153 lxc/list.go:631 lxc/storage_volume.go:1772
-#: lxc/warning.go:241
+#: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6107,7 +6107,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:807
+#: lxc/file.go:808
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6190,11 +6190,11 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:742 lxc/project.go:743
+#: lxc/project.go:743 lxc/project.go:744
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage_bucket.go:697 lxc/storage_bucket.go:698
+#: lxc/storage_bucket.go:698 lxc/storage_bucket.go:699
 msgid "Unset storage bucket configuration keys"
 msgstr ""
 
@@ -6242,11 +6242,11 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:747
+#: lxc/project.go:748
 msgid "Unset the key as a project property"
 msgstr ""
 
-#: lxc/storage_bucket.go:701
+#: lxc/storage_bucket.go:702
 msgid "Unset the key as a storage bucket property"
 msgstr ""
 
@@ -6325,7 +6325,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:71
+#: lxc/file.go:72
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6362,11 +6362,11 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:831
+#: lxc/auth.go:832
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:894
+#: lxc/auth.go:895
 msgid "View the current identity"
 msgstr ""
 
@@ -6397,15 +6397,15 @@ msgstr ""
 msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
-#: lxc/rebuild.go:27
+#: lxc/rebuild.go:28
 msgid ""
 "Wipe the instance root disk and re-initialize. The original image is used to "
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:156 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
+#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:526
+#: lxc/project.go:531 lxc/project.go:536 lxc/project.go:541 lxc/project.go:546
+#: lxc/project.go:551 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
 msgid "YES"
 msgstr ""
 
@@ -6425,7 +6425,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/rebuild.go:119
+#: lxc/rebuild.go:120
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
@@ -6437,12 +6437,12 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:329 lxc/auth.go:762 lxc/auth.go:893 lxc/auth.go:1689
+#: lxc/auth.go:330 lxc/auth.go:763 lxc/auth.go:894 lxc/auth.go:1690
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
-#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:31
+#: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
-#: lxc/operation.go:103 lxc/profile.go:700 lxc/project.go:467
-#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:68
+#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:468
+#: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
 
@@ -6470,7 +6470,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1254
+#: lxc/auth.go:1255
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6531,11 +6531,11 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:830
+#: lxc/auth.go:831
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1105 lxc/auth.go:1163 lxc/auth.go:1926
+#: lxc/auth.go:1106 lxc/auth.go:1164 lxc/auth.go:1927
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6543,13 +6543,13 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:96 lxc/auth.go:149 lxc/auth.go:199 lxc/auth.go:439
-#: lxc/auth.go:954 lxc/auth.go:1470 lxc/cluster_group.go:168
+#: lxc/auth.go:97 lxc/auth.go:150 lxc/auth.go:200 lxc/auth.go:440
+#: lxc/auth.go:955 lxc/auth.go:1471 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:514 lxc/auth.go:572
+#: lxc/auth.go:515 lxc/auth.go:573
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
@@ -6559,19 +6559,19 @@ msgstr ""
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:389
+#: lxc/auth.go:390
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1521 lxc/auth.go:1571 lxc/auth.go:1799
+#: lxc/auth.go:1522 lxc/auth.go:1572 lxc/auth.go:1800
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1873
+#: lxc/auth.go:1874
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1749
+#: lxc/auth.go:1750
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -6591,7 +6591,7 @@ msgstr ""
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
-#: lxc/rebuild.go:25
+#: lxc/rebuild.go:26
 msgid "[<remote>:]<image> [<remote>:]<instance>"
 msgstr ""
 
@@ -6674,20 +6674,20 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:170
+#: lxc/file.go:171
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:120
+#: lxc/file.go:121
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:240
+#: lxc/file.go:241
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:984
+#: lxc/file.go:985
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6838,12 +6838,12 @@ msgstr ""
 msgid "[<remote>:]<network> [key=value...]"
 msgstr ""
 
-#: lxc/operation.go:53 lxc/operation.go:191
+#: lxc/operation.go:54 lxc/operation.go:192
 msgid "[<remote>:]<operation>"
 msgstr ""
 
 #: lxc/storage.go:200 lxc/storage.go:259 lxc/storage.go:473 lxc/storage.go:844
-#: lxc/storage_bucket.go:454
+#: lxc/storage_bucket.go:455
 msgid "[<remote>:]<pool>"
 msgstr ""
 
@@ -6851,22 +6851,22 @@ msgstr ""
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
-#: lxc/storage_bucket.go:185 lxc/storage_bucket.go:247
-#: lxc/storage_bucket.go:627 lxc/storage_bucket.go:769
+#: lxc/storage_bucket.go:186 lxc/storage_bucket.go:248
+#: lxc/storage_bucket.go:628 lxc/storage_bucket.go:770
 msgid "[<remote>:]<pool> <bucket>"
 msgstr ""
 
-#: lxc/storage_bucket.go:380 lxc/storage_bucket.go:696
-#: lxc/storage_bucket.go:850 lxc/storage_bucket.go:956
-#: lxc/storage_bucket.go:1020 lxc/storage_bucket.go:1155
+#: lxc/storage_bucket.go:381 lxc/storage_bucket.go:697
+#: lxc/storage_bucket.go:851 lxc/storage_bucket.go:957
+#: lxc/storage_bucket.go:1021 lxc/storage_bucket.go:1156
 msgid "[<remote>:]<pool> <bucket> <key>"
 msgstr ""
 
-#: lxc/storage_bucket.go:533
+#: lxc/storage_bucket.go:534
 msgid "[<remote>:]<pool> <bucket> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_bucket.go:81
+#: lxc/storage_bucket.go:82
 msgid "[<remote>:]<pool> <bucket> [key=value...]"
 msgstr ""
 
@@ -6981,20 +6981,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:91 lxc/project.go:186 lxc/project.go:258 lxc/project.go:785
-#: lxc/project.go:846 lxc/project.go:913
+#: lxc/project.go:92 lxc/project.go:187 lxc/project.go:259 lxc/project.go:786
+#: lxc/project.go:847 lxc/project.go:914
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:394 lxc/project.go:741
+#: lxc/project.go:395 lxc/project.go:742
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:653
+#: lxc/project.go:654
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:587
+#: lxc/project.go:588
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7002,7 +7002,7 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:259 lxc/warning.go:301 lxc/warning.go:354
+#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
@@ -7058,7 +7058,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:555 lxc/remote.go:739
+#: lxc/project.go:556 lxc/remote.go:739
 msgid "current"
 msgstr ""
 
@@ -7105,20 +7105,20 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/auth.go:203
+#: lxc/auth.go:204
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:958
+#: lxc/auth.go:959
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1575
+#: lxc/auth.go:1576
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7196,20 +7196,20 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:988
+#: lxc/file.go:989
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:244
+#: lxc/file.go:245
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:469
+#: lxc/file.go:470
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7291,7 +7291,7 @@ msgid ""
 "  List instances with their running state and user comment."
 msgstr ""
 
-#: lxc/monitor.go:37
+#: lxc/monitor.go:38
 msgid ""
 "lxc monitor --type=logging\n"
 "    Only show log messages.\n"
@@ -7367,7 +7367,7 @@ msgid ""
 "    Create record r1 for zone z1 with configuration from config.yaml"
 msgstr ""
 
-#: lxc/operation.go:195
+#: lxc/operation.go:196
 msgid ""
 "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Show details on that operation UUID"
@@ -7410,7 +7410,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:95
+#: lxc/project.go:96
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7418,7 +7418,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:262
+#: lxc/project.go:263
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7449,7 +7449,7 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:85
 msgid ""
 "lxc storage bucket create p1 b01\n"
 "\tCreate a new storage bucket name b01 in storage pool p1\n"
@@ -7459,19 +7459,19 @@ msgid ""
 "of config.yaml"
 msgstr ""
 
-#: lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:251
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> < bucket.yaml\n"
 "    Update a storage bucket using the content of bucket.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1023
+#: lxc/storage_bucket.go:1024
 msgid ""
 "lxc storage bucket edit [<remote>:]<pool> <bucket> <key> < key.yaml\n"
 "    Update a storage bucket key using the content of key.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:854
 msgid ""
 "lxc storage bucket key create p1 b01 k1\n"
 "\tCreate a key called k1 for the bucket b01 in the pool p1.\n"
@@ -7481,14 +7481,14 @@ msgid ""
 "of config.yaml."
 msgstr ""
 
-#: lxc/storage_bucket.go:1158
+#: lxc/storage_bucket.go:1159
 msgid ""
 "lxc storage bucket key show default data foo\n"
 "    Will show the properties of a bucket key called \"foo\" for a bucket "
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_bucket.go:630
+#: lxc/storage_bucket.go:631
 msgid ""
 "lxc storage bucket show default data\n"
 "    Will show the properties of a bucket called \"data\" in the \"default\" "
@@ -7558,16 +7558,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1142
+#: lxc/file.go:1143
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1101
+#: lxc/file.go:1102
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1054
+#: lxc/file.go:1055
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/shared/cmd/cancel.go
+++ b/shared/cmd/cancel.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/signal"
@@ -56,13 +57,13 @@ func CancelableWait(rawOp any, progress *ProgressRenderer) error {
 			}
 
 			if err == nil {
-				return fmt.Errorf(i18n.G("Remote operation canceled by user"))
+				return errors.New(i18n.G("Remote operation canceled by user"))
 			}
 
 			count++
 
 			if count == 3 {
-				return fmt.Errorf(i18n.G("User signaled us three times, exiting. The remote operation will keep running"))
+				return errors.New(i18n.G("User signaled us three times, exiting. The remote operation will keep running"))
 			}
 
 			if progress != nil {


### PR DESCRIPTION
This is a mechanical change done with:

```
for f in $(git grep -l 'fmt\.Errorf(i18n.G([^%]\+))$'); do
  sed -i "/fmt\.Errorf(i18n.G([^%\]\+))$/ s/fmt\.Errorf/errors.New/" "${f}"
done
```

Manual fix-up to import `"errors"` where needed and drop `"fmt"` where no longer needed and finally committed with:

```
for f in $(git status -s -uno | awk '/^ M / {print $2}' | sed 's/\.go$//'); do
  git commit -sm "$f: use \`errors.New()\` where appropriate" "${f}.go"
done
```