### PR TITLE
VM: Firmware detection fixes (from Incus)

### DIFF
--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -1982,14 +1982,13 @@ func (d *qemu) setupNvram() error {
 		return err
 	}
 
-	// Generate a symlink if needed.
+	// Generate a symlink.
 	// This is so qemu.nvram can always be assumed to be the EDK2 vars file.
 	// The real file name is then used to determine what firmware must be selected.
-	if !shared.PathExists(d.nvramPath()) {
-		err = os.Symlink(vmFirmwareName, d.nvramPath())
-		if err != nil {
-			return err
-		}
+	_ = os.Remove(d.nvramPath())
+	err = os.Symlink(vmFirmwareName, d.nvramPath())
+	if err != nil {
+		return err
 	}
 
 	return nil

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -1938,11 +1938,11 @@ func (d *qemu) setupNvram() error {
 
 	d.logger.Debug("Generating NVRAM")
 
-	// Cleanup existing variables.
-	for _, firmwarePair := range edk2.GetAchitectureFirmwarePairs(d.architecture) {
-		err := os.Remove(filepath.Join(d.Path(), filepath.Base(firmwarePair.Vars)))
+	// Cleanup existing variables file.
+	for _, varsName := range edk2.GetAchitectureFirmwareVarsCandidates(d.architecture) {
+		err := os.Remove(filepath.Join(d.Path(), varsName))
 		if err != nil && !os.IsNotExist(err) {
-			return err
+			return fmt.Errorf("Failed removing firmware vars file %q: %w", varsName, err)
 		}
 	}
 

--- a/lxd/instance/drivers/edk2/edk2.go
+++ b/lxd/instance/drivers/edk2/edk2.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/osarch"
 )
 
@@ -170,9 +171,17 @@ func GetArchitectureFirmwarePairsForUsage(hostArch int, usage FirmwareUsage) []F
 		if found {
 			for _, firmwarePair := range usage {
 				for _, searchPath := range installation.Paths {
+					codePath := filepath.Join(searchPath, firmwarePair.Code)
+					varsPath := filepath.Join(searchPath, firmwarePair.Vars)
+
+					// Check both firmware code and vars paths exist - otherwise skip pair.
+					if !shared.PathExists(codePath) || !shared.PathExists(varsPath) {
+						continue
+					}
+
 					firmwares = append(firmwares, FirmwarePair{
-						Code: filepath.Join(searchPath, firmwarePair.Code),
-						Vars: filepath.Join(searchPath, firmwarePair.Vars),
+						Code: codePath,
+						Vars: varsPath,
 					})
 				}
 			}

--- a/lxd/instance/drivers/edk2/edk2.go
+++ b/lxd/instance/drivers/edk2/edk2.go
@@ -149,16 +149,21 @@ var architectureInstallations = map[int][]Installation{
 	}},
 }
 
-// GetAchitectureFirmwarePairs creates an array of FirmwarePair for a
-// specific host architecture.
-func GetAchitectureFirmwarePairs(hostArch int) []FirmwarePair {
-	firmwares := make([]FirmwarePair, 0)
-
-	for _, usage := range []FirmwareUsage{GENERIC, SECUREBOOT, CSM} {
-		firmwares = append(firmwares, GetArchitectureFirmwarePairsForUsage(hostArch, usage)...)
+// GetAchitectureFirmwareVarsCandidates returns a unique list of candidate vars names for hostArch for all usages.
+// It does not check whether the associated firmware files are present on the host now.
+// This can be used to check for the existence of previously used firmware vars files in an existing VM instance.
+func GetAchitectureFirmwareVarsCandidates(hostArch int) (varsNames []string) {
+	for _, installation := range architectureInstallations[hostArch] {
+		for _, usage := range installation.Usage {
+			for _, fwPair := range usage {
+				if !shared.ValueInSlice(fwPair.Vars, varsNames) {
+					varsNames = append(varsNames, fwPair.Vars)
+				}
+			}
+		}
 	}
 
-	return firmwares
+	return varsNames
 }
 
 // GetArchitectureFirmwarePairsForUsage creates an array of FirmwarePair

--- a/lxd/instance/drivers/edk2/edk2.go
+++ b/lxd/instance/drivers/edk2/edk2.go
@@ -166,8 +166,8 @@ func GetAchitectureFirmwareVarsCandidates(hostArch int) (varsNames []string) {
 	return varsNames
 }
 
-// GetArchitectureFirmwarePairsForUsage creates an array of FirmwarePair
-// for a specific host architecture and usage combination.
+// GetArchitectureFirmwarePairsForUsage returns FirmwarePair slice for a host architecture and usage combination.
+// It only includes FirmwarePairs where both the firmware and its vars file are found on the host.
 func GetArchitectureFirmwarePairsForUsage(hostArch int, usage FirmwareUsage) []FirmwarePair {
 	firmwares := make([]FirmwarePair, 0)
 


### PR DESCRIPTION
Based on:

- https://github.com/lxc/incus/pull/1187
- https://github.com/lxc/incus/pull/1193

Follows on from https://github.com/canonical/lxd/pull/14032

Also improves the removal of old firmware vars files by not checking the if the associated firmwares exist on the host and not trying to remove the same files multiple times.