### PR TITLE
api: Add `metrics_api_requests` extension.

### DIFF
--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -414,6 +414,7 @@ var APIExtensions = []string{
 	"instance_protection_start",
 	"devlxd_images_vm",
 	"disk_io_bus_virtio_blk",
+	"metrics_api_requests",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
NOTE: This change would normally be committed with an update to `doc/api-extensions.md` (582b2ccddeebbfa17df7becfd3979d4f5438a0a1) but this was missed. These commits need to be cherry-picked together.