### PR TITLE
Completions: Fix completions for config keys

### DIFF
--- a/lxc/completion.go
+++ b/lxc/completion.go
@@ -210,8 +210,33 @@ func (g *cmdGlobal) cmpImages(toComplete string) ([]string, cobra.ShellCompDirec
 	return results, cmpDirectives
 }
 
-func (g *cmdGlobal) cmpInstanceAllKeys() ([]string, cobra.ShellCompDirective) {
-	keys := []string{}
+func (g *cmdGlobal) cmpInstanceAllKeys(instanceName string) ([]string, cobra.ShellCompDirective) {
+	resources, err := g.ParseServers(instanceName)
+	if err != nil || len(resources) == 0 {
+		return nil, cobra.ShellCompDirectiveError
+	}
+
+	resource := resources[0]
+	client := resource.server
+
+	instanceNameOnly, _, err := client.GetInstance(instanceName)
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveError
+	}
+
+	var keys []string
+	instanceType := instanceNameOnly.Type
+
+	if instanceType == "container" {
+		for k := range instancetype.InstanceConfigKeysContainer {
+			keys = append(keys, k)
+		}
+	} else if instanceType == "virtual-machine" {
+		for k := range instancetype.InstanceConfigKeysVM {
+			keys = append(keys, k)
+		}
+	}
+
 	for k := range instancetype.InstanceConfigKeysAny {
 		keys = append(keys, k)
 	}

--- a/lxc/config.go
+++ b/lxc/config.go
@@ -404,7 +404,7 @@ func (c *cmdConfigGet) command() *cobra.Command {
 		}
 
 		if len(args) == 1 {
-			return c.global.cmpInstanceAllKeys()
+			return c.global.cmpInstanceAllKeys(args[0])
 		}
 
 		return nil, cobra.ShellCompDirectiveNoFileComp
@@ -557,7 +557,7 @@ lxc config set core.https_address=[::]:8443
 		}
 
 		if len(args) == 1 {
-			return c.global.cmpInstanceAllKeys()
+			return c.global.cmpInstanceAllKeys(args[0])
 		}
 
 		return nil, cobra.ShellCompDirectiveNoFileComp
@@ -906,7 +906,7 @@ func (c *cmdConfigUnset) command() *cobra.Command {
 		}
 
 		if len(args) == 1 {
-			return c.global.cmpInstanceAllKeys()
+			return c.global.cmpInstanceAllKeys(args[0])
 		}
 
 		return nil, cobra.ShellCompDirectiveNoFileComp

--- a/lxc/profile.go
+++ b/lxc/profile.go
@@ -932,7 +932,7 @@ For backward compatibility, a single configuration key may still be set with:
 		}
 
 		if len(args) == 1 {
-			return c.global.cmpInstanceAllKeys()
+			return c.global.cmpInstanceAllKeys(args[0])
 		}
 
 		return nil, cobra.ShellCompDirectiveNoFileComp


### PR DESCRIPTION
`cmpInstanceAllKeys()` was only grabbing config keys that apply to any instance, but we also want to grab/complete keys that are specific to containers or VM's.