### PR TITLE
Request: Fix request not counted warning

### DIFF
--- a/lxd/api.go
+++ b/lxd/api.go
@@ -205,7 +205,7 @@ func restServer(d *Daemon) *http.Server {
 	}
 
 	mux.NotFoundHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		lxdRequest.CountStartedRequest(r)
+		metrics.TrackStartedRequest(r)
 		logger.Info("Sending top level 404", logger.Ctx{"url": r.URL, "method": r.Method, "remote": r.RemoteAddr})
 		w.Header().Set("Content-Type", "application/json")
 		_ = response.NotFound(nil).Render(w, r)
@@ -264,7 +264,7 @@ func metricsServer(d *Daemon) *http.Server {
 	d.createCmd(mux, "1.0", metricsCmd)
 
 	mux.NotFoundHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		lxdRequest.CountStartedRequest(r)
+		metrics.TrackStartedRequest(r)
 		logger.Info("Sending top level 404", logger.Ctx{"url": r.URL, "method": r.Method, "remote": r.RemoteAddr})
 		w.Header().Set("Content-Type", "application/json")
 		_ = response.NotFound(nil).Render(w, r)

--- a/lxd/api.go
+++ b/lxd/api.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/gorilla/mux"
 
+	"github.com/canonical/lxd/lxd/auth"
 	clusterConfig "github.com/canonical/lxd/lxd/cluster/config"
 	"github.com/canonical/lxd/lxd/cluster/request"
 	"github.com/canonical/lxd/lxd/db"
@@ -221,6 +222,9 @@ func restServer(d *Daemon) *http.Server {
 
 func hoistReqVM(f func(*Daemon, instance.Instance, http.ResponseWriter, *http.Request) response.Response, d *Daemon) func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
+		// Set devlxd auth method to identify this request as coming from the /dev/lxd socket.
+		lxdRequest.SetCtxValue(r, lxdRequest.CtxProtocol, auth.AuthenticationMethodDevLXD)
+
 		trusted, inst, err := authenticateAgentCert(d.State(), r)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/lxd/auth/types.go
+++ b/lxd/auth/types.go
@@ -26,6 +26,9 @@ const (
 	// Note: Regardless of whether `core.trust_ca_certificates` is enabled, we still check if the client certificate
 	// fingerprint is in the identity cache. If they are found, standard TLS restrictions will apply.
 	AuthenticationMethodPKI string = "pki"
+
+	// AuthenticationMethodDevLXD is the authentication method for interacting with the devlxd API.
+	AuthenticationMethodDevLXD = "devlxd"
 )
 
 // PermissionChecker is a type alias for a function that returns whether a user has required permissions on an object.

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -387,11 +387,6 @@ func (d *Daemon) Authenticate(w http.ResponseWriter, r *http.Request) (trusted b
 		return true, "", auth.AuthenticationMethodUnix, nil, nil
 	}
 
-	// Devlxd unix socket credentials on main API.
-	if r.RemoteAddr == devlxdRemoteAddress {
-		return false, "", "", nil, fmt.Errorf("Main API query can't come from /dev/lxd socket")
-	}
-
 	// Cluster notification with wrong certificate.
 	if isClusterNotification(r) {
 		return false, "", "", nil, fmt.Errorf("Cluster notification isn't using trusted server certificate")

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -53,6 +53,7 @@ import (
 	"github.com/canonical/lxd/lxd/lifecycle"
 	"github.com/canonical/lxd/lxd/loki"
 	"github.com/canonical/lxd/lxd/maas"
+	"github.com/canonical/lxd/lxd/metrics"
 	networkZone "github.com/canonical/lxd/lxd/network/zone"
 	"github.com/canonical/lxd/lxd/node"
 	"github.com/canonical/lxd/lxd/request"
@@ -630,7 +631,7 @@ func (d *Daemon) createCmd(restAPI *mux.Router, version string, c APIEndpoint) {
 		// Only endpoints from the main API (version 1.0) should be counted for the metrics.
 		// This prevents internal endpoints from being included as well.
 		if version == "1.0" {
-			request.CountStartedRequest(r)
+			metrics.TrackStartedRequest(r)
 		}
 
 		w.Header().Set("Content-Type", "application/json")

--- a/lxd/devlxd.go
+++ b/lxd/devlxd.go
@@ -16,6 +16,7 @@ import (
 	"github.com/gorilla/mux"
 	"golang.org/x/sys/unix"
 
+	"github.com/canonical/lxd/lxd/auth"
 	"github.com/canonical/lxd/lxd/events"
 	"github.com/canonical/lxd/lxd/instance"
 	"github.com/canonical/lxd/lxd/instance/instancetype"
@@ -310,6 +311,9 @@ var handlers = []devLxdHandler{
 
 func hoistReq(f func(*Daemon, instance.Instance, http.ResponseWriter, *http.Request) response.Response, d *Daemon) func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
+		// Set devlxd auth method to identify this request as coming from the /dev/lxd socket.
+		request.SetCtxValue(r, request.CtxProtocol, auth.AuthenticationMethodDevLXD)
+
 		conn := ucred.GetConnFromContext(r.Context())
 		cred, ok := pidMapper.m[conn.(*net.UnixConn)]
 		if !ok {

--- a/lxd/devlxd.go
+++ b/lxd/devlxd.go
@@ -120,9 +120,6 @@ func devlxdImageExportHandler(d *Daemon, c instance.Instance, w http.ResponseWri
 		return response.DevLxdErrorResponse(api.StatusErrorf(http.StatusForbidden, "not authorized"), c.Type() == instancetype.VM)
 	}
 
-	// Use by security checks to distinguish devlxd vs lxd APIs
-	r.RemoteAddr = devlxdRemoteAddress
-
 	resp := imageExport(d, r)
 
 	err := resp.Render(w, r)

--- a/lxd/devlxd.go
+++ b/lxd/devlxd.go
@@ -31,8 +31,6 @@ import (
 	"github.com/canonical/lxd/shared/ws"
 )
 
-const devlxdRemoteAddress = "@devlxd"
-
 type hoistFunc func(f func(*Daemon, instance.Instance, http.ResponseWriter, *http.Request) response.Response, d *Daemon) func(http.ResponseWriter, *http.Request)
 
 type devlxdHandlerFunc func(d *Daemon, c instance.Instance, w http.ResponseWriter, r *http.Request) response.Response

--- a/lxd/events.go
+++ b/lxd/events.go
@@ -40,7 +40,7 @@ func (r *eventsServe) Render(w http.ResponseWriter, req *http.Request) error {
 
 	if err == nil {
 		// If there was an error on Render, the callback function will be called during the error handling.
-		request.MetricsCallback(req, metrics.Success)
+		metrics.UseMetricsCallback(req, metrics.Success)
 	}
 
 	return err

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -4107,7 +4107,10 @@ func imageExport(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	isDevLXDQuery := r.RemoteAddr == devlxdRemoteAddress
+	// Verify the auth method in the request context to determine if the request comes from the /dev/lxd socket.
+	authMethod, _ := auth.GetAuthenticationMethodFromCtx(r.Context())
+	isDevLXDQuery := authMethod == auth.AuthenticationMethodDevLXD
+
 	secret := r.FormValue("secret")
 	trusted := auth.IsTrusted(r.Context())
 

--- a/lxd/instance_sftp.go
+++ b/lxd/instance_sftp.go
@@ -175,7 +175,7 @@ func (r *sftpServeResponse) Render(w http.ResponseWriter, req *http.Request) err
 
 	wg.Wait() // Wait for copy go routine to finish.
 
-	request.MetricsCallback(req, metrics.Success)
+	metrics.UseMetricsCallback(req, metrics.Success)
 
 	return nil
 }

--- a/lxd/metrics/api_rates.go
+++ b/lxd/metrics/api_rates.go
@@ -97,9 +97,9 @@ func CountStartedRequest(r *http.Request) {
 	TrackStartedRequest(requestURL)
 }
 
-// MetricsCallback retrieves a callback function from the request context and calls it.
+// UseMetricsCallback retrieves a callback function from the request context and calls it.
 // The callback function is used to mark the request as completed for the API metrics.
-func MetricsCallback(req *http.Request, result RequestResult) {
+func UseMetricsCallback(req *http.Request, result RequestResult) {
 	callback, err := request.GetCtxValue[func(RequestResult)](req.Context(), request.MetricsCallbackFunc)
 	if err != nil && (strings.HasPrefix(req.URL.Path, "/1.0") || req.URL.Path == "/") {
 		// Log a warning if endpoint is part of the main API, and therefore should be counted fot the API metrics.

--- a/lxd/operations/response.go
+++ b/lxd/operations/response.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 
 	"github.com/canonical/lxd/lxd/metrics"
-	"github.com/canonical/lxd/lxd/request"
 	"github.com/canonical/lxd/lxd/response"
 	"github.com/canonical/lxd/lxd/util"
 	"github.com/canonical/lxd/shared/api"
@@ -31,9 +30,9 @@ func (r *operationResponse) Render(w http.ResponseWriter, req *http.Request) err
 	r.op.SetOnDone(func(op *Operation) {
 		sc := op.Status()
 		if sc == api.Success || sc == api.Cancelled {
-			request.MetricsCallback(req, metrics.Success)
+			metrics.UseMetricsCallback(req, metrics.Success)
 		} else {
-			request.MetricsCallback(req, metrics.ErrorServer)
+			metrics.UseMetricsCallback(req, metrics.ErrorServer)
 		}
 	})
 
@@ -123,7 +122,7 @@ func (r *forwardedOperationResponse) Render(w http.ResponseWriter, req *http.Req
 
 	if err == nil {
 		// If there was an error on Render, the callback function will be called during the error handling.
-		request.MetricsCallback(req, metrics.Success)
+		metrics.UseMetricsCallback(req, metrics.Success)
 	}
 
 	return err

--- a/lxd/operations/websocket.go
+++ b/lxd/operations/websocket.go
@@ -7,7 +7,6 @@ import (
 	"github.com/gorilla/websocket"
 
 	"github.com/canonical/lxd/lxd/metrics"
-	"github.com/canonical/lxd/lxd/request"
 	"github.com/canonical/lxd/lxd/response"
 	"github.com/canonical/lxd/shared/ws"
 )
@@ -32,7 +31,7 @@ func (r *operationWebSocket) Render(w http.ResponseWriter, req *http.Request) er
 
 	if err == nil {
 		// If there was an error on Render, the callback function will be called during the error handling.
-		request.MetricsCallback(req, metrics.Success)
+		metrics.UseMetricsCallback(req, metrics.Success)
 	}
 
 	return err
@@ -73,7 +72,7 @@ func (r *forwardedOperationWebSocket) Render(w http.ResponseWriter, req *http.Re
 	_ = target.Close()
 
 	// If there was an error on Render, the callback function will be called during the error handling.
-	request.MetricsCallback(req, metrics.Success)
+	metrics.UseMetricsCallback(req, metrics.Success)
 
 	return nil
 }

--- a/lxd/request/request.go
+++ b/lxd/request/request.go
@@ -4,12 +4,8 @@ import (
 	"context"
 	"net"
 	"net/http"
-	"strings"
-	"sync"
 
-	"github.com/canonical/lxd/lxd/metrics"
 	"github.com/canonical/lxd/shared/api"
-	"github.com/canonical/lxd/shared/logger"
 )
 
 // CreateRequestor extracts the lifecycle event requestor data from an http.Request context.
@@ -53,35 +49,4 @@ func CreateRequestor(r *http.Request) *api.EventLifecycleRequestor {
 // in the request context for later use.
 func SaveConnectionInContext(ctx context.Context, connection net.Conn) context.Context {
 	return context.WithValue(ctx, CtxConn, connection)
-}
-
-// CountStartedRequest tracks the request as started for the API metrics and
-// injects a callback function to track the request as completed.
-func CountStartedRequest(r *http.Request) {
-	requestURL := *r.URL
-
-	// Set the callback function to track the request as completed.
-	// Use sync.Once to ensure it can be called at most once.
-	var once sync.Once
-	callbackFunc := func(result metrics.RequestResult) {
-		once.Do(func() {
-			metrics.TrackCompletedRequest(requestURL, result)
-		})
-	}
-
-	SetCtxValue(r, MetricsCallbackFunc, callbackFunc)
-
-	metrics.TrackStartedRequest(requestURL)
-}
-
-// MetricsCallback retrieves a callback function from the request context and calls it.
-// The callback function is used to mark the request as completed for the API metrics.
-func MetricsCallback(request *http.Request, result metrics.RequestResult) {
-	callback, err := GetCtxValue[func(metrics.RequestResult)](request.Context(), MetricsCallbackFunc)
-	if err != nil && (strings.HasPrefix(request.URL.Path, "/1.0") || request.URL.Path == "/") {
-		// Log a warning if endpoint is part of the main API, and therefore should be counted fot the API metrics.
-		logger.Warn("Request will not be counted for the API metrics", logger.Ctx{"url": request.URL.Path, "method": request.Method, "remote": request.RemoteAddr})
-	} else if err == nil && callback != nil {
-		callback(result)
-	}
 }

--- a/lxd/response/response.go
+++ b/lxd/response/response.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/canonical/lxd/client"
 	"github.com/canonical/lxd/lxd/metrics"
-	"github.com/canonical/lxd/lxd/request"
 	"github.com/canonical/lxd/lxd/ucred"
 	"github.com/canonical/lxd/lxd/util"
 	"github.com/canonical/lxd/shared/api"
@@ -210,9 +209,9 @@ func (r *syncResponse) Render(w http.ResponseWriter, req *http.Request) (err err
 		// If there was an error on Render, the callback function will be called during the error handling.
 		if err == nil {
 			if r.success {
-				request.MetricsCallback(req, metrics.Success)
+				metrics.UseMetricsCallback(req, metrics.Success)
 			} else {
-				request.MetricsCallback(req, metrics.ErrorServer)
+				metrics.UseMetricsCallback(req, metrics.ErrorServer)
 			}
 		}
 	}()
@@ -368,10 +367,10 @@ func (r *errorResponse) Render(w http.ResponseWriter, req *http.Request) error {
 		// Use the callback function to count the request for the API metrics.
 		if r.code >= 400 && r.code < 500 {
 			// 4* codes are considered client errors on HTTP.
-			request.MetricsCallback(req, metrics.ErrorClient)
+			metrics.UseMetricsCallback(req, metrics.ErrorClient)
 		} else {
 			// Any other status code here shoud be higher than or equal to 500 and is considered a server error.
-			request.MetricsCallback(req, metrics.ErrorServer)
+			metrics.UseMetricsCallback(req, metrics.ErrorServer)
 		}
 	}()
 
@@ -437,7 +436,7 @@ func (r *fileResponse) Render(w http.ResponseWriter, req *http.Request) (err err
 	defer func() {
 		if err == nil {
 			// If there was an error on Render, the callback function will be called during the error handling.
-			request.MetricsCallback(req, metrics.Success)
+			metrics.UseMetricsCallback(req, metrics.Success)
 		}
 	}()
 
@@ -617,7 +616,7 @@ func (r *manualResponse) Render(w http.ResponseWriter, req *http.Request) error 
 
 	if err == nil {
 		// If there was an error on Render, the callback function will be called during the error handling.
-		request.MetricsCallback(req, metrics.Success)
+		metrics.UseMetricsCallback(req, metrics.Success)
 	}
 
 	return err


### PR DESCRIPTION
This makes it so that we don't expect the metrics callback to be present on devlxd endpoints and neither on the `/` endpoint.

It does so by reworkin how we check for requests originating from `/dev/lxd`. Instead of  setting the request remote address, this sets a newly introduced authentication method on the request context for all devlxd requests and uses that to validate devlxd requests. So this makes it possible to avoid logging a warning for devlxd requests when they are not supposed to be tracked for the API metrics. Thanks for the suggestion @markylaing :D.