### PR TITLE
Rework permissions checks (from Incus)

### DIFF
--- a/lxd/project/limits/permission_internal_test.go
+++ b/lxd/project/limits/permission_internal_test.go
@@ -4,8 +4,10 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/canonical/lxd/lxd/idmap"
+	"github.com/canonical/lxd/shared/api"
 )
 
 func TestParseHostIDMapRange(t *testing.T) {
@@ -74,4 +76,47 @@ func TestParseHostIDMapRange(t *testing.T) {
 		assert.ErrorIs(t, err, nil)
 		assert.Equal(t, idmaps, expected)
 	}
+}
+
+func checkProfileRestrictions(projectConfig map[string]string, profileConfig map[string]string) error {
+	proj := api.Project{
+		Name:   "proj1",
+		Config: projectConfig,
+	}
+
+	prof := api.Profile{
+		Name:   "prof1",
+		Config: profileConfig,
+	}
+
+	return checkRestrictions(proj, []api.Instance{}, []api.Profile{prof})
+}
+
+func TestProjectLowLevelRestrictions(t *testing.T) {
+	err := checkProfileRestrictions(
+		map[string]string{},
+		map[string]string{
+			"boot.host_shutdown_timeout": "15",
+		})
+	require.ErrorContains(t, err, "forbidden")
+
+	err = checkProfileRestrictions(
+		map[string]string{
+			"restricted":                     "true",
+			"restricted.containers.lowlevel": "allow",
+		},
+		map[string]string{
+			"security.devlxd.images": "true",
+		})
+	require.NoError(t, err)
+
+	err = checkProfileRestrictions(
+		map[string]string{
+			"restricted":                           "true",
+			"restricted.virtual-machines.lowlevel": "allow",
+		},
+		map[string]string{
+			"limits.memory.hugepages": "true",
+		})
+	require.NoError(t, err)
 }


### PR DESCRIPTION
Before this change, setting container-specific/VM-specific "low-level" config values on a profile required both `restricted.containers.lowlevel: true` and `restricted.virtual-machines.lowlevel: true`.

The test failed before and passes after.

Contains cherry-picks from https://github.com/lxc/incus/pull/827