### PR TITLE
Container: Match container disconnection with VMs

### DIFF
--- a/lxd/instance/drivers/driver_lxc_cmd.go
+++ b/lxd/instance/drivers/driver_lxc_cmd.go
@@ -41,6 +41,11 @@ func (c *lxcCmd) Wait() (int, error) {
 		err = ErrExecCommandNotFound
 	case 126:
 		err = ErrExecCommandNotExecutable
+	case 129, 137, 143:
+		// Container disconnections can result in different exit codes depending
+		// on what signal was used internally.
+		// 129 for SIGHUP, 137 for SIGKILL and 143 for SIGTERM are all possible.
+		err = ErrExecDisconnected
 	}
 
 	return exitStatus, err

--- a/test/suites/exec.sh
+++ b/test/suites/exec.sh
@@ -93,5 +93,15 @@ test_exec_exit_code() {
   lxc exec x1 -- invalid-command || exitCode=$?
   [ "${exitCode:-0}" -eq 127 ]
 
+  # Try disconnecting a container stopping forcefully and gracefully to make sure they match.
+  (sleep 1 && lxc restart -f x1) &
+  lxc exec x1 -- sleep 10 || exitCode=$?
+  [ "${exitCode:-0}" -eq 129 ]
+
+  wait $!
+  (sleep 1 && lxc stop x1) &
+  lxc exec x1 -- sleep 10 || exitCode=$?
+  [ "${exitCode:-0}" -eq 129 ]
+
   lxc delete --force x1
 }


### PR DESCRIPTION
Match container disconnection with VMs on `lxc exec`, making it return a 129 independentely on how the container disconnected.
The previous behavior was getting a 137 if the container was stopped forcefully and either a 129 or 143 if it was stopped gracefully.

An alternative would be changing VMs to return a 137 when stopped forcefully as well and stardardize the clean stop case to 129.