### PR TITLE
lxd/instance: Add support for armhf vm's on arm64 hosts

### DIFF
--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -2007,7 +2007,7 @@ func (d *qemu) qemuArchConfig(arch int) (path string, bus string, err error) {
 		}
 
 		return path, "pcie", nil
-	} else if arch == osarch.ARCH_64BIT_ARMV8_LITTLE_ENDIAN {
+	} else if arch == osarch.ARCH_32BIT_ARMV7_LITTLE_ENDIAN || arch == osarch.ARCH_32BIT_ARMV8_LITTLE_ENDIAN || arch == osarch.ARCH_64BIT_ARMV8_LITTLE_ENDIAN {
 		path, err := exec.LookPath(basePath + "qemu-system-aarch64")
 		if err != nil {
 			return "", "", err

--- a/lxd/instance/drivers/driver_qemu_templates.go
+++ b/lxd/instance/drivers/driver_qemu_templates.go
@@ -74,7 +74,7 @@ func qemuMachineType(architecture int) string {
 	switch architecture {
 	case osarch.ARCH_64BIT_INTEL_X86:
 		machineType = "q35"
-	case osarch.ARCH_64BIT_ARMV8_LITTLE_ENDIAN:
+	case osarch.ARCH_32BIT_ARMV7_LITTLE_ENDIAN, osarch.ARCH_32BIT_ARMV8_LITTLE_ENDIAN, osarch.ARCH_64BIT_ARMV8_LITTLE_ENDIAN:
 		machineType = "virt"
 	case osarch.ARCH_64BIT_POWERPC_LITTLE_ENDIAN:
 		machineType = "pseries"


### PR DESCRIPTION
This improvement will resolve https://github.com/canonical/lxd/issues/14001 with the inclusion of an armhf 32-bit lxd-agent binary in the lxd snap.