### PR TITLE
Backup before cluster reconfigure

### DIFF
--- a/doc/howto/cluster_recover.md
+++ b/doc/howto/cluster_recover.md
@@ -32,6 +32,10 @@ To determine which members have (or had) database roles, log on to any surviving
 
 ## Recover from quorum loss
 
+```{note}
+LXD automatically takes a backup of the database before making changes (see {ref}`automated_backups`).
+```
+
 If only one cluster member with the database role survives, complete the following
 steps. See [Reconfigure the cluster](#reconfigure-the-cluster) below for recovering
 more than one member.
@@ -59,10 +63,8 @@ See {ref}`cluster-manage-delete-members`.
 
 ## Reconfigure the cluster
 
-```{important}
-It is highly recommended to take a backup of `/var/snap/lxd/common/lxd/database`
-(for snap users) or `/var/lib/lxd/lxd/database` (otherwise) before reconfiguring
-the cluster.
+```{note}
+LXD automatically takes a backup of the database before making changes (see {ref}`automated_backups`).
 ```
 
 If some members of your cluster are no longer reachable, or if the cluster itself is unreachable due to a change in IP address or listening port number, you can reconfigure the cluster.
@@ -132,6 +134,18 @@ Complete the following steps on one database member:
 The cluster should now be fully available again with all surviving members reporting in.
 No information has been deleted from the database.
 All information about the cluster members and their instances is still there.
+
+(automated_backups)=
+## Automated Backups
+LXD automatically creates a backup of the database before making changes during
+recovery. The backup is just a tarball of `/var/snap/lxd/common/lxd/database`
+(for snap users) or `/var/lib/lxd/lxd/database` (otherwise). To reset the state
+of the database in case of a failure, simply delete the database directory and
+unpack the tarball in its place:
+
+    cd /var/snap/lxd/common/lxd
+    sudo rm -r database
+    sudo tar -xf db_backup.TIMESTAMP.tar.gz
 
 ## Manually alter Raft membership
 

--- a/lxd/cluster/recover.go
+++ b/lxd/cluster/recover.go
@@ -82,6 +82,11 @@ func localRaftNode(database *db.Node) (*db.RaftNode, error) {
 // member in the cluster. Use `Reconfigure` if more members should remain in
 // the raft configuration.
 func Recover(database *db.Node) error {
+	_, err := createDatabaseBackup(database.Dir())
+	if err != nil {
+		return fmt.Errorf("Failed creating backup: %w", err)
+	}
+
 	info, err := localRaftNode(database)
 	if err != nil {
 		return err
@@ -196,6 +201,11 @@ func writeGlobalNodesPatch(database *db.Node, nodes []db.RaftNode) error {
 // Addresses and node roles may be updated. Node IDs are read-only.
 // Returns the path to the new database state (recovery tarball).
 func Reconfigure(database *db.Node, raftNodes []db.RaftNode) (string, error) {
+	_, err := createDatabaseBackup(database.Dir())
+	if err != nil {
+		return "", fmt.Errorf("Failed creating backup: %w", err)
+	}
+
 	info, err := localRaftNode(database)
 	if err != nil {
 		return "", err
@@ -305,7 +315,12 @@ func DatabaseReplaceFromTarball(tarballPath string, database *db.Node) error {
 
 	logger.Warn("Recovery tarball located; attempting DB recovery", logger.Ctx{"tarball": tarballPath})
 
-	err := unpackTarball(tarballPath, unpackDir)
+	_, err := createDatabaseBackup(database.Dir())
+	if err != nil {
+		return fmt.Errorf("Failed creating backup: %w", err)
+	}
+
+	err = unpackTarball(tarballPath, unpackDir)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This follows a similar feature in microcluster. While any failure of the recovery process may be recoverable, expecting a user to surgically determine the exact step where the failure occurred, manually correct their `database/`, and create a recovery tarball is entirely unreasonable.

This PR creates a database backup `/var/snap/lxd/common/lxd/db_backup.TIMESTAMP.tar.gz` before any sensitive recovery operations so that a failed recovery doesn't cause data loss.

This also prevents `lxd cluster edit` from attempting to reconfigure the database more than once, as a failure during the recovery should allow the user to troubleshoot and retry from the backup.

LXD-1468