### PR TITLE
lxc/config: create `oidctokens` dir with 0750

### DIFF
--- a/lxc/config/config.go
+++ b/lxc/config/config.go
@@ -80,7 +80,7 @@ func (c *Config) SaveOIDCTokens() {
 	tokenParentPath := c.ConfigPath("oidctokens")
 
 	if !shared.PathExists(tokenParentPath) {
-		_ = os.MkdirAll(tokenParentPath, 0755)
+		_ = os.MkdirAll(tokenParentPath, 0750)
 	}
 
 	for remote, tokens := range c.oidcTokens {


### PR DESCRIPTION
The actual tokens are already safe with 0600 but let's also avoid disclosing which tokens we have by making the directory a bit more private. Same as the `servercerts` directory.