### PR TITLE
Remove type bound public access

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -184,6 +184,8 @@ jobs:
           sudo chmod o+w ./lxd/metadata/configuration.json
           sudo chmod o+w ./doc/metadata.txt
           sudo chmod o+w ./po/*
+          sudo chmod o+w ./lxd/auth/entitlements_generated.go
+          sudo chmod o+w ./lxd/auth/drivers/openfga_model.openfga
           make static-analysis
 
       - name: Unit tests (all)

--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -239,12 +239,9 @@ func api10Get(d *Daemon, r *http.Request) response.Response {
 		AuthMethods:   authMethods,
 	}
 
-	// If not authorized, return now. Untrusted users are not authorized.
-	err := s.Authorizer.CheckPermission(r.Context(), entity.ServerURL(), auth.EntitlementCanView)
-	if err != nil && auth.IsDeniedError(err) {
+	// If not authenticated, return now.
+	if !auth.IsTrusted(r.Context()) {
 		return response.SyncResponseETag(true, srv, nil)
-	} else if err != nil {
-		return response.SmartError(err)
 	}
 
 	// If a target was specified, forward the request to the relevant node.

--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -74,14 +74,14 @@ var targetGroupPrefix = "@"
 var clusterCmd = APIEndpoint{
 	Path: "cluster",
 
-	Get: APIEndpointAction{Handler: clusterGet, AccessHandler: allowPermission(entity.TypeServer, auth.EntitlementCanView)},
+	Get: APIEndpointAction{Handler: clusterGet, AccessHandler: allowAuthenticated},
 	Put: APIEndpointAction{Handler: clusterPut, AccessHandler: allowPermission(entity.TypeServer, auth.EntitlementCanEdit)},
 }
 
 var clusterNodesCmd = APIEndpoint{
 	Path: "cluster/members",
 
-	Get:  APIEndpointAction{Handler: clusterNodesGet, AccessHandler: allowPermission(entity.TypeServer, auth.EntitlementCanView)},
+	Get:  APIEndpointAction{Handler: clusterNodesGet, AccessHandler: allowAuthenticated},
 	Post: APIEndpointAction{Handler: clusterNodesPost, AccessHandler: allowPermission(entity.TypeServer, auth.EntitlementCanEdit)},
 }
 
@@ -89,7 +89,7 @@ var clusterNodeCmd = APIEndpoint{
 	Path: "cluster/members/{name}",
 
 	Delete: APIEndpointAction{Handler: clusterNodeDelete, AccessHandler: allowPermission(entity.TypeServer, auth.EntitlementCanEdit)},
-	Get:    APIEndpointAction{Handler: clusterNodeGet, AccessHandler: allowPermission(entity.TypeServer, auth.EntitlementCanView)},
+	Get:    APIEndpointAction{Handler: clusterNodeGet, AccessHandler: allowAuthenticated},
 	Patch:  APIEndpointAction{Handler: clusterNodePatch, AccessHandler: allowPermission(entity.TypeServer, auth.EntitlementCanEdit)},
 	Put:    APIEndpointAction{Handler: clusterNodePut, AccessHandler: allowPermission(entity.TypeServer, auth.EntitlementCanEdit)},
 	Post:   APIEndpointAction{Handler: clusterNodePost, AccessHandler: allowPermission(entity.TypeServer, auth.EntitlementCanEdit)},
@@ -98,7 +98,7 @@ var clusterNodeCmd = APIEndpoint{
 var clusterNodeStateCmd = APIEndpoint{
 	Path: "cluster/members/{name}/state",
 
-	Get:  APIEndpointAction{Handler: clusterNodeStateGet, AccessHandler: allowPermission(entity.TypeServer, auth.EntitlementCanView)},
+	Get:  APIEndpointAction{Handler: clusterNodeStateGet, AccessHandler: allowAuthenticated},
 	Post: APIEndpointAction{Handler: clusterNodeStatePost, AccessHandler: allowPermission(entity.TypeServer, auth.EntitlementCanEdit)},
 }
 
@@ -111,14 +111,14 @@ var clusterCertificateCmd = APIEndpoint{
 var clusterGroupsCmd = APIEndpoint{
 	Path: "cluster/groups",
 
-	Get:  APIEndpointAction{Handler: clusterGroupsGet, AccessHandler: allowPermission(entity.TypeServer, auth.EntitlementCanView)},
+	Get:  APIEndpointAction{Handler: clusterGroupsGet, AccessHandler: allowAuthenticated},
 	Post: APIEndpointAction{Handler: clusterGroupsPost, AccessHandler: allowPermission(entity.TypeServer, auth.EntitlementCanEdit)},
 }
 
 var clusterGroupCmd = APIEndpoint{
 	Path: "cluster/groups/{name}",
 
-	Get:    APIEndpointAction{Handler: clusterGroupGet, AccessHandler: allowPermission(entity.TypeServer, auth.EntitlementCanView)},
+	Get:    APIEndpointAction{Handler: clusterGroupGet, AccessHandler: allowAuthenticated},
 	Post:   APIEndpointAction{Handler: clusterGroupPost, AccessHandler: allowPermission(entity.TypeServer, auth.EntitlementCanEdit)},
 	Put:    APIEndpointAction{Handler: clusterGroupPut, AccessHandler: allowPermission(entity.TypeServer, auth.EntitlementCanEdit)},
 	Patch:  APIEndpointAction{Handler: clusterGroupPatch, AccessHandler: allowPermission(entity.TypeServer, auth.EntitlementCanEdit)},

--- a/lxd/auth/drivers/openfga.go
+++ b/lxd/auth/drivers/openfga.go
@@ -256,11 +256,14 @@ func (e *embeddedOpenFGA) CheckPermission(ctx context.Context, entityURL *api.UR
 
 	// If not allowed, decide if the user can view the resource.
 	if !resp.GetAllowed() {
+		err := auth.ValidateEntitlement(entityType, auth.EntitlementCanView)
+		doCheckCanView := err == nil
+
 		responseCode := http.StatusForbidden
 		if entitlement == auth.EntitlementCanView {
 			responseCode = http.StatusNotFound
-		} else {
-			// Otherwise, check if we can view the resource.
+		} else if doCheckCanView {
+			// Otherwise, if `can_view` is a valid entitlement for the entity type, check if the identity can view the resource.
 			req.TupleKey.Relation = string(auth.EntitlementCanView)
 
 			l.Debug("Checking OpenFGA relation")

--- a/lxd/auth/drivers/openfga_model.openfga
+++ b/lxd/auth/drivers/openfga_model.openfga
@@ -49,7 +49,6 @@ type server
     # Grants permission to edit server configuration, to edit cluster member configuration, to update the state of a cluster
     # member, to create, edit, and delete cluster groups, to update cluster member certificates, and to edit or delete warnings.
     define can_edit: [identity, service_account, group#member] or admin
-    define can_view: [identity:*, service_account:*]
 
     # Grants permission to view permissions, to create, edit, and delete identities, to view, create, edit, and delete
     # authorization groups, and to view, create, edit, and delete identity provider groups. Note that clients with this
@@ -152,7 +151,6 @@ type certificate
 type storage_pool
   relations
     define server: [server]
-    define can_view: can_view from server
 
     # Grants permission to edit the storage pool.
     define can_edit: [identity, service_account, group#member] or can_edit_storage_pools from server

--- a/lxd/auth/drivers/tls.go
+++ b/lxd/auth/drivers/tls.go
@@ -154,10 +154,7 @@ func (t *tls) allowProjectUnspecificEntityType(entitlement auth.Entitlement, ent
 	switch entityType {
 	case entity.TypeServer:
 		// Restricted TLS certificates have the following entitlements on server.
-		return shared.ValueInSlice(entitlement, []auth.Entitlement{auth.EntitlementCanView, auth.EntitlementCanViewResources, auth.EntitlementCanViewMetrics})
-	case entity.TypeStoragePool:
-		// Restricted TLS certificates can view all storage pools.
-		return entitlement == auth.EntitlementCanView
+		return shared.ValueInSlice(entitlement, []auth.Entitlement{auth.EntitlementCanViewResources, auth.EntitlementCanViewMetrics})
 	case entity.TypeIdentity:
 		// If the entity URL refers to the identity that made the request, then the second path argument of the URL is
 		// the identifier of the identity. This line allows the caller to view their own identity and no one else's.

--- a/lxd/auth/drivers/tls_test.go
+++ b/lxd/auth/drivers/tls_test.go
@@ -1,0 +1,317 @@
+package drivers
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/dustinkirkland/golang-petname"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/canonical/lxd/lxd/auth"
+	"github.com/canonical/lxd/lxd/identity"
+	"github.com/canonical/lxd/lxd/request"
+	"github.com/canonical/lxd/shared"
+	"github.com/canonical/lxd/shared/api"
+	"github.com/canonical/lxd/shared/entity"
+	"github.com/canonical/lxd/shared/logger"
+)
+
+type tlsSuite struct {
+	suite.Suite
+	authorizer          auth.Authorizer
+	idCache             *identity.Cache
+	fooRestrictedClient identity.CacheEntry
+	unrestrictedClient  identity.CacheEntry
+}
+
+func TestTLSSuite(t *testing.T) {
+	suite.Run(t, new(tlsSuite))
+}
+
+func (s *tlsSuite) SetupSuite() {
+	var err error
+	s.idCache = &identity.Cache{}
+	s.authorizer, err = LoadAuthorizer(context.Background(), DriverTLS, logger.Log, s.idCache)
+	s.Require().NoError(err)
+	s.fooRestrictedClient = s.newIdentity("foo-restricted", api.IdentityTypeCertificateClientRestricted, []string{"foo"})
+	s.unrestrictedClient = s.newIdentity("unrestricted", api.IdentityTypeCertificateClientUnrestricted, nil)
+	err = s.idCache.ReplaceAll([]identity.CacheEntry{s.fooRestrictedClient, s.unrestrictedClient}, nil)
+	s.Require().NoError(err)
+}
+
+func (s *tlsSuite) newIdentity(name string, identityType string, projects []string) identity.CacheEntry {
+	cert, _, err := shared.GenerateMemCert(true, shared.CertOptions{})
+	s.Require().NoError(err)
+	x509Cert, err := shared.ParseCert(cert)
+	s.Require().NoError(err)
+	certFingerprint := shared.CertFingerprint(x509Cert)
+	return identity.CacheEntry{
+		Identifier:           certFingerprint,
+		Name:                 name,
+		AuthenticationMethod: api.AuthenticationMethodTLS,
+		IdentityType:         identityType,
+		Projects:             projects,
+		Certificate:          x509Cert,
+	}
+}
+
+func (s *tlsSuite) setupCtx(id *identity.CacheEntry) context.Context {
+	ctx := context.Background()
+	if id == nil {
+		ctx = context.WithValue(ctx, request.CtxTrusted, false)
+		return ctx
+	}
+
+	ctx = context.WithValue(ctx, request.CtxTrusted, true)
+	ctx = context.WithValue(ctx, request.CtxProtocol, id.AuthenticationMethod)
+	return context.WithValue(ctx, request.CtxUsername, id.Identifier)
+}
+
+func (s *tlsSuite) TestTLSAuthorizer() {
+	type testCase struct {
+		id            *identity.CacheEntry
+		entityURL     *api.URL
+		entitlements  []auth.Entitlement
+		expectErr     bool
+		expectErrCode int
+	}
+
+	// Initial cases represent exceptions to entity types that are not project specific (e.g. cases handled by `allowProjectUnspecificEntityType`).
+	cases := []testCase{
+		{
+			id:        &s.fooRestrictedClient,
+			entityURL: entity.ServerURL(),
+			entitlements: []auth.Entitlement{
+				auth.EntitlementCanView,
+				auth.EntitlementCanViewResources,
+				auth.EntitlementCanViewMetrics,
+			},
+		},
+		{
+			id:        &s.fooRestrictedClient,
+			entityURL: entity.ServerURL(),
+			entitlements: []auth.Entitlement{
+				auth.EntitlementCanEdit,
+				auth.EntitlementCanViewPermissions,
+				auth.EntitlementCanCreateIdentities,
+				auth.EntitlementCanCreateGroups,
+				auth.EntitlementCanCreateIdentityProviderGroups,
+				auth.EntitlementCanCreateStoragePools,
+				auth.EntitlementCanCreateProjects,
+				auth.EntitlementCanOverrideClusterTargetRestriction,
+				auth.EntitlementCanViewPrivilegedEvents,
+				auth.EntitlementCanViewWarnings,
+			},
+			expectErr:     true,
+			expectErrCode: http.StatusForbidden,
+		},
+		{
+			id:           &s.fooRestrictedClient,
+			entityURL:    entity.StoragePoolURL(petname.Generate(2, "-")),
+			entitlements: []auth.Entitlement{auth.EntitlementCanView},
+		},
+		{
+			id:        &s.fooRestrictedClient,
+			entityURL: entity.StoragePoolURL(petname.Generate(2, "-")),
+			entitlements: []auth.Entitlement{
+				auth.EntitlementCanEdit,
+				auth.EntitlementCanDelete,
+			},
+			expectErr:     true,
+			expectErrCode: http.StatusForbidden,
+		},
+		{
+			id:           &s.fooRestrictedClient,
+			entityURL:    entity.IdentityURL(api.AuthenticationMethodTLS, s.fooRestrictedClient.Identifier),
+			entitlements: []auth.Entitlement{auth.EntitlementCanView},
+		},
+		{
+			id:        &s.fooRestrictedClient,
+			entityURL: entity.IdentityURL(api.AuthenticationMethodTLS, s.fooRestrictedClient.Identifier),
+			entitlements: []auth.Entitlement{
+				auth.EntitlementCanEdit,
+				auth.EntitlementCanDelete,
+			},
+			expectErr:     true,
+			expectErrCode: http.StatusForbidden,
+		},
+		{
+			id:        &s.fooRestrictedClient,
+			entityURL: entity.IdentityURL(api.AuthenticationMethodTLS, petname.Generate(2, "-")),
+			entitlements: []auth.Entitlement{
+				auth.EntitlementCanView,
+				auth.EntitlementCanEdit,
+				auth.EntitlementCanDelete,
+			},
+			expectErr:     true,
+			expectErrCode: http.StatusForbidden,
+		},
+		{
+			id:           &s.fooRestrictedClient,
+			entityURL:    entity.CertificateURL(s.fooRestrictedClient.Identifier),
+			entitlements: []auth.Entitlement{auth.EntitlementCanView},
+		},
+		{
+			id:        &s.fooRestrictedClient,
+			entityURL: entity.CertificateURL(s.fooRestrictedClient.Identifier),
+			entitlements: []auth.Entitlement{
+				auth.EntitlementCanEdit,
+				auth.EntitlementCanDelete,
+			},
+			expectErr:     true,
+			expectErrCode: http.StatusForbidden,
+		},
+		{
+			id:        &s.fooRestrictedClient,
+			entityURL: entity.CertificateURL(petname.Generate(2, "-")),
+			entitlements: []auth.Entitlement{
+				auth.EntitlementCanView,
+				auth.EntitlementCanEdit,
+				auth.EntitlementCanDelete,
+			},
+			expectErr:     true,
+			expectErrCode: http.StatusForbidden,
+		},
+		{
+			id:        &s.fooRestrictedClient,
+			entityURL: entity.ProjectURL("foo"),
+			entitlements: []auth.Entitlement{
+				auth.EntitlementCanView,
+				auth.EntitlementCanCreateImages,
+				auth.EntitlementCanCreateImageAliases,
+				auth.EntitlementCanCreateInstances,
+				auth.EntitlementCanCreateNetworks,
+				auth.EntitlementCanCreateNetworkACLs,
+				auth.EntitlementCanCreateNetworkZones,
+				auth.EntitlementCanCreateProfiles,
+				auth.EntitlementCanCreateStorageVolumes,
+				auth.EntitlementCanCreateStorageBuckets,
+				auth.EntitlementCanViewEvents,
+				auth.EntitlementCanViewOperations,
+				auth.EntitlementCanViewMetrics,
+			},
+		},
+		{
+			id:        &s.fooRestrictedClient,
+			entityURL: entity.ProjectURL("foo"),
+			entitlements: []auth.Entitlement{
+				auth.EntitlementCanEdit,
+				auth.EntitlementCanDelete,
+			},
+			expectErr:     true,
+			expectErrCode: http.StatusForbidden,
+		},
+		{
+			id:        &s.fooRestrictedClient,
+			entityURL: entity.ProjectURL(petname.Generate(2, "-")),
+			entitlements: []auth.Entitlement{
+				auth.EntitlementCanEdit,
+				auth.EntitlementCanDelete,
+				auth.EntitlementCanView,
+				auth.EntitlementCanCreateImages,
+				auth.EntitlementCanCreateImageAliases,
+				auth.EntitlementCanCreateInstances,
+				auth.EntitlementCanCreateNetworks,
+				auth.EntitlementCanCreateNetworkACLs,
+				auth.EntitlementCanCreateNetworkZones,
+				auth.EntitlementCanCreateProfiles,
+				auth.EntitlementCanCreateStorageVolumes,
+				auth.EntitlementCanCreateStorageBuckets,
+				auth.EntitlementCanViewEvents,
+				auth.EntitlementCanViewOperations,
+				auth.EntitlementCanViewMetrics,
+			},
+			expectErr:     true,
+			expectErrCode: http.StatusForbidden,
+		},
+	}
+
+	// Create cases for all remaining entity types.
+	for entityType, entitlements := range auth.EntityTypeToEntitlements {
+		var entityURL *api.URL
+		var pathArgs []string
+		var err error
+		for {
+			// Get an entity URL for the entity type by increasing the number of path arguments.
+			// This is very hacky but this way we don't need to export the "nPathArguments" function from the entity package.
+			entityURL, err = entityType.URL("", "", pathArgs...)
+			if err == nil {
+				break
+			}
+
+			pathArgs = append(pathArgs, petname.Generate(2, "-"))
+		}
+
+		projectSpecific, err := entityType.RequiresProject()
+		s.Require().NoError(err)
+		if !projectSpecific {
+			// Unrestricted client has full access.
+			cases = append(cases, testCase{
+				id:           &s.unrestrictedClient,
+				entityURL:    entityURL,
+				entitlements: entitlements,
+			})
+
+			if !shared.ValueInSlice(entityType, []entity.Type{entity.TypeServer, entity.TypeStoragePool, entity.TypeIdentity, entity.TypeProject, entity.TypeCertificate}) {
+				// If it's not project specific and we don't have a special case, all access checks should be denied.
+				cases = append(cases, testCase{
+					id:            &s.fooRestrictedClient,
+					entityURL:     entityURL,
+					entitlements:  entitlements,
+					expectErr:     true,
+					expectErrCode: http.StatusForbidden,
+				})
+			}
+
+			continue
+		}
+
+		fooEntityURL, err := entityType.URL("foo", "", pathArgs...)
+		s.Require().NoError(err)
+		notFooEntityURL, err := entityType.URL(petname.Generate(2, "-"), "", pathArgs...)
+		s.Require().NoError(err)
+
+		// All checks against "foo" project should succeed. All checks in "not foo" should not succeed.
+		cases = append(cases, testCase{
+			id:           &s.fooRestrictedClient,
+			entityURL:    fooEntityURL,
+			entitlements: entitlements,
+		}, testCase{
+			id:            &s.fooRestrictedClient,
+			entityURL:     notFooEntityURL,
+			entitlements:  entitlements,
+			expectErr:     true,
+			expectErrCode: http.StatusForbidden,
+		}, testCase{
+			// Unrestricted client has full access.
+			id:           &s.unrestrictedClient,
+			entityURL:    notFooEntityURL,
+			entitlements: entitlements,
+		})
+	}
+
+	for _, tt := range cases {
+		entityType, _, _, _, err := entity.ParseURL(tt.entityURL.URL)
+		s.Require().NoError(err)
+
+		for _, entitlement := range tt.entitlements {
+			ctx := s.setupCtx(tt.id)
+			err := s.authorizer.CheckPermission(ctx, tt.entityURL, entitlement)
+			if tt.expectErr {
+				s.T().Logf("%q does not have %q on %q", tt.id.Name, entitlement, tt.entityURL)
+				s.Assert().Error(err)
+				s.Assert().True(api.StatusErrorCheck(err, tt.expectErrCode))
+			} else {
+				s.T().Logf("%q has %q on %q", tt.id.Name, entitlement, tt.entityURL)
+				s.Assert().NoError(err)
+			}
+
+			// If we don't expect an error from CheckPermission (e.g. access is allowed), then we expect the permission
+			// checker to return true (and vice versa).
+			permissionChecker, err := s.authorizer.GetPermissionChecker(ctx, entitlement, entityType)
+			s.Assert().NoError(err)
+			s.Assert().Equal(!tt.expectErr, permissionChecker(tt.entityURL))
+		}
+	}
+}

--- a/lxd/auth/drivers/tls_test.go
+++ b/lxd/auth/drivers/tls_test.go
@@ -83,7 +83,6 @@ func (s *tlsSuite) TestTLSAuthorizer() {
 			id:        &s.fooRestrictedClient,
 			entityURL: entity.ServerURL(),
 			entitlements: []auth.Entitlement{
-				auth.EntitlementCanView,
 				auth.EntitlementCanViewResources,
 				auth.EntitlementCanViewMetrics,
 			},
@@ -102,21 +101,6 @@ func (s *tlsSuite) TestTLSAuthorizer() {
 				auth.EntitlementCanOverrideClusterTargetRestriction,
 				auth.EntitlementCanViewPrivilegedEvents,
 				auth.EntitlementCanViewWarnings,
-			},
-			expectErr:     true,
-			expectErrCode: http.StatusForbidden,
-		},
-		{
-			id:           &s.fooRestrictedClient,
-			entityURL:    entity.StoragePoolURL(petname.Generate(2, "-")),
-			entitlements: []auth.Entitlement{auth.EntitlementCanView},
-		},
-		{
-			id:        &s.fooRestrictedClient,
-			entityURL: entity.StoragePoolURL(petname.Generate(2, "-")),
-			entitlements: []auth.Entitlement{
-				auth.EntitlementCanEdit,
-				auth.EntitlementCanDelete,
 			},
 			expectErr:     true,
 			expectErrCode: http.StatusForbidden,

--- a/lxd/storage_pools.go
+++ b/lxd/storage_pools.go
@@ -47,7 +47,7 @@ var storagePoolCmd = APIEndpoint{
 	Path: "storage-pools/{poolName}",
 
 	Delete: APIEndpointAction{Handler: storagePoolDelete, AccessHandler: allowPermission(entity.TypeStoragePool, auth.EntitlementCanDelete, "poolName")},
-	Get:    APIEndpointAction{Handler: storagePoolGet, AccessHandler: allowPermission(entity.TypeStoragePool, auth.EntitlementCanView, "poolName")},
+	Get:    APIEndpointAction{Handler: storagePoolGet, AccessHandler: allowAuthenticated},
 	Patch:  APIEndpointAction{Handler: storagePoolPatch, AccessHandler: allowPermission(entity.TypeStoragePool, auth.EntitlementCanEdit, "poolName")},
 	Put:    APIEndpointAction{Handler: storagePoolPut, AccessHandler: allowPermission(entity.TypeStoragePool, auth.EntitlementCanEdit, "poolName")},
 }


### PR DESCRIPTION
Removes the [type-bound public access](https://openfga.dev/docs/modeling/public-access) for server and storage pool and replace with an authentication check. This is to simplify the model and the underlying OpenFGADatastore implementation.

This does not change any users existing permissions, as it is not possible to create a permission with `can_view` on `server` or `storage_pool`.

Additionally, this PR improves the TLS authorization driver (see commit message) and adds tests.