### PR TITLE
lxd: Deduplicate logging for instance types update failure

### DIFF
--- a/lxd/instance_instance_types.go
+++ b/lxd/instance_instance_types.go
@@ -159,10 +159,6 @@ func instanceRefreshTypes(ctx context.Context, s *state.State) error {
 	sources := map[string]string{}
 	err := downloadParse(".yaml", &sources)
 	if err != nil {
-		if err != ctx.Err() {
-			logger.Warnf("Failed to update instance types: %v", err)
-		}
-
 		return err
 	}
 


### PR DESCRIPTION
The same line is logged as an error on [lines 91-94](https://github.com/canonical/lxd/blob/main/lxd/instance_instance_types.go#L93).

Fixes #13964