### PR TITLE
Project: Don't fail creation on missing pools (from Incus)

### DIFF
--- a/lxd/api_project.go
+++ b/lxd/api_project.go
@@ -1407,7 +1407,7 @@ func projectValidateConfig(s *state.State, config map[string]string) error {
 
 		return nil
 	})
-	if err != nil {
+	if err != nil && !api.StatusErrorCheck(err, http.StatusNotFound) {
 		return fmt.Errorf("Failed loading storage pool names: %w", err)
 	}
 

--- a/test/main.sh
+++ b/test/main.sh
@@ -281,6 +281,7 @@ if [ "${1:-"all"}" != "cluster" ]; then
     run_test test_projects_limits "projects limits"
     run_test test_projects_usage "projects usage"
     run_test test_projects_yaml "projects with yaml initialization"
+    run_test test_projects_before_init "project operations before init"
     run_test test_projects_restrictions "projects restrictions"
     run_test test_container_devices_disk "container devices - disk"
     run_test test_container_devices_disk_restricted "container devices - disk - restricted"

--- a/test/suites/projects.sh
+++ b/test/suites/projects.sh
@@ -1146,3 +1146,16 @@ EOF
   lxc image delete testimage --project test-project-yaml
   lxc project delete test-project-yaml
 }
+
+# Test project operations with an uninitialized LXD.
+test_projects_before_init() {
+  LXD_INIT_DIR=$(mktemp -d -p "${TEST_DIR}" XXX)
+  chmod +x "${LXD_INIT_DIR}"
+  spawn_lxd "${LXD_INIT_DIR}" false
+
+  # Check if projects can be created and modified without any pre-existing storage pools.
+  LXD_DIR=${LXD_INIT_DIR} lxc project create foo
+  LXD_DIR=${LXD_INIT_DIR} lxc project set foo user.foo test
+
+  shutdown_lxd "${LXD_INIT_DIR}"
+}


### PR DESCRIPTION
From https://github.com/lxc/incus/pull/1109.

After https://github.com/canonical/lxd/pull/14078 got merged the following error started to appear on MicroCloud when forming clusters: `
Error: System "micro02" failed to join the cluster: Failed to update cluster status of services: Failed to join "LXD" cluster: Failed to configure cluster: Failed to initialize member: Failed to initialize storage pools and networks: Failed to update local member project "default": Failed loading storage pool names: Storage pool(s) not found`

The DB`s `GetStoragePoolNames()` returns 404 in case of no storage pools. This has to be checked explicitly otherwise the error is returned back to the caller.