### PR TITLE
Doc: Disable Dell link check due to possible rate limiting

### DIFF
--- a/doc/custom_conf.py
+++ b/doc/custom_conf.py
@@ -160,6 +160,9 @@ linkcheck_ignore = [
     'http://localhost:8000',
     r'/lxd/en/latest/api/.*',
     r'/api/.*',
+    # Those links may fail from time to time
+    'https://www.dell.com/',
+    'https://www.dell.com/en-us/shop/powerflex/sf/powerflex',
     ]
 
 # Pages on which to ignore anchors


### PR DESCRIPTION
It looks Dell is blocking the runner, maybe due to rate limiting.

See e.g. https://github.com/canonical/lxd/actions/runs/10846559707/job/30099763049