### PR TITLE
lxd/image: Acquire image lock for uploaded images

### DIFF
--- a/lxd/images.go
+++ b/lxd/images.go
@@ -796,6 +796,13 @@ func getImgPostInfo(s *state.State, r *http.Request, builddir string, project st
 		return nil, err
 	}
 
+	unlock, err := imageOperationLock(info.Fingerprint)
+	if err != nil {
+		return nil, err
+	}
+
+	defer unlock()
+
 	imageMeta, imageType, err := getImageMetadata(imageTmpFilename)
 	if err != nil {
 		l.Error("Failed to get image metadata", logger.Ctx{"err": err})


### PR DESCRIPTION
Fixes #13855 

`imageOperationLock`s are not being taken at the start of a `POST /1.0/images` because the image fingerprint can't be trusted until the file has been uploaded (see [lxd/images/go](https://github.com/canonical/lxd/blob/main/lxd/images.go#L1225)). This makes it fairly easy to forget to take a lock at all.