### PR TITLE
fsmonitor: Test unix devices with both drivers

### DIFF
--- a/doc/environment.md
+++ b/doc/environment.md
@@ -40,3 +40,4 @@ Name                            | Description
 `LXD_QEMU_FW_PATH`              | Path (or `:` separated list of paths) to firmware (OVMF, SeaBIOS) to be used by QEMU
 `LXD_IDMAPPED_MOUNTS_DISABLE`   | Disable idmapped mounts support (useful when testing traditional UID shifting)
 `LXD_DEVMONITOR_DIR`            | Path to be monitored by the device monitor. This is primarily for testing.
+`LXD_FSMONITOR_DRIVER`          | Driver to be used for file system monitoring. This is primarily for testing.

--- a/lxd/fsmonitor/drivers/load.go
+++ b/lxd/fsmonitor/drivers/load.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 
 	"github.com/canonical/lxd/lxd/fsmonitor"
 	"github.com/canonical/lxd/shared/logger"
@@ -38,6 +39,11 @@ func Load(ctx context.Context, path string, events ...fsmonitor.Event) (fsmonito
 		}
 
 		return d, nil
+	}
+
+	driverName := os.Getenv("LXD_FSMONITOR_DRIVER")
+	if driverName != "" {
+		return startMonitor(driverName)
 	}
 
 	driver, err := startMonitor("fanotify")

--- a/test/suites/container_devices_unix.sh
+++ b/test/suites/container_devices_unix.sh
@@ -1,9 +1,37 @@
 test_container_devices_unix_block() {
+  lxdFSMonitorDriver=${LXD_FSMONITOR_DRIVER:-}
+
+  shutdown_lxd "${LXD_DIR}"
+  export LXD_FSMONITOR_DRIVER="fanotify"
+  respawn_lxd "${LXD_DIR}" true
   _container_devices_unix "unix-block"
+
+  shutdown_lxd "${LXD_DIR}"
+  export LXD_FSMONITOR_DRIVER="inotify"
+  respawn_lxd "${LXD_DIR}" true
+  _container_devices_unix "unix-block"
+
+  shutdown_lxd "${LXD_DIR}"
+  export LXD_FSMONITOR_DRIVER="${lxdFSMonitorDriver}"
+  respawn_lxd "${LXD_DIR}" true
 }
 
 test_container_devices_unix_char() {
+  lxdFSMonitorDriver=${LXD_FSMONITOR_DRIVER:-}
+
+  shutdown_lxd "${LXD_DIR}"
+  export LXD_FSMONITOR_DRIVER="fanotify"
+  respawn_lxd "${LXD_DIR}" true
   _container_devices_unix "unix-char"
+
+  shutdown_lxd "${LXD_DIR}"
+  export LXD_FSMONITOR_DRIVER="inotify"
+  respawn_lxd "${LXD_DIR}" true
+  _container_devices_unix "unix-char"
+
+  shutdown_lxd "${LXD_DIR}"
+  export LXD_FSMONITOR_DRIVER="${lxdFSMonitorDriver}"
+  respawn_lxd "${LXD_DIR}" true
 }
 
 _container_devices_unix() {


### PR DESCRIPTION
The `fsmonitor` package has two drivers, but only fanotify is tested for unix devices (see https://github.com/canonical/lxd/pull/14110#discussion_r1761232451). This is the default driver but it may not be available in all kernels/architectures.

This PR adds an environment variable to force a specific driver to be used. The unix char and block device tests are then run with both drivers.

The `inotify` package was encountering some unknown events. As it turned out, mapping these events to `fsmonitor` events broke the test suite, so I've added exceptions for them to reduce log verbosity.