### PR TITLE
lxc: Add completions for server keys and console

### DIFF
--- a/client/interfaces.go
+++ b/client/interfaces.go
@@ -73,6 +73,7 @@ type InstanceServer interface {
 	ImageServer
 
 	// Server functions
+	GetMetadataConfiguration() (metadataConfiguration *api.MetadataConfiguration, err error)
 	GetMetrics() (metrics string, err error)
 	GetServer() (server *api.Server, ETag string, err error)
 	GetServerResources() (resources *api.Resources, err error)

--- a/client/lxd_server.go
+++ b/client/lxd_server.go
@@ -186,3 +186,21 @@ func (r *ProtocolLXD) GetMetrics() (string, error) {
 
 	return string(content), nil
 }
+
+// GetMetadataConfiguration returns metadata configuration for a server.
+func (r *ProtocolLXD) GetMetadataConfiguration() (*api.MetadataConfiguration, error) {
+	// Check that the server supports it.
+	err := r.CheckExtension("metadata_configuration")
+	if err != nil {
+		return nil, err
+	}
+
+	metadataConfiguration := api.MetadataConfiguration{}
+
+	_, err = r.queryStruct(http.MethodGet, api.NewURL().Path("metadata", "configuration").String(), nil, "", &metadataConfiguration)
+	if err != nil {
+		return nil, err
+	}
+
+	return &metadataConfiguration, err
+}

--- a/lxc/config.go
+++ b/lxc/config.go
@@ -400,6 +400,10 @@ func (c *cmdConfigGet) command() *cobra.Command {
 
 	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
+			if strings.Contains(toComplete, ".") {
+				return c.global.cmpServerAllKeys(toComplete)
+			}
+
 			return c.global.cmpInstances(toComplete)
 		}
 
@@ -553,6 +557,10 @@ lxc config set core.https_address=[::]:8443
 
 	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
+			if strings.Contains(toComplete, ".") {
+				return c.global.cmpServerAllKeys(toComplete)
+			}
+
 			return c.global.cmpInstances(toComplete)
 		}
 
@@ -902,6 +910,10 @@ func (c *cmdConfigUnset) command() *cobra.Command {
 
 	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
+			if strings.Contains(toComplete, ".") {
+				return c.global.cmpServerAllKeys(toComplete)
+			}
+
 			return c.global.cmpInstances(toComplete)
 		}
 

--- a/lxc/console.go
+++ b/lxc/console.go
@@ -44,6 +44,10 @@ as well as retrieve past log entries from it.`))
 	cmd.Flags().BoolVar(&c.flagShowLog, "show-log", false, i18n.G("Retrieve the container's console log"))
 	cmd.Flags().StringVarP(&c.flagType, "type", "t", "console", i18n.G("Type of connection to establish: 'console' for serial console, 'vga' for SPICE graphical output")+"``")
 
+	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return c.global.cmpInstances(toComplete)
+	}
+
 	return cmd
 }
 


### PR DESCRIPTION
Resolves https://github.com/canonical/lxd/issues/14098.

All the improvements made to the `lxc config get/set` completions have been tested locally. I made a minor change that deviates from the requirements outlined in https://github.com/canonical/lxd/issues/14098. Instead of typing `lxc config get foo:core.<tab>` to retrieve server configuration options, typing `lxc config get foo: core.<tab>` (notice the [SPACE]) will now return server configuration options. This change was implemented to differentiate from the conventional usage of `remote:instance` across the CLI. However, please let me know if you'd prefer server configuration completions without the [SPACE] 😄.