### PR TITLE
Add change detection to `make i18n` for easier commit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -248,7 +248,12 @@ update-po:
 	set -eu; \
 	for lang in $(LINGUAS); do\
 	    msgmerge --backup=none -U $$lang.po po/$(DOMAIN).pot; \
-	done
+	done; \
+	if [ -t 0 ] && ! git diff --quiet -- po/*.po; then \
+		read -rp "Would you like to commit i18n changes (Y/n)? " answer; \
+			if [ "$${answer:-y}" = "y" ] || [ "$${answer:-y}" = "Y" ]; then \
+				git commit -sm "i18n: Update translations." -- po/*.po; fi; \
+	fi
 
 .PHONY: update-pot
 update-pot:

--- a/Makefile
+++ b/Makefile
@@ -256,8 +256,9 @@ ifeq "$(LXD_OFFLINE)" ""
 	(cd / ; go install github.com/snapcore/snapd/i18n/xgettext-go@2.57.1)
 endif
 	xgettext-go -o po/$(DOMAIN).pot --add-comments-tag=TRANSLATORS: --sort-output --package-name=$(DOMAIN) --msgid-bugs-address=lxd@lists.canonical.com --keyword=i18n.G --keyword-plural=i18n.NG lxc/*.go lxc/*/*.go
+	if git diff --quiet --ignore-matching-lines='^\s*"POT-Creation-Date: .*\n"' -- po/*.pot; then git checkout -- po/*.pot; fi
 	if [ -t 0 ] && ! git diff --quiet --ignore-matching-lines='^\s*"POT-Creation-Date: .*\n"' -- po/*.pot; then \
-		read -rp "Would you like to commit i18n template changes (Y/n)? " answer; git diff -- po/*.pot; \
+		read -rp "Would you like to commit i18n template changes (Y/n)? " answer; \
 			if [ "$${answer:-y}" = "y" ] || [ "$${answer:-y}" = "Y" ]; then \
 				git commit -sm "i18n: Update translation templates." -- po/*.pot; fi; \
 	fi

--- a/Makefile
+++ b/Makefile
@@ -256,6 +256,11 @@ ifeq "$(LXD_OFFLINE)" ""
 	(cd / ; go install github.com/snapcore/snapd/i18n/xgettext-go@2.57.1)
 endif
 	xgettext-go -o po/$(DOMAIN).pot --add-comments-tag=TRANSLATORS: --sort-output --package-name=$(DOMAIN) --msgid-bugs-address=lxd@lists.canonical.com --keyword=i18n.G --keyword-plural=i18n.NG lxc/*.go lxc/*/*.go
+	if [ -t 0 ] && ! git diff --quiet --ignore-matching-lines='^\s*"POT-Creation-Date: .*\n"' -- po/*.pot; then \
+		read -rp "Would you like to commit i18n template changes (Y/n)? " answer; git diff -- po/*.pot; \
+			if [ "$${answer:-y}" = "y" ] || [ "$${answer:-y}" = "Y" ]; then \
+				git commit -sm "i18n: Update translation templates." -- po/*.pot; fi; \
+	fi
 
 .PHONY: build-mo
 build-mo: $(MOFILES)

--- a/po/ar.po
+++ b/po/ar.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-26 11:55-0600\n"
+"POT-Creation-Date: 2024-09-30 13:36-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -60,7 +60,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1227
+#: lxc/config.go:1239
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -475,7 +475,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:493 lxc/config.go:809
+#: lxc/config.go:497 lxc/config.go:817
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -495,7 +495,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:443 lxc/config.go:628 lxc/config.go:835
+#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -762,7 +762,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:388
+#: lxc/console.go:392
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -1012,7 +1012,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:694 lxc/config.go:1084
+#: lxc/config.go:702 lxc/config.go:1096
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1127,8 +1127,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:550 lxc/config.go:768
-#: lxc/config.go:899 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
+#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1251 lxc/network.go:1344 lxc/network.go:1416
 #: lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1207,7 +1207,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1327 lxc/config_metadata.go:156
+#: lxc/config.go:356 lxc/config.go:1339 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
@@ -1651,9 +1651,9 @@ msgstr ""
 #: lxc/cluster_group.go:316 lxc/cluster_group.go:440 lxc/cluster_group.go:522
 #: lxc/cluster_group.go:607 lxc/cluster_group.go:663 lxc/cluster_group.go:725
 #: lxc/cluster_role.go:24 lxc/cluster_role.go:51 lxc/cluster_role.go:115
-#: lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:538
-#: lxc/config.go:764 lxc/config.go:896 lxc/config.go:943 lxc/config.go:983
-#: lxc/config.go:1038 lxc/config.go:1129 lxc/config.go:1160 lxc/config.go:1214
+#: lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:542
+#: lxc/config.go:772 lxc/config.go:904 lxc/config.go:955 lxc/config.go:995
+#: lxc/config.go:1050 lxc/config.go:1141 lxc/config.go:1172 lxc/config.go:1226
 #: lxc/config_device.go:25 lxc/config_device.go:79 lxc/config_device.go:221
 #: lxc/config_device.go:318 lxc/config_device.go:401 lxc/config_device.go:503
 #: lxc/config_device.go:619 lxc/config_device.go:626 lxc/config_device.go:759
@@ -1926,7 +1926,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1213 lxc/config.go:1214
+#: lxc/config.go:1225 lxc/config.go:1226
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2050,7 +2050,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:459 lxc/config.go:654 lxc/config.go:686 lxc/network.go:1319
+#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1319
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
@@ -2060,7 +2060,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:648 lxc/config.go:680
+#: lxc/config.go:656 lxc/config.go:688
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2255,7 +2255,7 @@ msgstr ""
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:366
+#: lxc/console.go:370
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
@@ -2469,7 +2469,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:982 lxc/config.go:983
+#: lxc/config.go:994 lxc/config.go:995
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2867,7 +2867,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1008 lxc/config.go:1066 lxc/config.go:1185 lxc/config.go:1277
+#: lxc/config.go:1020 lxc/config.go:1078 lxc/config.go:1197 lxc/config.go:1289
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -3026,7 +3026,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:387
+#: lxc/console.go:391
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -3540,7 +3540,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:942 lxc/config.go:943
+#: lxc/config.go:954 lxc/config.go:955
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -4379,7 +4379,7 @@ msgstr ""
 
 #: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
@@ -4883,7 +4883,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1019
+#: lxc/config.go:1031
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5060,7 +5060,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1037 lxc/config.go:1038
+#: lxc/config.go:1049 lxc/config.go:1050
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5098,11 +5098,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:537
+#: lxc/config.go:541
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:538
+#: lxc/config.go:542
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5326,7 +5326,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:551
+#: lxc/config.go:555
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5391,7 +5391,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1159 lxc/config.go:1160
+#: lxc/config.go:1171 lxc/config.go:1172
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5399,7 +5399,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:763 lxc/config.go:764
+#: lxc/config.go:771 lxc/config.go:772
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5493,7 +5493,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:767
+#: lxc/config.go:775
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5744,7 +5744,7 @@ msgstr ""
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:126
+#: lxc/console.go:130
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -5806,12 +5806,12 @@ msgstr ""
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:479
+#: lxc/config.go:483
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:455
+#: lxc/config.go:459
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
@@ -5903,7 +5903,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:666
+#: lxc/config.go:674
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -5947,7 +5947,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:215
+#: lxc/console.go:219
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -5957,7 +5957,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:499 lxc/config.go:715 lxc/config.go:815
+#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6102,7 +6102,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:164
+#: lxc/console.go:168
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -6117,12 +6117,12 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:109
+#: lxc/console.go:113
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1128 lxc/config.go:1129
+#: lxc/config.go:1140 lxc/config.go:1141
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6142,7 +6142,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:895 lxc/config.go:896
+#: lxc/config.go:903 lxc/config.go:904
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6258,7 +6258,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:900
+#: lxc/config.go:908
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6607,7 +6607,7 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1158 lxc/config.go:1212 lxc/config_device.go:321
+#: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:321
 #: lxc/config_device.go:753 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:35
 msgid "[<remote>:]<instance>"
@@ -6629,11 +6629,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:981 lxc/config.go:1127
+#: lxc/config.go:993 lxc/config.go:1139
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1036
+#: lxc/config.go:1048
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -7030,7 +7030,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:762
+#: lxc/config.go:98 lxc/config.go:770
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7038,11 +7038,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:894
+#: lxc/config.go:391 lxc/config.go:902
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:536
+#: lxc/config.go:540
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -7166,7 +7166,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:543
+#: lxc/config.go:547
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7175,13 +7175,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1216
+#: lxc/config.go:1228
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1040
+#: lxc/config.go:1052
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"

--- a/po/ber.po
+++ b/po/ber.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-26 11:55-0600\n"
+"POT-Creation-Date: 2024-09-30 13:36-0400\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Berber <https://hosted.weblate.org/projects/linux-containers/"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1227
+#: lxc/config.go:1239
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -478,7 +478,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:493 lxc/config.go:809
+#: lxc/config.go:497 lxc/config.go:817
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -498,7 +498,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:443 lxc/config.go:628 lxc/config.go:835
+#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -765,7 +765,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:388
+#: lxc/console.go:392
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:694 lxc/config.go:1084
+#: lxc/config.go:702 lxc/config.go:1096
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1130,8 +1130,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:550 lxc/config.go:768
-#: lxc/config.go:899 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
+#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1251 lxc/network.go:1344 lxc/network.go:1416
 #: lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1210,7 +1210,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1327 lxc/config_metadata.go:156
+#: lxc/config.go:356 lxc/config.go:1339 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
@@ -1654,9 +1654,9 @@ msgstr ""
 #: lxc/cluster_group.go:316 lxc/cluster_group.go:440 lxc/cluster_group.go:522
 #: lxc/cluster_group.go:607 lxc/cluster_group.go:663 lxc/cluster_group.go:725
 #: lxc/cluster_role.go:24 lxc/cluster_role.go:51 lxc/cluster_role.go:115
-#: lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:538
-#: lxc/config.go:764 lxc/config.go:896 lxc/config.go:943 lxc/config.go:983
-#: lxc/config.go:1038 lxc/config.go:1129 lxc/config.go:1160 lxc/config.go:1214
+#: lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:542
+#: lxc/config.go:772 lxc/config.go:904 lxc/config.go:955 lxc/config.go:995
+#: lxc/config.go:1050 lxc/config.go:1141 lxc/config.go:1172 lxc/config.go:1226
 #: lxc/config_device.go:25 lxc/config_device.go:79 lxc/config_device.go:221
 #: lxc/config_device.go:318 lxc/config_device.go:401 lxc/config_device.go:503
 #: lxc/config_device.go:619 lxc/config_device.go:626 lxc/config_device.go:759
@@ -1929,7 +1929,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1213 lxc/config.go:1214
+#: lxc/config.go:1225 lxc/config.go:1226
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2053,7 +2053,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:459 lxc/config.go:654 lxc/config.go:686 lxc/network.go:1319
+#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1319
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
@@ -2063,7 +2063,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:648 lxc/config.go:680
+#: lxc/config.go:656 lxc/config.go:688
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2258,7 +2258,7 @@ msgstr ""
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:366
+#: lxc/console.go:370
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
@@ -2472,7 +2472,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:982 lxc/config.go:983
+#: lxc/config.go:994 lxc/config.go:995
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2870,7 +2870,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1008 lxc/config.go:1066 lxc/config.go:1185 lxc/config.go:1277
+#: lxc/config.go:1020 lxc/config.go:1078 lxc/config.go:1197 lxc/config.go:1289
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -3029,7 +3029,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:387
+#: lxc/console.go:391
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -3543,7 +3543,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:942 lxc/config.go:943
+#: lxc/config.go:954 lxc/config.go:955
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -4382,7 +4382,7 @@ msgstr ""
 
 #: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
@@ -4886,7 +4886,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1019
+#: lxc/config.go:1031
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5063,7 +5063,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1037 lxc/config.go:1038
+#: lxc/config.go:1049 lxc/config.go:1050
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5101,11 +5101,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:537
+#: lxc/config.go:541
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:538
+#: lxc/config.go:542
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5329,7 +5329,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:551
+#: lxc/config.go:555
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5394,7 +5394,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1159 lxc/config.go:1160
+#: lxc/config.go:1171 lxc/config.go:1172
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5402,7 +5402,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:763 lxc/config.go:764
+#: lxc/config.go:771 lxc/config.go:772
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5496,7 +5496,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:767
+#: lxc/config.go:775
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5747,7 +5747,7 @@ msgstr ""
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:126
+#: lxc/console.go:130
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -5809,12 +5809,12 @@ msgstr ""
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:479
+#: lxc/config.go:483
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:455
+#: lxc/config.go:459
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
@@ -5906,7 +5906,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:666
+#: lxc/config.go:674
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -5950,7 +5950,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:215
+#: lxc/console.go:219
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -5960,7 +5960,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:499 lxc/config.go:715 lxc/config.go:815
+#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6105,7 +6105,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:164
+#: lxc/console.go:168
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -6120,12 +6120,12 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:109
+#: lxc/console.go:113
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1128 lxc/config.go:1129
+#: lxc/config.go:1140 lxc/config.go:1141
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6145,7 +6145,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:895 lxc/config.go:896
+#: lxc/config.go:903 lxc/config.go:904
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6261,7 +6261,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:900
+#: lxc/config.go:908
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6610,7 +6610,7 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1158 lxc/config.go:1212 lxc/config_device.go:321
+#: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:321
 #: lxc/config_device.go:753 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:35
 msgid "[<remote>:]<instance>"
@@ -6632,11 +6632,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:981 lxc/config.go:1127
+#: lxc/config.go:993 lxc/config.go:1139
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1036
+#: lxc/config.go:1048
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -7033,7 +7033,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:762
+#: lxc/config.go:98 lxc/config.go:770
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7041,11 +7041,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:894
+#: lxc/config.go:391 lxc/config.go:902
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:536
+#: lxc/config.go:540
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -7169,7 +7169,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:543
+#: lxc/config.go:547
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7178,13 +7178,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1216
+#: lxc/config.go:1228
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1040
+#: lxc/config.go:1052
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"

--- a/po/bg.po
+++ b/po/bg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-26 11:55-0600\n"
+"POT-Creation-Date: 2024-09-30 13:36-0400\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Bulgarian <https://hosted.weblate.org/projects/linux-"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1227
+#: lxc/config.go:1239
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -478,7 +478,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:493 lxc/config.go:809
+#: lxc/config.go:497 lxc/config.go:817
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -498,7 +498,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:443 lxc/config.go:628 lxc/config.go:835
+#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -765,7 +765,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:388
+#: lxc/console.go:392
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:694 lxc/config.go:1084
+#: lxc/config.go:702 lxc/config.go:1096
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1130,8 +1130,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:550 lxc/config.go:768
-#: lxc/config.go:899 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
+#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1251 lxc/network.go:1344 lxc/network.go:1416
 #: lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1210,7 +1210,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1327 lxc/config_metadata.go:156
+#: lxc/config.go:356 lxc/config.go:1339 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
@@ -1654,9 +1654,9 @@ msgstr ""
 #: lxc/cluster_group.go:316 lxc/cluster_group.go:440 lxc/cluster_group.go:522
 #: lxc/cluster_group.go:607 lxc/cluster_group.go:663 lxc/cluster_group.go:725
 #: lxc/cluster_role.go:24 lxc/cluster_role.go:51 lxc/cluster_role.go:115
-#: lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:538
-#: lxc/config.go:764 lxc/config.go:896 lxc/config.go:943 lxc/config.go:983
-#: lxc/config.go:1038 lxc/config.go:1129 lxc/config.go:1160 lxc/config.go:1214
+#: lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:542
+#: lxc/config.go:772 lxc/config.go:904 lxc/config.go:955 lxc/config.go:995
+#: lxc/config.go:1050 lxc/config.go:1141 lxc/config.go:1172 lxc/config.go:1226
 #: lxc/config_device.go:25 lxc/config_device.go:79 lxc/config_device.go:221
 #: lxc/config_device.go:318 lxc/config_device.go:401 lxc/config_device.go:503
 #: lxc/config_device.go:619 lxc/config_device.go:626 lxc/config_device.go:759
@@ -1929,7 +1929,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1213 lxc/config.go:1214
+#: lxc/config.go:1225 lxc/config.go:1226
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2053,7 +2053,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:459 lxc/config.go:654 lxc/config.go:686 lxc/network.go:1319
+#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1319
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
@@ -2063,7 +2063,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:648 lxc/config.go:680
+#: lxc/config.go:656 lxc/config.go:688
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2258,7 +2258,7 @@ msgstr ""
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:366
+#: lxc/console.go:370
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
@@ -2472,7 +2472,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:982 lxc/config.go:983
+#: lxc/config.go:994 lxc/config.go:995
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2870,7 +2870,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1008 lxc/config.go:1066 lxc/config.go:1185 lxc/config.go:1277
+#: lxc/config.go:1020 lxc/config.go:1078 lxc/config.go:1197 lxc/config.go:1289
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -3029,7 +3029,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:387
+#: lxc/console.go:391
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -3543,7 +3543,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:942 lxc/config.go:943
+#: lxc/config.go:954 lxc/config.go:955
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -4382,7 +4382,7 @@ msgstr ""
 
 #: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
@@ -4886,7 +4886,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1019
+#: lxc/config.go:1031
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5063,7 +5063,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1037 lxc/config.go:1038
+#: lxc/config.go:1049 lxc/config.go:1050
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5101,11 +5101,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:537
+#: lxc/config.go:541
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:538
+#: lxc/config.go:542
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5329,7 +5329,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:551
+#: lxc/config.go:555
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5394,7 +5394,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1159 lxc/config.go:1160
+#: lxc/config.go:1171 lxc/config.go:1172
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5402,7 +5402,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:763 lxc/config.go:764
+#: lxc/config.go:771 lxc/config.go:772
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5496,7 +5496,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:767
+#: lxc/config.go:775
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5747,7 +5747,7 @@ msgstr ""
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:126
+#: lxc/console.go:130
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -5809,12 +5809,12 @@ msgstr ""
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:479
+#: lxc/config.go:483
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:455
+#: lxc/config.go:459
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
@@ -5906,7 +5906,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:666
+#: lxc/config.go:674
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -5950,7 +5950,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:215
+#: lxc/console.go:219
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -5960,7 +5960,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:499 lxc/config.go:715 lxc/config.go:815
+#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6105,7 +6105,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:164
+#: lxc/console.go:168
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -6120,12 +6120,12 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:109
+#: lxc/console.go:113
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1128 lxc/config.go:1129
+#: lxc/config.go:1140 lxc/config.go:1141
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6145,7 +6145,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:895 lxc/config.go:896
+#: lxc/config.go:903 lxc/config.go:904
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6261,7 +6261,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:900
+#: lxc/config.go:908
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6610,7 +6610,7 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1158 lxc/config.go:1212 lxc/config_device.go:321
+#: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:321
 #: lxc/config_device.go:753 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:35
 msgid "[<remote>:]<instance>"
@@ -6632,11 +6632,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:981 lxc/config.go:1127
+#: lxc/config.go:993 lxc/config.go:1139
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1036
+#: lxc/config.go:1048
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -7033,7 +7033,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:762
+#: lxc/config.go:98 lxc/config.go:770
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7041,11 +7041,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:894
+#: lxc/config.go:391 lxc/config.go:902
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:536
+#: lxc/config.go:540
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -7169,7 +7169,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:543
+#: lxc/config.go:547
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7178,13 +7178,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1216
+#: lxc/config.go:1228
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1040
+#: lxc/config.go:1052
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"

--- a/po/ca.po
+++ b/po/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-26 11:55-0600\n"
+"POT-Creation-Date: 2024-09-30 13:36-0400\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Catalan <https://hosted.weblate.org/projects/linux-containers/"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1227
+#: lxc/config.go:1239
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -478,7 +478,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:493 lxc/config.go:809
+#: lxc/config.go:497 lxc/config.go:817
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -498,7 +498,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:443 lxc/config.go:628 lxc/config.go:835
+#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -765,7 +765,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:388
+#: lxc/console.go:392
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:694 lxc/config.go:1084
+#: lxc/config.go:702 lxc/config.go:1096
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1130,8 +1130,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:550 lxc/config.go:768
-#: lxc/config.go:899 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
+#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1251 lxc/network.go:1344 lxc/network.go:1416
 #: lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1210,7 +1210,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1327 lxc/config_metadata.go:156
+#: lxc/config.go:356 lxc/config.go:1339 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
@@ -1654,9 +1654,9 @@ msgstr ""
 #: lxc/cluster_group.go:316 lxc/cluster_group.go:440 lxc/cluster_group.go:522
 #: lxc/cluster_group.go:607 lxc/cluster_group.go:663 lxc/cluster_group.go:725
 #: lxc/cluster_role.go:24 lxc/cluster_role.go:51 lxc/cluster_role.go:115
-#: lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:538
-#: lxc/config.go:764 lxc/config.go:896 lxc/config.go:943 lxc/config.go:983
-#: lxc/config.go:1038 lxc/config.go:1129 lxc/config.go:1160 lxc/config.go:1214
+#: lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:542
+#: lxc/config.go:772 lxc/config.go:904 lxc/config.go:955 lxc/config.go:995
+#: lxc/config.go:1050 lxc/config.go:1141 lxc/config.go:1172 lxc/config.go:1226
 #: lxc/config_device.go:25 lxc/config_device.go:79 lxc/config_device.go:221
 #: lxc/config_device.go:318 lxc/config_device.go:401 lxc/config_device.go:503
 #: lxc/config_device.go:619 lxc/config_device.go:626 lxc/config_device.go:759
@@ -1929,7 +1929,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1213 lxc/config.go:1214
+#: lxc/config.go:1225 lxc/config.go:1226
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2053,7 +2053,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:459 lxc/config.go:654 lxc/config.go:686 lxc/network.go:1319
+#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1319
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
@@ -2063,7 +2063,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:648 lxc/config.go:680
+#: lxc/config.go:656 lxc/config.go:688
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2258,7 +2258,7 @@ msgstr ""
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:366
+#: lxc/console.go:370
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
@@ -2472,7 +2472,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:982 lxc/config.go:983
+#: lxc/config.go:994 lxc/config.go:995
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2870,7 +2870,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1008 lxc/config.go:1066 lxc/config.go:1185 lxc/config.go:1277
+#: lxc/config.go:1020 lxc/config.go:1078 lxc/config.go:1197 lxc/config.go:1289
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -3029,7 +3029,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:387
+#: lxc/console.go:391
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -3543,7 +3543,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:942 lxc/config.go:943
+#: lxc/config.go:954 lxc/config.go:955
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -4382,7 +4382,7 @@ msgstr ""
 
 #: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
@@ -4886,7 +4886,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1019
+#: lxc/config.go:1031
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5063,7 +5063,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1037 lxc/config.go:1038
+#: lxc/config.go:1049 lxc/config.go:1050
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5101,11 +5101,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:537
+#: lxc/config.go:541
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:538
+#: lxc/config.go:542
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5329,7 +5329,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:551
+#: lxc/config.go:555
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5394,7 +5394,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1159 lxc/config.go:1160
+#: lxc/config.go:1171 lxc/config.go:1172
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5402,7 +5402,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:763 lxc/config.go:764
+#: lxc/config.go:771 lxc/config.go:772
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5496,7 +5496,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:767
+#: lxc/config.go:775
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5747,7 +5747,7 @@ msgstr ""
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:126
+#: lxc/console.go:130
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -5809,12 +5809,12 @@ msgstr ""
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:479
+#: lxc/config.go:483
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:455
+#: lxc/config.go:459
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
@@ -5906,7 +5906,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:666
+#: lxc/config.go:674
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -5950,7 +5950,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:215
+#: lxc/console.go:219
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -5960,7 +5960,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:499 lxc/config.go:715 lxc/config.go:815
+#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6105,7 +6105,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:164
+#: lxc/console.go:168
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -6120,12 +6120,12 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:109
+#: lxc/console.go:113
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1128 lxc/config.go:1129
+#: lxc/config.go:1140 lxc/config.go:1141
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6145,7 +6145,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:895 lxc/config.go:896
+#: lxc/config.go:903 lxc/config.go:904
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6261,7 +6261,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:900
+#: lxc/config.go:908
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6610,7 +6610,7 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1158 lxc/config.go:1212 lxc/config_device.go:321
+#: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:321
 #: lxc/config_device.go:753 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:35
 msgid "[<remote>:]<instance>"
@@ -6632,11 +6632,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:981 lxc/config.go:1127
+#: lxc/config.go:993 lxc/config.go:1139
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1036
+#: lxc/config.go:1048
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -7033,7 +7033,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:762
+#: lxc/config.go:98 lxc/config.go:770
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7041,11 +7041,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:894
+#: lxc/config.go:391 lxc/config.go:902
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:536
+#: lxc/config.go:540
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -7169,7 +7169,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:543
+#: lxc/config.go:547
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7178,13 +7178,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1216
+#: lxc/config.go:1228
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1040
+#: lxc/config.go:1052
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"

--- a/po/cs.po
+++ b/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-26 11:55-0600\n"
+"POT-Creation-Date: 2024-09-30 13:36-0400\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Czech <https://hosted.weblate.org/projects/linux-containers/"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1227
+#: lxc/config.go:1239
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -478,7 +478,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:493 lxc/config.go:809
+#: lxc/config.go:497 lxc/config.go:817
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -498,7 +498,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:443 lxc/config.go:628 lxc/config.go:835
+#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -765,7 +765,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:388
+#: lxc/console.go:392
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:694 lxc/config.go:1084
+#: lxc/config.go:702 lxc/config.go:1096
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1130,8 +1130,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:550 lxc/config.go:768
-#: lxc/config.go:899 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
+#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1251 lxc/network.go:1344 lxc/network.go:1416
 #: lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1210,7 +1210,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1327 lxc/config_metadata.go:156
+#: lxc/config.go:356 lxc/config.go:1339 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
@@ -1654,9 +1654,9 @@ msgstr ""
 #: lxc/cluster_group.go:316 lxc/cluster_group.go:440 lxc/cluster_group.go:522
 #: lxc/cluster_group.go:607 lxc/cluster_group.go:663 lxc/cluster_group.go:725
 #: lxc/cluster_role.go:24 lxc/cluster_role.go:51 lxc/cluster_role.go:115
-#: lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:538
-#: lxc/config.go:764 lxc/config.go:896 lxc/config.go:943 lxc/config.go:983
-#: lxc/config.go:1038 lxc/config.go:1129 lxc/config.go:1160 lxc/config.go:1214
+#: lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:542
+#: lxc/config.go:772 lxc/config.go:904 lxc/config.go:955 lxc/config.go:995
+#: lxc/config.go:1050 lxc/config.go:1141 lxc/config.go:1172 lxc/config.go:1226
 #: lxc/config_device.go:25 lxc/config_device.go:79 lxc/config_device.go:221
 #: lxc/config_device.go:318 lxc/config_device.go:401 lxc/config_device.go:503
 #: lxc/config_device.go:619 lxc/config_device.go:626 lxc/config_device.go:759
@@ -1929,7 +1929,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1213 lxc/config.go:1214
+#: lxc/config.go:1225 lxc/config.go:1226
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2053,7 +2053,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:459 lxc/config.go:654 lxc/config.go:686 lxc/network.go:1319
+#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1319
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
@@ -2063,7 +2063,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:648 lxc/config.go:680
+#: lxc/config.go:656 lxc/config.go:688
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2258,7 +2258,7 @@ msgstr ""
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:366
+#: lxc/console.go:370
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
@@ -2472,7 +2472,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:982 lxc/config.go:983
+#: lxc/config.go:994 lxc/config.go:995
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2870,7 +2870,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1008 lxc/config.go:1066 lxc/config.go:1185 lxc/config.go:1277
+#: lxc/config.go:1020 lxc/config.go:1078 lxc/config.go:1197 lxc/config.go:1289
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -3029,7 +3029,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:387
+#: lxc/console.go:391
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -3543,7 +3543,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:942 lxc/config.go:943
+#: lxc/config.go:954 lxc/config.go:955
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -4382,7 +4382,7 @@ msgstr ""
 
 #: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
@@ -4886,7 +4886,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1019
+#: lxc/config.go:1031
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5063,7 +5063,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1037 lxc/config.go:1038
+#: lxc/config.go:1049 lxc/config.go:1050
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5101,11 +5101,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:537
+#: lxc/config.go:541
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:538
+#: lxc/config.go:542
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5329,7 +5329,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:551
+#: lxc/config.go:555
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5394,7 +5394,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1159 lxc/config.go:1160
+#: lxc/config.go:1171 lxc/config.go:1172
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5402,7 +5402,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:763 lxc/config.go:764
+#: lxc/config.go:771 lxc/config.go:772
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5496,7 +5496,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:767
+#: lxc/config.go:775
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5747,7 +5747,7 @@ msgstr ""
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:126
+#: lxc/console.go:130
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -5809,12 +5809,12 @@ msgstr ""
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:479
+#: lxc/config.go:483
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:455
+#: lxc/config.go:459
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
@@ -5906,7 +5906,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:666
+#: lxc/config.go:674
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -5950,7 +5950,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:215
+#: lxc/console.go:219
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -5960,7 +5960,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:499 lxc/config.go:715 lxc/config.go:815
+#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6105,7 +6105,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:164
+#: lxc/console.go:168
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -6120,12 +6120,12 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:109
+#: lxc/console.go:113
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1128 lxc/config.go:1129
+#: lxc/config.go:1140 lxc/config.go:1141
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6145,7 +6145,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:895 lxc/config.go:896
+#: lxc/config.go:903 lxc/config.go:904
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6261,7 +6261,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:900
+#: lxc/config.go:908
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6610,7 +6610,7 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1158 lxc/config.go:1212 lxc/config_device.go:321
+#: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:321
 #: lxc/config_device.go:753 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:35
 msgid "[<remote>:]<instance>"
@@ -6632,11 +6632,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:981 lxc/config.go:1127
+#: lxc/config.go:993 lxc/config.go:1139
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1036
+#: lxc/config.go:1048
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -7033,7 +7033,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:762
+#: lxc/config.go:98 lxc/config.go:770
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7041,11 +7041,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:894
+#: lxc/config.go:391 lxc/config.go:902
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:536
+#: lxc/config.go:540
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -7169,7 +7169,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:543
+#: lxc/config.go:547
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7178,13 +7178,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1216
+#: lxc/config.go:1228
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1040
+#: lxc/config.go:1052
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-26 11:55-0600\n"
+"POT-Creation-Date: 2024-09-30 13:36-0400\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Krombel <krombel@krombel.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/linux-containers/"
@@ -100,7 +100,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/config.go:1227
+#: lxc/config.go:1239
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -730,7 +730,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:493 lxc/config.go:809
+#: lxc/config.go:497 lxc/config.go:817
 #, fuzzy
 msgid "--expanded cannot be used with a server"
 msgstr "--refresh kann nur mit Containern verwendet werden"
@@ -754,7 +754,7 @@ msgstr "--refresh kann nur mit Containern verwendet werden"
 msgid "--refresh can only be used with instances"
 msgstr "--refresh kann nur mit Containern verwendet werden"
 
-#: lxc/config.go:170 lxc/config.go:443 lxc/config.go:628 lxc/config.go:835
+#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
 #: lxc/info.go:461
 #, fuzzy
 msgid "--target cannot be used with instances"
@@ -1042,7 +1042,7 @@ msgstr "Architektur: %s\n"
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:388
+#: lxc/console.go:392
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -1311,7 +1311,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:694 lxc/config.go:1084
+#: lxc/config.go:702 lxc/config.go:1096
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1432,8 +1432,8 @@ msgstr "Gerät %s wurde von %s entfernt\n"
 msgid "Cluster member %s removed from group %s"
 msgstr "Gerät %s wurde von %s entfernt\n"
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:550 lxc/config.go:768
-#: lxc/config.go:899 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
+#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1251 lxc/network.go:1344 lxc/network.go:1416
 #: lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1515,7 +1515,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1327 lxc/config_metadata.go:156
+#: lxc/config.go:356 lxc/config.go:1339 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
@@ -1996,9 +1996,9 @@ msgstr ""
 #: lxc/cluster_group.go:316 lxc/cluster_group.go:440 lxc/cluster_group.go:522
 #: lxc/cluster_group.go:607 lxc/cluster_group.go:663 lxc/cluster_group.go:725
 #: lxc/cluster_role.go:24 lxc/cluster_role.go:51 lxc/cluster_role.go:115
-#: lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:538
-#: lxc/config.go:764 lxc/config.go:896 lxc/config.go:943 lxc/config.go:983
-#: lxc/config.go:1038 lxc/config.go:1129 lxc/config.go:1160 lxc/config.go:1214
+#: lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:542
+#: lxc/config.go:772 lxc/config.go:904 lxc/config.go:955 lxc/config.go:995
+#: lxc/config.go:1050 lxc/config.go:1141 lxc/config.go:1172 lxc/config.go:1226
 #: lxc/config_device.go:25 lxc/config_device.go:79 lxc/config_device.go:221
 #: lxc/config_device.go:318 lxc/config_device.go:401 lxc/config_device.go:503
 #: lxc/config_device.go:619 lxc/config_device.go:626 lxc/config_device.go:759
@@ -2290,7 +2290,7 @@ msgstr "Alternatives config Verzeichnis."
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1213 lxc/config.go:1214
+#: lxc/config.go:1225 lxc/config.go:1226
 #, fuzzy
 msgid "Edit instance UEFI variables"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -2427,7 +2427,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:459 lxc/config.go:654 lxc/config.go:686 lxc/network.go:1319
+#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1319
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
@@ -2437,7 +2437,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr "Fehler beim hinzufügen des Alias %s\n"
 
-#: lxc/config.go:648 lxc/config.go:680
+#: lxc/config.go:656 lxc/config.go:688
 #, fuzzy, c-format
 msgid "Error unsetting properties: %v"
 msgstr "Fehler beim hinzufügen des Alias %s\n"
@@ -2645,7 +2645,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Failed parsing SSH host key: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/console.go:366
+#: lxc/console.go:370
 #, fuzzy, c-format
 msgid "Failed starting command: %w"
 msgstr "Akzeptiere Zertifikat"
@@ -2864,7 +2864,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr "Generiere Nutzerzertifikat. Dies kann wenige Minuten dauern...\n"
 
-#: lxc/config.go:982 lxc/config.go:983
+#: lxc/config.go:994 lxc/config.go:995
 #, fuzzy
 msgid "Get UEFI variables for instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -3290,7 +3290,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1008 lxc/config.go:1066 lxc/config.go:1185 lxc/config.go:1277
+#: lxc/config.go:1020 lxc/config.go:1078 lxc/config.go:1197 lxc/config.go:1289
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -3457,7 +3457,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:387
+#: lxc/console.go:391
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -4019,7 +4019,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:942 lxc/config.go:943
+#: lxc/config.go:954 lxc/config.go:955
 #, fuzzy
 msgid "Manage instance UEFI variables"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -4920,7 +4920,7 @@ msgstr ""
 
 #: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
@@ -5458,7 +5458,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1019
+#: lxc/config.go:1031
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5645,7 +5645,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1037 lxc/config.go:1038
+#: lxc/config.go:1049 lxc/config.go:1050
 #, fuzzy
 msgid "Set UEFI variables for instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -5686,12 +5686,12 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:537
+#: lxc/config.go:541
 #, fuzzy
 msgid "Set instance or server configuration keys"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/config.go:538
+#: lxc/config.go:542
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5933,7 +5933,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Set the key as a storage volume property"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/config.go:551
+#: lxc/config.go:555
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -6002,7 +6002,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1159 lxc/config.go:1160
+#: lxc/config.go:1171 lxc/config.go:1172
 #, fuzzy
 msgid "Show instance UEFI variables"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -6012,7 +6012,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Show instance metadata files"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/config.go:763 lxc/config.go:764
+#: lxc/config.go:771 lxc/config.go:772
 #, fuzzy
 msgid "Show instance or server configurations"
 msgstr "Profil %s erstellt\n"
@@ -6120,7 +6120,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:767
+#: lxc/config.go:775
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -6385,7 +6385,7 @@ msgstr "--refresh kann nur mit Containern verwendet werden"
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:126
+#: lxc/console.go:130
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -6451,12 +6451,12 @@ msgstr "entfernte Instanz %s existiert nicht"
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/config.go:479
+#: lxc/config.go:483
 #, fuzzy, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/config.go:455
+#: lxc/config.go:459
 #, fuzzy, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -6550,7 +6550,7 @@ msgstr "entfernte Instanz %s existiert nicht"
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:666
+#: lxc/config.go:674
 #, fuzzy
 msgid "There is no config key to set on an instance snapshot."
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -6597,7 +6597,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:215
+#: lxc/console.go:219
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -6607,7 +6607,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:499 lxc/config.go:715 lxc/config.go:815
+#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6754,7 +6754,7 @@ msgstr "Unbekannter Befehl %s für Abbild"
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:164
+#: lxc/console.go:168
 #, fuzzy, c-format
 msgid "Unknown console type %q"
 msgstr "Unbekannter Befehl %s für Abbild"
@@ -6769,12 +6769,12 @@ msgstr "Unbekannter Befehl %s für Abbild"
 msgid "Unknown key: %s"
 msgstr "Unbekannter Befehl %s für Abbild"
 
-#: lxc/console.go:109
+#: lxc/console.go:113
 #, fuzzy, c-format
 msgid "Unknown output type %q"
 msgstr "Unbekannter Befehl %s für Abbild"
 
-#: lxc/config.go:1128 lxc/config.go:1129
+#: lxc/config.go:1140 lxc/config.go:1141
 #, fuzzy
 msgid "Unset UEFI variables for instance"
 msgstr "nicht alle Profile der Quelle sind am Ziel vorhanden."
@@ -6798,7 +6798,7 @@ msgstr "Alternatives config Verzeichnis."
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:895 lxc/config.go:896
+#: lxc/config.go:903 lxc/config.go:904
 #, fuzzy
 msgid "Unset instance or server configuration keys"
 msgstr "Alternatives config Verzeichnis."
@@ -6936,7 +6936,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Unset the key as a storage volume property"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/config.go:900
+#: lxc/config.go:908
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -7466,7 +7466,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/config.go:1158 lxc/config.go:1212 lxc/config_device.go:321
+#: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:321
 #: lxc/config_device.go:753 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:35
 #, fuzzy
@@ -7509,7 +7509,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/config.go:981 lxc/config.go:1127
+#: lxc/config.go:993 lxc/config.go:1139
 #, fuzzy
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
@@ -7517,7 +7517,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/config.go:1036
+#: lxc/config.go:1048
 #, fuzzy
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
@@ -8308,7 +8308,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/config.go:98 lxc/config.go:762
+#: lxc/config.go:98 lxc/config.go:770
 #, fuzzy
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
@@ -8326,7 +8326,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/config.go:391 lxc/config.go:894
+#: lxc/config.go:391 lxc/config.go:902
 #, fuzzy
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
@@ -8334,7 +8334,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/config.go:536
+#: lxc/config.go:540
 #, fuzzy
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
@@ -8475,7 +8475,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:543
+#: lxc/config.go:547
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -8484,13 +8484,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1216
+#: lxc/config.go:1228
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1040
+#: lxc/config.go:1052
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-26 11:55-0600\n"
+"POT-Creation-Date: 2024-09-30 13:36-0400\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/linux-containers/"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1227
+#: lxc/config.go:1239
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -478,7 +478,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:493 lxc/config.go:809
+#: lxc/config.go:497 lxc/config.go:817
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -498,7 +498,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:443 lxc/config.go:628 lxc/config.go:835
+#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -768,7 +768,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:388
+#: lxc/console.go:392
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:694 lxc/config.go:1084
+#: lxc/config.go:702 lxc/config.go:1096
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1134,8 +1134,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:550 lxc/config.go:768
-#: lxc/config.go:899 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
+#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1251 lxc/network.go:1344 lxc/network.go:1416
 #: lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1214,7 +1214,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1327 lxc/config_metadata.go:156
+#: lxc/config.go:356 lxc/config.go:1339 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
@@ -1666,9 +1666,9 @@ msgstr ""
 #: lxc/cluster_group.go:316 lxc/cluster_group.go:440 lxc/cluster_group.go:522
 #: lxc/cluster_group.go:607 lxc/cluster_group.go:663 lxc/cluster_group.go:725
 #: lxc/cluster_role.go:24 lxc/cluster_role.go:51 lxc/cluster_role.go:115
-#: lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:538
-#: lxc/config.go:764 lxc/config.go:896 lxc/config.go:943 lxc/config.go:983
-#: lxc/config.go:1038 lxc/config.go:1129 lxc/config.go:1160 lxc/config.go:1214
+#: lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:542
+#: lxc/config.go:772 lxc/config.go:904 lxc/config.go:955 lxc/config.go:995
+#: lxc/config.go:1050 lxc/config.go:1141 lxc/config.go:1172 lxc/config.go:1226
 #: lxc/config_device.go:25 lxc/config_device.go:79 lxc/config_device.go:221
 #: lxc/config_device.go:318 lxc/config_device.go:401 lxc/config_device.go:503
 #: lxc/config_device.go:619 lxc/config_device.go:626 lxc/config_device.go:759
@@ -1946,7 +1946,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1213 lxc/config.go:1214
+#: lxc/config.go:1225 lxc/config.go:1226
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2075,7 +2075,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:459 lxc/config.go:654 lxc/config.go:686 lxc/network.go:1319
+#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1319
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
@@ -2085,7 +2085,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:648 lxc/config.go:680
+#: lxc/config.go:656 lxc/config.go:688
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2280,7 +2280,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:366
+#: lxc/console.go:370
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
@@ -2494,7 +2494,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:982 lxc/config.go:983
+#: lxc/config.go:994 lxc/config.go:995
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2905,7 +2905,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1008 lxc/config.go:1066 lxc/config.go:1185 lxc/config.go:1277
+#: lxc/config.go:1020 lxc/config.go:1078 lxc/config.go:1197 lxc/config.go:1289
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -3064,7 +3064,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:387
+#: lxc/console.go:391
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -3582,7 +3582,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:942 lxc/config.go:943
+#: lxc/config.go:954 lxc/config.go:955
 #, fuzzy
 msgid "Manage instance UEFI variables"
 msgstr "  Χρήση δικτύου:"
@@ -4447,7 +4447,7 @@ msgstr ""
 
 #: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
@@ -4956,7 +4956,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1019
+#: lxc/config.go:1031
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5134,7 +5134,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1037 lxc/config.go:1038
+#: lxc/config.go:1049 lxc/config.go:1050
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5173,11 +5173,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:537
+#: lxc/config.go:541
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:538
+#: lxc/config.go:542
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5413,7 +5413,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:551
+#: lxc/config.go:555
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5480,7 +5480,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1159 lxc/config.go:1160
+#: lxc/config.go:1171 lxc/config.go:1172
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5488,7 +5488,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:763 lxc/config.go:764
+#: lxc/config.go:771 lxc/config.go:772
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5590,7 +5590,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:767
+#: lxc/config.go:775
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5842,7 +5842,7 @@ msgstr ""
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:126
+#: lxc/console.go:130
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -5904,12 +5904,12 @@ msgstr ""
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/config.go:479
+#: lxc/config.go:483
 #, fuzzy, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/config.go:455
+#: lxc/config.go:459
 #, fuzzy, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr "  Χρήση δικτύου:"
@@ -6001,7 +6001,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:666
+#: lxc/config.go:674
 #, fuzzy
 msgid "There is no config key to set on an instance snapshot."
 msgstr "  Χρήση δικτύου:"
@@ -6046,7 +6046,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:215
+#: lxc/console.go:219
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -6056,7 +6056,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:499 lxc/config.go:715 lxc/config.go:815
+#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6201,7 +6201,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:164
+#: lxc/console.go:168
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -6216,12 +6216,12 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:109
+#: lxc/console.go:113
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1128 lxc/config.go:1129
+#: lxc/config.go:1140 lxc/config.go:1141
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6242,7 +6242,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:895 lxc/config.go:896
+#: lxc/config.go:903 lxc/config.go:904
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6374,7 +6374,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:900
+#: lxc/config.go:908
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6723,7 +6723,7 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1158 lxc/config.go:1212 lxc/config_device.go:321
+#: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:321
 #: lxc/config_device.go:753 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:35
 msgid "[<remote>:]<instance>"
@@ -6745,11 +6745,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:981 lxc/config.go:1127
+#: lxc/config.go:993 lxc/config.go:1139
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1036
+#: lxc/config.go:1048
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -7146,7 +7146,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:762
+#: lxc/config.go:98 lxc/config.go:770
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7154,11 +7154,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:894
+#: lxc/config.go:391 lxc/config.go:902
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:536
+#: lxc/config.go:540
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -7282,7 +7282,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:543
+#: lxc/config.go:547
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7291,13 +7291,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1216
+#: lxc/config.go:1228
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1040
+#: lxc/config.go:1052
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"

--- a/po/eo.po
+++ b/po/eo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-26 11:55-0600\n"
+"POT-Creation-Date: 2024-09-30 13:36-0400\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Esperanto <https://hosted.weblate.org/projects/linux-"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1227
+#: lxc/config.go:1239
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -478,7 +478,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:493 lxc/config.go:809
+#: lxc/config.go:497 lxc/config.go:817
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -498,7 +498,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:443 lxc/config.go:628 lxc/config.go:835
+#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -765,7 +765,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:388
+#: lxc/console.go:392
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:694 lxc/config.go:1084
+#: lxc/config.go:702 lxc/config.go:1096
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1130,8 +1130,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:550 lxc/config.go:768
-#: lxc/config.go:899 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
+#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1251 lxc/network.go:1344 lxc/network.go:1416
 #: lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1210,7 +1210,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1327 lxc/config_metadata.go:156
+#: lxc/config.go:356 lxc/config.go:1339 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
@@ -1654,9 +1654,9 @@ msgstr ""
 #: lxc/cluster_group.go:316 lxc/cluster_group.go:440 lxc/cluster_group.go:522
 #: lxc/cluster_group.go:607 lxc/cluster_group.go:663 lxc/cluster_group.go:725
 #: lxc/cluster_role.go:24 lxc/cluster_role.go:51 lxc/cluster_role.go:115
-#: lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:538
-#: lxc/config.go:764 lxc/config.go:896 lxc/config.go:943 lxc/config.go:983
-#: lxc/config.go:1038 lxc/config.go:1129 lxc/config.go:1160 lxc/config.go:1214
+#: lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:542
+#: lxc/config.go:772 lxc/config.go:904 lxc/config.go:955 lxc/config.go:995
+#: lxc/config.go:1050 lxc/config.go:1141 lxc/config.go:1172 lxc/config.go:1226
 #: lxc/config_device.go:25 lxc/config_device.go:79 lxc/config_device.go:221
 #: lxc/config_device.go:318 lxc/config_device.go:401 lxc/config_device.go:503
 #: lxc/config_device.go:619 lxc/config_device.go:626 lxc/config_device.go:759
@@ -1929,7 +1929,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1213 lxc/config.go:1214
+#: lxc/config.go:1225 lxc/config.go:1226
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2053,7 +2053,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:459 lxc/config.go:654 lxc/config.go:686 lxc/network.go:1319
+#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1319
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
@@ -2063,7 +2063,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:648 lxc/config.go:680
+#: lxc/config.go:656 lxc/config.go:688
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2258,7 +2258,7 @@ msgstr ""
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:366
+#: lxc/console.go:370
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
@@ -2472,7 +2472,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:982 lxc/config.go:983
+#: lxc/config.go:994 lxc/config.go:995
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2870,7 +2870,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1008 lxc/config.go:1066 lxc/config.go:1185 lxc/config.go:1277
+#: lxc/config.go:1020 lxc/config.go:1078 lxc/config.go:1197 lxc/config.go:1289
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -3029,7 +3029,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:387
+#: lxc/console.go:391
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -3543,7 +3543,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:942 lxc/config.go:943
+#: lxc/config.go:954 lxc/config.go:955
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -4382,7 +4382,7 @@ msgstr ""
 
 #: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
@@ -4886,7 +4886,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1019
+#: lxc/config.go:1031
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5063,7 +5063,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1037 lxc/config.go:1038
+#: lxc/config.go:1049 lxc/config.go:1050
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5101,11 +5101,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:537
+#: lxc/config.go:541
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:538
+#: lxc/config.go:542
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5329,7 +5329,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:551
+#: lxc/config.go:555
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5394,7 +5394,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1159 lxc/config.go:1160
+#: lxc/config.go:1171 lxc/config.go:1172
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5402,7 +5402,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:763 lxc/config.go:764
+#: lxc/config.go:771 lxc/config.go:772
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5496,7 +5496,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:767
+#: lxc/config.go:775
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5747,7 +5747,7 @@ msgstr ""
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:126
+#: lxc/console.go:130
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -5809,12 +5809,12 @@ msgstr ""
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:479
+#: lxc/config.go:483
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:455
+#: lxc/config.go:459
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
@@ -5906,7 +5906,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:666
+#: lxc/config.go:674
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -5950,7 +5950,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:215
+#: lxc/console.go:219
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -5960,7 +5960,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:499 lxc/config.go:715 lxc/config.go:815
+#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6105,7 +6105,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:164
+#: lxc/console.go:168
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -6120,12 +6120,12 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:109
+#: lxc/console.go:113
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1128 lxc/config.go:1129
+#: lxc/config.go:1140 lxc/config.go:1141
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6145,7 +6145,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:895 lxc/config.go:896
+#: lxc/config.go:903 lxc/config.go:904
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6261,7 +6261,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:900
+#: lxc/config.go:908
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6610,7 +6610,7 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1158 lxc/config.go:1212 lxc/config_device.go:321
+#: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:321
 #: lxc/config_device.go:753 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:35
 msgid "[<remote>:]<instance>"
@@ -6632,11 +6632,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:981 lxc/config.go:1127
+#: lxc/config.go:993 lxc/config.go:1139
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1036
+#: lxc/config.go:1048
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -7033,7 +7033,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:762
+#: lxc/config.go:98 lxc/config.go:770
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7041,11 +7041,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:894
+#: lxc/config.go:391 lxc/config.go:902
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:536
+#: lxc/config.go:540
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -7169,7 +7169,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:543
+#: lxc/config.go:547
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7178,13 +7178,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1216
+#: lxc/config.go:1228
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1040
+#: lxc/config.go:1052
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-26 11:55-0600\n"
+"POT-Creation-Date: 2024-09-30 13:36-0400\n"
 "PO-Revision-Date: 2023-06-16 20:55+0000\n"
 "Last-Translator: Francisco Serrador <fserrador@gmail.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -108,7 +108,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/config.go:1227
+#: lxc/config.go:1239
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -717,7 +717,7 @@ msgstr "Perfil para aplicar al nuevo contenedor"
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:493 lxc/config.go:809
+#: lxc/config.go:497 lxc/config.go:817
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:443 lxc/config.go:628 lxc/config.go:835
+#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -1013,7 +1013,7 @@ msgstr "Arquitectura: %s"
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:388
+#: lxc/console.go:392
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -1269,7 +1269,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:694 lxc/config.go:1084
+#: lxc/config.go:702 lxc/config.go:1096
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1386,8 +1386,8 @@ msgstr "Perfil %s eliminado de %s"
 msgid "Cluster member %s removed from group %s"
 msgstr "Perfil %s eliminado de %s"
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:550 lxc/config.go:768
-#: lxc/config.go:899 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
+#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1251 lxc/network.go:1344 lxc/network.go:1416
 #: lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1468,7 +1468,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr "Perfil para aplicar al nuevo contenedor"
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1327 lxc/config_metadata.go:156
+#: lxc/config.go:356 lxc/config.go:1339 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
@@ -1928,9 +1928,9 @@ msgstr ""
 #: lxc/cluster_group.go:316 lxc/cluster_group.go:440 lxc/cluster_group.go:522
 #: lxc/cluster_group.go:607 lxc/cluster_group.go:663 lxc/cluster_group.go:725
 #: lxc/cluster_role.go:24 lxc/cluster_role.go:51 lxc/cluster_role.go:115
-#: lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:538
-#: lxc/config.go:764 lxc/config.go:896 lxc/config.go:943 lxc/config.go:983
-#: lxc/config.go:1038 lxc/config.go:1129 lxc/config.go:1160 lxc/config.go:1214
+#: lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:542
+#: lxc/config.go:772 lxc/config.go:904 lxc/config.go:955 lxc/config.go:995
+#: lxc/config.go:1050 lxc/config.go:1141 lxc/config.go:1172 lxc/config.go:1226
 #: lxc/config_device.go:25 lxc/config_device.go:79 lxc/config_device.go:221
 #: lxc/config_device.go:318 lxc/config_device.go:401 lxc/config_device.go:503
 #: lxc/config_device.go:619 lxc/config_device.go:626 lxc/config_device.go:759
@@ -2208,7 +2208,7 @@ msgstr "Perfil %s creado"
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1213 lxc/config.go:1214
+#: lxc/config.go:1225 lxc/config.go:1226
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2337,7 +2337,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:459 lxc/config.go:654 lxc/config.go:686 lxc/network.go:1319
+#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1319
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
@@ -2347,7 +2347,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr "Error actualizando el archivo de plantilla: %s"
 
-#: lxc/config.go:648 lxc/config.go:680
+#: lxc/config.go:656 lxc/config.go:688
 #, fuzzy, c-format
 msgid "Error unsetting properties: %v"
 msgstr "Error actualizando el archivo de plantilla: %s"
@@ -2546,7 +2546,7 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "Failed parsing SSH host key: %w"
 msgstr "Acepta certificado"
 
-#: lxc/console.go:366
+#: lxc/console.go:370
 #, fuzzy, c-format
 msgid "Failed starting command: %w"
 msgstr "Acepta certificado"
@@ -2761,7 +2761,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:982 lxc/config.go:983
+#: lxc/config.go:994 lxc/config.go:995
 #, fuzzy
 msgid "Get UEFI variables for instance"
 msgstr "Aliases:"
@@ -3179,7 +3179,7 @@ msgstr "Nombre del contenedor es obligatorio"
 msgid "Instance name is: %s"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/config.go:1008 lxc/config.go:1066 lxc/config.go:1185 lxc/config.go:1277
+#: lxc/config.go:1020 lxc/config.go:1078 lxc/config.go:1197 lxc/config.go:1289
 #, fuzzy
 msgid "Instance name must be specified"
 msgstr "Nombre del contenedor es: %s"
@@ -3341,7 +3341,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:387
+#: lxc/console.go:391
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -3872,7 +3872,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:942 lxc/config.go:943
+#: lxc/config.go:954 lxc/config.go:955
 #, fuzzy
 msgid "Manage instance UEFI variables"
 msgstr "Nombre del Miembro del Cluster"
@@ -4745,7 +4745,7 @@ msgstr ""
 
 #: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
@@ -5263,7 +5263,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1019
+#: lxc/config.go:1031
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5446,7 +5446,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1037 lxc/config.go:1038
+#: lxc/config.go:1049 lxc/config.go:1050
 #, fuzzy
 msgid "Set UEFI variables for instance"
 msgstr "Aliases:"
@@ -5486,11 +5486,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:537
+#: lxc/config.go:541
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:538
+#: lxc/config.go:542
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5726,7 +5726,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:551
+#: lxc/config.go:555
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5793,7 +5793,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1159 lxc/config.go:1160
+#: lxc/config.go:1171 lxc/config.go:1172
 #, fuzzy
 msgid "Show instance UEFI variables"
 msgstr "Dispositivo %s añadido a %s"
@@ -5802,7 +5802,7 @@ msgstr "Dispositivo %s añadido a %s"
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:763 lxc/config.go:764
+#: lxc/config.go:771 lxc/config.go:772
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5904,7 +5904,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:767
+#: lxc/config.go:775
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -6158,7 +6158,7 @@ msgstr "--container-only no se puede pasar cuando la fuente es una instantánea"
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:126
+#: lxc/console.go:130
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -6221,12 +6221,12 @@ msgstr ""
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/config.go:479
+#: lxc/config.go:483
 #, fuzzy, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/config.go:455
+#: lxc/config.go:459
 #, fuzzy, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr "Nombre del Miembro del Cluster"
@@ -6318,7 +6318,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:666
+#: lxc/config.go:674
 #, fuzzy
 msgid "There is no config key to set on an instance snapshot."
 msgstr "Nombre del Miembro del Cluster"
@@ -6364,7 +6364,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:215
+#: lxc/console.go:219
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -6374,7 +6374,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:499 lxc/config.go:715 lxc/config.go:815
+#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6521,7 +6521,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:164
+#: lxc/console.go:168
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -6536,12 +6536,12 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:109
+#: lxc/console.go:113
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1128 lxc/config.go:1129
+#: lxc/config.go:1140 lxc/config.go:1141
 #, fuzzy
 msgid "Unset UEFI variables for instance"
 msgstr "Aliases:"
@@ -6563,7 +6563,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:895 lxc/config.go:896
+#: lxc/config.go:903 lxc/config.go:904
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6695,7 +6695,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:900
+#: lxc/config.go:908
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -7084,7 +7084,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/config.go:1158 lxc/config.go:1212 lxc/config_device.go:321
+#: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:321
 #: lxc/config_device.go:753 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:35
 #, fuzzy
@@ -7111,12 +7111,12 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/config.go:981 lxc/config.go:1127
+#: lxc/config.go:993 lxc/config.go:1139
 #, fuzzy
 msgid "[<remote>:]<instance> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/config.go:1036
+#: lxc/config.go:1048
 #, fuzzy
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7604,7 +7604,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/config.go:98 lxc/config.go:762
+#: lxc/config.go:98 lxc/config.go:770
 #, fuzzy
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7614,12 +7614,12 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:][<instance>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/config.go:391 lxc/config.go:894
+#: lxc/config.go:391 lxc/config.go:902
 #, fuzzy
 msgid "[<remote>:][<instance>] <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/config.go:536
+#: lxc/config.go:540
 #, fuzzy
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7747,7 +7747,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:543
+#: lxc/config.go:547
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7756,13 +7756,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1216
+#: lxc/config.go:1228
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1040
+#: lxc/config.go:1052
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"

--- a/po/fa.po
+++ b/po/fa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-26 11:55-0600\n"
+"POT-Creation-Date: 2024-09-30 13:36-0400\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Persian <https://hosted.weblate.org/projects/linux-containers/"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1227
+#: lxc/config.go:1239
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -478,7 +478,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:493 lxc/config.go:809
+#: lxc/config.go:497 lxc/config.go:817
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -498,7 +498,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:443 lxc/config.go:628 lxc/config.go:835
+#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -765,7 +765,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:388
+#: lxc/console.go:392
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:694 lxc/config.go:1084
+#: lxc/config.go:702 lxc/config.go:1096
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1130,8 +1130,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:550 lxc/config.go:768
-#: lxc/config.go:899 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
+#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1251 lxc/network.go:1344 lxc/network.go:1416
 #: lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1210,7 +1210,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1327 lxc/config_metadata.go:156
+#: lxc/config.go:356 lxc/config.go:1339 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
@@ -1654,9 +1654,9 @@ msgstr ""
 #: lxc/cluster_group.go:316 lxc/cluster_group.go:440 lxc/cluster_group.go:522
 #: lxc/cluster_group.go:607 lxc/cluster_group.go:663 lxc/cluster_group.go:725
 #: lxc/cluster_role.go:24 lxc/cluster_role.go:51 lxc/cluster_role.go:115
-#: lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:538
-#: lxc/config.go:764 lxc/config.go:896 lxc/config.go:943 lxc/config.go:983
-#: lxc/config.go:1038 lxc/config.go:1129 lxc/config.go:1160 lxc/config.go:1214
+#: lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:542
+#: lxc/config.go:772 lxc/config.go:904 lxc/config.go:955 lxc/config.go:995
+#: lxc/config.go:1050 lxc/config.go:1141 lxc/config.go:1172 lxc/config.go:1226
 #: lxc/config_device.go:25 lxc/config_device.go:79 lxc/config_device.go:221
 #: lxc/config_device.go:318 lxc/config_device.go:401 lxc/config_device.go:503
 #: lxc/config_device.go:619 lxc/config_device.go:626 lxc/config_device.go:759
@@ -1929,7 +1929,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1213 lxc/config.go:1214
+#: lxc/config.go:1225 lxc/config.go:1226
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2053,7 +2053,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:459 lxc/config.go:654 lxc/config.go:686 lxc/network.go:1319
+#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1319
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
@@ -2063,7 +2063,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:648 lxc/config.go:680
+#: lxc/config.go:656 lxc/config.go:688
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2258,7 +2258,7 @@ msgstr ""
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:366
+#: lxc/console.go:370
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
@@ -2472,7 +2472,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:982 lxc/config.go:983
+#: lxc/config.go:994 lxc/config.go:995
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2870,7 +2870,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1008 lxc/config.go:1066 lxc/config.go:1185 lxc/config.go:1277
+#: lxc/config.go:1020 lxc/config.go:1078 lxc/config.go:1197 lxc/config.go:1289
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -3029,7 +3029,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:387
+#: lxc/console.go:391
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -3543,7 +3543,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:942 lxc/config.go:943
+#: lxc/config.go:954 lxc/config.go:955
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -4382,7 +4382,7 @@ msgstr ""
 
 #: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
@@ -4886,7 +4886,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1019
+#: lxc/config.go:1031
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5063,7 +5063,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1037 lxc/config.go:1038
+#: lxc/config.go:1049 lxc/config.go:1050
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5101,11 +5101,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:537
+#: lxc/config.go:541
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:538
+#: lxc/config.go:542
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5329,7 +5329,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:551
+#: lxc/config.go:555
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5394,7 +5394,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1159 lxc/config.go:1160
+#: lxc/config.go:1171 lxc/config.go:1172
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5402,7 +5402,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:763 lxc/config.go:764
+#: lxc/config.go:771 lxc/config.go:772
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5496,7 +5496,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:767
+#: lxc/config.go:775
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5747,7 +5747,7 @@ msgstr ""
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:126
+#: lxc/console.go:130
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -5809,12 +5809,12 @@ msgstr ""
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:479
+#: lxc/config.go:483
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:455
+#: lxc/config.go:459
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
@@ -5906,7 +5906,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:666
+#: lxc/config.go:674
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -5950,7 +5950,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:215
+#: lxc/console.go:219
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -5960,7 +5960,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:499 lxc/config.go:715 lxc/config.go:815
+#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6105,7 +6105,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:164
+#: lxc/console.go:168
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -6120,12 +6120,12 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:109
+#: lxc/console.go:113
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1128 lxc/config.go:1129
+#: lxc/config.go:1140 lxc/config.go:1141
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6145,7 +6145,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:895 lxc/config.go:896
+#: lxc/config.go:903 lxc/config.go:904
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6261,7 +6261,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:900
+#: lxc/config.go:908
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6610,7 +6610,7 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1158 lxc/config.go:1212 lxc/config_device.go:321
+#: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:321
 #: lxc/config_device.go:753 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:35
 msgid "[<remote>:]<instance>"
@@ -6632,11 +6632,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:981 lxc/config.go:1127
+#: lxc/config.go:993 lxc/config.go:1139
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1036
+#: lxc/config.go:1048
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -7033,7 +7033,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:762
+#: lxc/config.go:98 lxc/config.go:770
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7041,11 +7041,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:894
+#: lxc/config.go:391 lxc/config.go:902
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:536
+#: lxc/config.go:540
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -7169,7 +7169,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:543
+#: lxc/config.go:547
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7178,13 +7178,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1216
+#: lxc/config.go:1228
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1040
+#: lxc/config.go:1052
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-26 11:55-0600\n"
+"POT-Creation-Date: 2024-09-30 13:36-0400\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/linux-containers/"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1227
+#: lxc/config.go:1239
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -478,7 +478,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:493 lxc/config.go:809
+#: lxc/config.go:497 lxc/config.go:817
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -498,7 +498,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:443 lxc/config.go:628 lxc/config.go:835
+#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -765,7 +765,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:388
+#: lxc/console.go:392
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:694 lxc/config.go:1084
+#: lxc/config.go:702 lxc/config.go:1096
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1130,8 +1130,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:550 lxc/config.go:768
-#: lxc/config.go:899 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
+#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1251 lxc/network.go:1344 lxc/network.go:1416
 #: lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1210,7 +1210,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1327 lxc/config_metadata.go:156
+#: lxc/config.go:356 lxc/config.go:1339 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
@@ -1654,9 +1654,9 @@ msgstr ""
 #: lxc/cluster_group.go:316 lxc/cluster_group.go:440 lxc/cluster_group.go:522
 #: lxc/cluster_group.go:607 lxc/cluster_group.go:663 lxc/cluster_group.go:725
 #: lxc/cluster_role.go:24 lxc/cluster_role.go:51 lxc/cluster_role.go:115
-#: lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:538
-#: lxc/config.go:764 lxc/config.go:896 lxc/config.go:943 lxc/config.go:983
-#: lxc/config.go:1038 lxc/config.go:1129 lxc/config.go:1160 lxc/config.go:1214
+#: lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:542
+#: lxc/config.go:772 lxc/config.go:904 lxc/config.go:955 lxc/config.go:995
+#: lxc/config.go:1050 lxc/config.go:1141 lxc/config.go:1172 lxc/config.go:1226
 #: lxc/config_device.go:25 lxc/config_device.go:79 lxc/config_device.go:221
 #: lxc/config_device.go:318 lxc/config_device.go:401 lxc/config_device.go:503
 #: lxc/config_device.go:619 lxc/config_device.go:626 lxc/config_device.go:759
@@ -1929,7 +1929,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1213 lxc/config.go:1214
+#: lxc/config.go:1225 lxc/config.go:1226
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2053,7 +2053,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:459 lxc/config.go:654 lxc/config.go:686 lxc/network.go:1319
+#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1319
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
@@ -2063,7 +2063,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:648 lxc/config.go:680
+#: lxc/config.go:656 lxc/config.go:688
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2258,7 +2258,7 @@ msgstr ""
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:366
+#: lxc/console.go:370
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
@@ -2472,7 +2472,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:982 lxc/config.go:983
+#: lxc/config.go:994 lxc/config.go:995
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2870,7 +2870,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1008 lxc/config.go:1066 lxc/config.go:1185 lxc/config.go:1277
+#: lxc/config.go:1020 lxc/config.go:1078 lxc/config.go:1197 lxc/config.go:1289
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -3029,7 +3029,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:387
+#: lxc/console.go:391
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -3543,7 +3543,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:942 lxc/config.go:943
+#: lxc/config.go:954 lxc/config.go:955
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -4382,7 +4382,7 @@ msgstr ""
 
 #: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
@@ -4886,7 +4886,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1019
+#: lxc/config.go:1031
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5063,7 +5063,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1037 lxc/config.go:1038
+#: lxc/config.go:1049 lxc/config.go:1050
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5101,11 +5101,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:537
+#: lxc/config.go:541
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:538
+#: lxc/config.go:542
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5329,7 +5329,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:551
+#: lxc/config.go:555
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5394,7 +5394,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1159 lxc/config.go:1160
+#: lxc/config.go:1171 lxc/config.go:1172
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5402,7 +5402,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:763 lxc/config.go:764
+#: lxc/config.go:771 lxc/config.go:772
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5496,7 +5496,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:767
+#: lxc/config.go:775
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5747,7 +5747,7 @@ msgstr ""
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:126
+#: lxc/console.go:130
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -5809,12 +5809,12 @@ msgstr ""
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:479
+#: lxc/config.go:483
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:455
+#: lxc/config.go:459
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
@@ -5906,7 +5906,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:666
+#: lxc/config.go:674
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -5950,7 +5950,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:215
+#: lxc/console.go:219
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -5960,7 +5960,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:499 lxc/config.go:715 lxc/config.go:815
+#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6105,7 +6105,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:164
+#: lxc/console.go:168
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -6120,12 +6120,12 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:109
+#: lxc/console.go:113
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1128 lxc/config.go:1129
+#: lxc/config.go:1140 lxc/config.go:1141
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6145,7 +6145,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:895 lxc/config.go:896
+#: lxc/config.go:903 lxc/config.go:904
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6261,7 +6261,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:900
+#: lxc/config.go:908
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6610,7 +6610,7 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1158 lxc/config.go:1212 lxc/config_device.go:321
+#: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:321
 #: lxc/config_device.go:753 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:35
 msgid "[<remote>:]<instance>"
@@ -6632,11 +6632,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:981 lxc/config.go:1127
+#: lxc/config.go:993 lxc/config.go:1139
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1036
+#: lxc/config.go:1048
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -7033,7 +7033,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:762
+#: lxc/config.go:98 lxc/config.go:770
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7041,11 +7041,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:894
+#: lxc/config.go:391 lxc/config.go:902
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:536
+#: lxc/config.go:540
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -7169,7 +7169,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:543
+#: lxc/config.go:547
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7178,13 +7178,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1216
+#: lxc/config.go:1228
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1040
+#: lxc/config.go:1052
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-26 11:55-0600\n"
+"POT-Creation-Date: 2024-09-30 13:36-0400\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Wivik <seb+weblate@zedas.fr>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/linux-containers/"
@@ -100,7 +100,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/config.go:1227
+#: lxc/config.go:1239
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -725,7 +725,7 @@ msgstr "--console fonctionne seulement avec une instance seule"
 msgid "--empty cannot be combined with an image name"
 msgstr "--empty ne peut être combiné avec le nom d'une image"
 
-#: lxc/config.go:493 lxc/config.go:809
+#: lxc/config.go:497 lxc/config.go:817
 msgid "--expanded cannot be used with a server"
 msgstr "--expanded ne peut être utilisé avec un serveur"
 
@@ -745,7 +745,7 @@ msgstr "--project ne peut pas être utilisé avec la commande query"
 msgid "--refresh can only be used with instances"
 msgstr "--refresh ne peut être utilisé qu'avec des instances"
 
-#: lxc/config.go:170 lxc/config.go:443 lxc/config.go:628 lxc/config.go:835
+#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr "--target ne peut pas être utilisé avec des instances"
@@ -1046,7 +1046,7 @@ msgstr "Architecture : %s"
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:388
+#: lxc/console.go:392
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -1308,7 +1308,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr "impossible de spécifier uid/gid/mode en mode récursif"
 
-#: lxc/config.go:694 lxc/config.go:1084
+#: lxc/config.go:702 lxc/config.go:1096
 #, fuzzy, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1426,8 +1426,8 @@ msgstr "Périphérique %s retiré de %s"
 msgid "Cluster member %s removed from group %s"
 msgstr "Périphérique %s retiré de %s"
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:550 lxc/config.go:768
-#: lxc/config.go:899 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
+#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1251 lxc/network.go:1344 lxc/network.go:1416
 #: lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1517,7 +1517,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr "Clé/valeur de configuration à appliquer au nouveau conteneur"
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1327 lxc/config_metadata.go:156
+#: lxc/config.go:356 lxc/config.go:1339 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
@@ -2020,9 +2020,9 @@ msgstr "Récupération de l'image : %s"
 #: lxc/cluster_group.go:316 lxc/cluster_group.go:440 lxc/cluster_group.go:522
 #: lxc/cluster_group.go:607 lxc/cluster_group.go:663 lxc/cluster_group.go:725
 #: lxc/cluster_role.go:24 lxc/cluster_role.go:51 lxc/cluster_role.go:115
-#: lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:538
-#: lxc/config.go:764 lxc/config.go:896 lxc/config.go:943 lxc/config.go:983
-#: lxc/config.go:1038 lxc/config.go:1129 lxc/config.go:1160 lxc/config.go:1214
+#: lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:542
+#: lxc/config.go:772 lxc/config.go:904 lxc/config.go:955 lxc/config.go:995
+#: lxc/config.go:1050 lxc/config.go:1141 lxc/config.go:1172 lxc/config.go:1226
 #: lxc/config_device.go:25 lxc/config_device.go:79 lxc/config_device.go:221
 #: lxc/config_device.go:318 lxc/config_device.go:401 lxc/config_device.go:503
 #: lxc/config_device.go:619 lxc/config_device.go:626 lxc/config_device.go:759
@@ -2309,7 +2309,7 @@ msgstr "Clé de configuration invalide"
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1213 lxc/config.go:1214
+#: lxc/config.go:1225 lxc/config.go:1226
 #, fuzzy
 msgid "Edit instance UEFI variables"
 msgstr "L'arrêt du conteneur a échoué !"
@@ -2447,7 +2447,7 @@ msgstr "Récupération de l'image : %s"
 msgid "Error retrieving aliases: %w"
 msgstr "Récupération de l'image : %s"
 
-#: lxc/cluster.go:459 lxc/config.go:654 lxc/config.go:686 lxc/network.go:1319
+#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1319
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
@@ -2457,7 +2457,7 @@ msgstr "Récupération de l'image : %s"
 msgid "Error setting properties: %v"
 msgstr "Récupération de l'image : %s"
 
-#: lxc/config.go:648 lxc/config.go:680
+#: lxc/config.go:656 lxc/config.go:688
 #, fuzzy, c-format
 msgid "Error unsetting properties: %v"
 msgstr "Récupération de l'image : %s"
@@ -2676,7 +2676,7 @@ msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 msgid "Failed parsing SSH host key: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
-#: lxc/console.go:366
+#: lxc/console.go:370
 #, fuzzy, c-format
 msgid "Failed starting command: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
@@ -2896,7 +2896,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr "Génération d'un certificat client. Ceci peut prendre une minute…"
 
-#: lxc/config.go:982 lxc/config.go:983
+#: lxc/config.go:994 lxc/config.go:995
 #, fuzzy
 msgid "Get UEFI variables for instance"
 msgstr "Création du conteneur"
@@ -3334,7 +3334,7 @@ msgstr "Le nom du conteneur est obligatoire"
 msgid "Instance name is: %s"
 msgstr "Le nom du conteneur est : %s"
 
-#: lxc/config.go:1008 lxc/config.go:1066 lxc/config.go:1185 lxc/config.go:1277
+#: lxc/config.go:1020 lxc/config.go:1078 lxc/config.go:1197 lxc/config.go:1289
 #, fuzzy
 msgid "Instance name must be specified"
 msgstr "Le nom du conteneur est : %s"
@@ -3498,7 +3498,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:387
+#: lxc/console.go:391
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -4101,7 +4101,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:942 lxc/config.go:943
+#: lxc/config.go:954 lxc/config.go:955
 #, fuzzy
 msgid "Manage instance UEFI variables"
 msgstr "L'arrêt du conteneur a échoué !"
@@ -5021,7 +5021,7 @@ msgstr ""
 
 #: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
@@ -5563,7 +5563,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1019
+#: lxc/config.go:1031
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5770,7 +5770,7 @@ msgstr "Protocole du serveur (lxd ou simplestreams)"
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1037 lxc/config.go:1038
+#: lxc/config.go:1049 lxc/config.go:1050
 #, fuzzy
 msgid "Set UEFI variables for instance"
 msgstr "Création du conteneur"
@@ -5811,12 +5811,12 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:537
+#: lxc/config.go:541
 #, fuzzy
 msgid "Set instance or server configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/config.go:538
+#: lxc/config.go:542
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -6060,7 +6060,7 @@ msgstr "Copie de l'image : %s"
 msgid "Set the key as a storage volume property"
 msgstr "Copie de l'image : %s"
 
-#: lxc/config.go:551
+#: lxc/config.go:555
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -6129,7 +6129,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1159 lxc/config.go:1160
+#: lxc/config.go:1171 lxc/config.go:1172
 #, fuzzy
 msgid "Show instance UEFI variables"
 msgstr "L'arrêt du conteneur a échoué !"
@@ -6139,7 +6139,7 @@ msgstr "L'arrêt du conteneur a échoué !"
 msgid "Show instance metadata files"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/config.go:763 lxc/config.go:764
+#: lxc/config.go:771 lxc/config.go:772
 #, fuzzy
 msgid "Show instance or server configurations"
 msgstr "Afficher la configuration étendue"
@@ -6253,7 +6253,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr "impossible de supprimer le serveur distant par défaut"
 
-#: lxc/config.go:767
+#: lxc/config.go:775
 msgid "Show the expanded configuration"
 msgstr "Afficher la configuration étendue"
 
@@ -6520,7 +6520,7 @@ msgstr ""
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:126
+#: lxc/console.go:130
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -6591,12 +6591,12 @@ msgstr "Le périphérique indiqué n'existe pas"
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/config.go:479
+#: lxc/config.go:483
 #, fuzzy, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/config.go:455
+#: lxc/config.go:459
 #, fuzzy, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -6688,7 +6688,7 @@ msgstr "le périphérique indiqué ne correspond pas au réseau"
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr "Il n'existe pas d'\"image\".  Vouliez-vous un alias ?"
 
-#: lxc/config.go:666
+#: lxc/config.go:674
 #, fuzzy
 msgid "There is no config key to set on an instance snapshot."
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -6736,7 +6736,7 @@ msgstr "Pour attacher un réseau à un conteneur, utiliser : lxc network attach"
 msgid "To create a new network, use: lxc network create"
 msgstr "Pour créer un réseau, utiliser : lxc network create"
 
-#: lxc/console.go:215
+#: lxc/console.go:219
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -6748,7 +6748,7 @@ msgid ""
 msgstr ""
 "Pour démarrer votre premier conteneur, essayer : lxc launch ubuntu:16.04"
 
-#: lxc/config.go:306 lxc/config.go:499 lxc/config.go:715 lxc/config.go:815
+#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6896,7 +6896,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:164
+#: lxc/console.go:168
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -6911,12 +6911,12 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:109
+#: lxc/console.go:113
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1128 lxc/config.go:1129
+#: lxc/config.go:1140 lxc/config.go:1141
 #, fuzzy
 msgid "Unset UEFI variables for instance"
 msgstr "tous les profils de la source n'existent pas sur la cible"
@@ -6940,7 +6940,7 @@ msgstr "Clé de configuration invalide"
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:895 lxc/config.go:896
+#: lxc/config.go:903 lxc/config.go:904
 #, fuzzy
 msgid "Unset instance or server configuration keys"
 msgstr "Clé de configuration invalide"
@@ -7081,7 +7081,7 @@ msgstr "Copie de l'image : %s"
 msgid "Unset the key as a storage volume property"
 msgstr "Copie de l'image : %s"
 
-#: lxc/config.go:900
+#: lxc/config.go:908
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -7633,7 +7633,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config.go:1158 lxc/config.go:1212 lxc/config_device.go:321
+#: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:321
 #: lxc/config_device.go:753 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:35
 #, fuzzy
@@ -7679,7 +7679,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config.go:981 lxc/config.go:1127
+#: lxc/config.go:993 lxc/config.go:1139
 #, fuzzy
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
@@ -7687,7 +7687,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config.go:1036
+#: lxc/config.go:1048
 #, fuzzy
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
@@ -8553,7 +8553,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config.go:98 lxc/config.go:762
+#: lxc/config.go:98 lxc/config.go:770
 #, fuzzy
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
@@ -8577,7 +8577,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/config.go:391 lxc/config.go:894
+#: lxc/config.go:391 lxc/config.go:902
 #, fuzzy
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
@@ -8585,7 +8585,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config.go:536
+#: lxc/config.go:540
 #, fuzzy
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
@@ -8730,7 +8730,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:543
+#: lxc/config.go:547
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -8739,13 +8739,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1216
+#: lxc/config.go:1228
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1040
+#: lxc/config.go:1052
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"

--- a/po/he.po
+++ b/po/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-26 11:55-0600\n"
+"POT-Creation-Date: 2024-09-30 13:36-0400\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hebrew <https://hosted.weblate.org/projects/linux-containers/"
@@ -64,7 +64,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1227
+#: lxc/config.go:1239
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -479,7 +479,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:493 lxc/config.go:809
+#: lxc/config.go:497 lxc/config.go:817
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -499,7 +499,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:443 lxc/config.go:628 lxc/config.go:835
+#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -766,7 +766,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:388
+#: lxc/console.go:392
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -1016,7 +1016,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:694 lxc/config.go:1084
+#: lxc/config.go:702 lxc/config.go:1096
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1131,8 +1131,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:550 lxc/config.go:768
-#: lxc/config.go:899 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
+#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1251 lxc/network.go:1344 lxc/network.go:1416
 #: lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1211,7 +1211,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1327 lxc/config_metadata.go:156
+#: lxc/config.go:356 lxc/config.go:1339 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
@@ -1655,9 +1655,9 @@ msgstr ""
 #: lxc/cluster_group.go:316 lxc/cluster_group.go:440 lxc/cluster_group.go:522
 #: lxc/cluster_group.go:607 lxc/cluster_group.go:663 lxc/cluster_group.go:725
 #: lxc/cluster_role.go:24 lxc/cluster_role.go:51 lxc/cluster_role.go:115
-#: lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:538
-#: lxc/config.go:764 lxc/config.go:896 lxc/config.go:943 lxc/config.go:983
-#: lxc/config.go:1038 lxc/config.go:1129 lxc/config.go:1160 lxc/config.go:1214
+#: lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:542
+#: lxc/config.go:772 lxc/config.go:904 lxc/config.go:955 lxc/config.go:995
+#: lxc/config.go:1050 lxc/config.go:1141 lxc/config.go:1172 lxc/config.go:1226
 #: lxc/config_device.go:25 lxc/config_device.go:79 lxc/config_device.go:221
 #: lxc/config_device.go:318 lxc/config_device.go:401 lxc/config_device.go:503
 #: lxc/config_device.go:619 lxc/config_device.go:626 lxc/config_device.go:759
@@ -1930,7 +1930,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1213 lxc/config.go:1214
+#: lxc/config.go:1225 lxc/config.go:1226
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2054,7 +2054,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:459 lxc/config.go:654 lxc/config.go:686 lxc/network.go:1319
+#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1319
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
@@ -2064,7 +2064,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:648 lxc/config.go:680
+#: lxc/config.go:656 lxc/config.go:688
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2259,7 +2259,7 @@ msgstr ""
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:366
+#: lxc/console.go:370
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
@@ -2473,7 +2473,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:982 lxc/config.go:983
+#: lxc/config.go:994 lxc/config.go:995
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2871,7 +2871,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1008 lxc/config.go:1066 lxc/config.go:1185 lxc/config.go:1277
+#: lxc/config.go:1020 lxc/config.go:1078 lxc/config.go:1197 lxc/config.go:1289
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -3030,7 +3030,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:387
+#: lxc/console.go:391
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -3544,7 +3544,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:942 lxc/config.go:943
+#: lxc/config.go:954 lxc/config.go:955
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -4383,7 +4383,7 @@ msgstr ""
 
 #: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
@@ -4887,7 +4887,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1019
+#: lxc/config.go:1031
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5064,7 +5064,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1037 lxc/config.go:1038
+#: lxc/config.go:1049 lxc/config.go:1050
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5102,11 +5102,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:537
+#: lxc/config.go:541
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:538
+#: lxc/config.go:542
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5330,7 +5330,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:551
+#: lxc/config.go:555
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5395,7 +5395,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1159 lxc/config.go:1160
+#: lxc/config.go:1171 lxc/config.go:1172
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5403,7 +5403,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:763 lxc/config.go:764
+#: lxc/config.go:771 lxc/config.go:772
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5497,7 +5497,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:767
+#: lxc/config.go:775
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5748,7 +5748,7 @@ msgstr ""
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:126
+#: lxc/console.go:130
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -5810,12 +5810,12 @@ msgstr ""
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:479
+#: lxc/config.go:483
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:455
+#: lxc/config.go:459
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
@@ -5907,7 +5907,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:666
+#: lxc/config.go:674
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -5951,7 +5951,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:215
+#: lxc/console.go:219
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -5961,7 +5961,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:499 lxc/config.go:715 lxc/config.go:815
+#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6106,7 +6106,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:164
+#: lxc/console.go:168
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -6121,12 +6121,12 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:109
+#: lxc/console.go:113
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1128 lxc/config.go:1129
+#: lxc/config.go:1140 lxc/config.go:1141
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6146,7 +6146,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:895 lxc/config.go:896
+#: lxc/config.go:903 lxc/config.go:904
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6262,7 +6262,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:900
+#: lxc/config.go:908
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6611,7 +6611,7 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1158 lxc/config.go:1212 lxc/config_device.go:321
+#: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:321
 #: lxc/config_device.go:753 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:35
 msgid "[<remote>:]<instance>"
@@ -6633,11 +6633,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:981 lxc/config.go:1127
+#: lxc/config.go:993 lxc/config.go:1139
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1036
+#: lxc/config.go:1048
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -7034,7 +7034,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:762
+#: lxc/config.go:98 lxc/config.go:770
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7042,11 +7042,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:894
+#: lxc/config.go:391 lxc/config.go:902
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:536
+#: lxc/config.go:540
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -7170,7 +7170,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:543
+#: lxc/config.go:547
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7179,13 +7179,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1216
+#: lxc/config.go:1228
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1040
+#: lxc/config.go:1052
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"

--- a/po/hi.po
+++ b/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-26 11:55-0600\n"
+"POT-Creation-Date: 2024-09-30 13:36-0400\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hindi <https://hosted.weblate.org/projects/linux-containers/"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1227
+#: lxc/config.go:1239
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -478,7 +478,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:493 lxc/config.go:809
+#: lxc/config.go:497 lxc/config.go:817
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -498,7 +498,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:443 lxc/config.go:628 lxc/config.go:835
+#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -765,7 +765,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:388
+#: lxc/console.go:392
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:694 lxc/config.go:1084
+#: lxc/config.go:702 lxc/config.go:1096
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1130,8 +1130,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:550 lxc/config.go:768
-#: lxc/config.go:899 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
+#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1251 lxc/network.go:1344 lxc/network.go:1416
 #: lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1210,7 +1210,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1327 lxc/config_metadata.go:156
+#: lxc/config.go:356 lxc/config.go:1339 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
@@ -1654,9 +1654,9 @@ msgstr ""
 #: lxc/cluster_group.go:316 lxc/cluster_group.go:440 lxc/cluster_group.go:522
 #: lxc/cluster_group.go:607 lxc/cluster_group.go:663 lxc/cluster_group.go:725
 #: lxc/cluster_role.go:24 lxc/cluster_role.go:51 lxc/cluster_role.go:115
-#: lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:538
-#: lxc/config.go:764 lxc/config.go:896 lxc/config.go:943 lxc/config.go:983
-#: lxc/config.go:1038 lxc/config.go:1129 lxc/config.go:1160 lxc/config.go:1214
+#: lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:542
+#: lxc/config.go:772 lxc/config.go:904 lxc/config.go:955 lxc/config.go:995
+#: lxc/config.go:1050 lxc/config.go:1141 lxc/config.go:1172 lxc/config.go:1226
 #: lxc/config_device.go:25 lxc/config_device.go:79 lxc/config_device.go:221
 #: lxc/config_device.go:318 lxc/config_device.go:401 lxc/config_device.go:503
 #: lxc/config_device.go:619 lxc/config_device.go:626 lxc/config_device.go:759
@@ -1929,7 +1929,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1213 lxc/config.go:1214
+#: lxc/config.go:1225 lxc/config.go:1226
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2053,7 +2053,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:459 lxc/config.go:654 lxc/config.go:686 lxc/network.go:1319
+#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1319
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
@@ -2063,7 +2063,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:648 lxc/config.go:680
+#: lxc/config.go:656 lxc/config.go:688
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2258,7 +2258,7 @@ msgstr ""
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:366
+#: lxc/console.go:370
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
@@ -2472,7 +2472,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:982 lxc/config.go:983
+#: lxc/config.go:994 lxc/config.go:995
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2870,7 +2870,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1008 lxc/config.go:1066 lxc/config.go:1185 lxc/config.go:1277
+#: lxc/config.go:1020 lxc/config.go:1078 lxc/config.go:1197 lxc/config.go:1289
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -3029,7 +3029,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:387
+#: lxc/console.go:391
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -3543,7 +3543,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:942 lxc/config.go:943
+#: lxc/config.go:954 lxc/config.go:955
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -4382,7 +4382,7 @@ msgstr ""
 
 #: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
@@ -4886,7 +4886,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1019
+#: lxc/config.go:1031
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5063,7 +5063,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1037 lxc/config.go:1038
+#: lxc/config.go:1049 lxc/config.go:1050
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5101,11 +5101,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:537
+#: lxc/config.go:541
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:538
+#: lxc/config.go:542
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5329,7 +5329,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:551
+#: lxc/config.go:555
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5394,7 +5394,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1159 lxc/config.go:1160
+#: lxc/config.go:1171 lxc/config.go:1172
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5402,7 +5402,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:763 lxc/config.go:764
+#: lxc/config.go:771 lxc/config.go:772
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5496,7 +5496,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:767
+#: lxc/config.go:775
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5747,7 +5747,7 @@ msgstr ""
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:126
+#: lxc/console.go:130
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -5809,12 +5809,12 @@ msgstr ""
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:479
+#: lxc/config.go:483
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:455
+#: lxc/config.go:459
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
@@ -5906,7 +5906,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:666
+#: lxc/config.go:674
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -5950,7 +5950,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:215
+#: lxc/console.go:219
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -5960,7 +5960,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:499 lxc/config.go:715 lxc/config.go:815
+#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6105,7 +6105,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:164
+#: lxc/console.go:168
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -6120,12 +6120,12 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:109
+#: lxc/console.go:113
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1128 lxc/config.go:1129
+#: lxc/config.go:1140 lxc/config.go:1141
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6145,7 +6145,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:895 lxc/config.go:896
+#: lxc/config.go:903 lxc/config.go:904
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6261,7 +6261,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:900
+#: lxc/config.go:908
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6610,7 +6610,7 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1158 lxc/config.go:1212 lxc/config_device.go:321
+#: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:321
 #: lxc/config_device.go:753 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:35
 msgid "[<remote>:]<instance>"
@@ -6632,11 +6632,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:981 lxc/config.go:1127
+#: lxc/config.go:993 lxc/config.go:1139
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1036
+#: lxc/config.go:1048
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -7033,7 +7033,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:762
+#: lxc/config.go:98 lxc/config.go:770
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7041,11 +7041,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:894
+#: lxc/config.go:391 lxc/config.go:902
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:536
+#: lxc/config.go:540
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -7169,7 +7169,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:543
+#: lxc/config.go:547
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7178,13 +7178,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1216
+#: lxc/config.go:1228
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1040
+#: lxc/config.go:1052
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-26 11:55-0600\n"
+"POT-Creation-Date: 2024-09-30 13:36-0400\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Indonesian <https://hosted.weblate.org/projects/linux-"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1227
+#: lxc/config.go:1239
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -478,7 +478,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:493 lxc/config.go:809
+#: lxc/config.go:497 lxc/config.go:817
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -498,7 +498,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:443 lxc/config.go:628 lxc/config.go:835
+#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -765,7 +765,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:388
+#: lxc/console.go:392
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:694 lxc/config.go:1084
+#: lxc/config.go:702 lxc/config.go:1096
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1130,8 +1130,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:550 lxc/config.go:768
-#: lxc/config.go:899 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
+#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1251 lxc/network.go:1344 lxc/network.go:1416
 #: lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1210,7 +1210,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1327 lxc/config_metadata.go:156
+#: lxc/config.go:356 lxc/config.go:1339 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
@@ -1654,9 +1654,9 @@ msgstr ""
 #: lxc/cluster_group.go:316 lxc/cluster_group.go:440 lxc/cluster_group.go:522
 #: lxc/cluster_group.go:607 lxc/cluster_group.go:663 lxc/cluster_group.go:725
 #: lxc/cluster_role.go:24 lxc/cluster_role.go:51 lxc/cluster_role.go:115
-#: lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:538
-#: lxc/config.go:764 lxc/config.go:896 lxc/config.go:943 lxc/config.go:983
-#: lxc/config.go:1038 lxc/config.go:1129 lxc/config.go:1160 lxc/config.go:1214
+#: lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:542
+#: lxc/config.go:772 lxc/config.go:904 lxc/config.go:955 lxc/config.go:995
+#: lxc/config.go:1050 lxc/config.go:1141 lxc/config.go:1172 lxc/config.go:1226
 #: lxc/config_device.go:25 lxc/config_device.go:79 lxc/config_device.go:221
 #: lxc/config_device.go:318 lxc/config_device.go:401 lxc/config_device.go:503
 #: lxc/config_device.go:619 lxc/config_device.go:626 lxc/config_device.go:759
@@ -1929,7 +1929,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1213 lxc/config.go:1214
+#: lxc/config.go:1225 lxc/config.go:1226
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2053,7 +2053,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:459 lxc/config.go:654 lxc/config.go:686 lxc/network.go:1319
+#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1319
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
@@ -2063,7 +2063,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:648 lxc/config.go:680
+#: lxc/config.go:656 lxc/config.go:688
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2258,7 +2258,7 @@ msgstr ""
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:366
+#: lxc/console.go:370
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
@@ -2472,7 +2472,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:982 lxc/config.go:983
+#: lxc/config.go:994 lxc/config.go:995
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2870,7 +2870,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1008 lxc/config.go:1066 lxc/config.go:1185 lxc/config.go:1277
+#: lxc/config.go:1020 lxc/config.go:1078 lxc/config.go:1197 lxc/config.go:1289
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -3029,7 +3029,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:387
+#: lxc/console.go:391
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -3543,7 +3543,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:942 lxc/config.go:943
+#: lxc/config.go:954 lxc/config.go:955
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -4382,7 +4382,7 @@ msgstr ""
 
 #: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
@@ -4886,7 +4886,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1019
+#: lxc/config.go:1031
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5063,7 +5063,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1037 lxc/config.go:1038
+#: lxc/config.go:1049 lxc/config.go:1050
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5101,11 +5101,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:537
+#: lxc/config.go:541
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:538
+#: lxc/config.go:542
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5329,7 +5329,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:551
+#: lxc/config.go:555
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5394,7 +5394,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1159 lxc/config.go:1160
+#: lxc/config.go:1171 lxc/config.go:1172
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5402,7 +5402,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:763 lxc/config.go:764
+#: lxc/config.go:771 lxc/config.go:772
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5496,7 +5496,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:767
+#: lxc/config.go:775
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5747,7 +5747,7 @@ msgstr ""
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:126
+#: lxc/console.go:130
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -5809,12 +5809,12 @@ msgstr ""
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:479
+#: lxc/config.go:483
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:455
+#: lxc/config.go:459
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
@@ -5906,7 +5906,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:666
+#: lxc/config.go:674
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -5950,7 +5950,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:215
+#: lxc/console.go:219
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -5960,7 +5960,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:499 lxc/config.go:715 lxc/config.go:815
+#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6105,7 +6105,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:164
+#: lxc/console.go:168
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -6120,12 +6120,12 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:109
+#: lxc/console.go:113
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1128 lxc/config.go:1129
+#: lxc/config.go:1140 lxc/config.go:1141
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6145,7 +6145,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:895 lxc/config.go:896
+#: lxc/config.go:903 lxc/config.go:904
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6261,7 +6261,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:900
+#: lxc/config.go:908
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6610,7 +6610,7 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1158 lxc/config.go:1212 lxc/config_device.go:321
+#: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:321
 #: lxc/config_device.go:753 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:35
 msgid "[<remote>:]<instance>"
@@ -6632,11 +6632,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:981 lxc/config.go:1127
+#: lxc/config.go:993 lxc/config.go:1139
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1036
+#: lxc/config.go:1048
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -7033,7 +7033,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:762
+#: lxc/config.go:98 lxc/config.go:770
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7041,11 +7041,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:894
+#: lxc/config.go:391 lxc/config.go:902
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:536
+#: lxc/config.go:540
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -7169,7 +7169,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:543
+#: lxc/config.go:547
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7178,13 +7178,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1216
+#: lxc/config.go:1228
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1040
+#: lxc/config.go:1052
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-26 11:55-0600\n"
+"POT-Creation-Date: 2024-09-30 13:36-0400\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Luigi Operoso <brokenpip3@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/linux-containers/"
@@ -108,7 +108,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/config.go:1227
+#: lxc/config.go:1239
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -721,7 +721,7 @@ msgstr "non tutti i profili dell'origine esistono nella destinazione"
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:493 lxc/config.go:809
+#: lxc/config.go:497 lxc/config.go:817
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -741,7 +741,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:443 lxc/config.go:628 lxc/config.go:835
+#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -1015,7 +1015,7 @@ msgstr "Architettura: %s"
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:388
+#: lxc/console.go:392
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -1267,7 +1267,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:694 lxc/config.go:1084
+#: lxc/config.go:702 lxc/config.go:1096
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1384,8 +1384,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:550 lxc/config.go:768
-#: lxc/config.go:899 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
+#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1251 lxc/network.go:1344 lxc/network.go:1416
 #: lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1464,7 +1464,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1327 lxc/config_metadata.go:156
+#: lxc/config.go:356 lxc/config.go:1339 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
@@ -1923,9 +1923,9 @@ msgstr ""
 #: lxc/cluster_group.go:316 lxc/cluster_group.go:440 lxc/cluster_group.go:522
 #: lxc/cluster_group.go:607 lxc/cluster_group.go:663 lxc/cluster_group.go:725
 #: lxc/cluster_role.go:24 lxc/cluster_role.go:51 lxc/cluster_role.go:115
-#: lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:538
-#: lxc/config.go:764 lxc/config.go:896 lxc/config.go:943 lxc/config.go:983
-#: lxc/config.go:1038 lxc/config.go:1129 lxc/config.go:1160 lxc/config.go:1214
+#: lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:542
+#: lxc/config.go:772 lxc/config.go:904 lxc/config.go:955 lxc/config.go:995
+#: lxc/config.go:1050 lxc/config.go:1141 lxc/config.go:1172 lxc/config.go:1226
 #: lxc/config_device.go:25 lxc/config_device.go:79 lxc/config_device.go:221
 #: lxc/config_device.go:318 lxc/config_device.go:401 lxc/config_device.go:503
 #: lxc/config_device.go:619 lxc/config_device.go:626 lxc/config_device.go:759
@@ -2205,7 +2205,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1213 lxc/config.go:1214
+#: lxc/config.go:1225 lxc/config.go:1226
 #, fuzzy
 msgid "Edit instance UEFI variables"
 msgstr "Creazione del container in corso"
@@ -2334,7 +2334,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:459 lxc/config.go:654 lxc/config.go:686 lxc/network.go:1319
+#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1319
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
@@ -2344,7 +2344,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:648 lxc/config.go:680
+#: lxc/config.go:656 lxc/config.go:688
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2542,7 +2542,7 @@ msgstr "Il nome del container è: %s"
 msgid "Failed parsing SSH host key: %w"
 msgstr "Accetta certificato"
 
-#: lxc/console.go:366
+#: lxc/console.go:370
 #, fuzzy, c-format
 msgid "Failed starting command: %w"
 msgstr "Accetta certificato"
@@ -2758,7 +2758,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:982 lxc/config.go:983
+#: lxc/config.go:994 lxc/config.go:995
 #, fuzzy
 msgid "Get UEFI variables for instance"
 msgstr "Creazione del container in corso"
@@ -3171,7 +3171,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr "Il nome del container è: %s"
 
-#: lxc/config.go:1008 lxc/config.go:1066 lxc/config.go:1185 lxc/config.go:1277
+#: lxc/config.go:1020 lxc/config.go:1078 lxc/config.go:1197 lxc/config.go:1289
 #, fuzzy
 msgid "Instance name must be specified"
 msgstr "Il nome del container è: %s"
@@ -3334,7 +3334,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:387
+#: lxc/console.go:391
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -3870,7 +3870,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:942 lxc/config.go:943
+#: lxc/config.go:954 lxc/config.go:955
 #, fuzzy
 msgid "Manage instance UEFI variables"
 msgstr "Creazione del container in corso"
@@ -4745,7 +4745,7 @@ msgstr ""
 
 #: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
@@ -5263,7 +5263,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1019
+#: lxc/config.go:1031
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5446,7 +5446,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1037 lxc/config.go:1038
+#: lxc/config.go:1049 lxc/config.go:1050
 #, fuzzy
 msgid "Set UEFI variables for instance"
 msgstr "Creazione del container in corso"
@@ -5486,11 +5486,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:537
+#: lxc/config.go:541
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:538
+#: lxc/config.go:542
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5722,7 +5722,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:551
+#: lxc/config.go:555
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5789,7 +5789,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1159 lxc/config.go:1160
+#: lxc/config.go:1171 lxc/config.go:1172
 #, fuzzy
 msgid "Show instance UEFI variables"
 msgstr "errore di processamento degli alias %s\n"
@@ -5798,7 +5798,7 @@ msgstr "errore di processamento degli alias %s\n"
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:763 lxc/config.go:764
+#: lxc/config.go:771 lxc/config.go:772
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5900,7 +5900,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:767
+#: lxc/config.go:775
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -6156,7 +6156,7 @@ msgstr ""
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:126
+#: lxc/console.go:130
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -6219,12 +6219,12 @@ msgstr "il remote %s non esiste"
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr "Il nome del container è: %s"
 
-#: lxc/config.go:479
+#: lxc/config.go:483
 #, fuzzy, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr "Il nome del container è: %s"
 
-#: lxc/config.go:455
+#: lxc/config.go:459
 #, fuzzy, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr "Il nome del container è: %s"
@@ -6316,7 +6316,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:666
+#: lxc/config.go:674
 #, fuzzy
 msgid "There is no config key to set on an instance snapshot."
 msgstr "Il nome del container è: %s"
@@ -6362,7 +6362,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:215
+#: lxc/console.go:219
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -6372,7 +6372,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:499 lxc/config.go:715 lxc/config.go:815
+#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6519,7 +6519,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:164
+#: lxc/console.go:168
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -6534,12 +6534,12 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:109
+#: lxc/console.go:113
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1128 lxc/config.go:1129
+#: lxc/config.go:1140 lxc/config.go:1141
 #, fuzzy
 msgid "Unset UEFI variables for instance"
 msgstr "non tutti i profili dell'origine esistono nella destinazione"
@@ -6562,7 +6562,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:895 lxc/config.go:896
+#: lxc/config.go:903 lxc/config.go:904
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6688,7 +6688,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:900
+#: lxc/config.go:908
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -7081,7 +7081,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/config.go:1158 lxc/config.go:1212 lxc/config_device.go:321
+#: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:321
 #: lxc/config_device.go:753 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:35
 #, fuzzy
@@ -7108,12 +7108,12 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/config.go:981 lxc/config.go:1127
+#: lxc/config.go:993 lxc/config.go:1139
 #, fuzzy
 msgid "[<remote>:]<instance> <key>"
 msgstr "Creazione del container in corso"
 
-#: lxc/config.go:1036
+#: lxc/config.go:1048
 #, fuzzy
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr "Creazione del container in corso"
@@ -7601,7 +7601,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/config.go:98 lxc/config.go:762
+#: lxc/config.go:98 lxc/config.go:770
 #, fuzzy
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr "Creazione del container in corso"
@@ -7611,12 +7611,12 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:][<instance>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/config.go:391 lxc/config.go:894
+#: lxc/config.go:391 lxc/config.go:902
 #, fuzzy
 msgid "[<remote>:][<instance>] <key>"
 msgstr "Creazione del container in corso"
 
-#: lxc/config.go:536
+#: lxc/config.go:540
 #, fuzzy
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr "Creazione del container in corso"
@@ -7744,7 +7744,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:543
+#: lxc/config.go:547
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7753,13 +7753,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1216
+#: lxc/config.go:1228
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1040
+#: lxc/config.go:1052
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-26 11:55-0600\n"
+"POT-Creation-Date: 2024-09-30 13:36-0400\n"
 "PO-Revision-Date: 2023-03-10 15:14+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/linux-"
@@ -95,7 +95,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/config.go:1227
+#: lxc/config.go:1239
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -712,7 +712,7 @@ msgstr "--console は単一のインスタンスのときのみ指定できま�
 msgid "--empty cannot be combined with an image name"
 msgstr "--empty はイメージ名と同時に指定できません"
 
-#: lxc/config.go:493 lxc/config.go:809
+#: lxc/config.go:497 lxc/config.go:817
 msgid "--expanded cannot be used with a server"
 msgstr "--expanded はサーバーでは使えません"
 
@@ -732,7 +732,7 @@ msgstr "--project は query コマンドでは使えません"
 msgid "--refresh can only be used with instances"
 msgstr "--refresh はインスタンスの場合のみ使えます"
 
-#: lxc/config.go:170 lxc/config.go:443 lxc/config.go:628 lxc/config.go:835
+#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr "--target はインスタンスでは使えません"
@@ -1023,7 +1023,7 @@ msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 "本当に %s しますか? （対象: クラスターメンバー %q） (yes/no) [default=no]: "
 
-#: lxc/console.go:388
+#: lxc/console.go:392
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr "どちらもみつかりませんでした。raw SPICE ソケットはこちらにあります:"
 
@@ -1280,7 +1280,7 @@ msgstr "クラスタでない場合はカラムとして L は指定できませ
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr "再帰 (recursive) モードでは uid/gid/mode を指定できません"
 
-#: lxc/config.go:694 lxc/config.go:1084
+#: lxc/config.go:702 lxc/config.go:1096
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr "キー '%s' が設定されていないので削除できません"
@@ -1400,8 +1400,8 @@ msgstr "クラスターメンバー %s がグループ %s から削除されま�
 msgid "Cluster member %s removed from group %s"
 msgstr "クラスターメンバー %s がグループ %s から削除されました"
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:550 lxc/config.go:768
-#: lxc/config.go:899 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
+#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1251 lxc/network.go:1344 lxc/network.go:1416
 #: lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1484,7 +1484,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr "移動先のインスタンスに適用するキー/値の設定"
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1327 lxc/config_metadata.go:156
+#: lxc/config.go:356 lxc/config.go:1339 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
@@ -1951,9 +1951,9 @@ msgstr "警告を削除します"
 #: lxc/cluster_group.go:316 lxc/cluster_group.go:440 lxc/cluster_group.go:522
 #: lxc/cluster_group.go:607 lxc/cluster_group.go:663 lxc/cluster_group.go:725
 #: lxc/cluster_role.go:24 lxc/cluster_role.go:51 lxc/cluster_role.go:115
-#: lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:538
-#: lxc/config.go:764 lxc/config.go:896 lxc/config.go:943 lxc/config.go:983
-#: lxc/config.go:1038 lxc/config.go:1129 lxc/config.go:1160 lxc/config.go:1214
+#: lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:542
+#: lxc/config.go:772 lxc/config.go:904 lxc/config.go:955 lxc/config.go:995
+#: lxc/config.go:1050 lxc/config.go:1141 lxc/config.go:1172 lxc/config.go:1226
 #: lxc/config_device.go:25 lxc/config_device.go:79 lxc/config_device.go:221
 #: lxc/config_device.go:318 lxc/config_device.go:401 lxc/config_device.go:503
 #: lxc/config_device.go:619 lxc/config_device.go:626 lxc/config_device.go:759
@@ -2237,7 +2237,7 @@ msgstr "プロファイル設定をYAMLで編集します"
 msgid "Edit image properties"
 msgstr "イメージのプロパティを編集します"
 
-#: lxc/config.go:1213 lxc/config.go:1214
+#: lxc/config.go:1225 lxc/config.go:1226
 #, fuzzy
 msgid "Edit instance UEFI variables"
 msgstr "インスタンスのメタデータファイルを編集します"
@@ -2373,7 +2373,7 @@ msgstr "イメージの取得中: %s"
 msgid "Error retrieving aliases: %w"
 msgstr "イメージの取得中: %s"
 
-#: lxc/cluster.go:459 lxc/config.go:654 lxc/config.go:686 lxc/network.go:1319
+#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1319
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
@@ -2383,7 +2383,7 @@ msgstr "イメージの取得中: %s"
 msgid "Error setting properties: %v"
 msgstr "イメージの取得中: %s"
 
-#: lxc/config.go:648 lxc/config.go:680
+#: lxc/config.go:656 lxc/config.go:688
 #, fuzzy, c-format
 msgid "Error unsetting properties: %v"
 msgstr "イメージのプロパティを削除します"
@@ -2593,7 +2593,7 @@ msgstr "デバイス上書きのためのプロファイル %q のロードに�
 msgid "Failed parsing SSH host key: %w"
 msgstr "SSH ホスト鍵の読み取りに失敗しました: %w"
 
-#: lxc/console.go:366
+#: lxc/console.go:370
 #, c-format
 msgid "Failed starting command: %w"
 msgstr "コマンドの実行に失敗しました: %w"
@@ -2823,7 +2823,7 @@ msgstr "すべてのコマンドに対する man ページを作成します"
 msgid "Generating a client certificate. This may take a minute..."
 msgstr "クライアント証明書を生成します。1分ぐらいかかります..."
 
-#: lxc/config.go:982 lxc/config.go:983
+#: lxc/config.go:994 lxc/config.go:995
 #, fuzzy
 msgid "Get UEFI variables for instance"
 msgstr "インスタンスからファイルをマウントします"
@@ -3245,7 +3245,7 @@ msgstr "インスタンス名を指定する必要があります"
 msgid "Instance name is: %s"
 msgstr "インスタンス名: %s"
 
-#: lxc/config.go:1008 lxc/config.go:1066 lxc/config.go:1185 lxc/config.go:1277
+#: lxc/config.go:1020 lxc/config.go:1078 lxc/config.go:1197 lxc/config.go:1289
 #, fuzzy
 msgid "Instance name must be specified"
 msgstr "インスタンス名: %s"
@@ -3413,7 +3413,7 @@ msgstr "LOCATION"
 msgid "LXD - Command line client"
 msgstr "LXD - コマンドラインクライアント"
 
-#: lxc/console.go:387
+#: lxc/console.go:391
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 "LXD は spicy か remote-viewer がインストールされている場合は自動的にどちらか"
@@ -4089,7 +4089,7 @@ msgstr ""
 "イメージは全ハッシュ文字列、一意に定まるハッシュの短縮表現、(設定され\n"
 "ている場合は) エイリアスで参照できます。"
 
-#: lxc/config.go:942 lxc/config.go:943
+#: lxc/config.go:954 lxc/config.go:955
 #, fuzzy
 msgid "Manage instance UEFI variables"
 msgstr "インスタンスのメタデータファイルを管理します"
@@ -4960,7 +4960,7 @@ msgstr "終了するには ctrl+c を押してください"
 
 #: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
@@ -5478,7 +5478,7 @@ msgstr "レンダー: %s (%s)"
 msgid "Request a join token for adding a cluster member"
 msgstr "クラスターメンバーに join するためのトークンを要求します"
 
-#: lxc/config.go:1019
+#: lxc/config.go:1031
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5664,7 +5664,7 @@ msgstr "サーバのプロトコル (lxd or simplestreams)"
 msgid "Server version: %s\n"
 msgstr "サーバのバージョン: %s\n"
 
-#: lxc/config.go:1037 lxc/config.go:1038
+#: lxc/config.go:1049 lxc/config.go:1050
 #, fuzzy
 msgid "Set UEFI variables for instance"
 msgstr "インスタンスからファイルをマウントします"
@@ -5711,11 +5711,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr "イメージのプロパティを設定します"
 
-#: lxc/config.go:537
+#: lxc/config.go:541
 msgid "Set instance or server configuration keys"
 msgstr "インスタンスもしくはサーバの設定項目を設定します"
 
-#: lxc/config.go:538
+#: lxc/config.go:542
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5997,7 +5997,7 @@ msgstr "ストレージバケットに対する鍵を作成します"
 msgid "Set the key as a storage volume property"
 msgstr "新しいストレージボリュームをプロファイルに追加します"
 
-#: lxc/config.go:551
+#: lxc/config.go:555
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -6064,7 +6064,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr "イメージのプロパティを表示します"
 
-#: lxc/config.go:1159 lxc/config.go:1160
+#: lxc/config.go:1171 lxc/config.go:1172
 #, fuzzy
 msgid "Show instance UEFI variables"
 msgstr "インスタンスのメタデータファイルを表示します"
@@ -6073,7 +6073,7 @@ msgstr "インスタンスのメタデータファイルを表示します"
 msgid "Show instance metadata files"
 msgstr "インスタンスのメタデータファイルを表示します"
 
-#: lxc/config.go:763 lxc/config.go:764
+#: lxc/config.go:771 lxc/config.go:772
 msgid "Show instance or server configurations"
 msgstr "インスタンスもしくはサーバの設定を表示します"
 
@@ -6167,7 +6167,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr "デフォルトのリモートを表示します"
 
-#: lxc/config.go:767
+#: lxc/config.go:775
 msgid "Show the expanded configuration"
 msgstr "拡張した設定を表示する"
 
@@ -6419,7 +6419,7 @@ msgstr "--mode と --target-project は同時に指定できません"
 msgid "The --mode flag can't be used with --target"
 msgstr "--mode と --target は同時に指定できません"
 
-#: lxc/console.go:126
+#: lxc/console.go:130
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr "--show-log フラグは 'console' アウトプットタイプの時だけ使えます"
 
@@ -6486,12 +6486,12 @@ msgstr "プロファイルのデバイスが存在しません"
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
 
-#: lxc/config.go:479
+#: lxc/config.go:483
 #, fuzzy, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
 
-#: lxc/config.go:455
+#: lxc/config.go:459
 #, fuzzy, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
@@ -6585,7 +6585,7 @@ msgstr ""
 "publish 先にはイメージ名は指定できません。\"--alias\" オプションを使ってくだ"
 "さい。"
 
-#: lxc/config.go:666
+#: lxc/config.go:674
 #, fuzzy
 msgid "There is no config key to set on an instance snapshot."
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
@@ -6642,7 +6642,7 @@ msgid "To create a new network, use: lxc network create"
 msgstr ""
 "新しいネットワークを作成するには、lxc network create を使用してください"
 
-#: lxc/console.go:215
+#: lxc/console.go:219
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr "コンソールから切り離すには <ctrl>+a q を押します"
 
@@ -6656,7 +6656,7 @@ msgstr ""
 "さい\n"
 "仮想マシンの場合は \"lxc launch ubuntu:22.04 --vm\" と実行してみてください"
 
-#: lxc/config.go:306 lxc/config.go:499 lxc/config.go:715 lxc/config.go:815
+#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6805,7 +6805,7 @@ msgstr "クライアント %q の未知のチャンネルタイプ: %s"
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr "未知のカラム名の短縮形です '%c' ('%s' 中)"
 
-#: lxc/console.go:164
+#: lxc/console.go:168
 #, c-format
 msgid "Unknown console type %q"
 msgstr "未知のコンソールタイプ %q"
@@ -6820,12 +6820,12 @@ msgstr "未知のファイルタイプ '%s'"
 msgid "Unknown key: %s"
 msgstr "未知の設定: %s"
 
-#: lxc/console.go:109
+#: lxc/console.go:113
 #, c-format
 msgid "Unknown output type %q"
 msgstr "未知の出力タイプ: %q"
 
-#: lxc/config.go:1128 lxc/config.go:1129
+#: lxc/config.go:1140 lxc/config.go:1141
 #, fuzzy
 msgid "Unset UEFI variables for instance"
 msgstr "移動先のインスタンスのすべてのプロファイルを削除します"
@@ -6846,7 +6846,7 @@ msgstr "デバイスの設定を削除します"
 msgid "Unset image properties"
 msgstr "イメージのプロパティを削除します"
 
-#: lxc/config.go:895 lxc/config.go:896
+#: lxc/config.go:903 lxc/config.go:904
 msgid "Unset instance or server configuration keys"
 msgstr "インスタンスもしくはサーバの設定を削除します"
 
@@ -6971,7 +6971,7 @@ msgstr "ストレージバケットに対する鍵を作成します"
 msgid "Unset the key as a storage volume property"
 msgstr "新しいストレージボリュームをプロファイルに追加します"
 
-#: lxc/config.go:900
+#: lxc/config.go:908
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -7338,7 +7338,7 @@ msgstr "[<remote>:]<image> [<target>]"
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr "[<remote>:]<image> [[<remote>:]<image>...]"
 
-#: lxc/config.go:1158 lxc/config.go:1212 lxc/config_device.go:321
+#: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:321
 #: lxc/config_device.go:753 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:35
 msgid "[<remote>:]<instance>"
@@ -7360,12 +7360,12 @@ msgstr "[<remote>:]<instance> <device> <type> [key=value...]"
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr "[<remote>:]<instance> <device> [key=value...]"
 
-#: lxc/config.go:981 lxc/config.go:1127
+#: lxc/config.go:993 lxc/config.go:1139
 #, fuzzy
 msgid "[<remote>:]<instance> <key>"
 msgstr "[<remote>:][<instance>] <key>"
 
-#: lxc/config.go:1036
+#: lxc/config.go:1048
 #, fuzzy
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr "[<remote>:][<instance>] <key>=<value>..."
@@ -7783,7 +7783,7 @@ msgstr "[<remote>:]<zone> <record> <type> <value>"
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr "[<remote>:]<zone> <record> [key=value...]"
 
-#: lxc/config.go:98 lxc/config.go:762
+#: lxc/config.go:98 lxc/config.go:770
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr "[<remote>:][<instance>[/<snapshot>]]"
 
@@ -7791,11 +7791,11 @@ msgstr "[<remote>:][<instance>[/<snapshot>]]"
 msgid "[<remote>:][<instance>]"
 msgstr "[<remote>:][<instance>]"
 
-#: lxc/config.go:391 lxc/config.go:894
+#: lxc/config.go:391 lxc/config.go:902
 msgid "[<remote>:][<instance>] <key>"
 msgstr "[<remote>:][<instance>] <key>"
 
-#: lxc/config.go:536
+#: lxc/config.go:540
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr "[<remote>:][<instance>] <key>=<value>..."
 
@@ -7957,7 +7957,7 @@ msgstr ""
 "lxc config edit <instance> < instance.yaml\n"
 "    インスタンスの設定を config.yaml を使って更新します。"
 
-#: lxc/config.go:543
+#: lxc/config.go:547
 #, fuzzy
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
@@ -7975,7 +7975,7 @@ msgstr ""
 "lxc config set core.trust_password=blah\n"
 "    サーバの認証パスワードを blah に設定します。"
 
-#: lxc/config.go:1216
+#: lxc/config.go:1228
 #, fuzzy
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
@@ -7984,7 +7984,7 @@ msgstr ""
 "lxc config edit <instance> < instance.yaml\n"
 "    インスタンスの設定を config.yaml を使って更新します。"
 
-#: lxc/config.go:1040
+#: lxc/config.go:1052
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"

--- a/po/ka.po
+++ b/po/ka.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-26 11:55-0600\n"
+"POT-Creation-Date: 2024-09-30 13:36-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -60,7 +60,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1227
+#: lxc/config.go:1239
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -475,7 +475,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:493 lxc/config.go:809
+#: lxc/config.go:497 lxc/config.go:817
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -495,7 +495,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:443 lxc/config.go:628 lxc/config.go:835
+#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -762,7 +762,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:388
+#: lxc/console.go:392
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -1012,7 +1012,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:694 lxc/config.go:1084
+#: lxc/config.go:702 lxc/config.go:1096
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1127,8 +1127,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:550 lxc/config.go:768
-#: lxc/config.go:899 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
+#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1251 lxc/network.go:1344 lxc/network.go:1416
 #: lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1207,7 +1207,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1327 lxc/config_metadata.go:156
+#: lxc/config.go:356 lxc/config.go:1339 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
@@ -1651,9 +1651,9 @@ msgstr ""
 #: lxc/cluster_group.go:316 lxc/cluster_group.go:440 lxc/cluster_group.go:522
 #: lxc/cluster_group.go:607 lxc/cluster_group.go:663 lxc/cluster_group.go:725
 #: lxc/cluster_role.go:24 lxc/cluster_role.go:51 lxc/cluster_role.go:115
-#: lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:538
-#: lxc/config.go:764 lxc/config.go:896 lxc/config.go:943 lxc/config.go:983
-#: lxc/config.go:1038 lxc/config.go:1129 lxc/config.go:1160 lxc/config.go:1214
+#: lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:542
+#: lxc/config.go:772 lxc/config.go:904 lxc/config.go:955 lxc/config.go:995
+#: lxc/config.go:1050 lxc/config.go:1141 lxc/config.go:1172 lxc/config.go:1226
 #: lxc/config_device.go:25 lxc/config_device.go:79 lxc/config_device.go:221
 #: lxc/config_device.go:318 lxc/config_device.go:401 lxc/config_device.go:503
 #: lxc/config_device.go:619 lxc/config_device.go:626 lxc/config_device.go:759
@@ -1926,7 +1926,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1213 lxc/config.go:1214
+#: lxc/config.go:1225 lxc/config.go:1226
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2050,7 +2050,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:459 lxc/config.go:654 lxc/config.go:686 lxc/network.go:1319
+#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1319
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
@@ -2060,7 +2060,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:648 lxc/config.go:680
+#: lxc/config.go:656 lxc/config.go:688
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2255,7 +2255,7 @@ msgstr ""
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:366
+#: lxc/console.go:370
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
@@ -2469,7 +2469,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:982 lxc/config.go:983
+#: lxc/config.go:994 lxc/config.go:995
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2867,7 +2867,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1008 lxc/config.go:1066 lxc/config.go:1185 lxc/config.go:1277
+#: lxc/config.go:1020 lxc/config.go:1078 lxc/config.go:1197 lxc/config.go:1289
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -3026,7 +3026,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:387
+#: lxc/console.go:391
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -3540,7 +3540,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:942 lxc/config.go:943
+#: lxc/config.go:954 lxc/config.go:955
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -4379,7 +4379,7 @@ msgstr ""
 
 #: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
@@ -4883,7 +4883,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1019
+#: lxc/config.go:1031
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5060,7 +5060,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1037 lxc/config.go:1038
+#: lxc/config.go:1049 lxc/config.go:1050
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5098,11 +5098,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:537
+#: lxc/config.go:541
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:538
+#: lxc/config.go:542
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5326,7 +5326,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:551
+#: lxc/config.go:555
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5391,7 +5391,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1159 lxc/config.go:1160
+#: lxc/config.go:1171 lxc/config.go:1172
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5399,7 +5399,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:763 lxc/config.go:764
+#: lxc/config.go:771 lxc/config.go:772
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5493,7 +5493,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:767
+#: lxc/config.go:775
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5744,7 +5744,7 @@ msgstr ""
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:126
+#: lxc/console.go:130
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -5806,12 +5806,12 @@ msgstr ""
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:479
+#: lxc/config.go:483
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:455
+#: lxc/config.go:459
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
@@ -5903,7 +5903,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:666
+#: lxc/config.go:674
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -5947,7 +5947,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:215
+#: lxc/console.go:219
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -5957,7 +5957,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:499 lxc/config.go:715 lxc/config.go:815
+#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6102,7 +6102,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:164
+#: lxc/console.go:168
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -6117,12 +6117,12 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:109
+#: lxc/console.go:113
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1128 lxc/config.go:1129
+#: lxc/config.go:1140 lxc/config.go:1141
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6142,7 +6142,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:895 lxc/config.go:896
+#: lxc/config.go:903 lxc/config.go:904
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6258,7 +6258,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:900
+#: lxc/config.go:908
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6607,7 +6607,7 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1158 lxc/config.go:1212 lxc/config_device.go:321
+#: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:321
 #: lxc/config_device.go:753 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:35
 msgid "[<remote>:]<instance>"
@@ -6629,11 +6629,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:981 lxc/config.go:1127
+#: lxc/config.go:993 lxc/config.go:1139
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1036
+#: lxc/config.go:1048
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -7030,7 +7030,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:762
+#: lxc/config.go:98 lxc/config.go:770
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7038,11 +7038,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:894
+#: lxc/config.go:391 lxc/config.go:902
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:536
+#: lxc/config.go:540
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -7166,7 +7166,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:543
+#: lxc/config.go:547
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7175,13 +7175,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1216
+#: lxc/config.go:1228
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1040
+#: lxc/config.go:1052
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-26 11:55-0600\n"
+"POT-Creation-Date: 2024-09-30 13:36-0400\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Korean <https://hosted.weblate.org/projects/linux-containers/"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1227
+#: lxc/config.go:1239
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -478,7 +478,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:493 lxc/config.go:809
+#: lxc/config.go:497 lxc/config.go:817
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -498,7 +498,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:443 lxc/config.go:628 lxc/config.go:835
+#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -765,7 +765,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:388
+#: lxc/console.go:392
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:694 lxc/config.go:1084
+#: lxc/config.go:702 lxc/config.go:1096
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1130,8 +1130,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:550 lxc/config.go:768
-#: lxc/config.go:899 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
+#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1251 lxc/network.go:1344 lxc/network.go:1416
 #: lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1210,7 +1210,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1327 lxc/config_metadata.go:156
+#: lxc/config.go:356 lxc/config.go:1339 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
@@ -1654,9 +1654,9 @@ msgstr ""
 #: lxc/cluster_group.go:316 lxc/cluster_group.go:440 lxc/cluster_group.go:522
 #: lxc/cluster_group.go:607 lxc/cluster_group.go:663 lxc/cluster_group.go:725
 #: lxc/cluster_role.go:24 lxc/cluster_role.go:51 lxc/cluster_role.go:115
-#: lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:538
-#: lxc/config.go:764 lxc/config.go:896 lxc/config.go:943 lxc/config.go:983
-#: lxc/config.go:1038 lxc/config.go:1129 lxc/config.go:1160 lxc/config.go:1214
+#: lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:542
+#: lxc/config.go:772 lxc/config.go:904 lxc/config.go:955 lxc/config.go:995
+#: lxc/config.go:1050 lxc/config.go:1141 lxc/config.go:1172 lxc/config.go:1226
 #: lxc/config_device.go:25 lxc/config_device.go:79 lxc/config_device.go:221
 #: lxc/config_device.go:318 lxc/config_device.go:401 lxc/config_device.go:503
 #: lxc/config_device.go:619 lxc/config_device.go:626 lxc/config_device.go:759
@@ -1929,7 +1929,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1213 lxc/config.go:1214
+#: lxc/config.go:1225 lxc/config.go:1226
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2053,7 +2053,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:459 lxc/config.go:654 lxc/config.go:686 lxc/network.go:1319
+#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1319
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
@@ -2063,7 +2063,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:648 lxc/config.go:680
+#: lxc/config.go:656 lxc/config.go:688
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2258,7 +2258,7 @@ msgstr ""
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:366
+#: lxc/console.go:370
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
@@ -2472,7 +2472,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:982 lxc/config.go:983
+#: lxc/config.go:994 lxc/config.go:995
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2870,7 +2870,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1008 lxc/config.go:1066 lxc/config.go:1185 lxc/config.go:1277
+#: lxc/config.go:1020 lxc/config.go:1078 lxc/config.go:1197 lxc/config.go:1289
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -3029,7 +3029,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:387
+#: lxc/console.go:391
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -3543,7 +3543,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:942 lxc/config.go:943
+#: lxc/config.go:954 lxc/config.go:955
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -4382,7 +4382,7 @@ msgstr ""
 
 #: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
@@ -4886,7 +4886,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1019
+#: lxc/config.go:1031
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5063,7 +5063,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1037 lxc/config.go:1038
+#: lxc/config.go:1049 lxc/config.go:1050
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5101,11 +5101,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:537
+#: lxc/config.go:541
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:538
+#: lxc/config.go:542
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5329,7 +5329,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:551
+#: lxc/config.go:555
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5394,7 +5394,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1159 lxc/config.go:1160
+#: lxc/config.go:1171 lxc/config.go:1172
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5402,7 +5402,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:763 lxc/config.go:764
+#: lxc/config.go:771 lxc/config.go:772
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5496,7 +5496,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:767
+#: lxc/config.go:775
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5747,7 +5747,7 @@ msgstr ""
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:126
+#: lxc/console.go:130
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -5809,12 +5809,12 @@ msgstr ""
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:479
+#: lxc/config.go:483
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:455
+#: lxc/config.go:459
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
@@ -5906,7 +5906,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:666
+#: lxc/config.go:674
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -5950,7 +5950,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:215
+#: lxc/console.go:219
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -5960,7 +5960,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:499 lxc/config.go:715 lxc/config.go:815
+#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6105,7 +6105,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:164
+#: lxc/console.go:168
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -6120,12 +6120,12 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:109
+#: lxc/console.go:113
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1128 lxc/config.go:1129
+#: lxc/config.go:1140 lxc/config.go:1141
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6145,7 +6145,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:895 lxc/config.go:896
+#: lxc/config.go:903 lxc/config.go:904
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6261,7 +6261,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:900
+#: lxc/config.go:908
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6610,7 +6610,7 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1158 lxc/config.go:1212 lxc/config_device.go:321
+#: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:321
 #: lxc/config_device.go:753 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:35
 msgid "[<remote>:]<instance>"
@@ -6632,11 +6632,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:981 lxc/config.go:1127
+#: lxc/config.go:993 lxc/config.go:1139
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1036
+#: lxc/config.go:1048
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -7033,7 +7033,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:762
+#: lxc/config.go:98 lxc/config.go:770
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7041,11 +7041,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:894
+#: lxc/config.go:391 lxc/config.go:902
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:536
+#: lxc/config.go:540
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -7169,7 +7169,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:543
+#: lxc/config.go:547
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7178,13 +7178,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1216
+#: lxc/config.go:1228
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1040
+#: lxc/config.go:1052
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-        "POT-Creation-Date: 2024-09-26 11:55-0600\n"
+        "POT-Creation-Date: 2024-09-30 13:36-0400\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -57,7 +57,7 @@ msgid   "### This is a YAML representation of a storage volume.\n"
         "###   size: \"61203283968\""
 msgstr  ""
 
-#: lxc/config.go:1227
+#: lxc/config.go:1239
 msgid   "### This is a YAML representation of the UEFI variables configuration.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -446,7 +446,7 @@ msgstr  ""
 msgid   "--empty cannot be combined with an image name"
 msgstr  ""
 
-#: lxc/config.go:493 lxc/config.go:809
+#: lxc/config.go:497 lxc/config.go:817
 msgid   "--expanded cannot be used with a server"
 msgstr  ""
 
@@ -466,7 +466,7 @@ msgstr  ""
 msgid   "--refresh can only be used with instances"
 msgstr  ""
 
-#: lxc/config.go:170 lxc/config.go:443 lxc/config.go:628 lxc/config.go:835 lxc/info.go:461
+#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843 lxc/info.go:461
 msgid   "--target cannot be used with instances"
 msgstr  ""
 
@@ -724,7 +724,7 @@ msgstr  ""
 msgid   "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr  ""
 
-#: lxc/console.go:388
+#: lxc/console.go:392
 msgid   "As neither could be found, the raw SPICE socket can be found at:"
 msgstr  ""
 
@@ -971,7 +971,7 @@ msgstr  ""
 msgid   "Can't supply uid/gid/mode in recursive mode"
 msgstr  ""
 
-#: lxc/config.go:694 lxc/config.go:1084
+#: lxc/config.go:702 lxc/config.go:1096
 #, c-format
 msgid   "Can't unset key '%s', it's not currently set"
 msgstr  ""
@@ -1084,7 +1084,7 @@ msgstr  ""
 msgid   "Cluster member %s removed from group %s"
 msgstr  ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:550 lxc/config.go:768 lxc/config.go:899 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65 lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877 lxc/network.go:1251 lxc/network.go:1344 lxc/network.go:1416 lxc/network_forward.go:182 lxc/network_forward.go:264 lxc/network_forward.go:497 lxc/network_forward.go:649 lxc/network_forward.go:803 lxc/network_forward.go:892 lxc/network_forward.go:974 lxc/network_load_balancer.go:184 lxc/network_load_balancer.go:266 lxc/network_load_balancer.go:484 lxc/network_load_balancer.go:619 lxc/network_load_balancer.go:774 lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938 lxc/network_load_balancer.go:1051 lxc/network_load_balancer.go:1125 lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748 lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91 lxc/storage_bucket.go:191 lxc/storage_bucket.go:254 lxc/storage_bucket.go:385 lxc/storage_bucket.go:542 lxc/storage_bucket.go:635 lxc/storage_bucket.go:701 lxc/storage_bucket.go:776 lxc/storage_bucket.go:862 lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027 lxc/storage_bucket.go:1163 lxc/storage_volume.go:394 lxc/storage_volume.go:612 lxc/storage_volume.go:717 lxc/storage_volume.go:1005 lxc/storage_volume.go:1231 lxc/storage_volume.go:1360 lxc/storage_volume.go:1848 lxc/storage_volume.go:1940 lxc/storage_volume.go:2079 lxc/storage_volume.go:2239 lxc/storage_volume.go:2355 lxc/storage_volume.go:2416 lxc/storage_volume.go:2543 lxc/storage_volume.go:2631 lxc/storage_volume.go:2795
+#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776 lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65 lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877 lxc/network.go:1251 lxc/network.go:1344 lxc/network.go:1416 lxc/network_forward.go:182 lxc/network_forward.go:264 lxc/network_forward.go:497 lxc/network_forward.go:649 lxc/network_forward.go:803 lxc/network_forward.go:892 lxc/network_forward.go:974 lxc/network_load_balancer.go:184 lxc/network_load_balancer.go:266 lxc/network_load_balancer.go:484 lxc/network_load_balancer.go:619 lxc/network_load_balancer.go:774 lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938 lxc/network_load_balancer.go:1051 lxc/network_load_balancer.go:1125 lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748 lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91 lxc/storage_bucket.go:191 lxc/storage_bucket.go:254 lxc/storage_bucket.go:385 lxc/storage_bucket.go:542 lxc/storage_bucket.go:635 lxc/storage_bucket.go:701 lxc/storage_bucket.go:776 lxc/storage_bucket.go:862 lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027 lxc/storage_bucket.go:1163 lxc/storage_volume.go:394 lxc/storage_volume.go:612 lxc/storage_volume.go:717 lxc/storage_volume.go:1005 lxc/storage_volume.go:1231 lxc/storage_volume.go:1360 lxc/storage_volume.go:1848 lxc/storage_volume.go:1940 lxc/storage_volume.go:2079 lxc/storage_volume.go:2239 lxc/storage_volume.go:2355 lxc/storage_volume.go:2416 lxc/storage_volume.go:2543 lxc/storage_volume.go:2631 lxc/storage_volume.go:2795
 msgid   "Cluster member name"
 msgstr  ""
 
@@ -1135,7 +1135,7 @@ msgstr  ""
 msgid   "Config key/value to apply to the target instance"
 msgstr  ""
 
-#: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281 lxc/config.go:356 lxc/config.go:1327 lxc/config_metadata.go:156 lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759 lxc/network_acl.go:698 lxc/network_forward.go:767 lxc/network_load_balancer.go:738 lxc/network_peer.go:698 lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595 lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349 lxc/storage_bucket.go:1126 lxc/storage_volume.go:1150 lxc/storage_volume.go:1182
+#: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281 lxc/config.go:356 lxc/config.go:1339 lxc/config_metadata.go:156 lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759 lxc/network_acl.go:698 lxc/network_forward.go:767 lxc/network_load_balancer.go:738 lxc/network_peer.go:698 lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595 lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349 lxc/storage_bucket.go:1126 lxc/storage_volume.go:1150 lxc/storage_volume.go:1182
 #, c-format
 msgid   "Config parsing error: %s"
 msgstr  ""
@@ -1538,7 +1538,7 @@ msgstr  ""
 msgid   "Delete warning"
 msgstr  ""
 
-#: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159 lxc/alias.go:214 lxc/auth.go:31 lxc/auth.go:60 lxc/auth.go:99 lxc/auth.go:153 lxc/auth.go:202 lxc/auth.go:333 lxc/auth.go:393 lxc/auth.go:442 lxc/auth.go:494 lxc/auth.go:517 lxc/auth.go:576 lxc/auth.go:732 lxc/auth.go:766 lxc/auth.go:833 lxc/auth.go:896 lxc/auth.go:957 lxc/auth.go:1085 lxc/auth.go:1108 lxc/auth.go:1166 lxc/auth.go:1235 lxc/auth.go:1257 lxc/auth.go:1435 lxc/auth.go:1473 lxc/auth.go:1525 lxc/auth.go:1574 lxc/auth.go:1693 lxc/auth.go:1753 lxc/auth.go:1802 lxc/auth.go:1853 lxc/auth.go:1876 lxc/auth.go:1929 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677 lxc/cluster.go:770 lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087 lxc/cluster.go:1175 lxc/cluster.go:1299 lxc/cluster.go:1329 lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170 lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440 lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663 lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51 lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:538 lxc/config.go:764 lxc/config.go:896 lxc/config.go:943 lxc/config.go:983 lxc/config.go:1038 lxc/config.go:1129 lxc/config.go:1160 lxc/config.go:1214 lxc/config_device.go:25 lxc/config_device.go:79 lxc/config_device.go:221 lxc/config_device.go:318 lxc/config_device.go:401 lxc/config_device.go:503 lxc/config_device.go:619 lxc/config_device.go:626 lxc/config_device.go:759 lxc/config_device.go:844 lxc/config_metadata.go:28 lxc/config_metadata.go:56 lxc/config_metadata.go:189 lxc/config_template.go:28 lxc/config_template.go:68 lxc/config_template.go:119 lxc/config_template.go:173 lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34 lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651 lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41 lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173 lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090 lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638 lxc/image.go:1701 lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1005 lxc/network.go:1106 lxc/network.go:1185 lxc/network.go:1245 lxc/network.go:1341 lxc/network.go:1413 lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731 lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:51 lxc/network_forward.go:33 lxc/network_forward.go:90 lxc/network_forward.go:179 lxc/network_forward.go:256 lxc/network_forward.go:404 lxc/network_forward.go:489 lxc/network_forward.go:599 lxc/network_forward.go:646 lxc/network_forward.go:800 lxc/network_forward.go:874 lxc/network_forward.go:889 lxc/network_forward.go:970 lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476 lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935 lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1121 lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236 lxc/network_peer.go:360 lxc/network_peer.go:445 lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:165 lxc/network_zone.go:228 lxc/network_zone.go:301 lxc/network_zone.go:396 lxc/network_zone.go:484 lxc/network_zone.go:527 lxc/network_zone.go:654 lxc/network_zone.go:710 lxc/network_zone.go:767 lxc/network_zone.go:845 lxc/network_zone.go:909 lxc/network_zone.go:985 lxc/network_zone.go:1083 lxc/network_zone.go:1172 lxc/network_zone.go:1219 lxc/network_zone.go:1349 lxc/network_zone.go:1410 lxc/network_zone.go:1425 lxc/network_zone.go:1483 lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180 lxc/profile.go:271 lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493 lxc/profile.go:629 lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860 lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31 lxc/project.go:95 lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472 lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789 lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853 lxc/remote.go:917 lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250 lxc/storage_bucket.go:383 lxc/storage_bucket.go:459 lxc/storage_bucket.go:536 lxc/storage_bucket.go:630 lxc/storage_bucket.go:699 lxc/storage_bucket.go:733 lxc/storage_bucket.go:774 lxc/storage_bucket.go:853 lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158 lxc/storage_volume.go:58 lxc/storage_volume.go:169 lxc/storage_volume.go:283 lxc/storage_volume.go:390 lxc/storage_volume.go:605 lxc/storage_volume.go:714 lxc/storage_volume.go:801 lxc/storage_volume.go:899 lxc/storage_volume.go:996 lxc/storage_volume.go:1217 lxc/storage_volume.go:1348 lxc/storage_volume.go:1507 lxc/storage_volume.go:1591 lxc/storage_volume.go:1844 lxc/storage_volume.go:1937 lxc/storage_volume.go:2064 lxc/storage_volume.go:2222 lxc/storage_volume.go:2343 lxc/storage_volume.go:2405 lxc/storage_volume.go:2541 lxc/storage_volume.go:2624 lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
+#: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159 lxc/alias.go:214 lxc/auth.go:31 lxc/auth.go:60 lxc/auth.go:99 lxc/auth.go:153 lxc/auth.go:202 lxc/auth.go:333 lxc/auth.go:393 lxc/auth.go:442 lxc/auth.go:494 lxc/auth.go:517 lxc/auth.go:576 lxc/auth.go:732 lxc/auth.go:766 lxc/auth.go:833 lxc/auth.go:896 lxc/auth.go:957 lxc/auth.go:1085 lxc/auth.go:1108 lxc/auth.go:1166 lxc/auth.go:1235 lxc/auth.go:1257 lxc/auth.go:1435 lxc/auth.go:1473 lxc/auth.go:1525 lxc/auth.go:1574 lxc/auth.go:1693 lxc/auth.go:1753 lxc/auth.go:1802 lxc/auth.go:1853 lxc/auth.go:1876 lxc/auth.go:1929 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677 lxc/cluster.go:770 lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087 lxc/cluster.go:1175 lxc/cluster.go:1299 lxc/cluster.go:1329 lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170 lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440 lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663 lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51 lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:955 lxc/config.go:995 lxc/config.go:1050 lxc/config.go:1141 lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:25 lxc/config_device.go:79 lxc/config_device.go:221 lxc/config_device.go:318 lxc/config_device.go:401 lxc/config_device.go:503 lxc/config_device.go:619 lxc/config_device.go:626 lxc/config_device.go:759 lxc/config_device.go:844 lxc/config_metadata.go:28 lxc/config_metadata.go:56 lxc/config_metadata.go:189 lxc/config_template.go:28 lxc/config_template.go:68 lxc/config_template.go:119 lxc/config_template.go:173 lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34 lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651 lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41 lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173 lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090 lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638 lxc/image.go:1701 lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1005 lxc/network.go:1106 lxc/network.go:1185 lxc/network.go:1245 lxc/network.go:1341 lxc/network.go:1413 lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731 lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:51 lxc/network_forward.go:33 lxc/network_forward.go:90 lxc/network_forward.go:179 lxc/network_forward.go:256 lxc/network_forward.go:404 lxc/network_forward.go:489 lxc/network_forward.go:599 lxc/network_forward.go:646 lxc/network_forward.go:800 lxc/network_forward.go:874 lxc/network_forward.go:889 lxc/network_forward.go:970 lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476 lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935 lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1121 lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236 lxc/network_peer.go:360 lxc/network_peer.go:445 lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:165 lxc/network_zone.go:228 lxc/network_zone.go:301 lxc/network_zone.go:396 lxc/network_zone.go:484 lxc/network_zone.go:527 lxc/network_zone.go:654 lxc/network_zone.go:710 lxc/network_zone.go:767 lxc/network_zone.go:845 lxc/network_zone.go:909 lxc/network_zone.go:985 lxc/network_zone.go:1083 lxc/network_zone.go:1172 lxc/network_zone.go:1219 lxc/network_zone.go:1349 lxc/network_zone.go:1410 lxc/network_zone.go:1425 lxc/network_zone.go:1483 lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180 lxc/profile.go:271 lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493 lxc/profile.go:629 lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860 lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31 lxc/project.go:95 lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472 lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789 lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853 lxc/remote.go:917 lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250 lxc/storage_bucket.go:383 lxc/storage_bucket.go:459 lxc/storage_bucket.go:536 lxc/storage_bucket.go:630 lxc/storage_bucket.go:699 lxc/storage_bucket.go:733 lxc/storage_bucket.go:774 lxc/storage_bucket.go:853 lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158 lxc/storage_volume.go:58 lxc/storage_volume.go:169 lxc/storage_volume.go:283 lxc/storage_volume.go:390 lxc/storage_volume.go:605 lxc/storage_volume.go:714 lxc/storage_volume.go:801 lxc/storage_volume.go:899 lxc/storage_volume.go:996 lxc/storage_volume.go:1217 lxc/storage_volume.go:1348 lxc/storage_volume.go:1507 lxc/storage_volume.go:1591 lxc/storage_volume.go:1844 lxc/storage_volume.go:1937 lxc/storage_volume.go:2064 lxc/storage_volume.go:2222 lxc/storage_volume.go:2343 lxc/storage_volume.go:2405 lxc/storage_volume.go:2541 lxc/storage_volume.go:2624 lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid   "Description"
 msgstr  ""
 
@@ -1718,7 +1718,7 @@ msgstr  ""
 msgid   "Edit image properties"
 msgstr  ""
 
-#: lxc/config.go:1213 lxc/config.go:1214
+#: lxc/config.go:1225 lxc/config.go:1226
 msgid   "Edit instance UEFI variables"
 msgstr  ""
 
@@ -1837,12 +1837,12 @@ msgstr  ""
 msgid   "Error retrieving aliases: %w"
 msgstr  ""
 
-#: lxc/cluster.go:459 lxc/config.go:654 lxc/config.go:686 lxc/network.go:1319 lxc/network_acl.go:524 lxc/network_forward.go:572 lxc/network_load_balancer.go:559 lxc/network_peer.go:522 lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987 lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603 lxc/storage_volume.go:2155 lxc/storage_volume.go:2193
+#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1319 lxc/network_acl.go:524 lxc/network_forward.go:572 lxc/network_load_balancer.go:559 lxc/network_peer.go:522 lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987 lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603 lxc/storage_volume.go:2155 lxc/storage_volume.go:2193
 #, c-format
 msgid   "Error setting properties: %v"
 msgstr  ""
 
-#: lxc/config.go:648 lxc/config.go:680
+#: lxc/config.go:656 lxc/config.go:688
 #, c-format
 msgid   "Error unsetting properties: %v"
 msgstr  ""
@@ -2027,7 +2027,7 @@ msgstr  ""
 msgid   "Failed parsing SSH host key: %w"
 msgstr  ""
 
-#: lxc/console.go:366
+#: lxc/console.go:370
 #, c-format
 msgid   "Failed starting command: %w"
 msgstr  ""
@@ -2225,7 +2225,7 @@ msgstr  ""
 msgid   "Generating a client certificate. This may take a minute..."
 msgstr  ""
 
-#: lxc/config.go:982 lxc/config.go:983
+#: lxc/config.go:994 lxc/config.go:995
 msgid   "Get UEFI variables for instance"
 msgstr  ""
 
@@ -2619,7 +2619,7 @@ msgstr  ""
 msgid   "Instance name is: %s"
 msgstr  ""
 
-#: lxc/config.go:1008 lxc/config.go:1066 lxc/config.go:1185 lxc/config.go:1277
+#: lxc/config.go:1020 lxc/config.go:1078 lxc/config.go:1197 lxc/config.go:1289
 msgid   "Instance name must be specified"
 msgstr  ""
 
@@ -2773,7 +2773,7 @@ msgstr  ""
 msgid   "LXD - Command line client"
 msgstr  ""
 
-#: lxc/console.go:387
+#: lxc/console.go:391
 msgid   "LXD automatically uses either spicy or remote-viewer when present."
 msgstr  ""
 
@@ -3273,7 +3273,7 @@ msgid   "Manage images\n"
         "hash or alias name (if one is set)."
 msgstr  ""
 
-#: lxc/config.go:942 lxc/config.go:943
+#: lxc/config.go:954 lxc/config.go:955
 msgid   "Manage instance UEFI variables"
 msgstr  ""
 
@@ -4028,7 +4028,7 @@ msgstr  ""
 msgid   "Press ctrl+c to finish"
 msgstr  ""
 
-#: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860 lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357 lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239 lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760 lxc/network_acl.go:699 lxc/network_forward.go:768 lxc/network_load_balancer.go:739 lxc/network_peer.go:699 lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596 lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350 lxc/storage_bucket.go:1127 lxc/storage_volume.go:1151 lxc/storage_volume.go:1183
+#: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860 lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357 lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239 lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760 lxc/network_acl.go:699 lxc/network_forward.go:768 lxc/network_load_balancer.go:739 lxc/network_peer.go:699 lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596 lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350 lxc/storage_bucket.go:1127 lxc/storage_volume.go:1151 lxc/storage_volume.go:1183
 msgid   "Press enter to open the editor again or ctrl+c to abort change"
 msgstr  ""
 
@@ -4507,7 +4507,7 @@ msgstr  ""
 msgid   "Request a join token for adding a cluster member"
 msgstr  ""
 
-#: lxc/config.go:1019
+#: lxc/config.go:1031
 msgid   "Requested UEFI variable does not exist"
 msgstr  ""
 
@@ -4681,7 +4681,7 @@ msgstr  ""
 msgid   "Server version: %s\n"
 msgstr  ""
 
-#: lxc/config.go:1037 lxc/config.go:1038
+#: lxc/config.go:1049 lxc/config.go:1050
 msgid   "Set UEFI variables for instance"
 msgstr  ""
 
@@ -4715,11 +4715,11 @@ msgstr  ""
 msgid   "Set image properties"
 msgstr  ""
 
-#: lxc/config.go:537
+#: lxc/config.go:541
 msgid   "Set instance or server configuration keys"
 msgstr  ""
 
-#: lxc/config.go:538
+#: lxc/config.go:542
 msgid   "Set instance or server configuration keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
@@ -4919,7 +4919,7 @@ msgstr  ""
 msgid   "Set the key as a storage volume property"
 msgstr  ""
 
-#: lxc/config.go:551
+#: lxc/config.go:555
 msgid   "Set the key as an instance property"
 msgstr  ""
 
@@ -4980,7 +4980,7 @@ msgstr  ""
 msgid   "Show image properties"
 msgstr  ""
 
-#: lxc/config.go:1159 lxc/config.go:1160
+#: lxc/config.go:1171 lxc/config.go:1172
 msgid   "Show instance UEFI variables"
 msgstr  ""
 
@@ -4988,7 +4988,7 @@ msgstr  ""
 msgid   "Show instance metadata files"
 msgstr  ""
 
-#: lxc/config.go:763 lxc/config.go:764
+#: lxc/config.go:771 lxc/config.go:772
 msgid   "Show instance or server configurations"
 msgstr  ""
 
@@ -5080,7 +5080,7 @@ msgstr  ""
 msgid   "Show the default remote"
 msgstr  ""
 
-#: lxc/config.go:767
+#: lxc/config.go:775
 msgid   "Show the expanded configuration"
 msgstr  ""
 
@@ -5328,7 +5328,7 @@ msgstr  ""
 msgid   "The --mode flag can't be used with --target"
 msgstr  ""
 
-#: lxc/console.go:126
+#: lxc/console.go:130
 msgid   "The --show-log flag is only supported for by 'console' output type"
 msgstr  ""
 
@@ -5388,12 +5388,12 @@ msgstr  ""
 msgid   "The property %q does not exist on the cluster member %q: %v"
 msgstr  ""
 
-#: lxc/config.go:479
+#: lxc/config.go:483
 #, c-format
 msgid   "The property %q does not exist on the instance %q: %v"
 msgstr  ""
 
-#: lxc/config.go:455
+#: lxc/config.go:459
 #, c-format
 msgid   "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr  ""
@@ -5483,7 +5483,7 @@ msgstr  ""
 msgid   "There is no \"image name\".  Did you want an alias?"
 msgstr  ""
 
-#: lxc/config.go:666
+#: lxc/config.go:674
 msgid   "There is no config key to set on an instance snapshot."
 msgstr  ""
 
@@ -5523,7 +5523,7 @@ msgstr  ""
 msgid   "To create a new network, use: lxc network create"
 msgstr  ""
 
-#: lxc/console.go:215
+#: lxc/console.go:219
 msgid   "To detach from the console, press: <ctrl>+a q"
 msgstr  ""
 
@@ -5532,7 +5532,7 @@ msgid   "To start your first container, try: lxc launch ubuntu:24.04\n"
         "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr  ""
 
-#: lxc/config.go:306 lxc/config.go:499 lxc/config.go:715 lxc/config.go:815 lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
+#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823 lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid   "To use --target, the destination remote must be a cluster"
 msgstr  ""
 
@@ -5670,7 +5670,7 @@ msgstr  ""
 msgid   "Unknown column shorthand char '%c' in '%s'"
 msgstr  ""
 
-#: lxc/console.go:164
+#: lxc/console.go:168
 #, c-format
 msgid   "Unknown console type %q"
 msgstr  ""
@@ -5685,12 +5685,12 @@ msgstr  ""
 msgid   "Unknown key: %s"
 msgstr  ""
 
-#: lxc/console.go:109
+#: lxc/console.go:113
 #, c-format
 msgid   "Unknown output type %q"
 msgstr  ""
 
-#: lxc/config.go:1128 lxc/config.go:1129
+#: lxc/config.go:1140 lxc/config.go:1141
 msgid   "Unset UEFI variables for instance"
 msgstr  ""
 
@@ -5710,7 +5710,7 @@ msgstr  ""
 msgid   "Unset image properties"
 msgstr  ""
 
-#: lxc/config.go:895 lxc/config.go:896
+#: lxc/config.go:903 lxc/config.go:904
 msgid   "Unset instance or server configuration keys"
 msgstr  ""
 
@@ -5826,7 +5826,7 @@ msgstr  ""
 msgid   "Unset the key as a storage volume property"
 msgstr  ""
 
-#: lxc/config.go:900
+#: lxc/config.go:908
 msgid   "Unset the key as an instance property"
 msgstr  ""
 
@@ -6155,7 +6155,7 @@ msgstr  ""
 msgid   "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr  ""
 
-#: lxc/config.go:1158 lxc/config.go:1212 lxc/config_device.go:321 lxc/config_device.go:753 lxc/config_metadata.go:54 lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:35
+#: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:321 lxc/config_device.go:753 lxc/config_metadata.go:54 lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:35
 msgid   "[<remote>:]<instance>"
 msgstr  ""
 
@@ -6175,11 +6175,11 @@ msgstr  ""
 msgid   "[<remote>:]<instance> <device> [key=value...]"
 msgstr  ""
 
-#: lxc/config.go:981 lxc/config.go:1127
+#: lxc/config.go:993 lxc/config.go:1139
 msgid   "[<remote>:]<instance> <key>"
 msgstr  ""
 
-#: lxc/config.go:1036
+#: lxc/config.go:1048
 msgid   "[<remote>:]<instance> <key>=<value>..."
 msgstr  ""
 
@@ -6551,7 +6551,7 @@ msgstr  ""
 msgid   "[<remote>:]<zone> <record> [key=value...]"
 msgstr  ""
 
-#: lxc/config.go:98 lxc/config.go:762
+#: lxc/config.go:98 lxc/config.go:770
 msgid   "[<remote>:][<instance>[/<snapshot>]]"
 msgstr  ""
 
@@ -6559,11 +6559,11 @@ msgstr  ""
 msgid   "[<remote>:][<instance>]"
 msgstr  ""
 
-#: lxc/config.go:391 lxc/config.go:894
+#: lxc/config.go:391 lxc/config.go:902
 msgid   "[<remote>:][<instance>] <key>"
 msgstr  ""
 
-#: lxc/config.go:536
+#: lxc/config.go:540
 msgid   "[<remote>:][<instance>] <key>=<value>..."
 msgstr  ""
 
@@ -6671,7 +6671,7 @@ msgid   "lxc config edit <instance> < instance.yaml\n"
         "    Update the instance configuration from config.yaml."
 msgstr  ""
 
-#: lxc/config.go:543
+#: lxc/config.go:547
 msgid   "lxc config set [<remote>:]<instance> limits.cpu=2\n"
         "    Will set a CPU limit of \"2\" for the instance.\n"
         "\n"
@@ -6679,12 +6679,12 @@ msgid   "lxc config set [<remote>:]<instance> limits.cpu=2\n"
         "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr  ""
 
-#: lxc/config.go:1216
+#: lxc/config.go:1228
 msgid   "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
         "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr  ""
 
-#: lxc/config.go:1040
+#: lxc/config.go:1052
 msgid   "lxc config uefi set [<remote>:]<instance> testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
         "    Set a UEFI variable with name \"testvar\", GUID 9073e4e0-60ec-4b6e-9903-4c223c260f3c and value \"aabb\" (HEX-encoded) for the instance."
 msgstr  ""

--- a/po/mr.po
+++ b/po/mr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-26 11:55-0600\n"
+"POT-Creation-Date: 2024-09-30 13:36-0400\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Marathi <https://hosted.weblate.org/projects/linux-containers/"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1227
+#: lxc/config.go:1239
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -478,7 +478,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:493 lxc/config.go:809
+#: lxc/config.go:497 lxc/config.go:817
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -498,7 +498,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:443 lxc/config.go:628 lxc/config.go:835
+#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -765,7 +765,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:388
+#: lxc/console.go:392
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:694 lxc/config.go:1084
+#: lxc/config.go:702 lxc/config.go:1096
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1130,8 +1130,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:550 lxc/config.go:768
-#: lxc/config.go:899 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
+#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1251 lxc/network.go:1344 lxc/network.go:1416
 #: lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1210,7 +1210,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1327 lxc/config_metadata.go:156
+#: lxc/config.go:356 lxc/config.go:1339 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
@@ -1654,9 +1654,9 @@ msgstr ""
 #: lxc/cluster_group.go:316 lxc/cluster_group.go:440 lxc/cluster_group.go:522
 #: lxc/cluster_group.go:607 lxc/cluster_group.go:663 lxc/cluster_group.go:725
 #: lxc/cluster_role.go:24 lxc/cluster_role.go:51 lxc/cluster_role.go:115
-#: lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:538
-#: lxc/config.go:764 lxc/config.go:896 lxc/config.go:943 lxc/config.go:983
-#: lxc/config.go:1038 lxc/config.go:1129 lxc/config.go:1160 lxc/config.go:1214
+#: lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:542
+#: lxc/config.go:772 lxc/config.go:904 lxc/config.go:955 lxc/config.go:995
+#: lxc/config.go:1050 lxc/config.go:1141 lxc/config.go:1172 lxc/config.go:1226
 #: lxc/config_device.go:25 lxc/config_device.go:79 lxc/config_device.go:221
 #: lxc/config_device.go:318 lxc/config_device.go:401 lxc/config_device.go:503
 #: lxc/config_device.go:619 lxc/config_device.go:626 lxc/config_device.go:759
@@ -1929,7 +1929,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1213 lxc/config.go:1214
+#: lxc/config.go:1225 lxc/config.go:1226
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2053,7 +2053,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:459 lxc/config.go:654 lxc/config.go:686 lxc/network.go:1319
+#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1319
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
@@ -2063,7 +2063,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:648 lxc/config.go:680
+#: lxc/config.go:656 lxc/config.go:688
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2258,7 +2258,7 @@ msgstr ""
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:366
+#: lxc/console.go:370
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
@@ -2472,7 +2472,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:982 lxc/config.go:983
+#: lxc/config.go:994 lxc/config.go:995
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2870,7 +2870,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1008 lxc/config.go:1066 lxc/config.go:1185 lxc/config.go:1277
+#: lxc/config.go:1020 lxc/config.go:1078 lxc/config.go:1197 lxc/config.go:1289
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -3029,7 +3029,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:387
+#: lxc/console.go:391
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -3543,7 +3543,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:942 lxc/config.go:943
+#: lxc/config.go:954 lxc/config.go:955
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -4382,7 +4382,7 @@ msgstr ""
 
 #: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
@@ -4886,7 +4886,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1019
+#: lxc/config.go:1031
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5063,7 +5063,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1037 lxc/config.go:1038
+#: lxc/config.go:1049 lxc/config.go:1050
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5101,11 +5101,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:537
+#: lxc/config.go:541
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:538
+#: lxc/config.go:542
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5329,7 +5329,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:551
+#: lxc/config.go:555
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5394,7 +5394,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1159 lxc/config.go:1160
+#: lxc/config.go:1171 lxc/config.go:1172
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5402,7 +5402,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:763 lxc/config.go:764
+#: lxc/config.go:771 lxc/config.go:772
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5496,7 +5496,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:767
+#: lxc/config.go:775
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5747,7 +5747,7 @@ msgstr ""
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:126
+#: lxc/console.go:130
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -5809,12 +5809,12 @@ msgstr ""
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:479
+#: lxc/config.go:483
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:455
+#: lxc/config.go:459
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
@@ -5906,7 +5906,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:666
+#: lxc/config.go:674
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -5950,7 +5950,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:215
+#: lxc/console.go:219
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -5960,7 +5960,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:499 lxc/config.go:715 lxc/config.go:815
+#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6105,7 +6105,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:164
+#: lxc/console.go:168
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -6120,12 +6120,12 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:109
+#: lxc/console.go:113
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1128 lxc/config.go:1129
+#: lxc/config.go:1140 lxc/config.go:1141
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6145,7 +6145,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:895 lxc/config.go:896
+#: lxc/config.go:903 lxc/config.go:904
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6261,7 +6261,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:900
+#: lxc/config.go:908
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6610,7 +6610,7 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1158 lxc/config.go:1212 lxc/config_device.go:321
+#: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:321
 #: lxc/config_device.go:753 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:35
 msgid "[<remote>:]<instance>"
@@ -6632,11 +6632,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:981 lxc/config.go:1127
+#: lxc/config.go:993 lxc/config.go:1139
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1036
+#: lxc/config.go:1048
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -7033,7 +7033,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:762
+#: lxc/config.go:98 lxc/config.go:770
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7041,11 +7041,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:894
+#: lxc/config.go:391 lxc/config.go:902
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:536
+#: lxc/config.go:540
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -7169,7 +7169,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:543
+#: lxc/config.go:547
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7178,13 +7178,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1216
+#: lxc/config.go:1228
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1040
+#: lxc/config.go:1052
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-26 11:55-0600\n"
+"POT-Creation-Date: 2024-09-30 13:36-0400\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Norwegian Bokmål <https://hosted.weblate.org/projects/linux-"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1227
+#: lxc/config.go:1239
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -478,7 +478,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:493 lxc/config.go:809
+#: lxc/config.go:497 lxc/config.go:817
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -498,7 +498,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:443 lxc/config.go:628 lxc/config.go:835
+#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -765,7 +765,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:388
+#: lxc/console.go:392
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:694 lxc/config.go:1084
+#: lxc/config.go:702 lxc/config.go:1096
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1130,8 +1130,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:550 lxc/config.go:768
-#: lxc/config.go:899 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
+#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1251 lxc/network.go:1344 lxc/network.go:1416
 #: lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1210,7 +1210,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1327 lxc/config_metadata.go:156
+#: lxc/config.go:356 lxc/config.go:1339 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
@@ -1654,9 +1654,9 @@ msgstr ""
 #: lxc/cluster_group.go:316 lxc/cluster_group.go:440 lxc/cluster_group.go:522
 #: lxc/cluster_group.go:607 lxc/cluster_group.go:663 lxc/cluster_group.go:725
 #: lxc/cluster_role.go:24 lxc/cluster_role.go:51 lxc/cluster_role.go:115
-#: lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:538
-#: lxc/config.go:764 lxc/config.go:896 lxc/config.go:943 lxc/config.go:983
-#: lxc/config.go:1038 lxc/config.go:1129 lxc/config.go:1160 lxc/config.go:1214
+#: lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:542
+#: lxc/config.go:772 lxc/config.go:904 lxc/config.go:955 lxc/config.go:995
+#: lxc/config.go:1050 lxc/config.go:1141 lxc/config.go:1172 lxc/config.go:1226
 #: lxc/config_device.go:25 lxc/config_device.go:79 lxc/config_device.go:221
 #: lxc/config_device.go:318 lxc/config_device.go:401 lxc/config_device.go:503
 #: lxc/config_device.go:619 lxc/config_device.go:626 lxc/config_device.go:759
@@ -1929,7 +1929,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1213 lxc/config.go:1214
+#: lxc/config.go:1225 lxc/config.go:1226
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2053,7 +2053,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:459 lxc/config.go:654 lxc/config.go:686 lxc/network.go:1319
+#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1319
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
@@ -2063,7 +2063,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:648 lxc/config.go:680
+#: lxc/config.go:656 lxc/config.go:688
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2258,7 +2258,7 @@ msgstr ""
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:366
+#: lxc/console.go:370
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
@@ -2472,7 +2472,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:982 lxc/config.go:983
+#: lxc/config.go:994 lxc/config.go:995
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2870,7 +2870,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1008 lxc/config.go:1066 lxc/config.go:1185 lxc/config.go:1277
+#: lxc/config.go:1020 lxc/config.go:1078 lxc/config.go:1197 lxc/config.go:1289
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -3029,7 +3029,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:387
+#: lxc/console.go:391
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -3543,7 +3543,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:942 lxc/config.go:943
+#: lxc/config.go:954 lxc/config.go:955
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -4382,7 +4382,7 @@ msgstr ""
 
 #: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
@@ -4886,7 +4886,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1019
+#: lxc/config.go:1031
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5063,7 +5063,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1037 lxc/config.go:1038
+#: lxc/config.go:1049 lxc/config.go:1050
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5101,11 +5101,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:537
+#: lxc/config.go:541
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:538
+#: lxc/config.go:542
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5329,7 +5329,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:551
+#: lxc/config.go:555
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5394,7 +5394,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1159 lxc/config.go:1160
+#: lxc/config.go:1171 lxc/config.go:1172
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5402,7 +5402,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:763 lxc/config.go:764
+#: lxc/config.go:771 lxc/config.go:772
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5496,7 +5496,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:767
+#: lxc/config.go:775
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5747,7 +5747,7 @@ msgstr ""
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:126
+#: lxc/console.go:130
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -5809,12 +5809,12 @@ msgstr ""
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:479
+#: lxc/config.go:483
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:455
+#: lxc/config.go:459
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
@@ -5906,7 +5906,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:666
+#: lxc/config.go:674
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -5950,7 +5950,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:215
+#: lxc/console.go:219
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -5960,7 +5960,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:499 lxc/config.go:715 lxc/config.go:815
+#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6105,7 +6105,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:164
+#: lxc/console.go:168
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -6120,12 +6120,12 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:109
+#: lxc/console.go:113
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1128 lxc/config.go:1129
+#: lxc/config.go:1140 lxc/config.go:1141
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6145,7 +6145,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:895 lxc/config.go:896
+#: lxc/config.go:903 lxc/config.go:904
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6261,7 +6261,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:900
+#: lxc/config.go:908
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6610,7 +6610,7 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1158 lxc/config.go:1212 lxc/config_device.go:321
+#: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:321
 #: lxc/config_device.go:753 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:35
 msgid "[<remote>:]<instance>"
@@ -6632,11 +6632,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:981 lxc/config.go:1127
+#: lxc/config.go:993 lxc/config.go:1139
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1036
+#: lxc/config.go:1048
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -7033,7 +7033,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:762
+#: lxc/config.go:98 lxc/config.go:770
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7041,11 +7041,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:894
+#: lxc/config.go:391 lxc/config.go:902
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:536
+#: lxc/config.go:540
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -7169,7 +7169,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:543
+#: lxc/config.go:547
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7178,13 +7178,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1216
+#: lxc/config.go:1228
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1040
+#: lxc/config.go:1052
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-26 11:55-0600\n"
+"POT-Creation-Date: 2024-09-30 13:36-0400\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Heimen Stoffels <vistausss@fastmail.com>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/linux-containers/"
@@ -99,7 +99,7 @@ msgstr ""
 "### config:\n"
 "###  size: \"61203283968\""
 
-#: lxc/config.go:1227
+#: lxc/config.go:1239
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -702,7 +702,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:493 lxc/config.go:809
+#: lxc/config.go:497 lxc/config.go:817
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -722,7 +722,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:443 lxc/config.go:628 lxc/config.go:835
+#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -989,7 +989,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:388
+#: lxc/console.go:392
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:694 lxc/config.go:1084
+#: lxc/config.go:702 lxc/config.go:1096
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1354,8 +1354,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:550 lxc/config.go:768
-#: lxc/config.go:899 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
+#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1251 lxc/network.go:1344 lxc/network.go:1416
 #: lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1434,7 +1434,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1327 lxc/config_metadata.go:156
+#: lxc/config.go:356 lxc/config.go:1339 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
@@ -1878,9 +1878,9 @@ msgstr ""
 #: lxc/cluster_group.go:316 lxc/cluster_group.go:440 lxc/cluster_group.go:522
 #: lxc/cluster_group.go:607 lxc/cluster_group.go:663 lxc/cluster_group.go:725
 #: lxc/cluster_role.go:24 lxc/cluster_role.go:51 lxc/cluster_role.go:115
-#: lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:538
-#: lxc/config.go:764 lxc/config.go:896 lxc/config.go:943 lxc/config.go:983
-#: lxc/config.go:1038 lxc/config.go:1129 lxc/config.go:1160 lxc/config.go:1214
+#: lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:542
+#: lxc/config.go:772 lxc/config.go:904 lxc/config.go:955 lxc/config.go:995
+#: lxc/config.go:1050 lxc/config.go:1141 lxc/config.go:1172 lxc/config.go:1226
 #: lxc/config_device.go:25 lxc/config_device.go:79 lxc/config_device.go:221
 #: lxc/config_device.go:318 lxc/config_device.go:401 lxc/config_device.go:503
 #: lxc/config_device.go:619 lxc/config_device.go:626 lxc/config_device.go:759
@@ -2153,7 +2153,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1213 lxc/config.go:1214
+#: lxc/config.go:1225 lxc/config.go:1226
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2277,7 +2277,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:459 lxc/config.go:654 lxc/config.go:686 lxc/network.go:1319
+#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1319
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
@@ -2287,7 +2287,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:648 lxc/config.go:680
+#: lxc/config.go:656 lxc/config.go:688
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2482,7 +2482,7 @@ msgstr ""
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:366
+#: lxc/console.go:370
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
@@ -2696,7 +2696,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:982 lxc/config.go:983
+#: lxc/config.go:994 lxc/config.go:995
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -3094,7 +3094,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1008 lxc/config.go:1066 lxc/config.go:1185 lxc/config.go:1277
+#: lxc/config.go:1020 lxc/config.go:1078 lxc/config.go:1197 lxc/config.go:1289
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -3253,7 +3253,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:387
+#: lxc/console.go:391
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -3767,7 +3767,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:942 lxc/config.go:943
+#: lxc/config.go:954 lxc/config.go:955
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -4606,7 +4606,7 @@ msgstr ""
 
 #: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
@@ -5110,7 +5110,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1019
+#: lxc/config.go:1031
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5287,7 +5287,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1037 lxc/config.go:1038
+#: lxc/config.go:1049 lxc/config.go:1050
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5325,11 +5325,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:537
+#: lxc/config.go:541
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:538
+#: lxc/config.go:542
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5553,7 +5553,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:551
+#: lxc/config.go:555
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5618,7 +5618,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1159 lxc/config.go:1160
+#: lxc/config.go:1171 lxc/config.go:1172
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5626,7 +5626,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:763 lxc/config.go:764
+#: lxc/config.go:771 lxc/config.go:772
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5720,7 +5720,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:767
+#: lxc/config.go:775
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5971,7 +5971,7 @@ msgstr ""
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:126
+#: lxc/console.go:130
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -6033,12 +6033,12 @@ msgstr ""
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:479
+#: lxc/config.go:483
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:455
+#: lxc/config.go:459
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
@@ -6130,7 +6130,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:666
+#: lxc/config.go:674
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -6174,7 +6174,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:215
+#: lxc/console.go:219
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -6184,7 +6184,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:499 lxc/config.go:715 lxc/config.go:815
+#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6329,7 +6329,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:164
+#: lxc/console.go:168
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -6344,12 +6344,12 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:109
+#: lxc/console.go:113
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1128 lxc/config.go:1129
+#: lxc/config.go:1140 lxc/config.go:1141
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6369,7 +6369,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:895 lxc/config.go:896
+#: lxc/config.go:903 lxc/config.go:904
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6485,7 +6485,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:900
+#: lxc/config.go:908
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6834,7 +6834,7 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1158 lxc/config.go:1212 lxc/config_device.go:321
+#: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:321
 #: lxc/config_device.go:753 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:35
 msgid "[<remote>:]<instance>"
@@ -6856,11 +6856,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:981 lxc/config.go:1127
+#: lxc/config.go:993 lxc/config.go:1139
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1036
+#: lxc/config.go:1048
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -7257,7 +7257,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:762
+#: lxc/config.go:98 lxc/config.go:770
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7265,11 +7265,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:894
+#: lxc/config.go:391 lxc/config.go:902
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:536
+#: lxc/config.go:540
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -7393,7 +7393,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:543
+#: lxc/config.go:547
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7402,13 +7402,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1216
+#: lxc/config.go:1228
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1040
+#: lxc/config.go:1052
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"

--- a/po/pa.po
+++ b/po/pa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-26 11:55-0600\n"
+"POT-Creation-Date: 2024-09-30 13:36-0400\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Punjabi <https://hosted.weblate.org/projects/linux-containers/"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1227
+#: lxc/config.go:1239
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -478,7 +478,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:493 lxc/config.go:809
+#: lxc/config.go:497 lxc/config.go:817
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -498,7 +498,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:443 lxc/config.go:628 lxc/config.go:835
+#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -765,7 +765,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:388
+#: lxc/console.go:392
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:694 lxc/config.go:1084
+#: lxc/config.go:702 lxc/config.go:1096
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1130,8 +1130,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:550 lxc/config.go:768
-#: lxc/config.go:899 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
+#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1251 lxc/network.go:1344 lxc/network.go:1416
 #: lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1210,7 +1210,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1327 lxc/config_metadata.go:156
+#: lxc/config.go:356 lxc/config.go:1339 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
@@ -1654,9 +1654,9 @@ msgstr ""
 #: lxc/cluster_group.go:316 lxc/cluster_group.go:440 lxc/cluster_group.go:522
 #: lxc/cluster_group.go:607 lxc/cluster_group.go:663 lxc/cluster_group.go:725
 #: lxc/cluster_role.go:24 lxc/cluster_role.go:51 lxc/cluster_role.go:115
-#: lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:538
-#: lxc/config.go:764 lxc/config.go:896 lxc/config.go:943 lxc/config.go:983
-#: lxc/config.go:1038 lxc/config.go:1129 lxc/config.go:1160 lxc/config.go:1214
+#: lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:542
+#: lxc/config.go:772 lxc/config.go:904 lxc/config.go:955 lxc/config.go:995
+#: lxc/config.go:1050 lxc/config.go:1141 lxc/config.go:1172 lxc/config.go:1226
 #: lxc/config_device.go:25 lxc/config_device.go:79 lxc/config_device.go:221
 #: lxc/config_device.go:318 lxc/config_device.go:401 lxc/config_device.go:503
 #: lxc/config_device.go:619 lxc/config_device.go:626 lxc/config_device.go:759
@@ -1929,7 +1929,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1213 lxc/config.go:1214
+#: lxc/config.go:1225 lxc/config.go:1226
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2053,7 +2053,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:459 lxc/config.go:654 lxc/config.go:686 lxc/network.go:1319
+#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1319
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
@@ -2063,7 +2063,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:648 lxc/config.go:680
+#: lxc/config.go:656 lxc/config.go:688
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2258,7 +2258,7 @@ msgstr ""
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:366
+#: lxc/console.go:370
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
@@ -2472,7 +2472,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:982 lxc/config.go:983
+#: lxc/config.go:994 lxc/config.go:995
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2870,7 +2870,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1008 lxc/config.go:1066 lxc/config.go:1185 lxc/config.go:1277
+#: lxc/config.go:1020 lxc/config.go:1078 lxc/config.go:1197 lxc/config.go:1289
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -3029,7 +3029,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:387
+#: lxc/console.go:391
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -3543,7 +3543,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:942 lxc/config.go:943
+#: lxc/config.go:954 lxc/config.go:955
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -4382,7 +4382,7 @@ msgstr ""
 
 #: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
@@ -4886,7 +4886,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1019
+#: lxc/config.go:1031
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5063,7 +5063,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1037 lxc/config.go:1038
+#: lxc/config.go:1049 lxc/config.go:1050
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5101,11 +5101,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:537
+#: lxc/config.go:541
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:538
+#: lxc/config.go:542
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5329,7 +5329,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:551
+#: lxc/config.go:555
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5394,7 +5394,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1159 lxc/config.go:1160
+#: lxc/config.go:1171 lxc/config.go:1172
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5402,7 +5402,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:763 lxc/config.go:764
+#: lxc/config.go:771 lxc/config.go:772
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5496,7 +5496,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:767
+#: lxc/config.go:775
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5747,7 +5747,7 @@ msgstr ""
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:126
+#: lxc/console.go:130
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -5809,12 +5809,12 @@ msgstr ""
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:479
+#: lxc/config.go:483
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:455
+#: lxc/config.go:459
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
@@ -5906,7 +5906,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:666
+#: lxc/config.go:674
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -5950,7 +5950,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:215
+#: lxc/console.go:219
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -5960,7 +5960,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:499 lxc/config.go:715 lxc/config.go:815
+#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6105,7 +6105,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:164
+#: lxc/console.go:168
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -6120,12 +6120,12 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:109
+#: lxc/console.go:113
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1128 lxc/config.go:1129
+#: lxc/config.go:1140 lxc/config.go:1141
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6145,7 +6145,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:895 lxc/config.go:896
+#: lxc/config.go:903 lxc/config.go:904
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6261,7 +6261,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:900
+#: lxc/config.go:908
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6610,7 +6610,7 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1158 lxc/config.go:1212 lxc/config_device.go:321
+#: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:321
 #: lxc/config_device.go:753 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:35
 msgid "[<remote>:]<instance>"
@@ -6632,11 +6632,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:981 lxc/config.go:1127
+#: lxc/config.go:993 lxc/config.go:1139
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1036
+#: lxc/config.go:1048
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -7033,7 +7033,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:762
+#: lxc/config.go:98 lxc/config.go:770
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7041,11 +7041,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:894
+#: lxc/config.go:391 lxc/config.go:902
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:536
+#: lxc/config.go:540
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -7169,7 +7169,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:543
+#: lxc/config.go:547
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7178,13 +7178,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1216
+#: lxc/config.go:1228
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1040
+#: lxc/config.go:1052
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-26 11:55-0600\n"
+"POT-Creation-Date: 2024-09-30 13:36-0400\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/linux-containers/"
@@ -97,7 +97,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/config.go:1227
+#: lxc/config.go:1239
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -740,7 +740,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:493 lxc/config.go:809
+#: lxc/config.go:497 lxc/config.go:817
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -760,7 +760,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:443 lxc/config.go:628 lxc/config.go:835
+#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -1027,7 +1027,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:388
+#: lxc/console.go:392
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -1277,7 +1277,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:694 lxc/config.go:1084
+#: lxc/config.go:702 lxc/config.go:1096
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1392,8 +1392,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:550 lxc/config.go:768
-#: lxc/config.go:899 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
+#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1251 lxc/network.go:1344 lxc/network.go:1416
 #: lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1472,7 +1472,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1327 lxc/config_metadata.go:156
+#: lxc/config.go:356 lxc/config.go:1339 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
@@ -1916,9 +1916,9 @@ msgstr ""
 #: lxc/cluster_group.go:316 lxc/cluster_group.go:440 lxc/cluster_group.go:522
 #: lxc/cluster_group.go:607 lxc/cluster_group.go:663 lxc/cluster_group.go:725
 #: lxc/cluster_role.go:24 lxc/cluster_role.go:51 lxc/cluster_role.go:115
-#: lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:538
-#: lxc/config.go:764 lxc/config.go:896 lxc/config.go:943 lxc/config.go:983
-#: lxc/config.go:1038 lxc/config.go:1129 lxc/config.go:1160 lxc/config.go:1214
+#: lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:542
+#: lxc/config.go:772 lxc/config.go:904 lxc/config.go:955 lxc/config.go:995
+#: lxc/config.go:1050 lxc/config.go:1141 lxc/config.go:1172 lxc/config.go:1226
 #: lxc/config_device.go:25 lxc/config_device.go:79 lxc/config_device.go:221
 #: lxc/config_device.go:318 lxc/config_device.go:401 lxc/config_device.go:503
 #: lxc/config_device.go:619 lxc/config_device.go:626 lxc/config_device.go:759
@@ -2191,7 +2191,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1213 lxc/config.go:1214
+#: lxc/config.go:1225 lxc/config.go:1226
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2315,7 +2315,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:459 lxc/config.go:654 lxc/config.go:686 lxc/network.go:1319
+#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1319
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
@@ -2325,7 +2325,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:648 lxc/config.go:680
+#: lxc/config.go:656 lxc/config.go:688
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2520,7 +2520,7 @@ msgstr ""
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:366
+#: lxc/console.go:370
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
@@ -2734,7 +2734,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:982 lxc/config.go:983
+#: lxc/config.go:994 lxc/config.go:995
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -3132,7 +3132,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1008 lxc/config.go:1066 lxc/config.go:1185 lxc/config.go:1277
+#: lxc/config.go:1020 lxc/config.go:1078 lxc/config.go:1197 lxc/config.go:1289
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -3291,7 +3291,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:387
+#: lxc/console.go:391
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -3805,7 +3805,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:942 lxc/config.go:943
+#: lxc/config.go:954 lxc/config.go:955
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -4644,7 +4644,7 @@ msgstr ""
 
 #: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
@@ -5148,7 +5148,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1019
+#: lxc/config.go:1031
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5325,7 +5325,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1037 lxc/config.go:1038
+#: lxc/config.go:1049 lxc/config.go:1050
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5363,11 +5363,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:537
+#: lxc/config.go:541
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:538
+#: lxc/config.go:542
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5591,7 +5591,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:551
+#: lxc/config.go:555
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5656,7 +5656,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1159 lxc/config.go:1160
+#: lxc/config.go:1171 lxc/config.go:1172
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5664,7 +5664,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:763 lxc/config.go:764
+#: lxc/config.go:771 lxc/config.go:772
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5758,7 +5758,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:767
+#: lxc/config.go:775
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -6009,7 +6009,7 @@ msgstr ""
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:126
+#: lxc/console.go:130
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -6071,12 +6071,12 @@ msgstr ""
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:479
+#: lxc/config.go:483
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:455
+#: lxc/config.go:459
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
@@ -6168,7 +6168,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:666
+#: lxc/config.go:674
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -6212,7 +6212,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:215
+#: lxc/console.go:219
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -6222,7 +6222,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:499 lxc/config.go:715 lxc/config.go:815
+#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6367,7 +6367,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:164
+#: lxc/console.go:168
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -6382,12 +6382,12 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:109
+#: lxc/console.go:113
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1128 lxc/config.go:1129
+#: lxc/config.go:1140 lxc/config.go:1141
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6407,7 +6407,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:895 lxc/config.go:896
+#: lxc/config.go:903 lxc/config.go:904
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6523,7 +6523,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:900
+#: lxc/config.go:908
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6872,7 +6872,7 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1158 lxc/config.go:1212 lxc/config_device.go:321
+#: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:321
 #: lxc/config_device.go:753 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:35
 msgid "[<remote>:]<instance>"
@@ -6894,11 +6894,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:981 lxc/config.go:1127
+#: lxc/config.go:993 lxc/config.go:1139
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1036
+#: lxc/config.go:1048
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -7295,7 +7295,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:762
+#: lxc/config.go:98 lxc/config.go:770
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7303,11 +7303,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:894
+#: lxc/config.go:391 lxc/config.go:902
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:536
+#: lxc/config.go:540
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -7431,7 +7431,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:543
+#: lxc/config.go:547
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7440,13 +7440,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1216
+#: lxc/config.go:1228
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1040
+#: lxc/config.go:1052
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"

--- a/po/pt.po
+++ b/po/pt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-26 11:55-0600\n"
+"POT-Creation-Date: 2024-09-30 13:36-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -60,7 +60,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1227
+#: lxc/config.go:1239
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -475,7 +475,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:493 lxc/config.go:809
+#: lxc/config.go:497 lxc/config.go:817
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -495,7 +495,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:443 lxc/config.go:628 lxc/config.go:835
+#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -762,7 +762,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:388
+#: lxc/console.go:392
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -1012,7 +1012,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:694 lxc/config.go:1084
+#: lxc/config.go:702 lxc/config.go:1096
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1127,8 +1127,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:550 lxc/config.go:768
-#: lxc/config.go:899 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
+#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1251 lxc/network.go:1344 lxc/network.go:1416
 #: lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1207,7 +1207,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1327 lxc/config_metadata.go:156
+#: lxc/config.go:356 lxc/config.go:1339 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
@@ -1651,9 +1651,9 @@ msgstr ""
 #: lxc/cluster_group.go:316 lxc/cluster_group.go:440 lxc/cluster_group.go:522
 #: lxc/cluster_group.go:607 lxc/cluster_group.go:663 lxc/cluster_group.go:725
 #: lxc/cluster_role.go:24 lxc/cluster_role.go:51 lxc/cluster_role.go:115
-#: lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:538
-#: lxc/config.go:764 lxc/config.go:896 lxc/config.go:943 lxc/config.go:983
-#: lxc/config.go:1038 lxc/config.go:1129 lxc/config.go:1160 lxc/config.go:1214
+#: lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:542
+#: lxc/config.go:772 lxc/config.go:904 lxc/config.go:955 lxc/config.go:995
+#: lxc/config.go:1050 lxc/config.go:1141 lxc/config.go:1172 lxc/config.go:1226
 #: lxc/config_device.go:25 lxc/config_device.go:79 lxc/config_device.go:221
 #: lxc/config_device.go:318 lxc/config_device.go:401 lxc/config_device.go:503
 #: lxc/config_device.go:619 lxc/config_device.go:626 lxc/config_device.go:759
@@ -1926,7 +1926,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1213 lxc/config.go:1214
+#: lxc/config.go:1225 lxc/config.go:1226
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2050,7 +2050,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:459 lxc/config.go:654 lxc/config.go:686 lxc/network.go:1319
+#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1319
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
@@ -2060,7 +2060,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:648 lxc/config.go:680
+#: lxc/config.go:656 lxc/config.go:688
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2255,7 +2255,7 @@ msgstr ""
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:366
+#: lxc/console.go:370
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
@@ -2469,7 +2469,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:982 lxc/config.go:983
+#: lxc/config.go:994 lxc/config.go:995
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2867,7 +2867,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1008 lxc/config.go:1066 lxc/config.go:1185 lxc/config.go:1277
+#: lxc/config.go:1020 lxc/config.go:1078 lxc/config.go:1197 lxc/config.go:1289
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -3026,7 +3026,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:387
+#: lxc/console.go:391
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -3540,7 +3540,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:942 lxc/config.go:943
+#: lxc/config.go:954 lxc/config.go:955
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -4379,7 +4379,7 @@ msgstr ""
 
 #: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
@@ -4883,7 +4883,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1019
+#: lxc/config.go:1031
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5060,7 +5060,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1037 lxc/config.go:1038
+#: lxc/config.go:1049 lxc/config.go:1050
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5098,11 +5098,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:537
+#: lxc/config.go:541
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:538
+#: lxc/config.go:542
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5326,7 +5326,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:551
+#: lxc/config.go:555
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5391,7 +5391,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1159 lxc/config.go:1160
+#: lxc/config.go:1171 lxc/config.go:1172
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5399,7 +5399,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:763 lxc/config.go:764
+#: lxc/config.go:771 lxc/config.go:772
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5493,7 +5493,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:767
+#: lxc/config.go:775
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5744,7 +5744,7 @@ msgstr ""
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:126
+#: lxc/console.go:130
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -5806,12 +5806,12 @@ msgstr ""
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:479
+#: lxc/config.go:483
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:455
+#: lxc/config.go:459
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
@@ -5903,7 +5903,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:666
+#: lxc/config.go:674
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -5947,7 +5947,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:215
+#: lxc/console.go:219
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -5957,7 +5957,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:499 lxc/config.go:715 lxc/config.go:815
+#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6102,7 +6102,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:164
+#: lxc/console.go:168
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -6117,12 +6117,12 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:109
+#: lxc/console.go:113
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1128 lxc/config.go:1129
+#: lxc/config.go:1140 lxc/config.go:1141
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6142,7 +6142,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:895 lxc/config.go:896
+#: lxc/config.go:903 lxc/config.go:904
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6258,7 +6258,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:900
+#: lxc/config.go:908
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6607,7 +6607,7 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1158 lxc/config.go:1212 lxc/config_device.go:321
+#: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:321
 #: lxc/config_device.go:753 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:35
 msgid "[<remote>:]<instance>"
@@ -6629,11 +6629,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:981 lxc/config.go:1127
+#: lxc/config.go:993 lxc/config.go:1139
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1036
+#: lxc/config.go:1048
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -7030,7 +7030,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:762
+#: lxc/config.go:98 lxc/config.go:770
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7038,11 +7038,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:894
+#: lxc/config.go:391 lxc/config.go:902
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:536
+#: lxc/config.go:540
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -7166,7 +7166,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:543
+#: lxc/config.go:547
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7175,13 +7175,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1216
+#: lxc/config.go:1228
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1040
+#: lxc/config.go:1052
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-26 11:55-0600\n"
+"POT-Creation-Date: 2024-09-30 13:36-0400\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Renato dos Santos <renato.santos@wplex.com.br>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -102,7 +102,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/config.go:1227
+#: lxc/config.go:1239
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -730,7 +730,7 @@ msgstr "Configuração chave/valor para aplicar ao novo contêiner"
 msgid "--empty cannot be combined with an image name"
 msgstr "--refresh só pode ser usado com containers"
 
-#: lxc/config.go:493 lxc/config.go:809
+#: lxc/config.go:497 lxc/config.go:817
 #, fuzzy
 msgid "--expanded cannot be used with a server"
 msgstr "--refresh só pode ser usado com containers"
@@ -755,7 +755,7 @@ msgstr "--refresh só pode ser usado com containers"
 msgid "--refresh can only be used with instances"
 msgstr "--refresh só pode ser usado com containers"
 
-#: lxc/config.go:170 lxc/config.go:443 lxc/config.go:628 lxc/config.go:835
+#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
 #: lxc/info.go:461
 #, fuzzy
 msgid "--target cannot be used with instances"
@@ -1034,7 +1034,7 @@ msgstr "Arquitetura: %v"
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:388
+#: lxc/console.go:392
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -1293,7 +1293,7 @@ msgstr "Não pode especificar a coluna L, quando não em cluster"
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr "Não é possível fornecer o uid/gid/modo no modo recursivo"
 
-#: lxc/config.go:694 lxc/config.go:1084
+#: lxc/config.go:702 lxc/config.go:1096
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr "Não é possível remover chave '%s', não está atualmente definido"
@@ -1410,8 +1410,8 @@ msgstr "Dispositivo %s removido de %s"
 msgid "Cluster member %s removed from group %s"
 msgstr "Dispositivo %s removido de %s"
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:550 lxc/config.go:768
-#: lxc/config.go:899 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
+#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1251 lxc/network.go:1344 lxc/network.go:1416
 #: lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1499,7 +1499,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr "Configuração chave/valor para aplicar ao novo contêiner"
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1327 lxc/config_metadata.go:156
+#: lxc/config.go:356 lxc/config.go:1339 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
@@ -1975,9 +1975,9 @@ msgstr ""
 #: lxc/cluster_group.go:316 lxc/cluster_group.go:440 lxc/cluster_group.go:522
 #: lxc/cluster_group.go:607 lxc/cluster_group.go:663 lxc/cluster_group.go:725
 #: lxc/cluster_role.go:24 lxc/cluster_role.go:51 lxc/cluster_role.go:115
-#: lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:538
-#: lxc/config.go:764 lxc/config.go:896 lxc/config.go:943 lxc/config.go:983
-#: lxc/config.go:1038 lxc/config.go:1129 lxc/config.go:1160 lxc/config.go:1214
+#: lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:542
+#: lxc/config.go:772 lxc/config.go:904 lxc/config.go:955 lxc/config.go:995
+#: lxc/config.go:1050 lxc/config.go:1141 lxc/config.go:1172 lxc/config.go:1226
 #: lxc/config_device.go:25 lxc/config_device.go:79 lxc/config_device.go:221
 #: lxc/config_device.go:318 lxc/config_device.go:401 lxc/config_device.go:503
 #: lxc/config_device.go:619 lxc/config_device.go:626 lxc/config_device.go:759
@@ -2262,7 +2262,7 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Edit image properties"
 msgstr "Editar propriedades da imagem"
 
-#: lxc/config.go:1213 lxc/config.go:1214
+#: lxc/config.go:1225 lxc/config.go:1226
 #, fuzzy
 msgid "Edit instance UEFI variables"
 msgstr "Editar arquivos de metadados do container"
@@ -2399,7 +2399,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:459 lxc/config.go:654 lxc/config.go:686 lxc/network.go:1319
+#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1319
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
@@ -2409,7 +2409,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr "Editar propriedades da imagem"
 
-#: lxc/config.go:648 lxc/config.go:680
+#: lxc/config.go:656 lxc/config.go:688
 #, fuzzy, c-format
 msgid "Error unsetting properties: %v"
 msgstr "Editar propriedades da imagem"
@@ -2605,7 +2605,7 @@ msgstr "Nome de membro do cluster"
 msgid "Failed parsing SSH host key: %w"
 msgstr "Aceitar certificado"
 
-#: lxc/console.go:366
+#: lxc/console.go:370
 #, fuzzy, c-format
 msgid "Failed starting command: %w"
 msgstr "Aceitar certificado"
@@ -2820,7 +2820,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:982 lxc/config.go:983
+#: lxc/config.go:994 lxc/config.go:995
 #, fuzzy
 msgid "Get UEFI variables for instance"
 msgstr "Adicionar perfis aos containers"
@@ -3240,7 +3240,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1008 lxc/config.go:1066 lxc/config.go:1185 lxc/config.go:1277
+#: lxc/config.go:1020 lxc/config.go:1078 lxc/config.go:1197 lxc/config.go:1289
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -3401,7 +3401,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:387
+#: lxc/console.go:391
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -3931,7 +3931,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:942 lxc/config.go:943
+#: lxc/config.go:954 lxc/config.go:955
 #, fuzzy
 msgid "Manage instance UEFI variables"
 msgstr "Editar arquivos de metadados do container"
@@ -4809,7 +4809,7 @@ msgstr ""
 
 #: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
@@ -5338,7 +5338,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1019
+#: lxc/config.go:1031
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5525,7 +5525,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1037 lxc/config.go:1038
+#: lxc/config.go:1049 lxc/config.go:1050
 #, fuzzy
 msgid "Set UEFI variables for instance"
 msgstr "Adicionar perfis aos containers"
@@ -5567,12 +5567,12 @@ msgstr ""
 msgid "Set image properties"
 msgstr "Editar propriedades da imagem"
 
-#: lxc/config.go:537
+#: lxc/config.go:541
 #, fuzzy
 msgid "Set instance or server configuration keys"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: lxc/config.go:538
+#: lxc/config.go:542
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5811,7 +5811,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr "Desconectar volumes de armazenamento dos perfis"
 
-#: lxc/config.go:551
+#: lxc/config.go:555
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5880,7 +5880,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1159 lxc/config.go:1160
+#: lxc/config.go:1171 lxc/config.go:1172
 #, fuzzy
 msgid "Show instance UEFI variables"
 msgstr "Editar arquivos de metadados do container"
@@ -5890,7 +5890,7 @@ msgstr "Editar arquivos de metadados do container"
 msgid "Show instance metadata files"
 msgstr "Editar arquivos de metadados do container"
 
-#: lxc/config.go:763 lxc/config.go:764
+#: lxc/config.go:771 lxc/config.go:772
 #, fuzzy
 msgid "Show instance or server configurations"
 msgstr "Editar configurações do container ou do servidor como YAML"
@@ -5997,7 +5997,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:767
+#: lxc/config.go:775
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -6253,7 +6253,7 @@ msgstr "--refresh só pode ser usado com containers"
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:126
+#: lxc/console.go:130
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -6317,12 +6317,12 @@ msgstr ""
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr "Nome de membro do cluster"
 
-#: lxc/config.go:479
+#: lxc/config.go:483
 #, fuzzy, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr "Nome de membro do cluster"
 
-#: lxc/config.go:455
+#: lxc/config.go:459
 #, fuzzy, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr "Nome de membro do cluster"
@@ -6414,7 +6414,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:666
+#: lxc/config.go:674
 #, fuzzy
 msgid "There is no config key to set on an instance snapshot."
 msgstr "Nome de membro do cluster"
@@ -6460,7 +6460,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:215
+#: lxc/console.go:219
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -6470,7 +6470,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:499 lxc/config.go:715 lxc/config.go:815
+#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6617,7 +6617,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:164
+#: lxc/console.go:168
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -6632,12 +6632,12 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:109
+#: lxc/console.go:113
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1128 lxc/config.go:1129
+#: lxc/config.go:1140 lxc/config.go:1141
 #, fuzzy
 msgid "Unset UEFI variables for instance"
 msgstr "Não pode fornecer um nome para a imagem de destino"
@@ -6662,7 +6662,7 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Unset image properties"
 msgstr "Editar propriedades da imagem"
 
-#: lxc/config.go:895 lxc/config.go:896
+#: lxc/config.go:903 lxc/config.go:904
 #, fuzzy
 msgid "Unset instance or server configuration keys"
 msgstr "Editar configurações do container ou do servidor como YAML"
@@ -6797,7 +6797,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:900
+#: lxc/config.go:908
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -7173,7 +7173,7 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1158 lxc/config.go:1212 lxc/config_device.go:321
+#: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:321
 #: lxc/config_device.go:753 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:35
 msgid "[<remote>:]<instance>"
@@ -7195,12 +7195,12 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:981 lxc/config.go:1127
+#: lxc/config.go:993 lxc/config.go:1139
 #, fuzzy
 msgid "[<remote>:]<instance> <key>"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/config.go:1036
+#: lxc/config.go:1048
 #, fuzzy
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr "Editar templates de arquivo do container"
@@ -7641,7 +7641,7 @@ msgstr "Editar templates de arquivo do container"
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/config.go:98 lxc/config.go:762
+#: lxc/config.go:98 lxc/config.go:770
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7649,11 +7649,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:894
+#: lxc/config.go:391 lxc/config.go:902
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:536
+#: lxc/config.go:540
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -7780,7 +7780,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:543
+#: lxc/config.go:547
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7789,13 +7789,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1216
+#: lxc/config.go:1228
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1040
+#: lxc/config.go:1052
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-26 11:55-0600\n"
+"POT-Creation-Date: 2024-09-30 13:36-0400\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Александр Киль <shorrey@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -106,7 +106,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/config.go:1227
+#: lxc/config.go:1239
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -735,7 +735,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:493 lxc/config.go:809
+#: lxc/config.go:497 lxc/config.go:817
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -755,7 +755,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:443 lxc/config.go:628 lxc/config.go:835
+#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -1035,7 +1035,7 @@ msgstr "Архитектура: %v"
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:388
+#: lxc/console.go:392
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -1290,7 +1290,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:694 lxc/config.go:1084
+#: lxc/config.go:702 lxc/config.go:1096
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1410,8 +1410,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:550 lxc/config.go:768
-#: lxc/config.go:899 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
+#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1251 lxc/network.go:1344 lxc/network.go:1416
 #: lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1490,7 +1490,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1327 lxc/config_metadata.go:156
+#: lxc/config.go:356 lxc/config.go:1339 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
@@ -1964,9 +1964,9 @@ msgstr ""
 #: lxc/cluster_group.go:316 lxc/cluster_group.go:440 lxc/cluster_group.go:522
 #: lxc/cluster_group.go:607 lxc/cluster_group.go:663 lxc/cluster_group.go:725
 #: lxc/cluster_role.go:24 lxc/cluster_role.go:51 lxc/cluster_role.go:115
-#: lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:538
-#: lxc/config.go:764 lxc/config.go:896 lxc/config.go:943 lxc/config.go:983
-#: lxc/config.go:1038 lxc/config.go:1129 lxc/config.go:1160 lxc/config.go:1214
+#: lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:542
+#: lxc/config.go:772 lxc/config.go:904 lxc/config.go:955 lxc/config.go:995
+#: lxc/config.go:1050 lxc/config.go:1141 lxc/config.go:1172 lxc/config.go:1226
 #: lxc/config_device.go:25 lxc/config_device.go:79 lxc/config_device.go:221
 #: lxc/config_device.go:318 lxc/config_device.go:401 lxc/config_device.go:503
 #: lxc/config_device.go:619 lxc/config_device.go:626 lxc/config_device.go:759
@@ -2246,7 +2246,7 @@ msgstr "Копирование образа: %s"
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1213 lxc/config.go:1214
+#: lxc/config.go:1225 lxc/config.go:1226
 #, fuzzy
 msgid "Edit instance UEFI variables"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -2378,7 +2378,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:459 lxc/config.go:654 lxc/config.go:686 lxc/network.go:1319
+#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1319
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
@@ -2388,7 +2388,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr "Копирование образа: %s"
 
-#: lxc/config.go:648 lxc/config.go:680
+#: lxc/config.go:656 lxc/config.go:688
 #, fuzzy, c-format
 msgid "Error unsetting properties: %v"
 msgstr "Копирование образа: %s"
@@ -2592,7 +2592,7 @@ msgstr "Копирование образа: %s"
 msgid "Failed parsing SSH host key: %w"
 msgstr "Принять сертификат"
 
-#: lxc/console.go:366
+#: lxc/console.go:370
 #, fuzzy, c-format
 msgid "Failed starting command: %w"
 msgstr "Принять сертификат"
@@ -2807,7 +2807,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:982 lxc/config.go:983
+#: lxc/config.go:994 lxc/config.go:995
 #, fuzzy
 msgid "Get UEFI variables for instance"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -3228,7 +3228,7 @@ msgstr "Имя контейнера является обязательным"
 msgid "Instance name is: %s"
 msgstr "Имя контейнера: %s"
 
-#: lxc/config.go:1008 lxc/config.go:1066 lxc/config.go:1185 lxc/config.go:1277
+#: lxc/config.go:1020 lxc/config.go:1078 lxc/config.go:1197 lxc/config.go:1289
 #, fuzzy
 msgid "Instance name must be specified"
 msgstr "Имя контейнера: %s"
@@ -3390,7 +3390,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:387
+#: lxc/console.go:391
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -3929,7 +3929,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:942 lxc/config.go:943
+#: lxc/config.go:954 lxc/config.go:955
 #, fuzzy
 msgid "Manage instance UEFI variables"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -4817,7 +4817,7 @@ msgstr ""
 
 #: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
@@ -5338,7 +5338,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1019
+#: lxc/config.go:1031
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5522,7 +5522,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1037 lxc/config.go:1038
+#: lxc/config.go:1049 lxc/config.go:1050
 #, fuzzy
 msgid "Set UEFI variables for instance"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -5562,11 +5562,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:537
+#: lxc/config.go:541
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:538
+#: lxc/config.go:542
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5804,7 +5804,7 @@ msgstr "Копирование образа: %s"
 msgid "Set the key as a storage volume property"
 msgstr "Копирование образа: %s"
 
-#: lxc/config.go:551
+#: lxc/config.go:555
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5872,7 +5872,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1159 lxc/config.go:1160
+#: lxc/config.go:1171 lxc/config.go:1172
 #, fuzzy
 msgid "Show instance UEFI variables"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -5882,7 +5882,7 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Show instance metadata files"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/config.go:763 lxc/config.go:764
+#: lxc/config.go:771 lxc/config.go:772
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5986,7 +5986,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:767
+#: lxc/config.go:775
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -6244,7 +6244,7 @@ msgstr ""
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:126
+#: lxc/console.go:130
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -6306,12 +6306,12 @@ msgstr ""
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr "Копирование образа: %s"
 
-#: lxc/config.go:479
+#: lxc/config.go:483
 #, fuzzy, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr "Копирование образа: %s"
 
-#: lxc/config.go:455
+#: lxc/config.go:459
 #, fuzzy, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr "Копирование образа: %s"
@@ -6403,7 +6403,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:666
+#: lxc/config.go:674
 #, fuzzy
 msgid "There is no config key to set on an instance snapshot."
 msgstr "Копирование образа: %s"
@@ -6448,7 +6448,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:215
+#: lxc/console.go:219
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -6458,7 +6458,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:499 lxc/config.go:715 lxc/config.go:815
+#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6604,7 +6604,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:164
+#: lxc/console.go:168
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -6619,12 +6619,12 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:109
+#: lxc/console.go:113
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1128 lxc/config.go:1129
+#: lxc/config.go:1140 lxc/config.go:1141
 #, fuzzy
 msgid "Unset UEFI variables for instance"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -6646,7 +6646,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:895 lxc/config.go:896
+#: lxc/config.go:903 lxc/config.go:904
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6780,7 +6780,7 @@ msgstr "Копирование образа: %s"
 msgid "Unset the key as a storage volume property"
 msgstr "Копирование образа: %s"
 
-#: lxc/config.go:900
+#: lxc/config.go:908
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -7287,7 +7287,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config.go:1158 lxc/config.go:1212 lxc/config_device.go:321
+#: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:321
 #: lxc/config_device.go:753 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:35
 #, fuzzy
@@ -7329,7 +7329,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config.go:981 lxc/config.go:1127
+#: lxc/config.go:993 lxc/config.go:1139
 #, fuzzy
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
@@ -7337,7 +7337,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config.go:1036
+#: lxc/config.go:1048
 #, fuzzy
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
@@ -8102,7 +8102,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config.go:98 lxc/config.go:762
+#: lxc/config.go:98 lxc/config.go:770
 #, fuzzy
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
@@ -8118,7 +8118,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config.go:391 lxc/config.go:894
+#: lxc/config.go:391 lxc/config.go:902
 #, fuzzy
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
@@ -8126,7 +8126,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config.go:536
+#: lxc/config.go:540
 #, fuzzy
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
@@ -8266,7 +8266,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:543
+#: lxc/config.go:547
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -8275,13 +8275,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1216
+#: lxc/config.go:1228
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1040
+#: lxc/config.go:1052
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"

--- a/po/si.po
+++ b/po/si.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-26 11:55-0600\n"
+"POT-Creation-Date: 2024-09-30 13:36-0400\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Sinhala <https://hosted.weblate.org/projects/linux-containers/"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1227
+#: lxc/config.go:1239
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -478,7 +478,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:493 lxc/config.go:809
+#: lxc/config.go:497 lxc/config.go:817
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -498,7 +498,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:443 lxc/config.go:628 lxc/config.go:835
+#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -765,7 +765,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:388
+#: lxc/console.go:392
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:694 lxc/config.go:1084
+#: lxc/config.go:702 lxc/config.go:1096
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1130,8 +1130,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:550 lxc/config.go:768
-#: lxc/config.go:899 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
+#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1251 lxc/network.go:1344 lxc/network.go:1416
 #: lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1210,7 +1210,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1327 lxc/config_metadata.go:156
+#: lxc/config.go:356 lxc/config.go:1339 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
@@ -1654,9 +1654,9 @@ msgstr ""
 #: lxc/cluster_group.go:316 lxc/cluster_group.go:440 lxc/cluster_group.go:522
 #: lxc/cluster_group.go:607 lxc/cluster_group.go:663 lxc/cluster_group.go:725
 #: lxc/cluster_role.go:24 lxc/cluster_role.go:51 lxc/cluster_role.go:115
-#: lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:538
-#: lxc/config.go:764 lxc/config.go:896 lxc/config.go:943 lxc/config.go:983
-#: lxc/config.go:1038 lxc/config.go:1129 lxc/config.go:1160 lxc/config.go:1214
+#: lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:542
+#: lxc/config.go:772 lxc/config.go:904 lxc/config.go:955 lxc/config.go:995
+#: lxc/config.go:1050 lxc/config.go:1141 lxc/config.go:1172 lxc/config.go:1226
 #: lxc/config_device.go:25 lxc/config_device.go:79 lxc/config_device.go:221
 #: lxc/config_device.go:318 lxc/config_device.go:401 lxc/config_device.go:503
 #: lxc/config_device.go:619 lxc/config_device.go:626 lxc/config_device.go:759
@@ -1929,7 +1929,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1213 lxc/config.go:1214
+#: lxc/config.go:1225 lxc/config.go:1226
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2053,7 +2053,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:459 lxc/config.go:654 lxc/config.go:686 lxc/network.go:1319
+#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1319
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
@@ -2063,7 +2063,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:648 lxc/config.go:680
+#: lxc/config.go:656 lxc/config.go:688
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2258,7 +2258,7 @@ msgstr ""
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:366
+#: lxc/console.go:370
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
@@ -2472,7 +2472,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:982 lxc/config.go:983
+#: lxc/config.go:994 lxc/config.go:995
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2870,7 +2870,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1008 lxc/config.go:1066 lxc/config.go:1185 lxc/config.go:1277
+#: lxc/config.go:1020 lxc/config.go:1078 lxc/config.go:1197 lxc/config.go:1289
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -3029,7 +3029,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:387
+#: lxc/console.go:391
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -3543,7 +3543,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:942 lxc/config.go:943
+#: lxc/config.go:954 lxc/config.go:955
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -4382,7 +4382,7 @@ msgstr ""
 
 #: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
@@ -4886,7 +4886,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1019
+#: lxc/config.go:1031
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5063,7 +5063,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1037 lxc/config.go:1038
+#: lxc/config.go:1049 lxc/config.go:1050
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5101,11 +5101,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:537
+#: lxc/config.go:541
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:538
+#: lxc/config.go:542
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5329,7 +5329,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:551
+#: lxc/config.go:555
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5394,7 +5394,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1159 lxc/config.go:1160
+#: lxc/config.go:1171 lxc/config.go:1172
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5402,7 +5402,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:763 lxc/config.go:764
+#: lxc/config.go:771 lxc/config.go:772
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5496,7 +5496,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:767
+#: lxc/config.go:775
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5747,7 +5747,7 @@ msgstr ""
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:126
+#: lxc/console.go:130
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -5809,12 +5809,12 @@ msgstr ""
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:479
+#: lxc/config.go:483
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:455
+#: lxc/config.go:459
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
@@ -5906,7 +5906,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:666
+#: lxc/config.go:674
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -5950,7 +5950,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:215
+#: lxc/console.go:219
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -5960,7 +5960,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:499 lxc/config.go:715 lxc/config.go:815
+#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6105,7 +6105,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:164
+#: lxc/console.go:168
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -6120,12 +6120,12 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:109
+#: lxc/console.go:113
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1128 lxc/config.go:1129
+#: lxc/config.go:1140 lxc/config.go:1141
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6145,7 +6145,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:895 lxc/config.go:896
+#: lxc/config.go:903 lxc/config.go:904
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6261,7 +6261,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:900
+#: lxc/config.go:908
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6610,7 +6610,7 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1158 lxc/config.go:1212 lxc/config_device.go:321
+#: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:321
 #: lxc/config_device.go:753 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:35
 msgid "[<remote>:]<instance>"
@@ -6632,11 +6632,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:981 lxc/config.go:1127
+#: lxc/config.go:993 lxc/config.go:1139
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1036
+#: lxc/config.go:1048
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -7033,7 +7033,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:762
+#: lxc/config.go:98 lxc/config.go:770
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7041,11 +7041,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:894
+#: lxc/config.go:391 lxc/config.go:902
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:536
+#: lxc/config.go:540
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -7169,7 +7169,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:543
+#: lxc/config.go:547
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7178,13 +7178,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1216
+#: lxc/config.go:1228
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1040
+#: lxc/config.go:1052
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"

--- a/po/sl.po
+++ b/po/sl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-26 11:55-0600\n"
+"POT-Creation-Date: 2024-09-30 13:36-0400\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Slovenian <https://hosted.weblate.org/projects/linux-"
@@ -64,7 +64,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1227
+#: lxc/config.go:1239
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -479,7 +479,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:493 lxc/config.go:809
+#: lxc/config.go:497 lxc/config.go:817
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -499,7 +499,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:443 lxc/config.go:628 lxc/config.go:835
+#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -766,7 +766,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:388
+#: lxc/console.go:392
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -1016,7 +1016,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:694 lxc/config.go:1084
+#: lxc/config.go:702 lxc/config.go:1096
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1131,8 +1131,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:550 lxc/config.go:768
-#: lxc/config.go:899 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
+#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1251 lxc/network.go:1344 lxc/network.go:1416
 #: lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1211,7 +1211,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1327 lxc/config_metadata.go:156
+#: lxc/config.go:356 lxc/config.go:1339 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
@@ -1655,9 +1655,9 @@ msgstr ""
 #: lxc/cluster_group.go:316 lxc/cluster_group.go:440 lxc/cluster_group.go:522
 #: lxc/cluster_group.go:607 lxc/cluster_group.go:663 lxc/cluster_group.go:725
 #: lxc/cluster_role.go:24 lxc/cluster_role.go:51 lxc/cluster_role.go:115
-#: lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:538
-#: lxc/config.go:764 lxc/config.go:896 lxc/config.go:943 lxc/config.go:983
-#: lxc/config.go:1038 lxc/config.go:1129 lxc/config.go:1160 lxc/config.go:1214
+#: lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:542
+#: lxc/config.go:772 lxc/config.go:904 lxc/config.go:955 lxc/config.go:995
+#: lxc/config.go:1050 lxc/config.go:1141 lxc/config.go:1172 lxc/config.go:1226
 #: lxc/config_device.go:25 lxc/config_device.go:79 lxc/config_device.go:221
 #: lxc/config_device.go:318 lxc/config_device.go:401 lxc/config_device.go:503
 #: lxc/config_device.go:619 lxc/config_device.go:626 lxc/config_device.go:759
@@ -1930,7 +1930,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1213 lxc/config.go:1214
+#: lxc/config.go:1225 lxc/config.go:1226
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2054,7 +2054,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:459 lxc/config.go:654 lxc/config.go:686 lxc/network.go:1319
+#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1319
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
@@ -2064,7 +2064,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:648 lxc/config.go:680
+#: lxc/config.go:656 lxc/config.go:688
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2259,7 +2259,7 @@ msgstr ""
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:366
+#: lxc/console.go:370
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
@@ -2473,7 +2473,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:982 lxc/config.go:983
+#: lxc/config.go:994 lxc/config.go:995
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2871,7 +2871,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1008 lxc/config.go:1066 lxc/config.go:1185 lxc/config.go:1277
+#: lxc/config.go:1020 lxc/config.go:1078 lxc/config.go:1197 lxc/config.go:1289
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -3030,7 +3030,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:387
+#: lxc/console.go:391
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -3544,7 +3544,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:942 lxc/config.go:943
+#: lxc/config.go:954 lxc/config.go:955
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -4383,7 +4383,7 @@ msgstr ""
 
 #: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
@@ -4887,7 +4887,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1019
+#: lxc/config.go:1031
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5064,7 +5064,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1037 lxc/config.go:1038
+#: lxc/config.go:1049 lxc/config.go:1050
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5102,11 +5102,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:537
+#: lxc/config.go:541
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:538
+#: lxc/config.go:542
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5330,7 +5330,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:551
+#: lxc/config.go:555
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5395,7 +5395,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1159 lxc/config.go:1160
+#: lxc/config.go:1171 lxc/config.go:1172
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5403,7 +5403,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:763 lxc/config.go:764
+#: lxc/config.go:771 lxc/config.go:772
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5497,7 +5497,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:767
+#: lxc/config.go:775
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5748,7 +5748,7 @@ msgstr ""
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:126
+#: lxc/console.go:130
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -5810,12 +5810,12 @@ msgstr ""
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:479
+#: lxc/config.go:483
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:455
+#: lxc/config.go:459
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
@@ -5907,7 +5907,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:666
+#: lxc/config.go:674
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -5951,7 +5951,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:215
+#: lxc/console.go:219
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -5961,7 +5961,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:499 lxc/config.go:715 lxc/config.go:815
+#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6106,7 +6106,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:164
+#: lxc/console.go:168
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -6121,12 +6121,12 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:109
+#: lxc/console.go:113
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1128 lxc/config.go:1129
+#: lxc/config.go:1140 lxc/config.go:1141
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6146,7 +6146,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:895 lxc/config.go:896
+#: lxc/config.go:903 lxc/config.go:904
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6262,7 +6262,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:900
+#: lxc/config.go:908
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6611,7 +6611,7 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1158 lxc/config.go:1212 lxc/config_device.go:321
+#: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:321
 #: lxc/config_device.go:753 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:35
 msgid "[<remote>:]<instance>"
@@ -6633,11 +6633,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:981 lxc/config.go:1127
+#: lxc/config.go:993 lxc/config.go:1139
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1036
+#: lxc/config.go:1048
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -7034,7 +7034,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:762
+#: lxc/config.go:98 lxc/config.go:770
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7042,11 +7042,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:894
+#: lxc/config.go:391 lxc/config.go:902
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:536
+#: lxc/config.go:540
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -7170,7 +7170,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:543
+#: lxc/config.go:547
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7179,13 +7179,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1216
+#: lxc/config.go:1228
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1040
+#: lxc/config.go:1052
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-26 11:55-0600\n"
+"POT-Creation-Date: 2024-09-30 13:36-0400\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Serbian <https://hosted.weblate.org/projects/linux-containers/"
@@ -64,7 +64,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1227
+#: lxc/config.go:1239
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -479,7 +479,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:493 lxc/config.go:809
+#: lxc/config.go:497 lxc/config.go:817
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -499,7 +499,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:443 lxc/config.go:628 lxc/config.go:835
+#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -766,7 +766,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:388
+#: lxc/console.go:392
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -1016,7 +1016,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:694 lxc/config.go:1084
+#: lxc/config.go:702 lxc/config.go:1096
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1131,8 +1131,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:550 lxc/config.go:768
-#: lxc/config.go:899 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
+#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1251 lxc/network.go:1344 lxc/network.go:1416
 #: lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1211,7 +1211,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1327 lxc/config_metadata.go:156
+#: lxc/config.go:356 lxc/config.go:1339 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
@@ -1655,9 +1655,9 @@ msgstr ""
 #: lxc/cluster_group.go:316 lxc/cluster_group.go:440 lxc/cluster_group.go:522
 #: lxc/cluster_group.go:607 lxc/cluster_group.go:663 lxc/cluster_group.go:725
 #: lxc/cluster_role.go:24 lxc/cluster_role.go:51 lxc/cluster_role.go:115
-#: lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:538
-#: lxc/config.go:764 lxc/config.go:896 lxc/config.go:943 lxc/config.go:983
-#: lxc/config.go:1038 lxc/config.go:1129 lxc/config.go:1160 lxc/config.go:1214
+#: lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:542
+#: lxc/config.go:772 lxc/config.go:904 lxc/config.go:955 lxc/config.go:995
+#: lxc/config.go:1050 lxc/config.go:1141 lxc/config.go:1172 lxc/config.go:1226
 #: lxc/config_device.go:25 lxc/config_device.go:79 lxc/config_device.go:221
 #: lxc/config_device.go:318 lxc/config_device.go:401 lxc/config_device.go:503
 #: lxc/config_device.go:619 lxc/config_device.go:626 lxc/config_device.go:759
@@ -1930,7 +1930,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1213 lxc/config.go:1214
+#: lxc/config.go:1225 lxc/config.go:1226
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2054,7 +2054,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:459 lxc/config.go:654 lxc/config.go:686 lxc/network.go:1319
+#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1319
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
@@ -2064,7 +2064,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:648 lxc/config.go:680
+#: lxc/config.go:656 lxc/config.go:688
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2259,7 +2259,7 @@ msgstr ""
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:366
+#: lxc/console.go:370
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
@@ -2473,7 +2473,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:982 lxc/config.go:983
+#: lxc/config.go:994 lxc/config.go:995
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2871,7 +2871,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1008 lxc/config.go:1066 lxc/config.go:1185 lxc/config.go:1277
+#: lxc/config.go:1020 lxc/config.go:1078 lxc/config.go:1197 lxc/config.go:1289
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -3030,7 +3030,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:387
+#: lxc/console.go:391
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -3544,7 +3544,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:942 lxc/config.go:943
+#: lxc/config.go:954 lxc/config.go:955
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -4383,7 +4383,7 @@ msgstr ""
 
 #: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
@@ -4887,7 +4887,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1019
+#: lxc/config.go:1031
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5064,7 +5064,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1037 lxc/config.go:1038
+#: lxc/config.go:1049 lxc/config.go:1050
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5102,11 +5102,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:537
+#: lxc/config.go:541
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:538
+#: lxc/config.go:542
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5330,7 +5330,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:551
+#: lxc/config.go:555
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5395,7 +5395,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1159 lxc/config.go:1160
+#: lxc/config.go:1171 lxc/config.go:1172
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5403,7 +5403,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:763 lxc/config.go:764
+#: lxc/config.go:771 lxc/config.go:772
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5497,7 +5497,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:767
+#: lxc/config.go:775
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5748,7 +5748,7 @@ msgstr ""
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:126
+#: lxc/console.go:130
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -5810,12 +5810,12 @@ msgstr ""
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:479
+#: lxc/config.go:483
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:455
+#: lxc/config.go:459
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
@@ -5907,7 +5907,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:666
+#: lxc/config.go:674
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -5951,7 +5951,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:215
+#: lxc/console.go:219
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -5961,7 +5961,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:499 lxc/config.go:715 lxc/config.go:815
+#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6106,7 +6106,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:164
+#: lxc/console.go:168
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -6121,12 +6121,12 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:109
+#: lxc/console.go:113
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1128 lxc/config.go:1129
+#: lxc/config.go:1140 lxc/config.go:1141
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6146,7 +6146,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:895 lxc/config.go:896
+#: lxc/config.go:903 lxc/config.go:904
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6262,7 +6262,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:900
+#: lxc/config.go:908
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6611,7 +6611,7 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1158 lxc/config.go:1212 lxc/config_device.go:321
+#: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:321
 #: lxc/config_device.go:753 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:35
 msgid "[<remote>:]<instance>"
@@ -6633,11 +6633,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:981 lxc/config.go:1127
+#: lxc/config.go:993 lxc/config.go:1139
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1036
+#: lxc/config.go:1048
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -7034,7 +7034,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:762
+#: lxc/config.go:98 lxc/config.go:770
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7042,11 +7042,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:894
+#: lxc/config.go:391 lxc/config.go:902
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:536
+#: lxc/config.go:540
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -7170,7 +7170,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:543
+#: lxc/config.go:547
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7179,13 +7179,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1216
+#: lxc/config.go:1228
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1040
+#: lxc/config.go:1052
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-26 11:55-0600\n"
+"POT-Creation-Date: 2024-09-30 13:36-0400\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Swedish <https://hosted.weblate.org/projects/linux-containers/"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1227
+#: lxc/config.go:1239
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -478,7 +478,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:493 lxc/config.go:809
+#: lxc/config.go:497 lxc/config.go:817
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -498,7 +498,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:443 lxc/config.go:628 lxc/config.go:835
+#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -765,7 +765,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:388
+#: lxc/console.go:392
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:694 lxc/config.go:1084
+#: lxc/config.go:702 lxc/config.go:1096
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1130,8 +1130,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:550 lxc/config.go:768
-#: lxc/config.go:899 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
+#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1251 lxc/network.go:1344 lxc/network.go:1416
 #: lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1210,7 +1210,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1327 lxc/config_metadata.go:156
+#: lxc/config.go:356 lxc/config.go:1339 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
@@ -1654,9 +1654,9 @@ msgstr ""
 #: lxc/cluster_group.go:316 lxc/cluster_group.go:440 lxc/cluster_group.go:522
 #: lxc/cluster_group.go:607 lxc/cluster_group.go:663 lxc/cluster_group.go:725
 #: lxc/cluster_role.go:24 lxc/cluster_role.go:51 lxc/cluster_role.go:115
-#: lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:538
-#: lxc/config.go:764 lxc/config.go:896 lxc/config.go:943 lxc/config.go:983
-#: lxc/config.go:1038 lxc/config.go:1129 lxc/config.go:1160 lxc/config.go:1214
+#: lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:542
+#: lxc/config.go:772 lxc/config.go:904 lxc/config.go:955 lxc/config.go:995
+#: lxc/config.go:1050 lxc/config.go:1141 lxc/config.go:1172 lxc/config.go:1226
 #: lxc/config_device.go:25 lxc/config_device.go:79 lxc/config_device.go:221
 #: lxc/config_device.go:318 lxc/config_device.go:401 lxc/config_device.go:503
 #: lxc/config_device.go:619 lxc/config_device.go:626 lxc/config_device.go:759
@@ -1929,7 +1929,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1213 lxc/config.go:1214
+#: lxc/config.go:1225 lxc/config.go:1226
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2053,7 +2053,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:459 lxc/config.go:654 lxc/config.go:686 lxc/network.go:1319
+#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1319
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
@@ -2063,7 +2063,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:648 lxc/config.go:680
+#: lxc/config.go:656 lxc/config.go:688
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2258,7 +2258,7 @@ msgstr ""
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:366
+#: lxc/console.go:370
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
@@ -2472,7 +2472,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:982 lxc/config.go:983
+#: lxc/config.go:994 lxc/config.go:995
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2870,7 +2870,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1008 lxc/config.go:1066 lxc/config.go:1185 lxc/config.go:1277
+#: lxc/config.go:1020 lxc/config.go:1078 lxc/config.go:1197 lxc/config.go:1289
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -3029,7 +3029,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:387
+#: lxc/console.go:391
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -3543,7 +3543,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:942 lxc/config.go:943
+#: lxc/config.go:954 lxc/config.go:955
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -4382,7 +4382,7 @@ msgstr ""
 
 #: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
@@ -4886,7 +4886,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1019
+#: lxc/config.go:1031
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5063,7 +5063,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1037 lxc/config.go:1038
+#: lxc/config.go:1049 lxc/config.go:1050
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5101,11 +5101,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:537
+#: lxc/config.go:541
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:538
+#: lxc/config.go:542
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5329,7 +5329,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:551
+#: lxc/config.go:555
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5394,7 +5394,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1159 lxc/config.go:1160
+#: lxc/config.go:1171 lxc/config.go:1172
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5402,7 +5402,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:763 lxc/config.go:764
+#: lxc/config.go:771 lxc/config.go:772
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5496,7 +5496,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:767
+#: lxc/config.go:775
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5747,7 +5747,7 @@ msgstr ""
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:126
+#: lxc/console.go:130
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -5809,12 +5809,12 @@ msgstr ""
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:479
+#: lxc/config.go:483
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:455
+#: lxc/config.go:459
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
@@ -5906,7 +5906,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:666
+#: lxc/config.go:674
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -5950,7 +5950,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:215
+#: lxc/console.go:219
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -5960,7 +5960,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:499 lxc/config.go:715 lxc/config.go:815
+#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6105,7 +6105,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:164
+#: lxc/console.go:168
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -6120,12 +6120,12 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:109
+#: lxc/console.go:113
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1128 lxc/config.go:1129
+#: lxc/config.go:1140 lxc/config.go:1141
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6145,7 +6145,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:895 lxc/config.go:896
+#: lxc/config.go:903 lxc/config.go:904
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6261,7 +6261,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:900
+#: lxc/config.go:908
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6610,7 +6610,7 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1158 lxc/config.go:1212 lxc/config_device.go:321
+#: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:321
 #: lxc/config_device.go:753 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:35
 msgid "[<remote>:]<instance>"
@@ -6632,11 +6632,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:981 lxc/config.go:1127
+#: lxc/config.go:993 lxc/config.go:1139
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1036
+#: lxc/config.go:1048
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -7033,7 +7033,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:762
+#: lxc/config.go:98 lxc/config.go:770
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7041,11 +7041,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:894
+#: lxc/config.go:391 lxc/config.go:902
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:536
+#: lxc/config.go:540
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -7169,7 +7169,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:543
+#: lxc/config.go:547
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7178,13 +7178,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1216
+#: lxc/config.go:1228
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1040
+#: lxc/config.go:1052
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"

--- a/po/te.po
+++ b/po/te.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-26 11:55-0600\n"
+"POT-Creation-Date: 2024-09-30 13:36-0400\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Telugu <https://hosted.weblate.org/projects/linux-containers/"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1227
+#: lxc/config.go:1239
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -478,7 +478,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:493 lxc/config.go:809
+#: lxc/config.go:497 lxc/config.go:817
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -498,7 +498,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:443 lxc/config.go:628 lxc/config.go:835
+#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -765,7 +765,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:388
+#: lxc/console.go:392
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:694 lxc/config.go:1084
+#: lxc/config.go:702 lxc/config.go:1096
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1130,8 +1130,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:550 lxc/config.go:768
-#: lxc/config.go:899 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
+#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1251 lxc/network.go:1344 lxc/network.go:1416
 #: lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1210,7 +1210,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1327 lxc/config_metadata.go:156
+#: lxc/config.go:356 lxc/config.go:1339 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
@@ -1654,9 +1654,9 @@ msgstr ""
 #: lxc/cluster_group.go:316 lxc/cluster_group.go:440 lxc/cluster_group.go:522
 #: lxc/cluster_group.go:607 lxc/cluster_group.go:663 lxc/cluster_group.go:725
 #: lxc/cluster_role.go:24 lxc/cluster_role.go:51 lxc/cluster_role.go:115
-#: lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:538
-#: lxc/config.go:764 lxc/config.go:896 lxc/config.go:943 lxc/config.go:983
-#: lxc/config.go:1038 lxc/config.go:1129 lxc/config.go:1160 lxc/config.go:1214
+#: lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:542
+#: lxc/config.go:772 lxc/config.go:904 lxc/config.go:955 lxc/config.go:995
+#: lxc/config.go:1050 lxc/config.go:1141 lxc/config.go:1172 lxc/config.go:1226
 #: lxc/config_device.go:25 lxc/config_device.go:79 lxc/config_device.go:221
 #: lxc/config_device.go:318 lxc/config_device.go:401 lxc/config_device.go:503
 #: lxc/config_device.go:619 lxc/config_device.go:626 lxc/config_device.go:759
@@ -1929,7 +1929,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1213 lxc/config.go:1214
+#: lxc/config.go:1225 lxc/config.go:1226
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2053,7 +2053,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:459 lxc/config.go:654 lxc/config.go:686 lxc/network.go:1319
+#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1319
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
@@ -2063,7 +2063,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:648 lxc/config.go:680
+#: lxc/config.go:656 lxc/config.go:688
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2258,7 +2258,7 @@ msgstr ""
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:366
+#: lxc/console.go:370
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
@@ -2472,7 +2472,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:982 lxc/config.go:983
+#: lxc/config.go:994 lxc/config.go:995
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2870,7 +2870,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1008 lxc/config.go:1066 lxc/config.go:1185 lxc/config.go:1277
+#: lxc/config.go:1020 lxc/config.go:1078 lxc/config.go:1197 lxc/config.go:1289
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -3029,7 +3029,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:387
+#: lxc/console.go:391
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -3543,7 +3543,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:942 lxc/config.go:943
+#: lxc/config.go:954 lxc/config.go:955
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -4382,7 +4382,7 @@ msgstr ""
 
 #: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
@@ -4886,7 +4886,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1019
+#: lxc/config.go:1031
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5063,7 +5063,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1037 lxc/config.go:1038
+#: lxc/config.go:1049 lxc/config.go:1050
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5101,11 +5101,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:537
+#: lxc/config.go:541
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:538
+#: lxc/config.go:542
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5329,7 +5329,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:551
+#: lxc/config.go:555
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5394,7 +5394,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1159 lxc/config.go:1160
+#: lxc/config.go:1171 lxc/config.go:1172
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5402,7 +5402,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:763 lxc/config.go:764
+#: lxc/config.go:771 lxc/config.go:772
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5496,7 +5496,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:767
+#: lxc/config.go:775
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5747,7 +5747,7 @@ msgstr ""
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:126
+#: lxc/console.go:130
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -5809,12 +5809,12 @@ msgstr ""
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:479
+#: lxc/config.go:483
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:455
+#: lxc/config.go:459
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
@@ -5906,7 +5906,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:666
+#: lxc/config.go:674
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -5950,7 +5950,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:215
+#: lxc/console.go:219
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -5960,7 +5960,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:499 lxc/config.go:715 lxc/config.go:815
+#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6105,7 +6105,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:164
+#: lxc/console.go:168
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -6120,12 +6120,12 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:109
+#: lxc/console.go:113
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1128 lxc/config.go:1129
+#: lxc/config.go:1140 lxc/config.go:1141
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6145,7 +6145,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:895 lxc/config.go:896
+#: lxc/config.go:903 lxc/config.go:904
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6261,7 +6261,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:900
+#: lxc/config.go:908
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6610,7 +6610,7 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1158 lxc/config.go:1212 lxc/config_device.go:321
+#: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:321
 #: lxc/config_device.go:753 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:35
 msgid "[<remote>:]<instance>"
@@ -6632,11 +6632,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:981 lxc/config.go:1127
+#: lxc/config.go:993 lxc/config.go:1139
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1036
+#: lxc/config.go:1048
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -7033,7 +7033,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:762
+#: lxc/config.go:98 lxc/config.go:770
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7041,11 +7041,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:894
+#: lxc/config.go:391 lxc/config.go:902
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:536
+#: lxc/config.go:540
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -7169,7 +7169,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:543
+#: lxc/config.go:547
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7178,13 +7178,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1216
+#: lxc/config.go:1228
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1040
+#: lxc/config.go:1052
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"

--- a/po/th.po
+++ b/po/th.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-26 11:55-0600\n"
+"POT-Creation-Date: 2024-09-30 13:36-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -60,7 +60,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1227
+#: lxc/config.go:1239
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -475,7 +475,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:493 lxc/config.go:809
+#: lxc/config.go:497 lxc/config.go:817
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -495,7 +495,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:443 lxc/config.go:628 lxc/config.go:835
+#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -762,7 +762,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:388
+#: lxc/console.go:392
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -1012,7 +1012,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:694 lxc/config.go:1084
+#: lxc/config.go:702 lxc/config.go:1096
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1127,8 +1127,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:550 lxc/config.go:768
-#: lxc/config.go:899 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
+#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1251 lxc/network.go:1344 lxc/network.go:1416
 #: lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1207,7 +1207,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1327 lxc/config_metadata.go:156
+#: lxc/config.go:356 lxc/config.go:1339 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
@@ -1651,9 +1651,9 @@ msgstr ""
 #: lxc/cluster_group.go:316 lxc/cluster_group.go:440 lxc/cluster_group.go:522
 #: lxc/cluster_group.go:607 lxc/cluster_group.go:663 lxc/cluster_group.go:725
 #: lxc/cluster_role.go:24 lxc/cluster_role.go:51 lxc/cluster_role.go:115
-#: lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:538
-#: lxc/config.go:764 lxc/config.go:896 lxc/config.go:943 lxc/config.go:983
-#: lxc/config.go:1038 lxc/config.go:1129 lxc/config.go:1160 lxc/config.go:1214
+#: lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:542
+#: lxc/config.go:772 lxc/config.go:904 lxc/config.go:955 lxc/config.go:995
+#: lxc/config.go:1050 lxc/config.go:1141 lxc/config.go:1172 lxc/config.go:1226
 #: lxc/config_device.go:25 lxc/config_device.go:79 lxc/config_device.go:221
 #: lxc/config_device.go:318 lxc/config_device.go:401 lxc/config_device.go:503
 #: lxc/config_device.go:619 lxc/config_device.go:626 lxc/config_device.go:759
@@ -1926,7 +1926,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1213 lxc/config.go:1214
+#: lxc/config.go:1225 lxc/config.go:1226
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2050,7 +2050,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:459 lxc/config.go:654 lxc/config.go:686 lxc/network.go:1319
+#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1319
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
@@ -2060,7 +2060,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:648 lxc/config.go:680
+#: lxc/config.go:656 lxc/config.go:688
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2255,7 +2255,7 @@ msgstr ""
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:366
+#: lxc/console.go:370
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
@@ -2469,7 +2469,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:982 lxc/config.go:983
+#: lxc/config.go:994 lxc/config.go:995
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2867,7 +2867,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1008 lxc/config.go:1066 lxc/config.go:1185 lxc/config.go:1277
+#: lxc/config.go:1020 lxc/config.go:1078 lxc/config.go:1197 lxc/config.go:1289
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -3026,7 +3026,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:387
+#: lxc/console.go:391
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -3540,7 +3540,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:942 lxc/config.go:943
+#: lxc/config.go:954 lxc/config.go:955
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -4379,7 +4379,7 @@ msgstr ""
 
 #: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
@@ -4883,7 +4883,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1019
+#: lxc/config.go:1031
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5060,7 +5060,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1037 lxc/config.go:1038
+#: lxc/config.go:1049 lxc/config.go:1050
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5098,11 +5098,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:537
+#: lxc/config.go:541
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:538
+#: lxc/config.go:542
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5326,7 +5326,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:551
+#: lxc/config.go:555
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5391,7 +5391,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1159 lxc/config.go:1160
+#: lxc/config.go:1171 lxc/config.go:1172
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5399,7 +5399,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:763 lxc/config.go:764
+#: lxc/config.go:771 lxc/config.go:772
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5493,7 +5493,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:767
+#: lxc/config.go:775
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5744,7 +5744,7 @@ msgstr ""
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:126
+#: lxc/console.go:130
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -5806,12 +5806,12 @@ msgstr ""
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:479
+#: lxc/config.go:483
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:455
+#: lxc/config.go:459
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
@@ -5903,7 +5903,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:666
+#: lxc/config.go:674
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -5947,7 +5947,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:215
+#: lxc/console.go:219
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -5957,7 +5957,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:499 lxc/config.go:715 lxc/config.go:815
+#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6102,7 +6102,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:164
+#: lxc/console.go:168
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -6117,12 +6117,12 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:109
+#: lxc/console.go:113
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1128 lxc/config.go:1129
+#: lxc/config.go:1140 lxc/config.go:1141
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6142,7 +6142,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:895 lxc/config.go:896
+#: lxc/config.go:903 lxc/config.go:904
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6258,7 +6258,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:900
+#: lxc/config.go:908
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6607,7 +6607,7 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1158 lxc/config.go:1212 lxc/config_device.go:321
+#: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:321
 #: lxc/config_device.go:753 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:35
 msgid "[<remote>:]<instance>"
@@ -6629,11 +6629,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:981 lxc/config.go:1127
+#: lxc/config.go:993 lxc/config.go:1139
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1036
+#: lxc/config.go:1048
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -7030,7 +7030,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:762
+#: lxc/config.go:98 lxc/config.go:770
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7038,11 +7038,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:894
+#: lxc/config.go:391 lxc/config.go:902
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:536
+#: lxc/config.go:540
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -7166,7 +7166,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:543
+#: lxc/config.go:547
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7175,13 +7175,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1216
+#: lxc/config.go:1228
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1040
+#: lxc/config.go:1052
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-26 11:55-0600\n"
+"POT-Creation-Date: 2024-09-30 13:36-0400\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Turkish <https://hosted.weblate.org/projects/linux-containers/"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1227
+#: lxc/config.go:1239
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -478,7 +478,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:493 lxc/config.go:809
+#: lxc/config.go:497 lxc/config.go:817
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -498,7 +498,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:443 lxc/config.go:628 lxc/config.go:835
+#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -765,7 +765,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:388
+#: lxc/console.go:392
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:694 lxc/config.go:1084
+#: lxc/config.go:702 lxc/config.go:1096
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1130,8 +1130,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:550 lxc/config.go:768
-#: lxc/config.go:899 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
+#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1251 lxc/network.go:1344 lxc/network.go:1416
 #: lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1210,7 +1210,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1327 lxc/config_metadata.go:156
+#: lxc/config.go:356 lxc/config.go:1339 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
@@ -1654,9 +1654,9 @@ msgstr ""
 #: lxc/cluster_group.go:316 lxc/cluster_group.go:440 lxc/cluster_group.go:522
 #: lxc/cluster_group.go:607 lxc/cluster_group.go:663 lxc/cluster_group.go:725
 #: lxc/cluster_role.go:24 lxc/cluster_role.go:51 lxc/cluster_role.go:115
-#: lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:538
-#: lxc/config.go:764 lxc/config.go:896 lxc/config.go:943 lxc/config.go:983
-#: lxc/config.go:1038 lxc/config.go:1129 lxc/config.go:1160 lxc/config.go:1214
+#: lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:542
+#: lxc/config.go:772 lxc/config.go:904 lxc/config.go:955 lxc/config.go:995
+#: lxc/config.go:1050 lxc/config.go:1141 lxc/config.go:1172 lxc/config.go:1226
 #: lxc/config_device.go:25 lxc/config_device.go:79 lxc/config_device.go:221
 #: lxc/config_device.go:318 lxc/config_device.go:401 lxc/config_device.go:503
 #: lxc/config_device.go:619 lxc/config_device.go:626 lxc/config_device.go:759
@@ -1929,7 +1929,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1213 lxc/config.go:1214
+#: lxc/config.go:1225 lxc/config.go:1226
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2053,7 +2053,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:459 lxc/config.go:654 lxc/config.go:686 lxc/network.go:1319
+#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1319
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
@@ -2063,7 +2063,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:648 lxc/config.go:680
+#: lxc/config.go:656 lxc/config.go:688
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2258,7 +2258,7 @@ msgstr ""
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:366
+#: lxc/console.go:370
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
@@ -2472,7 +2472,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:982 lxc/config.go:983
+#: lxc/config.go:994 lxc/config.go:995
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2870,7 +2870,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1008 lxc/config.go:1066 lxc/config.go:1185 lxc/config.go:1277
+#: lxc/config.go:1020 lxc/config.go:1078 lxc/config.go:1197 lxc/config.go:1289
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -3029,7 +3029,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:387
+#: lxc/console.go:391
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -3543,7 +3543,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:942 lxc/config.go:943
+#: lxc/config.go:954 lxc/config.go:955
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -4382,7 +4382,7 @@ msgstr ""
 
 #: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
@@ -4886,7 +4886,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1019
+#: lxc/config.go:1031
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5063,7 +5063,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1037 lxc/config.go:1038
+#: lxc/config.go:1049 lxc/config.go:1050
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5101,11 +5101,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:537
+#: lxc/config.go:541
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:538
+#: lxc/config.go:542
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5329,7 +5329,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:551
+#: lxc/config.go:555
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5394,7 +5394,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1159 lxc/config.go:1160
+#: lxc/config.go:1171 lxc/config.go:1172
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5402,7 +5402,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:763 lxc/config.go:764
+#: lxc/config.go:771 lxc/config.go:772
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5496,7 +5496,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:767
+#: lxc/config.go:775
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5747,7 +5747,7 @@ msgstr ""
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:126
+#: lxc/console.go:130
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -5809,12 +5809,12 @@ msgstr ""
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:479
+#: lxc/config.go:483
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:455
+#: lxc/config.go:459
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
@@ -5906,7 +5906,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:666
+#: lxc/config.go:674
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -5950,7 +5950,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:215
+#: lxc/console.go:219
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -5960,7 +5960,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:499 lxc/config.go:715 lxc/config.go:815
+#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6105,7 +6105,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:164
+#: lxc/console.go:168
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -6120,12 +6120,12 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:109
+#: lxc/console.go:113
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1128 lxc/config.go:1129
+#: lxc/config.go:1140 lxc/config.go:1141
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6145,7 +6145,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:895 lxc/config.go:896
+#: lxc/config.go:903 lxc/config.go:904
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6261,7 +6261,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:900
+#: lxc/config.go:908
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6610,7 +6610,7 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1158 lxc/config.go:1212 lxc/config_device.go:321
+#: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:321
 #: lxc/config_device.go:753 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:35
 msgid "[<remote>:]<instance>"
@@ -6632,11 +6632,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:981 lxc/config.go:1127
+#: lxc/config.go:993 lxc/config.go:1139
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1036
+#: lxc/config.go:1048
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -7033,7 +7033,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:762
+#: lxc/config.go:98 lxc/config.go:770
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7041,11 +7041,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:894
+#: lxc/config.go:391 lxc/config.go:902
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:536
+#: lxc/config.go:540
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -7169,7 +7169,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:543
+#: lxc/config.go:547
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7178,13 +7178,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1216
+#: lxc/config.go:1228
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1040
+#: lxc/config.go:1052
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"

--- a/po/tzm.po
+++ b/po/tzm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-26 11:55-0600\n"
+"POT-Creation-Date: 2024-09-30 13:36-0400\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Tamazight (Central Atlas) <https://hosted.weblate.org/"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1227
+#: lxc/config.go:1239
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -478,7 +478,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:493 lxc/config.go:809
+#: lxc/config.go:497 lxc/config.go:817
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -498,7 +498,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:443 lxc/config.go:628 lxc/config.go:835
+#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -765,7 +765,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:388
+#: lxc/console.go:392
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:694 lxc/config.go:1084
+#: lxc/config.go:702 lxc/config.go:1096
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1130,8 +1130,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:550 lxc/config.go:768
-#: lxc/config.go:899 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
+#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1251 lxc/network.go:1344 lxc/network.go:1416
 #: lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1210,7 +1210,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1327 lxc/config_metadata.go:156
+#: lxc/config.go:356 lxc/config.go:1339 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
@@ -1654,9 +1654,9 @@ msgstr ""
 #: lxc/cluster_group.go:316 lxc/cluster_group.go:440 lxc/cluster_group.go:522
 #: lxc/cluster_group.go:607 lxc/cluster_group.go:663 lxc/cluster_group.go:725
 #: lxc/cluster_role.go:24 lxc/cluster_role.go:51 lxc/cluster_role.go:115
-#: lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:538
-#: lxc/config.go:764 lxc/config.go:896 lxc/config.go:943 lxc/config.go:983
-#: lxc/config.go:1038 lxc/config.go:1129 lxc/config.go:1160 lxc/config.go:1214
+#: lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:542
+#: lxc/config.go:772 lxc/config.go:904 lxc/config.go:955 lxc/config.go:995
+#: lxc/config.go:1050 lxc/config.go:1141 lxc/config.go:1172 lxc/config.go:1226
 #: lxc/config_device.go:25 lxc/config_device.go:79 lxc/config_device.go:221
 #: lxc/config_device.go:318 lxc/config_device.go:401 lxc/config_device.go:503
 #: lxc/config_device.go:619 lxc/config_device.go:626 lxc/config_device.go:759
@@ -1929,7 +1929,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1213 lxc/config.go:1214
+#: lxc/config.go:1225 lxc/config.go:1226
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2053,7 +2053,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:459 lxc/config.go:654 lxc/config.go:686 lxc/network.go:1319
+#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1319
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
@@ -2063,7 +2063,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:648 lxc/config.go:680
+#: lxc/config.go:656 lxc/config.go:688
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2258,7 +2258,7 @@ msgstr ""
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:366
+#: lxc/console.go:370
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
@@ -2472,7 +2472,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:982 lxc/config.go:983
+#: lxc/config.go:994 lxc/config.go:995
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2870,7 +2870,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1008 lxc/config.go:1066 lxc/config.go:1185 lxc/config.go:1277
+#: lxc/config.go:1020 lxc/config.go:1078 lxc/config.go:1197 lxc/config.go:1289
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -3029,7 +3029,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:387
+#: lxc/console.go:391
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -3543,7 +3543,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:942 lxc/config.go:943
+#: lxc/config.go:954 lxc/config.go:955
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -4382,7 +4382,7 @@ msgstr ""
 
 #: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
@@ -4886,7 +4886,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1019
+#: lxc/config.go:1031
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5063,7 +5063,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1037 lxc/config.go:1038
+#: lxc/config.go:1049 lxc/config.go:1050
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5101,11 +5101,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:537
+#: lxc/config.go:541
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:538
+#: lxc/config.go:542
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5329,7 +5329,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:551
+#: lxc/config.go:555
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5394,7 +5394,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1159 lxc/config.go:1160
+#: lxc/config.go:1171 lxc/config.go:1172
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5402,7 +5402,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:763 lxc/config.go:764
+#: lxc/config.go:771 lxc/config.go:772
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5496,7 +5496,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:767
+#: lxc/config.go:775
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5747,7 +5747,7 @@ msgstr ""
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:126
+#: lxc/console.go:130
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -5809,12 +5809,12 @@ msgstr ""
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:479
+#: lxc/config.go:483
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:455
+#: lxc/config.go:459
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
@@ -5906,7 +5906,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:666
+#: lxc/config.go:674
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -5950,7 +5950,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:215
+#: lxc/console.go:219
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -5960,7 +5960,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:499 lxc/config.go:715 lxc/config.go:815
+#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6105,7 +6105,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:164
+#: lxc/console.go:168
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -6120,12 +6120,12 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:109
+#: lxc/console.go:113
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1128 lxc/config.go:1129
+#: lxc/config.go:1140 lxc/config.go:1141
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6145,7 +6145,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:895 lxc/config.go:896
+#: lxc/config.go:903 lxc/config.go:904
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6261,7 +6261,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:900
+#: lxc/config.go:908
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6610,7 +6610,7 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1158 lxc/config.go:1212 lxc/config_device.go:321
+#: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:321
 #: lxc/config_device.go:753 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:35
 msgid "[<remote>:]<instance>"
@@ -6632,11 +6632,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:981 lxc/config.go:1127
+#: lxc/config.go:993 lxc/config.go:1139
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1036
+#: lxc/config.go:1048
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -7033,7 +7033,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:762
+#: lxc/config.go:98 lxc/config.go:770
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7041,11 +7041,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:894
+#: lxc/config.go:391 lxc/config.go:902
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:536
+#: lxc/config.go:540
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -7169,7 +7169,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:543
+#: lxc/config.go:547
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7178,13 +7178,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1216
+#: lxc/config.go:1228
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1040
+#: lxc/config.go:1052
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"

--- a/po/ug.po
+++ b/po/ug.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-26 11:55-0600\n"
+"POT-Creation-Date: 2024-09-30 13:36-0400\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Uyghur <https://hosted.weblate.org/projects/linux-containers/"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1227
+#: lxc/config.go:1239
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -478,7 +478,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:493 lxc/config.go:809
+#: lxc/config.go:497 lxc/config.go:817
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -498,7 +498,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:443 lxc/config.go:628 lxc/config.go:835
+#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -765,7 +765,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:388
+#: lxc/console.go:392
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:694 lxc/config.go:1084
+#: lxc/config.go:702 lxc/config.go:1096
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1130,8 +1130,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:550 lxc/config.go:768
-#: lxc/config.go:899 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
+#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1251 lxc/network.go:1344 lxc/network.go:1416
 #: lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1210,7 +1210,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1327 lxc/config_metadata.go:156
+#: lxc/config.go:356 lxc/config.go:1339 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
@@ -1654,9 +1654,9 @@ msgstr ""
 #: lxc/cluster_group.go:316 lxc/cluster_group.go:440 lxc/cluster_group.go:522
 #: lxc/cluster_group.go:607 lxc/cluster_group.go:663 lxc/cluster_group.go:725
 #: lxc/cluster_role.go:24 lxc/cluster_role.go:51 lxc/cluster_role.go:115
-#: lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:538
-#: lxc/config.go:764 lxc/config.go:896 lxc/config.go:943 lxc/config.go:983
-#: lxc/config.go:1038 lxc/config.go:1129 lxc/config.go:1160 lxc/config.go:1214
+#: lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:542
+#: lxc/config.go:772 lxc/config.go:904 lxc/config.go:955 lxc/config.go:995
+#: lxc/config.go:1050 lxc/config.go:1141 lxc/config.go:1172 lxc/config.go:1226
 #: lxc/config_device.go:25 lxc/config_device.go:79 lxc/config_device.go:221
 #: lxc/config_device.go:318 lxc/config_device.go:401 lxc/config_device.go:503
 #: lxc/config_device.go:619 lxc/config_device.go:626 lxc/config_device.go:759
@@ -1929,7 +1929,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1213 lxc/config.go:1214
+#: lxc/config.go:1225 lxc/config.go:1226
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2053,7 +2053,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:459 lxc/config.go:654 lxc/config.go:686 lxc/network.go:1319
+#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1319
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
@@ -2063,7 +2063,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:648 lxc/config.go:680
+#: lxc/config.go:656 lxc/config.go:688
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2258,7 +2258,7 @@ msgstr ""
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:366
+#: lxc/console.go:370
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
@@ -2472,7 +2472,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:982 lxc/config.go:983
+#: lxc/config.go:994 lxc/config.go:995
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2870,7 +2870,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1008 lxc/config.go:1066 lxc/config.go:1185 lxc/config.go:1277
+#: lxc/config.go:1020 lxc/config.go:1078 lxc/config.go:1197 lxc/config.go:1289
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -3029,7 +3029,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:387
+#: lxc/console.go:391
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -3543,7 +3543,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:942 lxc/config.go:943
+#: lxc/config.go:954 lxc/config.go:955
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -4382,7 +4382,7 @@ msgstr ""
 
 #: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
@@ -4886,7 +4886,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1019
+#: lxc/config.go:1031
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5063,7 +5063,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1037 lxc/config.go:1038
+#: lxc/config.go:1049 lxc/config.go:1050
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5101,11 +5101,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:537
+#: lxc/config.go:541
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:538
+#: lxc/config.go:542
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5329,7 +5329,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:551
+#: lxc/config.go:555
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5394,7 +5394,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1159 lxc/config.go:1160
+#: lxc/config.go:1171 lxc/config.go:1172
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5402,7 +5402,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:763 lxc/config.go:764
+#: lxc/config.go:771 lxc/config.go:772
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5496,7 +5496,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:767
+#: lxc/config.go:775
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5747,7 +5747,7 @@ msgstr ""
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:126
+#: lxc/console.go:130
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -5809,12 +5809,12 @@ msgstr ""
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:479
+#: lxc/config.go:483
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:455
+#: lxc/config.go:459
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
@@ -5906,7 +5906,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:666
+#: lxc/config.go:674
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -5950,7 +5950,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:215
+#: lxc/console.go:219
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -5960,7 +5960,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:499 lxc/config.go:715 lxc/config.go:815
+#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6105,7 +6105,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:164
+#: lxc/console.go:168
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -6120,12 +6120,12 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:109
+#: lxc/console.go:113
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1128 lxc/config.go:1129
+#: lxc/config.go:1140 lxc/config.go:1141
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6145,7 +6145,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:895 lxc/config.go:896
+#: lxc/config.go:903 lxc/config.go:904
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6261,7 +6261,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:900
+#: lxc/config.go:908
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6610,7 +6610,7 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1158 lxc/config.go:1212 lxc/config_device.go:321
+#: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:321
 #: lxc/config_device.go:753 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:35
 msgid "[<remote>:]<instance>"
@@ -6632,11 +6632,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:981 lxc/config.go:1127
+#: lxc/config.go:993 lxc/config.go:1139
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1036
+#: lxc/config.go:1048
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -7033,7 +7033,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:762
+#: lxc/config.go:98 lxc/config.go:770
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7041,11 +7041,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:894
+#: lxc/config.go:391 lxc/config.go:902
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:536
+#: lxc/config.go:540
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -7169,7 +7169,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:543
+#: lxc/config.go:547
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7178,13 +7178,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1216
+#: lxc/config.go:1228
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1040
+#: lxc/config.go:1052
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-26 11:55-0600\n"
+"POT-Creation-Date: 2024-09-30 13:36-0400\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Ukrainian <https://hosted.weblate.org/projects/linux-"
@@ -64,7 +64,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1227
+#: lxc/config.go:1239
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -479,7 +479,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:493 lxc/config.go:809
+#: lxc/config.go:497 lxc/config.go:817
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -499,7 +499,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:443 lxc/config.go:628 lxc/config.go:835
+#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -766,7 +766,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:388
+#: lxc/console.go:392
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -1016,7 +1016,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:694 lxc/config.go:1084
+#: lxc/config.go:702 lxc/config.go:1096
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1131,8 +1131,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:550 lxc/config.go:768
-#: lxc/config.go:899 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
+#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1251 lxc/network.go:1344 lxc/network.go:1416
 #: lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1211,7 +1211,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1327 lxc/config_metadata.go:156
+#: lxc/config.go:356 lxc/config.go:1339 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
@@ -1655,9 +1655,9 @@ msgstr ""
 #: lxc/cluster_group.go:316 lxc/cluster_group.go:440 lxc/cluster_group.go:522
 #: lxc/cluster_group.go:607 lxc/cluster_group.go:663 lxc/cluster_group.go:725
 #: lxc/cluster_role.go:24 lxc/cluster_role.go:51 lxc/cluster_role.go:115
-#: lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:538
-#: lxc/config.go:764 lxc/config.go:896 lxc/config.go:943 lxc/config.go:983
-#: lxc/config.go:1038 lxc/config.go:1129 lxc/config.go:1160 lxc/config.go:1214
+#: lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:542
+#: lxc/config.go:772 lxc/config.go:904 lxc/config.go:955 lxc/config.go:995
+#: lxc/config.go:1050 lxc/config.go:1141 lxc/config.go:1172 lxc/config.go:1226
 #: lxc/config_device.go:25 lxc/config_device.go:79 lxc/config_device.go:221
 #: lxc/config_device.go:318 lxc/config_device.go:401 lxc/config_device.go:503
 #: lxc/config_device.go:619 lxc/config_device.go:626 lxc/config_device.go:759
@@ -1930,7 +1930,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1213 lxc/config.go:1214
+#: lxc/config.go:1225 lxc/config.go:1226
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2054,7 +2054,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:459 lxc/config.go:654 lxc/config.go:686 lxc/network.go:1319
+#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1319
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
@@ -2064,7 +2064,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:648 lxc/config.go:680
+#: lxc/config.go:656 lxc/config.go:688
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2259,7 +2259,7 @@ msgstr ""
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:366
+#: lxc/console.go:370
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
@@ -2473,7 +2473,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:982 lxc/config.go:983
+#: lxc/config.go:994 lxc/config.go:995
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2871,7 +2871,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1008 lxc/config.go:1066 lxc/config.go:1185 lxc/config.go:1277
+#: lxc/config.go:1020 lxc/config.go:1078 lxc/config.go:1197 lxc/config.go:1289
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -3030,7 +3030,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:387
+#: lxc/console.go:391
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -3544,7 +3544,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:942 lxc/config.go:943
+#: lxc/config.go:954 lxc/config.go:955
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -4383,7 +4383,7 @@ msgstr ""
 
 #: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
@@ -4887,7 +4887,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1019
+#: lxc/config.go:1031
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5064,7 +5064,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1037 lxc/config.go:1038
+#: lxc/config.go:1049 lxc/config.go:1050
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5102,11 +5102,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:537
+#: lxc/config.go:541
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:538
+#: lxc/config.go:542
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5330,7 +5330,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:551
+#: lxc/config.go:555
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5395,7 +5395,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1159 lxc/config.go:1160
+#: lxc/config.go:1171 lxc/config.go:1172
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5403,7 +5403,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:763 lxc/config.go:764
+#: lxc/config.go:771 lxc/config.go:772
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5497,7 +5497,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:767
+#: lxc/config.go:775
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5748,7 +5748,7 @@ msgstr ""
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:126
+#: lxc/console.go:130
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -5810,12 +5810,12 @@ msgstr ""
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:479
+#: lxc/config.go:483
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:455
+#: lxc/config.go:459
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
@@ -5907,7 +5907,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:666
+#: lxc/config.go:674
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -5951,7 +5951,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:215
+#: lxc/console.go:219
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -5961,7 +5961,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:499 lxc/config.go:715 lxc/config.go:815
+#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6106,7 +6106,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:164
+#: lxc/console.go:168
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -6121,12 +6121,12 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:109
+#: lxc/console.go:113
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1128 lxc/config.go:1129
+#: lxc/config.go:1140 lxc/config.go:1141
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6146,7 +6146,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:895 lxc/config.go:896
+#: lxc/config.go:903 lxc/config.go:904
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6262,7 +6262,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:900
+#: lxc/config.go:908
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6611,7 +6611,7 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1158 lxc/config.go:1212 lxc/config_device.go:321
+#: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:321
 #: lxc/config_device.go:753 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:35
 msgid "[<remote>:]<instance>"
@@ -6633,11 +6633,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:981 lxc/config.go:1127
+#: lxc/config.go:993 lxc/config.go:1139
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1036
+#: lxc/config.go:1048
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -7034,7 +7034,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:762
+#: lxc/config.go:98 lxc/config.go:770
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7042,11 +7042,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:894
+#: lxc/config.go:391 lxc/config.go:902
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:536
+#: lxc/config.go:540
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -7170,7 +7170,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:543
+#: lxc/config.go:547
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7179,13 +7179,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1216
+#: lxc/config.go:1228
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1040
+#: lxc/config.go:1052
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-26 11:55-0600\n"
+"POT-Creation-Date: 2024-09-30 13:36-0400\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: 0x0916 <w@laoqinren.net>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -97,7 +97,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/config.go:1227
+#: lxc/config.go:1239
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -639,7 +639,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:493 lxc/config.go:809
+#: lxc/config.go:497 lxc/config.go:817
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -659,7 +659,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:443 lxc/config.go:628 lxc/config.go:835
+#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:388
+#: lxc/console.go:392
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -1176,7 +1176,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:694 lxc/config.go:1084
+#: lxc/config.go:702 lxc/config.go:1096
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1291,8 +1291,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:550 lxc/config.go:768
-#: lxc/config.go:899 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
+#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1251 lxc/network.go:1344 lxc/network.go:1416
 #: lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1371,7 +1371,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1327 lxc/config_metadata.go:156
+#: lxc/config.go:356 lxc/config.go:1339 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
@@ -1815,9 +1815,9 @@ msgstr ""
 #: lxc/cluster_group.go:316 lxc/cluster_group.go:440 lxc/cluster_group.go:522
 #: lxc/cluster_group.go:607 lxc/cluster_group.go:663 lxc/cluster_group.go:725
 #: lxc/cluster_role.go:24 lxc/cluster_role.go:51 lxc/cluster_role.go:115
-#: lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:538
-#: lxc/config.go:764 lxc/config.go:896 lxc/config.go:943 lxc/config.go:983
-#: lxc/config.go:1038 lxc/config.go:1129 lxc/config.go:1160 lxc/config.go:1214
+#: lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:542
+#: lxc/config.go:772 lxc/config.go:904 lxc/config.go:955 lxc/config.go:995
+#: lxc/config.go:1050 lxc/config.go:1141 lxc/config.go:1172 lxc/config.go:1226
 #: lxc/config_device.go:25 lxc/config_device.go:79 lxc/config_device.go:221
 #: lxc/config_device.go:318 lxc/config_device.go:401 lxc/config_device.go:503
 #: lxc/config_device.go:619 lxc/config_device.go:626 lxc/config_device.go:759
@@ -2090,7 +2090,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1213 lxc/config.go:1214
+#: lxc/config.go:1225 lxc/config.go:1226
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2214,7 +2214,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:459 lxc/config.go:654 lxc/config.go:686 lxc/network.go:1319
+#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1319
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
@@ -2224,7 +2224,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:648 lxc/config.go:680
+#: lxc/config.go:656 lxc/config.go:688
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2419,7 +2419,7 @@ msgstr ""
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:366
+#: lxc/console.go:370
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
@@ -2633,7 +2633,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:982 lxc/config.go:983
+#: lxc/config.go:994 lxc/config.go:995
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -3031,7 +3031,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1008 lxc/config.go:1066 lxc/config.go:1185 lxc/config.go:1277
+#: lxc/config.go:1020 lxc/config.go:1078 lxc/config.go:1197 lxc/config.go:1289
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -3190,7 +3190,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:387
+#: lxc/console.go:391
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -3704,7 +3704,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:942 lxc/config.go:943
+#: lxc/config.go:954 lxc/config.go:955
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -4543,7 +4543,7 @@ msgstr ""
 
 #: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
@@ -5047,7 +5047,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1019
+#: lxc/config.go:1031
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5224,7 +5224,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1037 lxc/config.go:1038
+#: lxc/config.go:1049 lxc/config.go:1050
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5262,11 +5262,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:537
+#: lxc/config.go:541
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:538
+#: lxc/config.go:542
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5490,7 +5490,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:551
+#: lxc/config.go:555
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5555,7 +5555,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1159 lxc/config.go:1160
+#: lxc/config.go:1171 lxc/config.go:1172
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5563,7 +5563,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:763 lxc/config.go:764
+#: lxc/config.go:771 lxc/config.go:772
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5657,7 +5657,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:767
+#: lxc/config.go:775
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5908,7 +5908,7 @@ msgstr ""
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:126
+#: lxc/console.go:130
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -5970,12 +5970,12 @@ msgstr ""
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:479
+#: lxc/config.go:483
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:455
+#: lxc/config.go:459
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
@@ -6067,7 +6067,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:666
+#: lxc/config.go:674
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -6111,7 +6111,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:215
+#: lxc/console.go:219
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -6121,7 +6121,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:499 lxc/config.go:715 lxc/config.go:815
+#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6266,7 +6266,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:164
+#: lxc/console.go:168
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -6281,12 +6281,12 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:109
+#: lxc/console.go:113
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1128 lxc/config.go:1129
+#: lxc/config.go:1140 lxc/config.go:1141
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6306,7 +6306,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:895 lxc/config.go:896
+#: lxc/config.go:903 lxc/config.go:904
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6422,7 +6422,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:900
+#: lxc/config.go:908
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6771,7 +6771,7 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1158 lxc/config.go:1212 lxc/config_device.go:321
+#: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:321
 #: lxc/config_device.go:753 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:35
 msgid "[<remote>:]<instance>"
@@ -6793,11 +6793,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:981 lxc/config.go:1127
+#: lxc/config.go:993 lxc/config.go:1139
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1036
+#: lxc/config.go:1048
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -7194,7 +7194,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:762
+#: lxc/config.go:98 lxc/config.go:770
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7202,11 +7202,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:894
+#: lxc/config.go:391 lxc/config.go:902
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:536
+#: lxc/config.go:540
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -7330,7 +7330,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:543
+#: lxc/config.go:547
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7339,13 +7339,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1216
+#: lxc/config.go:1228
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1040
+#: lxc/config.go:1052
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"

--- a/po/zh_Hant.po
+++ b/po/zh_Hant.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-26 11:55-0600\n"
+"POT-Creation-Date: 2024-09-30 13:36-0400\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Chinese (Traditional) <https://hosted.weblate.org/projects/"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1227
+#: lxc/config.go:1239
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -478,7 +478,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:493 lxc/config.go:809
+#: lxc/config.go:497 lxc/config.go:817
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -498,7 +498,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:443 lxc/config.go:628 lxc/config.go:835
+#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -765,7 +765,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:388
+#: lxc/console.go:392
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:694 lxc/config.go:1084
+#: lxc/config.go:702 lxc/config.go:1096
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1130,8 +1130,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:550 lxc/config.go:768
-#: lxc/config.go:899 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
+#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1251 lxc/network.go:1344 lxc/network.go:1416
 #: lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1210,7 +1210,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1327 lxc/config_metadata.go:156
+#: lxc/config.go:356 lxc/config.go:1339 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
@@ -1654,9 +1654,9 @@ msgstr ""
 #: lxc/cluster_group.go:316 lxc/cluster_group.go:440 lxc/cluster_group.go:522
 #: lxc/cluster_group.go:607 lxc/cluster_group.go:663 lxc/cluster_group.go:725
 #: lxc/cluster_role.go:24 lxc/cluster_role.go:51 lxc/cluster_role.go:115
-#: lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:538
-#: lxc/config.go:764 lxc/config.go:896 lxc/config.go:943 lxc/config.go:983
-#: lxc/config.go:1038 lxc/config.go:1129 lxc/config.go:1160 lxc/config.go:1214
+#: lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:542
+#: lxc/config.go:772 lxc/config.go:904 lxc/config.go:955 lxc/config.go:995
+#: lxc/config.go:1050 lxc/config.go:1141 lxc/config.go:1172 lxc/config.go:1226
 #: lxc/config_device.go:25 lxc/config_device.go:79 lxc/config_device.go:221
 #: lxc/config_device.go:318 lxc/config_device.go:401 lxc/config_device.go:503
 #: lxc/config_device.go:619 lxc/config_device.go:626 lxc/config_device.go:759
@@ -1929,7 +1929,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1213 lxc/config.go:1214
+#: lxc/config.go:1225 lxc/config.go:1226
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2053,7 +2053,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:459 lxc/config.go:654 lxc/config.go:686 lxc/network.go:1319
+#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1319
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
@@ -2063,7 +2063,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:648 lxc/config.go:680
+#: lxc/config.go:656 lxc/config.go:688
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2258,7 +2258,7 @@ msgstr ""
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:366
+#: lxc/console.go:370
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
@@ -2472,7 +2472,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:982 lxc/config.go:983
+#: lxc/config.go:994 lxc/config.go:995
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2870,7 +2870,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1008 lxc/config.go:1066 lxc/config.go:1185 lxc/config.go:1277
+#: lxc/config.go:1020 lxc/config.go:1078 lxc/config.go:1197 lxc/config.go:1289
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -3029,7 +3029,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:387
+#: lxc/console.go:391
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -3543,7 +3543,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:942 lxc/config.go:943
+#: lxc/config.go:954 lxc/config.go:955
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -4382,7 +4382,7 @@ msgstr ""
 
 #: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
@@ -4886,7 +4886,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1019
+#: lxc/config.go:1031
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5063,7 +5063,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1037 lxc/config.go:1038
+#: lxc/config.go:1049 lxc/config.go:1050
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5101,11 +5101,11 @@ msgstr ""
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:537
+#: lxc/config.go:541
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:538
+#: lxc/config.go:542
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5329,7 +5329,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:551
+#: lxc/config.go:555
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5394,7 +5394,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1159 lxc/config.go:1160
+#: lxc/config.go:1171 lxc/config.go:1172
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5402,7 +5402,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:763 lxc/config.go:764
+#: lxc/config.go:771 lxc/config.go:772
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5496,7 +5496,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:767
+#: lxc/config.go:775
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5747,7 +5747,7 @@ msgstr ""
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:126
+#: lxc/console.go:130
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -5809,12 +5809,12 @@ msgstr ""
 msgid "The property %q does not exist on the cluster member %q: %v"
 msgstr ""
 
-#: lxc/config.go:479
+#: lxc/config.go:483
 #, c-format
 msgid "The property %q does not exist on the instance %q: %v"
 msgstr ""
 
-#: lxc/config.go:455
+#: lxc/config.go:459
 #, c-format
 msgid "The property %q does not exist on the instance snapshot %s/%s: %v"
 msgstr ""
@@ -5906,7 +5906,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:666
+#: lxc/config.go:674
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -5950,7 +5950,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:215
+#: lxc/console.go:219
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -5960,7 +5960,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:499 lxc/config.go:715 lxc/config.go:815
+#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6105,7 +6105,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:164
+#: lxc/console.go:168
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -6120,12 +6120,12 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:109
+#: lxc/console.go:113
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1128 lxc/config.go:1129
+#: lxc/config.go:1140 lxc/config.go:1141
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6145,7 +6145,7 @@ msgstr ""
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:895 lxc/config.go:896
+#: lxc/config.go:903 lxc/config.go:904
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6261,7 +6261,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:900
+#: lxc/config.go:908
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6610,7 +6610,7 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1158 lxc/config.go:1212 lxc/config_device.go:321
+#: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:321
 #: lxc/config_device.go:753 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:35
 msgid "[<remote>:]<instance>"
@@ -6632,11 +6632,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:981 lxc/config.go:1127
+#: lxc/config.go:993 lxc/config.go:1139
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1036
+#: lxc/config.go:1048
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -7033,7 +7033,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:762
+#: lxc/config.go:98 lxc/config.go:770
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7041,11 +7041,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:894
+#: lxc/config.go:391 lxc/config.go:902
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:536
+#: lxc/config.go:540
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -7169,7 +7169,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:543
+#: lxc/config.go:547
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7178,13 +7178,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1216
+#: lxc/config.go:1228
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1040
+#: lxc/config.go:1052
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"


### PR DESCRIPTION
This tries to add some basic change detection to `make update-pot`, `make update-po` and the meta target `make i18n` so that they suggest committing changes with a "canned" message.