### PR TITLE
lxd/init: Differentiate managed and unmanaged network

### DIFF
--- a/lxd/main_init_interactive.go
+++ b/lxd/main_init_interactive.go
@@ -349,27 +349,51 @@ func (c *cmdInit) askNetworking(config *api.InitPreseed, d lxd.InstanceServer) e
 		}
 
 		if useExistingInterface {
+			networks, err := d.GetNetworks()
+			if err != nil {
+				return err
+			}
+
 			for {
 				interfaceName, err := c.global.asker.AskString("Name of the existing bridge or host interface: ", "", nil)
 				if err != nil {
 					return err
 				}
 
-				if !shared.PathExists(fmt.Sprintf("/sys/class/net/%s", interfaceName)) {
+				// Try to find the existing network.
+				var network *api.Network
+				for _, n := range networks {
+					if n.Name == interfaceName {
+						network = &n
+						break
+					}
+				}
+
+				if network == nil {
 					fmt.Println("The requested interface doesn't exist. Please choose another one.")
 					continue
 				}
 
-				// Add to the default profile
-				config.Node.Profiles[0].Devices["eth0"] = map[string]string{
-					"type":    "nic",
-					"nictype": "macvlan",
-					"name":    "eth0",
-					"parent":  interfaceName,
-				}
+				// Add to the default profile.
+				if network.Managed {
+					// Add managed network.
+					config.Node.Profiles[0].Devices["eth0"] = map[string]string{
+						"name":    "eth0",
+						"type":    "nic",
+						"network": network.Name,
+					}
+				} else {
+					// Add unmanaged network.
+					config.Node.Profiles[0].Devices["eth0"] = map[string]string{
+						"name":    "eth0",
+						"type":    "nic",
+						"nictype": "macvlan",
+						"parent":  network.Name,
+					}
 
-				if shared.PathExists(fmt.Sprintf("/sys/class/net/%s/bridge", interfaceName)) {
-					config.Node.Profiles[0].Devices["eth0"]["nictype"] = "bridged"
+					if network.Type == "bridge" {
+						config.Node.Profiles[0].Devices["eth0"]["nictype"] = "bridged"
+					}
 				}
 
 				if config.Node.Config["maas.api.url"] != nil {


### PR DESCRIPTION
When using `lxd init` to configure default profile with an existing network, differentiate between managed and unmanaged networks by first trying to retrieve an existing network (and checking if it is managed).

Unamanaged network:
```sh
...
Would you like to configure LXD to use an existing bridge or host interface? (yes/no) [default=no]: yes
Name of the existing bridge or host interface: tmpbr0
...
Would you like a YAML "lxd init" preseed to be printed? (yes/no) [default=no]: y
config: {}
networks: []
storage_pools: []
storage_volumes: []
profiles:
- config: {}
  description: ""
  devices:
    eth0:
      name: eth0
      nictype: bridged # <--
      parent: tmpbr0   # <--
      type: nic
  name: default
projects: []
cluster: null
```

Managed network:
```sh
...
Would you like to configure LXD to use an existing bridge or host interface? (yes/no) [default=no]: yes
Name of the existing bridge or host interface: lxdbr0
...
Would you like a YAML "lxd init" preseed to be printed? (yes/no) [default=no]: y
config: {}
networks: []
storage_pools: []
storage_volumes: []
profiles:
- config: {}
  description: ""
  devices:
    eth0:
      name: eth0
      network: lxdbr0 # <--
      type: nic
  name: default
projects: []
cluster: null
```

Closes https://github.com/canonical/lxd/issues/13468