### PR TITLE
lxd-migrate: Prevent invalid instance names

### DIFF
--- a/lxd-migrate/main_migrate.go
+++ b/lxd-migrate/main_migrate.go
@@ -20,6 +20,7 @@ import (
 	"gopkg.in/yaml.v2"
 
 	"github.com/canonical/lxd/client"
+	"github.com/canonical/lxd/lxd/instance/instancetype"
 	"github.com/canonical/lxd/lxd/storage/block"
 	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/api"
@@ -570,7 +571,7 @@ func (c *cmdMigrate) runInteractive(config *cmdMigrateData, server lxd.InstanceS
 
 	server = server.UseProject(config.Project)
 
-	// Instance name
+	// Instance name.
 	if config.InstanceArgs.Name == "" {
 		instanceNames, err := server.GetInstanceNames(api.InstanceTypeAny)
 		if err != nil {
@@ -583,6 +584,14 @@ func (c *cmdMigrate) runInteractive(config *cmdMigrateData, server lxd.InstanceS
 				return err
 			}
 
+			// Validate instance name.
+			err = instancetype.ValidName(instanceName, false)
+			if err != nil {
+				fmt.Println(err)
+				continue
+			}
+
+			// Ensure instance name is not already used.
 			if slices.Contains(instanceNames, instanceName) {
 				fmt.Printf("Instance %q already exists\n", instanceName)
 				continue
@@ -724,9 +733,17 @@ func (c *cmdMigrate) run(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// Precheck instance type.
+	// Check instance type.
 	if c.flagInstanceType != "" && !slices.Contains([]string{"container", "vm"}, c.flagInstanceType) {
 		return fmt.Errorf("Invalid instance type %q: Valid values are [%s]", c.flagInstanceType, strings.Join([]string{"container", "vm"}, ", "))
+	}
+
+	// Check instance name.
+	if c.flagInstanceName != "" {
+		err := instancetype.ValidName(c.flagInstanceName, false)
+		if err != nil {
+			return err
+		}
 	}
 
 	// Check source path. This is only precheck, as we cannot know the whether

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -3869,7 +3869,7 @@ func (d *lxc) Rename(newName string, applyTemplateTrigger bool) error {
 	d.logger.Info("Renaming instance", ctxMap)
 
 	// Quick checks.
-	err = instance.ValidName(newName, d.IsSnapshot())
+	err = instancetype.ValidName(newName, d.IsSnapshot())
 	if err != nil {
 		return err
 	}

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -5168,7 +5168,7 @@ func (d *qemu) Rename(newName string, applyTemplateTrigger bool) error {
 	d.logger.Info("Renaming instance", ctxMap)
 
 	// Quick checks.
-	err = instance.ValidName(newName, d.IsSnapshot())
+	err = instancetype.ValidName(newName, d.IsSnapshot())
 	if err != nil {
 		return err
 	}

--- a/lxd/instance_logs.go
+++ b/lxd/instance_logs.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/canonical/lxd/lxd/auth"
 	"github.com/canonical/lxd/lxd/instance"
+	"github.com/canonical/lxd/lxd/instance/instancetype"
 	"github.com/canonical/lxd/lxd/lifecycle"
 	"github.com/canonical/lxd/lxd/project"
 	"github.com/canonical/lxd/lxd/request"
@@ -153,7 +154,7 @@ func instanceLogsGet(d *Daemon, r *http.Request) response.Response {
 		return resp
 	}
 
-	err = instance.ValidName(name, false)
+	err = instancetype.ValidName(name, false)
 	if err != nil {
 		return response.BadRequest(err)
 	}
@@ -248,7 +249,7 @@ func instanceLogGet(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	err = instance.ValidName(name, false)
+	err = instancetype.ValidName(name, false)
 	if err != nil {
 		return response.BadRequest(err)
 	}
@@ -332,7 +333,7 @@ func instanceLogDelete(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	err = instance.ValidName(name, false)
+	err = instancetype.ValidName(name, false)
 	if err != nil {
 		return response.BadRequest(err)
 	}
@@ -439,7 +440,7 @@ func instanceExecOutputsGet(d *Daemon, r *http.Request) response.Response {
 		return resp
 	}
 
-	err = instance.ValidName(name, false)
+	err = instancetype.ValidName(name, false)
 	if err != nil {
 		return response.BadRequest(err)
 	}
@@ -549,7 +550,7 @@ func instanceExecOutputGet(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	err = instance.ValidName(name, false)
+	err = instancetype.ValidName(name, false)
 	if err != nil {
 		return response.BadRequest(err)
 	}
@@ -649,7 +650,7 @@ func instanceExecOutputDelete(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	err = instance.ValidName(name, false)
+	err = instancetype.ValidName(name, false)
 	if err != nil {
 		return response.BadRequest(err)
 	}

--- a/lxd/instance_post.go
+++ b/lxd/instance_post.go
@@ -314,7 +314,7 @@ func instancePost(d *Daemon, r *http.Request) response.Response {
 	}
 
 	// Check the new instance name is valid.
-	err = instance.ValidName(req.Name, false)
+	err = instancetype.ValidName(req.Name, false)
 	if err != nil {
 		return response.BadRequest(err)
 	}

--- a/lxd/instances_post.go
+++ b/lxd/instances_post.go
@@ -1256,7 +1256,7 @@ func instancesPost(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	err = instance.ValidName(req.Name, false)
+	err = instancetype.ValidName(req.Name, false)
 	if err != nil {
 		return response.BadRequest(err)
 	}

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -724,19 +724,19 @@ func (b *lxdBackend) CreateInstanceFromBackup(srcBackup backup.Info, srcData io.
 	defer l.Debug("CreateInstanceFromBackup finished")
 
 	// Validate the names in the backup.yaml file as these could be malicious.
-	err := instance.ValidName(srcBackup.Name, false)
+	err := instancetype.ValidName(srcBackup.Name, false)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	err = instance.ValidName(srcBackup.Config.Container.Name, false)
+	err = instancetype.ValidName(srcBackup.Config.Container.Name, false)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	for _, snapName := range srcBackup.Snapshots {
 		snapInstName := fmt.Sprintf("%s%s%s", srcBackup.Name, shared.SnapshotDelimiter, snapName)
-		err = instance.ValidName(snapInstName, true)
+		err = instancetype.ValidName(snapInstName, true)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -744,7 +744,7 @@ func (b *lxdBackend) CreateInstanceFromBackup(srcBackup backup.Info, srcData io.
 
 	for _, snap := range srcBackup.Config.Snapshots {
 		snapInstName := fmt.Sprintf("%s%s%s", srcBackup.Name, shared.SnapshotDelimiter, snap.Name)
-		err = instance.ValidName(snapInstName, true)
+		err = instancetype.ValidName(snapInstName, true)
 		if err != nil {
 			return nil, nil, err
 		}


### PR DESCRIPTION
Prevent `lxd-migrate` from progressing if instance name is not valid.

Noninteractive mode:
```sh
$ sudo ./lxd-migrate --name "test test"
Error: Invalid instance name "test test": Name can only contain alphanumeric and hyphen characters

$ sudo ./lxd-migrate --name "test"
The local LXD server is the target [default=yes]: ...
```

Interactive mode:
```sh
$ sudo ./lxd-migrate
The local LXD server is the target [default=yes]: 
Would you like to create a container (1) or virtual-machine (2)?: 1
Name of the new instance: test test
Invalid instance name "test test": Name can only contain alphanumeric and hyphen characters
Name of the new instance: test
Please provide the path to a root filesystem: ...
```

Closes https://github.com/canonical/lxd/issues/12130