### PR TITLE
test/suites/tls_restrictions: don't check for broken pipe error

### DIFF
--- a/test/suites/tls_restrictions.sh
+++ b/test/suites/tls_restrictions.sh
@@ -443,11 +443,10 @@ test_tls_version() {
     my_curl --tls-max 1.2 --ciphers "${cipher}" -X GET "https://${LXD_ADDR}" -w "%{errormsg}\n" | grep -F "alert handshake failure"
   done
 
-  echo "TLS 1.2 with ciphers known to be a broken pipe error"
+  echo "TLS 1.2 with ciphers known to be cause broken pipe errors or empty replies or connection resets"
   for cipher in ECDHE-ECDSA-AES128-SHA ECDHE-ECDSA-AES256-SHA; do
     echo "Testing TLS 1.2: ${cipher}"
     ! my_curl --tls-max 1.2 --ciphers "${cipher}" -X GET "https://${LXD_ADDR}" -w "%{errormsg}\n" || false
-    my_curl --tls-max 1.2 --ciphers "${cipher}" -X GET "https://${LXD_ADDR}" -w "%{errormsg}\n" | grep -F "Broken pipe, errno"
   done
 
   echo "TLS 1.1 is not working"


### PR DESCRIPTION
Making a TLS 1.2 connection with an unsupported cipher does not reliably produces a broken pipe error:

```
for _ in $(seq 100); do
    for cipher in ECDHE-ECDSA-AES128-SHA ECDHE-ECDSA-AES256-SHA; do
        my_curl --tls-max 1.2 --ciphers "${cipher}" -X GET "https://${LXD_ADDR}" -w "%{errormsg}\n"
    done
done 2>&1 | sort | uniq -c
      1 Empty reply from server
    196 OpenSSL SSL_write: Broken pipe, errno 32
      3 OpenSSL SSL_write: Connection reset by peer, errno 104
```

but it always fail so let not look for a specific error, just make sure the connection fails.