### PR TITLE
Storage: Return `growFileSystem` errors

### DIFF
--- a/lxd/storage/drivers/utils.go
+++ b/lxd/storage/drivers/utils.go
@@ -537,21 +537,20 @@ func growFileSystem(fsType string, devPath string, vol Volume) error {
 	}
 
 	return vol.MountTask(func(mountPath string, op *operations.Operation) error {
-		var msg string
 		var err error
 		switch fsType {
 		case "ext4":
-			msg, err = shared.TryRunCommand("resize2fs", devPath)
+			_, err = shared.TryRunCommand("resize2fs", devPath)
 		case "xfs":
-			msg, err = shared.TryRunCommand("xfs_growfs", mountPath)
+			_, err = shared.TryRunCommand("xfs_growfs", mountPath)
 		case "btrfs":
-			msg, err = shared.TryRunCommand("btrfs", "filesystem", "resize", "max", mountPath)
+			_, err = shared.TryRunCommand("btrfs", "filesystem", "resize", "max", mountPath)
 		default:
 			return fmt.Errorf("Unrecognised filesystem type %q", fsType)
 		}
 
 		if err != nil {
-			return fmt.Errorf("Could not grow underlying %q filesystem for %q: %s", fsType, devPath, msg)
+			return fmt.Errorf("Could not grow underlying %q filesystem for %q: %w", fsType, devPath, err)
 		}
 
 		return nil


### PR DESCRIPTION
`msg` only contains stdout from the child process, so this wasn't passing back any information about what actually failed.

Still working on root cause for these failures: https://github.com/canonical/lxd/actions/runs/10919085792/attempts/1?pr=14122