### PR TITLE
Add API types for configuration metadata

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -2475,3 +2475,8 @@ for a project, the pool is excluded from `lxc storage list` in that project.
 
 Adds a new {config:option}`instance-miscellaneous:ubuntu_pro.guest_attach` configuration option for instances.
 When set to `on`, if the host has guest attachment enabled, the guest can request a guest token for Ubuntu Pro via `devlxd`.
+
+## `metadata_configuration_entity_types`
+
+This adds entity type metadata to `GET /1.0/metadata/configuration`.
+The entity type metadata is a JSON object under the `entities` key.

--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -2774,6 +2774,111 @@ definitions:
         title: InstancesPut represents the fields available for a mass update.
         type: object
         x-go-package: github.com/canonical/lxd/shared/api
+    MetadataConfiguration:
+        properties:
+            configs:
+                additionalProperties:
+                    additionalProperties:
+                        $ref: '#/definitions/MetadataConfigurationConfigKeys'
+                    type: object
+                description: Configs contains all server configuration metadata.
+                type: object
+                x-go-name: Configs
+            entities:
+                additionalProperties:
+                    $ref: '#/definitions/MetadataConfigurationEntity'
+                description: |-
+                    Entities contains all authorization related metadata.
+
+                    API extension: metadata_configuration_entity_types
+                type: object
+                x-go-name: Entities
+        title: MetadataConfiguration contains metadata about the LXD server configuration options.
+        type: object
+        x-go-package: github.com/canonical/lxd/shared/api
+    MetadataConfigurationConfigKey:
+        properties:
+            condition:
+                description: Condition describes conditions under which the configuration key can be applied.
+                example: Virtual machines only.
+                type: string
+                x-go-name: Condition
+            defaultdesc:
+                description: DefaultDescription contains a description of the configuration key.
+                example: A general description of a configuration key.
+                type: string
+                x-go-name: DefaultDescription
+            longdesc:
+                description: LongDescription contains a long-form description of the configuration key.
+                example: A much more in-depth description of the configuration key, including where and how it is used.
+                type: string
+                x-go-name: LongDescription
+            managed:
+                description: Managed describes whether the configuration key is managed by LXD.
+                example: yes.
+                type: string
+                x-go-name: Managed
+            required:
+                description: Required describes conditions under which the configuration key is required.
+                example: On device creation.
+                type: string
+                x-go-name: Required
+            shortdesc:
+                description: ShortDescription contains a short-form description of the configuration key.
+                example: A key for doing X.
+                type: string
+                x-go-name: ShortDescription
+            type:
+                description: Type describes the type of the key.
+                example: Comma delimited CIDR format subnets.
+                type: string
+                x-go-name: Type
+        title: MetadataConfigurationConfigKey contains metadata about a LXD server configuration option.
+        type: object
+        x-go-package: github.com/canonical/lxd/shared/api
+    MetadataConfigurationConfigKeys:
+        properties:
+            keys:
+                items:
+                    additionalProperties:
+                        $ref: '#/definitions/MetadataConfigurationConfigKey'
+                    type: object
+                type: array
+                x-go-name: Keys
+        title: MetadataConfigurationConfigKeys contains metadata about LXD server configuration options.
+        type: object
+        x-go-package: github.com/canonical/lxd/shared/api
+    MetadataConfigurationEntity:
+        properties:
+            entitlements:
+                description: Entitlements contains a list of entitlements that apply to a specific entity type.
+                items:
+                    $ref: '#/definitions/MetadataConfigurationEntityEntitlement'
+                type: array
+                x-go-name: Entitlements
+            project_specific:
+                description: ProjectSpecific indicates whether the entity is project specific.
+                example: true
+                type: boolean
+                x-go-name: ProjectSpecific
+        title: MetadataConfigurationEntity contains metadata about LXD server entities and available entitlements for authorization.
+        type: object
+        x-go-package: github.com/canonical/lxd/shared/api
+    MetadataConfigurationEntityEntitlement:
+        properties:
+            description:
+                description: Description describes the entitlement.
+                example: Grants permission to do X, Y, and Z.
+                type: string
+                x-go-name: Description
+            name:
+                description: Name contains the name of the entitlement.
+                example: can_edit
+                type: string
+                x-go-name: Name
+        title: MetadataConfigurationEntityEntitlement contains metadata about a LXD server entitlement.
+        type: object
+        x-go-package: github.com/canonical/lxd/shared/api
     Network:
         description: Network represents a LXD network
         properties:
@@ -11381,8 +11486,7 @@ paths:
                         description: Sync response
                         properties:
                             metadata:
-                                description: The generated metadata configuration
-                                type: string
+                                $ref: '#/definitions/MetadataConfiguration'
                             status:
                                 description: Status description
                                 example: Success

--- a/lxd/documentation.go
+++ b/lxd/documentation.go
@@ -47,8 +47,7 @@ var generatedDoc embed.FS
 //	          description: Status code
 //	          example: 200
 //	        metadata:
-//	          type: string
-//	          description: The generated metadata configuration
+//	          $ref: "#/definitions/MetadataConfiguration"
 //	  "403":
 //	    $ref: "#/responses/Forbidden"
 //	  "500":

--- a/lxd/documentation.go
+++ b/lxd/documentation.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 
 	"github.com/canonical/lxd/lxd/response"
+	"github.com/canonical/lxd/shared/api"
 )
 
 var metadataConfigurationCmd = APIEndpoint{
@@ -58,7 +59,7 @@ func metadataConfigurationGet(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	var data map[string]any
+	var data api.MetadataConfiguration
 	err = json.Unmarshal(file, &data)
 	if err != nil {
 		return response.SmartError(err)

--- a/lxd/lxd-metadata/lxd_metadata.go
+++ b/lxd/lxd-metadata/lxd_metadata.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/canonical/lxd/shared"
+	"github.com/canonical/lxd/shared/api"
 
 	"gopkg.in/yaml.v2"
 )
@@ -462,7 +463,7 @@ func writeDocFile(inputJSONPath, outputTxtPath string) error {
 		}
 	}
 
-	entities := make(map[string][]map[string]string)
+	entities := make(map[string]api.MetadataConfigurationEntity)
 	err = json.Unmarshal(jsonDoc.Entities, &entities)
 	if err != nil {
 		return err
@@ -476,11 +477,11 @@ func writeDocFile(inputJSONPath, outputTxtPath string) error {
 	sort.Strings(sortedEntityNames)
 
 	for _, entityName := range sortedEntityNames {
-		entitlements := entities[entityName]
+		entity := entities[entityName]
 		buffer.WriteString(fmt.Sprintf("<!-- entity group %s start -->\n", entityName))
-		for _, entitlement := range entitlements {
-			buffer.WriteString(fmt.Sprintf("`%s`\n", entitlement["name"]))
-			buffer.WriteString(fmt.Sprintf(": %s\n\n", entitlement["description"]))
+		for _, entitlement := range entity.Entitlements {
+			buffer.WriteString(fmt.Sprintf("`%s`\n", entitlement.Name))
+			buffer.WriteString(fmt.Sprintf(": %s\n\n", entitlement.Description))
 		}
 
 		buffer.WriteString("\n")

--- a/lxd/lxd-metadata/lxd_metadata.go
+++ b/lxd/lxd-metadata/lxd_metadata.go
@@ -13,7 +13,6 @@ import (
 	"path/filepath"
 	"regexp"
 	"sort"
-	"strconv"
 	"strings"
 	"time"
 
@@ -41,37 +40,6 @@ type IterableAny interface {
 type doc struct {
 	Configs  map[string]map[string]map[string][]any `json:"configs"`
 	Entities json.RawMessage                        `json:"entities"`
-}
-
-// detectType detects the type of a string and returns the corresponding value.
-func detectType(s string) any {
-	i, err := strconv.Atoi(s)
-	if err == nil {
-		return i
-	}
-
-	b, err := strconv.ParseBool(s)
-	if err == nil {
-		return b
-	}
-
-	f, err := strconv.ParseFloat(s, 64)
-	if err == nil {
-		return f
-	}
-
-	t, err := time.Parse(time.RFC3339, s)
-	if err == nil {
-		return t
-	}
-
-	// special characters handling
-	if s == "-" {
-		return ""
-	}
-
-	// If all conversions fail, it's a string
-	return s
 }
 
 // sortConfigKeys alphabetically sorts the entries by key (config option key) within each config group in an entity.
@@ -285,7 +253,7 @@ func parse(path string, outputJSONPath string, excludedPaths []string, substitut
 						continue
 					}
 
-					configKeyEntry[metadataMap["key"]].(map[string]any)[dataKVMatch[1]] = detectType(dataKVMatch[2])
+					configKeyEntry[metadataMap["key"]].(map[string]any)[dataKVMatch[1]] = dataKVMatch[2]
 				}
 
 				// There can be multiple entities for a given group

--- a/lxd/lxd-metadata/lxd_metadata.go
+++ b/lxd/lxd-metadata/lxd_metadata.go
@@ -309,6 +309,13 @@ func parse(path string, outputJSONPath string, excludedPaths []string, substitut
 		return nil, fmt.Errorf("Error while marshaling project documentation: %v", err)
 	}
 
+	// Validate that what we've generated is valid against our API definition.
+	var metadataConfiguration api.MetadataConfiguration
+	err = json.Unmarshal(data, &metadataConfiguration)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to unmarshal generated metadata into MetadataConfiguration API type: %w", err)
+	}
+
 	if outputJSONPath != "" {
 		buf := bytes.NewBufferString("")
 		_, err = buf.Write(data)

--- a/lxd/metadata/configuration.json
+++ b/lxd/metadata/configuration.json
@@ -4321,7 +4321,7 @@
 					},
 					{
 						"network.nat": {
-							"defaultdesc": true,
+							"defaultdesc": "true",
 							"longdesc": "",
 							"required": "no",
 							"shortdesc": "Whether to generate records for NAT-ed subnets",

--- a/lxd/metadata/configuration.json
+++ b/lxd/metadata/configuration.json
@@ -6587,585 +6587,633 @@
 		}
 	},
 	"entities": {
-		"certificate": [
-			{
-				"name": "can_view",
-				"description": "Grants permission to view the certificate."
-			},
-			{
-				"name": "can_edit",
-				"description": "Grants permission to edit the certificate."
-			},
-			{
-				"name": "can_delete",
-				"description": "Grants permission to delete the certificate."
-			}
-		],
-		"group": [
-			{
-				"name": "can_view",
-				"description": "Grants permission to view the group. Identities can always view groups that they are a member of."
-			},
-			{
-				"name": "can_edit",
-				"description": "Grants permission to edit the group."
-			},
-			{
-				"name": "can_delete",
-				"description": "Grants permission to delete the group."
-			}
-		],
-		"identity": [
-			{
-				"name": "can_view",
-				"description": "Grants permission to view the identity."
-			},
-			{
-				"name": "can_edit",
-				"description": "Grants permission to edit the identity."
-			},
-			{
-				"name": "can_delete",
-				"description": "Grants permission to delete the identity."
-			}
-		],
-		"identity_provider_group": [
-			{
-				"name": "can_view",
-				"description": "Grants permission to view the identity provider group."
-			},
-			{
-				"name": "can_edit",
-				"description": "Grants permission to edit the identity provider group."
-			},
-			{
-				"name": "can_delete",
-				"description": "Grants permission to delete the identity provider group."
-			}
-		],
-		"image": [
-			{
-				"name": "can_edit",
-				"description": "Grants permission to edit the image."
-			},
-			{
-				"name": "can_delete",
-				"description": "Grants permission to delete the image."
-			},
-			{
-				"name": "can_view",
-				"description": "Grants permission to view the image."
-			}
-		],
-		"image_alias": [
-			{
-				"name": "can_edit",
-				"description": "Grants permission to edit the image alias."
-			},
-			{
-				"name": "can_delete",
-				"description": "Grants permission to delete the image alias."
-			},
-			{
-				"name": "can_view",
-				"description": "Grants permission to view the image alias."
-			}
-		],
-		"instance": [
-			{
-				"name": "user",
-				"description": "Grants permission to view the instance, to access files, and to start a terminal or console session."
-			},
-			{
-				"name": "operator",
-				"description": "Grants permission to view the instance, to access files, start a terminal or console session, and to manage snapshots and backups."
-			},
-			{
-				"name": "can_edit",
-				"description": "Grants permission to edit the instance."
-			},
-			{
-				"name": "can_delete",
-				"description": "Grants permission to delete the instance."
-			},
-			{
-				"name": "can_view",
-				"description": "Grants permission to view the instance."
-			},
-			{
-				"name": "can_update_state",
-				"description": "Grants permission to change the instance state."
-			},
-			{
-				"name": "can_manage_snapshots",
-				"description": "Grants permission to create and delete snapshots of the instance."
-			},
-			{
-				"name": "can_manage_backups",
-				"description": "Grants permission to create and delete backups of the instance."
-			},
-			{
-				"name": "can_connect_sftp",
-				"description": "Grants permission to get an SFTP client for the instance."
-			},
-			{
-				"name": "can_access_files",
-				"description": "Grants permission to push or pull files into or out of the instance."
-			},
-			{
-				"name": "can_access_console",
-				"description": "Grants permission to start a console session."
-			},
-			{
-				"name": "can_exec",
-				"description": "Grants permission to start a terminal session."
-			}
-		],
-		"network": [
-			{
-				"name": "can_edit",
-				"description": "Grants permission to edit the network."
-			},
-			{
-				"name": "can_delete",
-				"description": "Grants permission to delete the network."
-			},
-			{
-				"name": "can_view",
-				"description": "Grants permission to view the network."
-			}
-		],
-		"network_acl": [
-			{
-				"name": "can_edit",
-				"description": "Grants permission to edit the network ACL."
-			},
-			{
-				"name": "can_delete",
-				"description": "Grants permission to delete the network ACL."
-			},
-			{
-				"name": "can_view",
-				"description": "Grants permission to view the network ACL."
-			}
-		],
-		"network_zone": [
-			{
-				"name": "can_edit",
-				"description": "Grants permission to edit the network zone."
-			},
-			{
-				"name": "can_delete",
-				"description": "Grants permission to delete the network zone."
-			},
-			{
-				"name": "can_view",
-				"description": "Grants permission to view the network zone."
-			}
-		],
-		"profile": [
-			{
-				"name": "can_edit",
-				"description": "Grants permission to edit the profile."
-			},
-			{
-				"name": "can_delete",
-				"description": "Grants permission to delete the profile."
-			},
-			{
-				"name": "can_view",
-				"description": "Grants permission to view the profile."
-			}
-		],
-		"project": [
-			{
-				"name": "operator",
-				"description": "Grants permission to create, view, edit, and delete all resources belonging to the project, but does not grant permission to edit the project configuration itself."
-			},
-			{
-				"name": "viewer",
-				"description": "Grants permission to view all resources belonging to the project."
-			},
-			{
-				"name": "can_view",
-				"description": "Grants permission to view the project."
-			},
-			{
-				"name": "can_edit",
-				"description": "Grants permission to edit the project."
-			},
-			{
-				"name": "can_delete",
-				"description": "Grants permission to delete the project."
-			},
-			{
-				"name": "image_manager",
-				"description": "Grants permission to create, view, edit, and delete all images belonging to the project."
-			},
-			{
-				"name": "can_create_images",
-				"description": "Grants permission to create images."
-			},
-			{
-				"name": "can_view_images",
-				"description": "Grants permission to view images."
-			},
-			{
-				"name": "can_edit_images",
-				"description": "Grants permission to edit images."
-			},
-			{
-				"name": "can_delete_images",
-				"description": "Grants permission to delete images."
-			},
-			{
-				"name": "image_alias_manager",
-				"description": "Grants permission to create, view, edit, and delete all image aliases belonging to the project."
-			},
-			{
-				"name": "can_create_image_aliases",
-				"description": "Grants permission to create image aliases."
-			},
-			{
-				"name": "can_view_image_aliases",
-				"description": "Grants permission to view image aliases."
-			},
-			{
-				"name": "can_edit_image_aliases",
-				"description": "Grants permission to edit image aliases."
-			},
-			{
-				"name": "can_delete_image_aliases",
-				"description": "Grants permission to delete image aliases."
-			},
-			{
-				"name": "instance_manager",
-				"description": "Grants permission to create, view, edit, and delete all instances belonging to the project."
-			},
-			{
-				"name": "can_create_instances",
-				"description": "Grants permission to create instances."
-			},
-			{
-				"name": "can_view_instances",
-				"description": "Grants permission to view instances."
-			},
-			{
-				"name": "can_edit_instances",
-				"description": "Grants permission to edit instances."
-			},
-			{
-				"name": "can_delete_instances",
-				"description": "Grants permission to delete instances."
-			},
-			{
-				"name": "can_operate_instances",
-				"description": "Grants permission to view instances, manage their state, manage their snapshots and backups, start terminal or console sessions, and access their files."
-			},
-			{
-				"name": "network_manager",
-				"description": "Grants permission to create, view, edit, and delete all networks belonging to the project."
-			},
-			{
-				"name": "can_create_networks",
-				"description": "Grants permission to create networks."
-			},
-			{
-				"name": "can_view_networks",
-				"description": "Grants permission to view networks."
-			},
-			{
-				"name": "can_edit_networks",
-				"description": "Grants permission to edit networks."
-			},
-			{
-				"name": "can_delete_networks",
-				"description": "Grants permission to delete networks."
-			},
-			{
-				"name": "network_acl_manager",
-				"description": "Grants permission to create, view, edit, and delete all network ACLs belonging to the project."
-			},
-			{
-				"name": "can_create_network_acls",
-				"description": "Grants permission to create network ACLs."
-			},
-			{
-				"name": "can_view_network_acls",
-				"description": "Grants permission to view network ACLs."
-			},
-			{
-				"name": "can_edit_network_acls",
-				"description": "Grants permission to edit network ACLs."
-			},
-			{
-				"name": "can_delete_network_acls",
-				"description": "Grants permission to delete network ACLs."
-			},
-			{
-				"name": "network_zone_manager",
-				"description": "Grants permission to create, view, edit, and delete all network zones belonging to the project."
-			},
-			{
-				"name": "can_create_network_zones",
-				"description": "Grants permission to create network zones."
-			},
-			{
-				"name": "can_view_network_zones",
-				"description": "Grants permission to view network zones."
-			},
-			{
-				"name": "can_edit_network_zones",
-				"description": "Grants permission to edit network zones."
-			},
-			{
-				"name": "can_delete_network_zones",
-				"description": "Grants permission to delete network zones."
-			},
-			{
-				"name": "profile_manager",
-				"description": "Grants permission to create, view, edit, and delete all profiles belonging to the project."
-			},
-			{
-				"name": "can_create_profiles",
-				"description": "Grants permission to create profiles."
-			},
-			{
-				"name": "can_view_profiles",
-				"description": "Grants permission to view profiles."
-			},
-			{
-				"name": "can_edit_profiles",
-				"description": "Grants permission to edit profiles."
-			},
-			{
-				"name": "can_delete_profiles",
-				"description": "Grants permission to delete profiles."
-			},
-			{
-				"name": "storage_volume_manager",
-				"description": "Grants permission to create, view, edit, and delete all storage volumes belonging to the project."
-			},
-			{
-				"name": "can_create_storage_volumes",
-				"description": "Grants permission to create storage volumes."
-			},
-			{
-				"name": "can_view_storage_volumes",
-				"description": "Grants permission to view storage volumes."
-			},
-			{
-				"name": "can_edit_storage_volumes",
-				"description": "Grants permission to edit storage volumes."
-			},
-			{
-				"name": "can_delete_storage_volumes",
-				"description": "Grants permission to delete storage volumes."
-			},
-			{
-				"name": "storage_bucket_manager",
-				"description": "Grants permission to create, view, edit, and delete all storage buckets belonging to the project."
-			},
-			{
-				"name": "can_create_storage_buckets",
-				"description": "Grants permission to create storage buckets."
-			},
-			{
-				"name": "can_view_storage_buckets",
-				"description": "Grants permission to view storage buckets."
-			},
-			{
-				"name": "can_edit_storage_buckets",
-				"description": "Grants permission to edit storage buckets."
-			},
-			{
-				"name": "can_delete_storage_buckets",
-				"description": "Grants permission to delete storage buckets."
-			},
-			{
-				"name": "can_view_operations",
-				"description": "Grants permission to view operations relating to the project."
-			},
-			{
-				"name": "can_view_events",
-				"description": "Grants permission to view events relating to the project."
-			},
-			{
-				"name": "can_view_metrics",
-				"description": "Grants permission to view project level metrics."
-			}
-		],
-		"server": [
-			{
-				"name": "admin",
-				"description": "Grants full access to LXD as if via Unix socket."
-			},
-			{
-				"name": "viewer",
-				"description": "Grants access to view all resources in the LXD server."
-			},
-			{
-				"name": "can_edit",
-				"description": "Grants permission to edit server configuration, to edit cluster member configuration, to update the state of a cluster member, to create, edit, and delete cluster groups, to update cluster member certificates, and to edit or delete warnings."
-			},
-			{
-				"name": "permission_manager",
-				"description": "Grants permission to view permissions, to create, edit, and delete identities, to view, create, edit, and delete authorization groups, and to view, create, edit, and delete identity provider groups. Note that clients with this permission are able to elevate their own privileges."
-			},
-			{
-				"name": "can_view_permissions",
-				"description": "Grants permission to view permissions."
-			},
-			{
-				"name": "can_create_identities",
-				"description": "Grants permission to create identities."
-			},
-			{
-				"name": "can_view_identities",
-				"description": "Grants permission to view identities."
-			},
-			{
-				"name": "can_edit_identities",
-				"description": "Grants permission to edit identities."
-			},
-			{
-				"name": "can_delete_identities",
-				"description": "Grants permission to delete identities."
-			},
-			{
-				"name": "can_create_groups",
-				"description": "Grants permission to create authorization groups."
-			},
-			{
-				"name": "can_view_groups",
-				"description": "Grants permission to view authorization groups."
-			},
-			{
-				"name": "can_edit_groups",
-				"description": "Grants permission to edit authorization groups."
-			},
-			{
-				"name": "can_delete_groups",
-				"description": "Grants permission to delete authorization groups."
-			},
-			{
-				"name": "can_create_identity_provider_groups",
-				"description": "Grants permission to create identity provider groups."
-			},
-			{
-				"name": "can_view_identity_provider_groups",
-				"description": "Grants permission to view identity provider groups."
-			},
-			{
-				"name": "can_edit_identity_provider_groups",
-				"description": "Grants permission to edit identity provider groups."
-			},
-			{
-				"name": "can_delete_identity_provider_groups",
-				"description": "Grants permission to delete identity provider groups."
-			},
-			{
-				"name": "storage_pool_manager",
-				"description": "Grants permission to create, edit, and delete storage pools."
-			},
-			{
-				"name": "can_create_storage_pools",
-				"description": "Grants permission to create storage pools."
-			},
-			{
-				"name": "can_edit_storage_pools",
-				"description": "Grants permission to edit storage pools."
-			},
-			{
-				"name": "can_delete_storage_pools",
-				"description": "Grants permission to delete storage pools."
-			},
-			{
-				"name": "project_manager",
-				"description": "Grants permission to view, create, edit, and delete projects, and to create, edit, and delete any resources that are owned by those projects."
-			},
-			{
-				"name": "can_create_projects",
-				"description": "Grants permission to create projects."
-			},
-			{
-				"name": "can_view_projects",
-				"description": "Grants permission to view projects, and all resources within those projects."
-			},
-			{
-				"name": "can_edit_projects",
-				"description": "Grants permission to edit projects, and all resources within those projects."
-			},
-			{
-				"name": "can_delete_projects",
-				"description": "Grants permission to delete projects."
-			},
-			{
-				"name": "can_override_cluster_target_restriction",
-				"description": "If a project is configured with `restricted.cluster.target`, clients with this permission can override the restriction."
-			},
-			{
-				"name": "can_view_privileged_events",
-				"description": "Grants permission to view privileged event types, such as logging events."
-			},
-			{
-				"name": "can_view_resources",
-				"description": "Grants permission to view server and storage pool resource usage information."
-			},
-			{
-				"name": "can_view_metrics",
-				"description": "Grants permission to view all server and project level metrics."
-			},
-			{
-				"name": "can_view_warnings",
-				"description": "Grants permission to view warnings."
-			}
-		],
-		"storage_bucket": [
-			{
-				"name": "can_edit",
-				"description": "Grants permission to edit the storage bucket."
-			},
-			{
-				"name": "can_delete",
-				"description": "Grants permission to delete the storage bucket."
-			},
-			{
-				"name": "can_view",
-				"description": "Grants permission to view the storage bucket."
-			}
-		],
-		"storage_pool": [
-			{
-				"name": "can_edit",
-				"description": "Grants permission to edit the storage pool."
-			},
-			{
-				"name": "can_delete",
-				"description": "Grants permission to delete the storage pool."
-			}
-		],
-		"storage_volume": [
-			{
-				"name": "can_edit",
-				"description": "Grants permission to edit the storage volume."
-			},
-			{
-				"name": "can_delete",
-				"description": "Grants permission to delete the storage volume."
-			},
-			{
-				"name": "can_view",
-				"description": "Grants permission to view the storage volume."
-			},
-			{
-				"name": "can_manage_snapshots",
-				"description": "Grants permission to create and delete snapshots of the storage volume."
-			},
-			{
-				"name": "can_manage_backups",
-				"description": "Grants permission to create and delete backups of the storage volume."
-			}
-		]
+		"certificate": {
+			"project_specific": false,
+			"entitlements": [
+				{
+					"name": "can_view",
+					"description": "Grants permission to view the certificate."
+				},
+				{
+					"name": "can_edit",
+					"description": "Grants permission to edit the certificate."
+				},
+				{
+					"name": "can_delete",
+					"description": "Grants permission to delete the certificate."
+				}
+			]
+		},
+		"group": {
+			"project_specific": false,
+			"entitlements": [
+				{
+					"name": "can_view",
+					"description": "Grants permission to view the group. Identities can always view groups that they are a member of."
+				},
+				{
+					"name": "can_edit",
+					"description": "Grants permission to edit the group."
+				},
+				{
+					"name": "can_delete",
+					"description": "Grants permission to delete the group."
+				}
+			]
+		},
+		"identity": {
+			"project_specific": false,
+			"entitlements": [
+				{
+					"name": "can_view",
+					"description": "Grants permission to view the identity."
+				},
+				{
+					"name": "can_edit",
+					"description": "Grants permission to edit the identity."
+				},
+				{
+					"name": "can_delete",
+					"description": "Grants permission to delete the identity."
+				}
+			]
+		},
+		"identity_provider_group": {
+			"project_specific": false,
+			"entitlements": [
+				{
+					"name": "can_view",
+					"description": "Grants permission to view the identity provider group."
+				},
+				{
+					"name": "can_edit",
+					"description": "Grants permission to edit the identity provider group."
+				},
+				{
+					"name": "can_delete",
+					"description": "Grants permission to delete the identity provider group."
+				}
+			]
+		},
+		"image": {
+			"project_specific": true,
+			"entitlements": [
+				{
+					"name": "can_edit",
+					"description": "Grants permission to edit the image."
+				},
+				{
+					"name": "can_delete",
+					"description": "Grants permission to delete the image."
+				},
+				{
+					"name": "can_view",
+					"description": "Grants permission to view the image."
+				}
+			]
+		},
+		"image_alias": {
+			"project_specific": true,
+			"entitlements": [
+				{
+					"name": "can_edit",
+					"description": "Grants permission to edit the image alias."
+				},
+				{
+					"name": "can_delete",
+					"description": "Grants permission to delete the image alias."
+				},
+				{
+					"name": "can_view",
+					"description": "Grants permission to view the image alias."
+				}
+			]
+		},
+		"instance": {
+			"project_specific": true,
+			"entitlements": [
+				{
+					"name": "user",
+					"description": "Grants permission to view the instance, to access files, and to start a terminal or console session."
+				},
+				{
+					"name": "operator",
+					"description": "Grants permission to view the instance, to access files, start a terminal or console session, and to manage snapshots and backups."
+				},
+				{
+					"name": "can_edit",
+					"description": "Grants permission to edit the instance."
+				},
+				{
+					"name": "can_delete",
+					"description": "Grants permission to delete the instance."
+				},
+				{
+					"name": "can_view",
+					"description": "Grants permission to view the instance."
+				},
+				{
+					"name": "can_update_state",
+					"description": "Grants permission to change the instance state."
+				},
+				{
+					"name": "can_manage_snapshots",
+					"description": "Grants permission to create and delete snapshots of the instance."
+				},
+				{
+					"name": "can_manage_backups",
+					"description": "Grants permission to create and delete backups of the instance."
+				},
+				{
+					"name": "can_connect_sftp",
+					"description": "Grants permission to get an SFTP client for the instance."
+				},
+				{
+					"name": "can_access_files",
+					"description": "Grants permission to push or pull files into or out of the instance."
+				},
+				{
+					"name": "can_access_console",
+					"description": "Grants permission to start a console session."
+				},
+				{
+					"name": "can_exec",
+					"description": "Grants permission to start a terminal session."
+				}
+			]
+		},
+		"network": {
+			"project_specific": true,
+			"entitlements": [
+				{
+					"name": "can_edit",
+					"description": "Grants permission to edit the network."
+				},
+				{
+					"name": "can_delete",
+					"description": "Grants permission to delete the network."
+				},
+				{
+					"name": "can_view",
+					"description": "Grants permission to view the network."
+				}
+			]
+		},
+		"network_acl": {
+			"project_specific": true,
+			"entitlements": [
+				{
+					"name": "can_edit",
+					"description": "Grants permission to edit the network ACL."
+				},
+				{
+					"name": "can_delete",
+					"description": "Grants permission to delete the network ACL."
+				},
+				{
+					"name": "can_view",
+					"description": "Grants permission to view the network ACL."
+				}
+			]
+		},
+		"network_zone": {
+			"project_specific": true,
+			"entitlements": [
+				{
+					"name": "can_edit",
+					"description": "Grants permission to edit the network zone."
+				},
+				{
+					"name": "can_delete",
+					"description": "Grants permission to delete the network zone."
+				},
+				{
+					"name": "can_view",
+					"description": "Grants permission to view the network zone."
+				}
+			]
+		},
+		"profile": {
+			"project_specific": true,
+			"entitlements": [
+				{
+					"name": "can_edit",
+					"description": "Grants permission to edit the profile."
+				},
+				{
+					"name": "can_delete",
+					"description": "Grants permission to delete the profile."
+				},
+				{
+					"name": "can_view",
+					"description": "Grants permission to view the profile."
+				}
+			]
+		},
+		"project": {
+			"project_specific": false,
+			"entitlements": [
+				{
+					"name": "operator",
+					"description": "Grants permission to create, view, edit, and delete all resources belonging to the project, but does not grant permission to edit the project configuration itself."
+				},
+				{
+					"name": "viewer",
+					"description": "Grants permission to view all resources belonging to the project."
+				},
+				{
+					"name": "can_view",
+					"description": "Grants permission to view the project."
+				},
+				{
+					"name": "can_edit",
+					"description": "Grants permission to edit the project."
+				},
+				{
+					"name": "can_delete",
+					"description": "Grants permission to delete the project."
+				},
+				{
+					"name": "image_manager",
+					"description": "Grants permission to create, view, edit, and delete all images belonging to the project."
+				},
+				{
+					"name": "can_create_images",
+					"description": "Grants permission to create images."
+				},
+				{
+					"name": "can_view_images",
+					"description": "Grants permission to view images."
+				},
+				{
+					"name": "can_edit_images",
+					"description": "Grants permission to edit images."
+				},
+				{
+					"name": "can_delete_images",
+					"description": "Grants permission to delete images."
+				},
+				{
+					"name": "image_alias_manager",
+					"description": "Grants permission to create, view, edit, and delete all image aliases belonging to the project."
+				},
+				{
+					"name": "can_create_image_aliases",
+					"description": "Grants permission to create image aliases."
+				},
+				{
+					"name": "can_view_image_aliases",
+					"description": "Grants permission to view image aliases."
+				},
+				{
+					"name": "can_edit_image_aliases",
+					"description": "Grants permission to edit image aliases."
+				},
+				{
+					"name": "can_delete_image_aliases",
+					"description": "Grants permission to delete image aliases."
+				},
+				{
+					"name": "instance_manager",
+					"description": "Grants permission to create, view, edit, and delete all instances belonging to the project."
+				},
+				{
+					"name": "can_create_instances",
+					"description": "Grants permission to create instances."
+				},
+				{
+					"name": "can_view_instances",
+					"description": "Grants permission to view instances."
+				},
+				{
+					"name": "can_edit_instances",
+					"description": "Grants permission to edit instances."
+				},
+				{
+					"name": "can_delete_instances",
+					"description": "Grants permission to delete instances."
+				},
+				{
+					"name": "can_operate_instances",
+					"description": "Grants permission to view instances, manage their state, manage their snapshots and backups, start terminal or console sessions, and access their files."
+				},
+				{
+					"name": "network_manager",
+					"description": "Grants permission to create, view, edit, and delete all networks belonging to the project."
+				},
+				{
+					"name": "can_create_networks",
+					"description": "Grants permission to create networks."
+				},
+				{
+					"name": "can_view_networks",
+					"description": "Grants permission to view networks."
+				},
+				{
+					"name": "can_edit_networks",
+					"description": "Grants permission to edit networks."
+				},
+				{
+					"name": "can_delete_networks",
+					"description": "Grants permission to delete networks."
+				},
+				{
+					"name": "network_acl_manager",
+					"description": "Grants permission to create, view, edit, and delete all network ACLs belonging to the project."
+				},
+				{
+					"name": "can_create_network_acls",
+					"description": "Grants permission to create network ACLs."
+				},
+				{
+					"name": "can_view_network_acls",
+					"description": "Grants permission to view network ACLs."
+				},
+				{
+					"name": "can_edit_network_acls",
+					"description": "Grants permission to edit network ACLs."
+				},
+				{
+					"name": "can_delete_network_acls",
+					"description": "Grants permission to delete network ACLs."
+				},
+				{
+					"name": "network_zone_manager",
+					"description": "Grants permission to create, view, edit, and delete all network zones belonging to the project."
+				},
+				{
+					"name": "can_create_network_zones",
+					"description": "Grants permission to create network zones."
+				},
+				{
+					"name": "can_view_network_zones",
+					"description": "Grants permission to view network zones."
+				},
+				{
+					"name": "can_edit_network_zones",
+					"description": "Grants permission to edit network zones."
+				},
+				{
+					"name": "can_delete_network_zones",
+					"description": "Grants permission to delete network zones."
+				},
+				{
+					"name": "profile_manager",
+					"description": "Grants permission to create, view, edit, and delete all profiles belonging to the project."
+				},
+				{
+					"name": "can_create_profiles",
+					"description": "Grants permission to create profiles."
+				},
+				{
+					"name": "can_view_profiles",
+					"description": "Grants permission to view profiles."
+				},
+				{
+					"name": "can_edit_profiles",
+					"description": "Grants permission to edit profiles."
+				},
+				{
+					"name": "can_delete_profiles",
+					"description": "Grants permission to delete profiles."
+				},
+				{
+					"name": "storage_volume_manager",
+					"description": "Grants permission to create, view, edit, and delete all storage volumes belonging to the project."
+				},
+				{
+					"name": "can_create_storage_volumes",
+					"description": "Grants permission to create storage volumes."
+				},
+				{
+					"name": "can_view_storage_volumes",
+					"description": "Grants permission to view storage volumes."
+				},
+				{
+					"name": "can_edit_storage_volumes",
+					"description": "Grants permission to edit storage volumes."
+				},
+				{
+					"name": "can_delete_storage_volumes",
+					"description": "Grants permission to delete storage volumes."
+				},
+				{
+					"name": "storage_bucket_manager",
+					"description": "Grants permission to create, view, edit, and delete all storage buckets belonging to the project."
+				},
+				{
+					"name": "can_create_storage_buckets",
+					"description": "Grants permission to create storage buckets."
+				},
+				{
+					"name": "can_view_storage_buckets",
+					"description": "Grants permission to view storage buckets."
+				},
+				{
+					"name": "can_edit_storage_buckets",
+					"description": "Grants permission to edit storage buckets."
+				},
+				{
+					"name": "can_delete_storage_buckets",
+					"description": "Grants permission to delete storage buckets."
+				},
+				{
+					"name": "can_view_operations",
+					"description": "Grants permission to view operations relating to the project."
+				},
+				{
+					"name": "can_view_events",
+					"description": "Grants permission to view events relating to the project."
+				},
+				{
+					"name": "can_view_metrics",
+					"description": "Grants permission to view project level metrics."
+				}
+			]
+		},
+		"server": {
+			"project_specific": false,
+			"entitlements": [
+				{
+					"name": "admin",
+					"description": "Grants full access to LXD as if via Unix socket."
+				},
+				{
+					"name": "viewer",
+					"description": "Grants access to view all resources in the LXD server."
+				},
+				{
+					"name": "can_edit",
+					"description": "Grants permission to edit server configuration, to edit cluster member configuration, to update the state of a cluster member, to create, edit, and delete cluster groups, to update cluster member certificates, and to edit or delete warnings."
+				},
+				{
+					"name": "permission_manager",
+					"description": "Grants permission to view permissions, to create, edit, and delete identities, to view, create, edit, and delete authorization groups, and to view, create, edit, and delete identity provider groups. Note that clients with this permission are able to elevate their own privileges."
+				},
+				{
+					"name": "can_view_permissions",
+					"description": "Grants permission to view permissions."
+				},
+				{
+					"name": "can_create_identities",
+					"description": "Grants permission to create identities."
+				},
+				{
+					"name": "can_view_identities",
+					"description": "Grants permission to view identities."
+				},
+				{
+					"name": "can_edit_identities",
+					"description": "Grants permission to edit identities."
+				},
+				{
+					"name": "can_delete_identities",
+					"description": "Grants permission to delete identities."
+				},
+				{
+					"name": "can_create_groups",
+					"description": "Grants permission to create authorization groups."
+				},
+				{
+					"name": "can_view_groups",
+					"description": "Grants permission to view authorization groups."
+				},
+				{
+					"name": "can_edit_groups",
+					"description": "Grants permission to edit authorization groups."
+				},
+				{
+					"name": "can_delete_groups",
+					"description": "Grants permission to delete authorization groups."
+				},
+				{
+					"name": "can_create_identity_provider_groups",
+					"description": "Grants permission to create identity provider groups."
+				},
+				{
+					"name": "can_view_identity_provider_groups",
+					"description": "Grants permission to view identity provider groups."
+				},
+				{
+					"name": "can_edit_identity_provider_groups",
+					"description": "Grants permission to edit identity provider groups."
+				},
+				{
+					"name": "can_delete_identity_provider_groups",
+					"description": "Grants permission to delete identity provider groups."
+				},
+				{
+					"name": "storage_pool_manager",
+					"description": "Grants permission to create, edit, and delete storage pools."
+				},
+				{
+					"name": "can_create_storage_pools",
+					"description": "Grants permission to create storage pools."
+				},
+				{
+					"name": "can_edit_storage_pools",
+					"description": "Grants permission to edit storage pools."
+				},
+				{
+					"name": "can_delete_storage_pools",
+					"description": "Grants permission to delete storage pools."
+				},
+				{
+					"name": "project_manager",
+					"description": "Grants permission to view, create, edit, and delete projects, and to create, edit, and delete any resources that are owned by those projects."
+				},
+				{
+					"name": "can_create_projects",
+					"description": "Grants permission to create projects."
+				},
+				{
+					"name": "can_view_projects",
+					"description": "Grants permission to view projects, and all resources within those projects."
+				},
+				{
+					"name": "can_edit_projects",
+					"description": "Grants permission to edit projects, and all resources within those projects."
+				},
+				{
+					"name": "can_delete_projects",
+					"description": "Grants permission to delete projects."
+				},
+				{
+					"name": "can_override_cluster_target_restriction",
+					"description": "If a project is configured with `restricted.cluster.target`, clients with this permission can override the restriction."
+				},
+				{
+					"name": "can_view_privileged_events",
+					"description": "Grants permission to view privileged event types, such as logging events."
+				},
+				{
+					"name": "can_view_resources",
+					"description": "Grants permission to view server and storage pool resource usage information."
+				},
+				{
+					"name": "can_view_metrics",
+					"description": "Grants permission to view all server and project level metrics."
+				},
+				{
+					"name": "can_view_warnings",
+					"description": "Grants permission to view warnings."
+				}
+			]
+		},
+		"storage_bucket": {
+			"project_specific": true,
+			"entitlements": [
+				{
+					"name": "can_edit",
+					"description": "Grants permission to edit the storage bucket."
+				},
+				{
+					"name": "can_delete",
+					"description": "Grants permission to delete the storage bucket."
+				},
+				{
+					"name": "can_view",
+					"description": "Grants permission to view the storage bucket."
+				}
+			]
+		},
+		"storage_pool": {
+			"project_specific": false,
+			"entitlements": [
+				{
+					"name": "can_edit",
+					"description": "Grants permission to edit the storage pool."
+				},
+				{
+					"name": "can_delete",
+					"description": "Grants permission to delete the storage pool."
+				}
+			]
+		},
+		"storage_volume": {
+			"project_specific": true,
+			"entitlements": [
+				{
+					"name": "can_edit",
+					"description": "Grants permission to edit the storage volume."
+				},
+				{
+					"name": "can_delete",
+					"description": "Grants permission to delete the storage volume."
+				},
+				{
+					"name": "can_view",
+					"description": "Grants permission to view the storage volume."
+				},
+				{
+					"name": "can_manage_snapshots",
+					"description": "Grants permission to create and delete snapshots of the storage volume."
+				},
+				{
+					"name": "can_manage_backups",
+					"description": "Grants permission to create and delete backups of the storage volume."
+				}
+			]
+		}
 	}
 }

--- a/shared/api/metadata_configuration.go
+++ b/shared/api/metadata_configuration.go
@@ -1,0 +1,99 @@
+package api
+
+// MetadataConfiguration contains metadata about the LXD server configuration options.
+//
+// swagger:model
+//
+// API extension: metadata_configuration.
+type MetadataConfiguration struct {
+	// Configs contains all server configuration metadata.
+	Configs map[string]map[string]MetadataConfigurationConfigKeys `json:"configs" yaml:"configs"`
+
+	// Entities contains all authorization related metadata.
+	//
+	// API extension: metadata_configuration_entity_types
+	Entities map[string]MetadataConfigurationEntity `json:"entities" yaml:"entities"`
+}
+
+// MetadataConfigurationConfigKeys contains metadata about LXD server configuration options.
+//
+// swagger:model
+//
+// API extension: metadata_configuration.
+type MetadataConfigurationConfigKeys struct {
+	Keys []map[string]MetadataConfigurationConfigKey `json:"keys" yaml:"keys"`
+}
+
+// MetadataConfigurationConfigKey contains metadata about a LXD server configuration option.
+//
+// swagger:model
+//
+// API extension: metadata_configuration.
+type MetadataConfigurationConfigKey struct {
+	// DefaultDescription contains a description of the configuration key.
+	//
+	// Example: A general description of a configuration key.
+	DefaultDescription string `json:"defaultdesc" yaml:"defaultdesc"`
+
+	// LongDescription contains a long-form description of the configuration key.
+	//
+	// Example: A much more in-depth description of the configuration key, including where and how it is used.
+	LongDescription string `json:"longdesc" yaml:"longdesc"`
+
+	// ShortDescription contains a short-form description of the configuration key.
+	//
+	// Example: A key for doing X.
+	ShortDescription string `json:"shortdesc" yaml:"shortdesc"`
+
+	// Type describes the type of the key.
+	//
+	// Example: Comma delimited CIDR format subnets.
+	Type string `json:"type" yaml:"type"`
+
+	// Condition describes conditions under which the configuration key can be applied.
+	//
+	// Example: Virtual machines only.
+	Condition string `json:"condition" yaml:"condition"`
+
+	// Required describes conditions under which the configuration key is required.
+	//
+	// Example: On device creation.
+	Required string `json:"required" yaml:"required"`
+
+	// Managed describes whether the configuration key is managed by LXD.
+	//
+	// Example: yes.
+	Managed string `json:"managed"`
+}
+
+// MetadataConfigurationEntity contains metadata about LXD server entities and available entitlements for authorization.
+//
+// swagger:model
+//
+// API extension: metadata_configuration_entity_types.
+type MetadataConfigurationEntity struct {
+	// ProjectSpecific indicates whether the entity is project specific.
+	//
+	// Example: true
+	ProjectSpecific bool `json:"project_specific" yaml:"project_specific"`
+
+	// Entitlements contains a list of entitlements that apply to a specific entity type.
+	Entitlements []MetadataConfigurationEntityEntitlement `json:"entitlements" yaml:"entitlements"`
+}
+
+// MetadataConfigurationEntityEntitlement contains metadata about a LXD server entitlement.
+//
+// swagger:model
+//
+// API extension: metadata_configuration_entity_types.
+type MetadataConfigurationEntityEntitlement struct {
+	// Name contains the name of the entitlement.
+	//
+	// Example: can_edit
+	Name string `json:"name" yaml:"name"`
+
+	// Description describes the entitlement.
+	//
+	// Example: Grants permission to do X, Y, and Z.
+	Description string `json:"description" yaml:"description"`
+}

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -417,6 +417,7 @@ var APIExtensions = []string{
 	"metrics_api_requests",
 	"projects_limits_disk_pool",
 	"ubuntu_pro_guest_attach",
+	"metadata_configuration_entity_types",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
This is so that we can manage configuration metadata with API extensions as we do with any other API response over `/1.0`

* Adds an API extension for adding entity metadata to `GET /1.0/configuration/metadata`.
* Adds types under `shared/api` for configuration metadata.
* Updates entity metadata such that each entity maps to a JSON object, with `requires_project` and `entitlements` fields.
* Enforces that generated metadata conforms to the new API type.
* Updates the swagger doc for `GET /1.0/configuration/metadata` to include the newly defined type.