### PR TITLE
lxd/image: Revert "Acquire image lock for uploaded images"

### DIFF
--- a/lxd/images.go
+++ b/lxd/images.go
@@ -796,13 +796,6 @@ func getImgPostInfo(s *state.State, r *http.Request, builddir string, project st
 		return nil, err
 	}
 
-	unlock, err := imageOperationLock(info.Fingerprint)
-	if err != nil {
-		return nil, err
-	}
-
-	defer unlock()
-
 	imageMeta, imageType, err := getImageMetadata(imageTmpFilename)
 	if err != nil {
 		l.Error("Failed to get image metadata", logger.Ctx{"err": err})


### PR DESCRIPTION
This reverts commit 8a59f7fd1a21f078d6f47cb7b7bfbfd35bd5bb2a.

Only going to revert this one to make sure that the locking is the cause of the test failures.