### PR TITLE
lxd: Update copy op response body when source is snapshot

### DIFF
--- a/lxd/instances_post.go
+++ b/lxd/instances_post.go
@@ -631,7 +631,14 @@ func createFromCopy(s *state.State, r *http.Request, projectName string, profile
 	}
 
 	resources := map[string][]api.URL{}
-	resources["instances"] = []api.URL{*api.NewURL().Path(version.APIVersion, "instances", req.Name), *api.NewURL().Path(version.APIVersion, "instances", req.Source.Source)}
+	resources["instances"] = []api.URL{*api.NewURL().Path(version.APIVersion, "instances", req.Name)}
+
+	if shared.IsSnapshot(req.Source.Source) {
+		cName, sName, _ := api.GetParentAndSnapshotName(req.Source.Source)
+		resources["instances_snapshots"] = []api.URL{*api.NewURL().Path(version.APIVersion, "instances", cName, "snapshots", sName)}
+	} else {
+		resources["instances"] = append(resources["instances"], *api.NewURL().Path(version.APIVersion, "instances", req.Source.Source))
+	}
 
 	if dbType == instancetype.Container {
 		resources["containers"] = resources["instances"]


### PR DESCRIPTION
This PR updates the copy operation response body when using a snapshot as the source. Previously, the response body allocated the snapshot to `resources.instances` and `resources.containers`. This is not entirely accurate, so we now check to see if the source is a snapshot, and if so, we allocate it to `resources.instances_snapshots` instead of `resources.instances` and `resources.containers`.

Closes https://github.com/canonical/lxd/issues/13999.