### PR TITLE
lxd-agent: Handle built-in vsock module (from Incus)

### DIFF
--- a/lxd-agent/main_agent.go
+++ b/lxd-agent/main_agent.go
@@ -114,16 +114,19 @@ func (c *cmdAgent) Run(cmd *cobra.Command, args []string) error {
 	reconfigureNetworkInterfaces()
 
 	// Load the kernel driver.
-	logger.Info("Loading vsock module")
-	err = util.LoadModule("vsock")
-	if err != nil {
-		return fmt.Errorf("Unable to load the vsock kernel module: %w", err)
-	}
+	if !shared.PathExists("/dev/vsock") {
+		logger.Info("Loading vsock module")
 
-	// Wait for vsock device to appear.
-	for i := 0; i < 5; i++ {
-		if !shared.PathExists("/dev/vsock") {
-			time.Sleep(1 * time.Second)
+		err = util.LoadModule("vsock")
+		if err != nil {
+			return fmt.Errorf("Unable to load the vsock kernel module: %w", err)
+		}
+
+		// Wait for vsock device to appear.
+		for i := 0; i < 5; i++ {
+			if !shared.PathExists("/dev/vsock") {
+				time.Sleep(1 * time.Second)
+			}
 		}
 	}
 


### PR DESCRIPTION
(cherry picked from https://github.com/lxc/incus/pull/389/commits/c3172b748e0eba8cfd4e959a14bc609a14fa5ac7)

License: Apache-2.0