### PR TITLE
lxc: Prevent accept-certificate flag when using trust token

### DIFF
--- a/lxc/remote.go
+++ b/lxc/remote.go
@@ -294,6 +294,16 @@ func (c *cmdRemoteAdd) run(cmd *cobra.Command, args []string) error {
 		return errors.New(i18n.G("Remote address must not be empty"))
 	}
 
+	// Trust token cannot be used when auth type is set to OIDC.
+	if c.flagToken != "" && c.flagAuthType == "oidc" {
+		return errors.New(i18n.G("Trust token cannot be used with OIDC authentication"))
+	}
+
+	// Trust token cannot be used for public remotes.
+	if c.flagToken != "" && c.flagPublic {
+		return errors.New(i18n.G("Trust token cannot be used for public remotes"))
+	}
+
 	// Validate the server name.
 	if strings.Contains(server, ":") {
 		return errors.New(i18n.G("Remote names may not contain colons"))

--- a/lxc/remote.go
+++ b/lxc/remote.go
@@ -153,8 +153,13 @@ func (c *cmdRemoteAdd) findProject(d lxd.InstanceServer, project string) (string
 	return project, nil
 }
 
-func (c *cmdRemoteAdd) runToken(server string, token string, rawToken *api.CertificateAddToken) error {
+func (c *cmdRemoteAdd) runToken(addr string, server string, token string, rawToken *api.CertificateAddToken) error {
 	conf := c.global.conf
+
+	// Certificate cannot be blindly accepted when using a trust token.
+	if c.flagAcceptCert {
+		return errors.New(i18n.G("The --accept-certificate flag is not supported when adding a remote using a trust token"))
+	}
 
 	if !conf.HasClientCertificate() {
 		fmt.Fprint(os.Stderr, i18n.G("Generating a client certificate. This may take a minute...")+"\n")
@@ -164,6 +169,12 @@ func (c *cmdRemoteAdd) runToken(server string, token string, rawToken *api.Certi
 		}
 	}
 
+	// If address is provided, use token on that specific address.
+	if addr != "" {
+		return c.addRemoteFromToken(addr, server, token, rawToken.Fingerprint)
+	}
+
+	// Otherwise, iterate over all addresses within the token.
 	for _, addr := range rawToken.Addresses {
 		addr = fmt.Sprintf("https://%s", addr)
 
@@ -179,6 +190,7 @@ func (c *cmdRemoteAdd) runToken(server string, token string, rawToken *api.Certi
 		return nil
 	}
 
+	// Finally, fallback to manual input.
 	fmt.Println(i18n.G("All server addresses are unavailable"))
 	fmt.Print(i18n.G("Please provide an alternate server address (empty to abort):") + " ")
 
@@ -304,6 +316,11 @@ func (c *cmdRemoteAdd) run(cmd *cobra.Command, args []string) error {
 		return errors.New(i18n.G("Trust token cannot be used for public remotes"))
 	}
 
+	// Certificate cannot be blindly accepted when using a trust token.
+	if c.flagToken != "" && c.flagAcceptCert {
+		return errors.New(i18n.G("The --accept-certificate flag is not supported when adding a remote using a trust token"))
+	}
+
 	// Validate the server name.
 	if strings.Contains(server, ":") {
 		return errors.New(i18n.G("Remote names may not contain colons"))
@@ -329,9 +346,11 @@ func (c *cmdRemoteAdd) run(cmd *cobra.Command, args []string) error {
 		conf.Remotes = map[string]config.Remote{}
 	}
 
+	// Check if the first argument is a trust token. In such case, we need to
+	// decode it and use it to connect to the remote.
 	rawToken, err := shared.CertificateTokenDecode(addr)
 	if err == nil {
-		return c.runToken(server, addr, rawToken)
+		return c.runToken("", server, addr, rawToken)
 	}
 
 	// Complex remote URL parsing
@@ -445,6 +464,16 @@ func (c *cmdRemoteAdd) run(cmd *cobra.Command, args []string) error {
 
 		conf.Remotes[server] = remote
 		return conf.SaveConfig(c.global.confPath)
+	}
+
+	// Handle adding a remote with trust token.
+	if c.flagToken != "" {
+		rawToken, err := shared.CertificateTokenDecode(c.flagToken)
+		if err != nil {
+			return fmt.Errorf(i18n.G("Failed to decode trust token: %w"), err)
+		}
+
+		return c.runToken(addr, server, c.flagToken, rawToken)
 	}
 
 	// Check if the system CA worked for the TLS connection
@@ -594,11 +623,9 @@ func (c *cmdRemoteAdd) run(cmd *cobra.Command, args []string) error {
 			// use the token instead and prompt for it if not present.
 			if d.(lxd.InstanceServer).HasExtension("explicit_trust_token") && c.flagPassword == "" {
 				// Prompt for trust token.
-				if c.flagToken == "" {
-					c.flagToken, err = c.global.asker.AskString(fmt.Sprintf(i18n.G("Trust token for %s: "), server), "", nil)
-					if err != nil {
-						return err
-					}
+				c.flagToken, err = c.global.asker.AskString(fmt.Sprintf(i18n.G("Trust token for %s: "), server), "", nil)
+				if err != nil {
+					return err
 				}
 
 				req.TrustToken = c.flagToken

--- a/lxc/remote.go
+++ b/lxc/remote.go
@@ -449,22 +449,39 @@ func (c *cmdRemoteAdd) run(cmd *cobra.Command, args []string) error {
 
 	// Handle certificate prompt
 	if certificate != nil {
+		// Prompt for certificate acceptance if user did not allow us to blindly
+		// accept the remote certificate.
 		if !c.flagAcceptCert {
 			digest := shared.CertFingerprint(certificate)
 
 			fmt.Printf("%s: %s\n", i18n.G("Certificate fingerprint"), digest)
 			fmt.Print(i18n.G("ok (y/n/[fingerprint])?") + " ")
-			line, err := shared.ReadStdin()
-			if err != nil {
-				return err
-			}
+			for {
+				line, err := shared.ReadStdin()
+				if err != nil {
+					return err
+				}
 
-			if string(line) != digest {
+				// Continue with adding the remote if digest matches, or the user
+				// confirmed a fingerprint.
+				if string(line) == digest || strings.ToLower(string(line[0])) == i18n.G("y") {
+					break
+				}
+
+				// If the input length matches the certificate fingerprint length
+				// but the fingerprints do not match, return an error. This ensures
+				// the scripts do not hang if incorrect fingerprint is provided.
+				if len(line) == len(digest) {
+					return errors.New(i18n.G("The provided fingerprint does not match the server certificate fingerprint"))
+				}
+
+				// Error out if the user didn't confirm the fingerprint.
 				if len(line) < 1 || strings.ToLower(string(line[0])) == i18n.G("n") {
 					return errors.New(i18n.G("Server certificate NACKed by user"))
-				} else if strings.ToLower(string(line[0])) != i18n.G("y") {
-					return errors.New(i18n.G("Please type 'y', 'n' or the fingerprint:"))
 				}
+
+				// Ask again for any other invalid input.
+				fmt.Print(i18n.G("Please type 'y', 'n' or the fingerprint: "))
 			}
 		}
 

--- a/lxc/remote.go
+++ b/lxc/remote.go
@@ -267,9 +267,22 @@ func (c *cmdRemoteAdd) addRemoteFromToken(addr string, server string, token stri
 		req.Password = token
 	}
 
+	// Add client certificate to trust store. Even if we are already trusted (src.Auth == "trusted"),
+	// we want to send the token to invalidate it. Therefore, we can ignore the conflict error, which
+	// is thrown if we are trying to add a client cert that is already trusted by LXD remote.
 	err = d.CreateCertificate(req)
+	if err != nil && !api.StatusErrorCheck(err, http.StatusConflict) {
+		return err
+	}
+
+	// And check if trusted now.
+	srv, _, err := d.GetServer()
 	if err != nil {
-		return fmt.Errorf(i18n.G("Failed to create certificate: %w"), err)
+		return err
+	}
+
+	if srv.Auth != "trusted" {
+		return errors.New(i18n.G("Server doesn't trust us after authentication"))
 	}
 
 	// Handle project.

--- a/lxd/certificates.go
+++ b/lxd/certificates.go
@@ -478,6 +478,28 @@ func certificatesPost(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(fmt.Errorf("Failed to get authentication status: %w", err))
 	}
 
+	// If caller is already trusted and the trust token is provided, we validate the token and cancel
+	// the corresponding token operation.
+	if trusted && req.TrustToken != "" {
+		// Decode the trust token.
+		joinToken, err := shared.CertificateTokenDecode(req.TrustToken)
+		if err != nil {
+			return response.Forbidden(nil)
+		}
+
+		// Validate the token and cancel the corresponding operation.
+		tokenReq, err := certificateTokenValid(s, r, joinToken)
+		if err != nil {
+			return response.InternalError(fmt.Errorf("Failed during search for certificate add token operation: %w", err))
+		}
+
+		if tokenReq == nil {
+			return response.Forbidden(fmt.Errorf("No matching certificate add operation found"))
+		}
+
+		return response.Conflict(fmt.Errorf("Client is already trusted"))
+	}
+
 	// If caller is already trusted and does not have permission to create certificates, they cannot create more certificates.
 	if trusted && !userCanCreateCertificates && req.Certificate == "" && !req.Token {
 		return response.BadRequest(fmt.Errorf("Client is already trusted"))

--- a/po/ar.po
+++ b/po/ar.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-08 07:43+0100\n"
+"POT-Creation-Date: 2024-10-14 13:30+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -46,7 +46,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1024
+#: lxc/storage_volume.go:1030
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -512,15 +512,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:850 lxc/remote.go:915
+#: lxc/remote.go:917 lxc/remote.go:982
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:963
+#: lxc/remote.go:1030
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:769
+#: lxc/remote.go:836
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -553,7 +553,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:751
+#: lxc/remote.go:818
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -702,7 +702,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:581
+#: lxc/remote.go:648
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -735,11 +735,11 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1590
+#: lxc/storage_volume.go:1596
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:182
+#: lxc/remote.go:194
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -810,7 +810,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:552
+#: lxc/remote.go:621
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -846,16 +846,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2696
+#: lxc/storage_volume.go:2702
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2773
+#: lxc/export.go:192 lxc/storage_volume.go:2779
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:654 lxc/storage_volume.go:1521
+#: lxc/info.go:654 lxc/storage_volume.go:1527
 msgid "Backups:"
 msgstr ""
 
@@ -876,7 +876,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:679
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:685
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -919,7 +919,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1733
+#: lxc/storage_volume.go:1739
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -988,7 +988,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:894
+#: lxc/remote.go:961
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1004,7 +1004,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1749 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1021,12 +1021,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:486
+#: lxc/storage_volume.go:492
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:440
+#: lxc/storage_volume.go:446
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1054,11 +1054,11 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:509
 msgid "Certificate fingerprint"
 msgstr ""
 
-#: lxc/remote.go:219
+#: lxc/remote.go:231
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
@@ -1073,7 +1073,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:620
+#: lxc/remote.go:687
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1147,13 +1147,13 @@ msgstr ""
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
 #: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
-#: lxc/storage_volume.go:612 lxc/storage_volume.go:717
-#: lxc/storage_volume.go:1005 lxc/storage_volume.go:1231
-#: lxc/storage_volume.go:1360 lxc/storage_volume.go:1848
-#: lxc/storage_volume.go:1940 lxc/storage_volume.go:2079
-#: lxc/storage_volume.go:2239 lxc/storage_volume.go:2355
-#: lxc/storage_volume.go:2416 lxc/storage_volume.go:2543
-#: lxc/storage_volume.go:2631 lxc/storage_volume.go:2795
+#: lxc/storage_volume.go:618 lxc/storage_volume.go:723
+#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1237
+#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1854
+#: lxc/storage_volume.go:1946 lxc/storage_volume.go:2085
+#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2361
+#: lxc/storage_volume.go:2422 lxc/storage_volume.go:2549
+#: lxc/storage_volume.go:2637 lxc/storage_volume.go:2801
 msgid "Cluster member name"
 msgstr ""
 
@@ -1169,7 +1169,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1589
+#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1595
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1213,17 +1213,17 @@ msgstr ""
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1150
-#: lxc/storage_volume.go:1182
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
+#: lxc/storage_volume.go:1188
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:613
+#: lxc/storage_volume.go:619
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1467
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1307,7 +1307,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:508
+#: lxc/storage_volume.go:514
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1321,12 +1321,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:490
+#: lxc/remote.go:559
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:225 lxc/remote.go:474
+#: lxc/remote.go:237 lxc/remote.go:543
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1365,7 +1365,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:485
+#: lxc/remote.go:554
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1434,7 +1434,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:604 lxc/storage_volume.go:605
+#: lxc/storage_volume.go:610 lxc/storage_volume.go:611
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1486,7 +1486,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1475
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1481
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1521,7 +1521,7 @@ msgstr ""
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1732
+#: lxc/storage_volume.go:1738
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1541,7 +1541,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2630
+#: lxc/storage_volume.go:2636
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1637,7 +1637,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:713 lxc/storage_volume.go:714
+#: lxc/storage_volume.go:719 lxc/storage_volume.go:720
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1729,9 +1729,9 @@ msgstr ""
 #: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
 #: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
 #: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:648
-#: lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853 lxc/remote.go:917
-#: lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:715
+#: lxc/remote.go:753 lxc/remote.go:839 lxc/remote.go:920 lxc/remote.go:984
+#: lxc/remote.go:1032 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1743,26 +1743,26 @@ msgstr ""
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
 #: lxc/storage_volume.go:169 lxc/storage_volume.go:283
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:605
-#: lxc/storage_volume.go:714 lxc/storage_volume.go:801
-#: lxc/storage_volume.go:899 lxc/storage_volume.go:996
-#: lxc/storage_volume.go:1217 lxc/storage_volume.go:1348
-#: lxc/storage_volume.go:1507 lxc/storage_volume.go:1591
-#: lxc/storage_volume.go:1844 lxc/storage_volume.go:1937
-#: lxc/storage_volume.go:2064 lxc/storage_volume.go:2222
-#: lxc/storage_volume.go:2343 lxc/storage_volume.go:2405
-#: lxc/storage_volume.go:2541 lxc/storage_volume.go:2624
-#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:611
+#: lxc/storage_volume.go:720 lxc/storage_volume.go:807
+#: lxc/storage_volume.go:905 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:1223 lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1513 lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1850 lxc/storage_volume.go:1943
+#: lxc/storage_volume.go:2070 lxc/storage_volume.go:2228
+#: lxc/storage_volume.go:2349 lxc/storage_volume.go:2411
+#: lxc/storage_volume.go:2547 lxc/storage_volume.go:2630
+#: lxc/storage_volume.go:2796 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1448
+#: lxc/storage_volume.go:1454
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:1849
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:1855
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1774,11 +1774,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:800 lxc/storage_volume.go:801
+#: lxc/storage_volume.go:806 lxc/storage_volume.go:807
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:898 lxc/storage_volume.go:899
+#: lxc/storage_volume.go:904 lxc/storage_volume.go:905
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -2004,7 +2004,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:995 lxc/storage_volume.go:996
+#: lxc/storage_volume.go:1001 lxc/storage_volume.go:1002
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2012,7 +2012,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1766
+#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1772
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2069,7 +2069,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2193
+#: lxc/storage_volume.go:2161 lxc/storage_volume.go:2199
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2083,8 +2083,8 @@ msgstr ""
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2149
-#: lxc/storage_volume.go:2187
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2155
+#: lxc/storage_volume.go:2193
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2126,8 +2126,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1508
-#: lxc/storage_volume.go:1558
+#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1514
+#: lxc/storage_volume.go:1564
 msgid "Expires at"
 msgstr ""
 
@@ -2151,7 +2151,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2623 lxc/storage_volume.go:2624
+#: lxc/storage_volume.go:2629 lxc/storage_volume.go:2630
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2163,11 +2163,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2627
+#: lxc/storage_volume.go:2633
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2756
+#: lxc/export.go:152 lxc/storage_volume.go:2762
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2284,11 +2284,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:191
+#: lxc/remote.go:203
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:242
+#: lxc/remote.go:254
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2298,7 +2298,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:232
+#: lxc/remote.go:244
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2308,12 +2308,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:260
+#: lxc/remote.go:486
 #, c-format
-msgid "Failed to create certificate: %w"
+msgid "Failed to decode trust token: %w"
 msgstr ""
 
-#: lxc/remote.go:267
+#: lxc/remote.go:292
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2338,7 +2338,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:237
+#: lxc/remote.go:249
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2425,9 +2425,9 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:690 lxc/storage.go:657
+#: lxc/project.go:919 lxc/remote.go:757 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1608 lxc/warning.go:94
+#: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2463,7 +2463,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:754
+#: lxc/remote.go:821
 msgid "GLOBAL"
 msgstr ""
 
@@ -2483,7 +2483,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:160 lxc/remote.go:401
+#: lxc/remote.go:165 lxc/remote.go:443
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2551,7 +2551,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1238
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2615,11 +2615,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1216 lxc/storage_volume.go:1217
+#: lxc/storage_volume.go:1222 lxc/storage_volume.go:1223
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:469
+#: lxc/storage_volume.go:475
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2743,7 +2743,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2415
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2421
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2757,7 +2757,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2414
+#: lxc/storage_volume.go:2420
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2807,7 +2807,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2790
+#: lxc/storage_volume.go:2796
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2815,7 +2815,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2789
+#: lxc/storage_volume.go:2795
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2837,11 +2837,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2797
+#: lxc/storage_volume.go:2803
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2871
+#: lxc/storage_volume.go:2877
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2907,7 +2907,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:353
+#: lxc/remote.go:395
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2967,7 +2967,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2000
+#: lxc/move.go:148 lxc/storage_volume.go:2006
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2975,7 +2975,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1996
+#: lxc/storage_volume.go:2002
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2988,14 +2988,14 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:342
+#: lxc/remote.go:384
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1064 lxc/storage_volume.go:1281
-#: lxc/storage_volume.go:1405 lxc/storage_volume.go:1985
-#: lxc/storage_volume.go:2132 lxc/storage_volume.go:2284
+#: lxc/storage_volume.go:1070 lxc/storage_volume.go:1287
+#: lxc/storage_volume.go:1411 lxc/storage_volume.go:1991
+#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2290
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3041,7 +3041,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1739 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1745 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3344,11 +3344,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1586
+#: lxc/storage_volume.go:1592
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1597
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3368,7 +3368,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:685 lxc/remote.go:686
+#: lxc/remote.go:752 lxc/remote.go:753
 msgid "List the available remotes"
 msgstr ""
 
@@ -3407,7 +3407,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1464
+#: lxc/info.go:489 lxc/storage_volume.go:1470
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3871,12 +3871,12 @@ msgstr ""
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:323 lxc/storage_volume.go:643
-#: lxc/storage_volume.go:750 lxc/storage_volume.go:841
-#: lxc/storage_volume.go:939 lxc/storage_volume.go:1053
-#: lxc/storage_volume.go:1270 lxc/storage_volume.go:1974
-#: lxc/storage_volume.go:2115 lxc/storage_volume.go:2273
-#: lxc/storage_volume.go:2464 lxc/storage_volume.go:2581
+#: lxc/storage_volume.go:323 lxc/storage_volume.go:649
+#: lxc/storage_volume.go:756 lxc/storage_volume.go:847
+#: lxc/storage_volume.go:945 lxc/storage_volume.go:1059
+#: lxc/storage_volume.go:1276 lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:2121 lxc/storage_volume.go:2279
+#: lxc/storage_volume.go:2470 lxc/storage_volume.go:2587
 msgid "Missing pool name"
 msgstr ""
 
@@ -3895,11 +3895,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:432 lxc/storage_volume.go:1884
+#: lxc/storage_volume.go:438 lxc/storage_volume.go:1890
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1394
+#: lxc/storage_volume.go:1400
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -3936,8 +3936,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:861
-#: lxc/storage_volume.go:958
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:867
+#: lxc/storage_volume.go:964
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -3974,7 +3974,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1843 lxc/storage_volume.go:1844
+#: lxc/storage_volume.go:1849 lxc/storage_volume.go:1850
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -3982,11 +3982,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1850
+#: lxc/storage_volume.go:1856
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:512
+#: lxc/storage_volume.go:518
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4012,8 +4012,8 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
-#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1731
+#: lxc/remote.go:815 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
 msgstr ""
 
@@ -4039,7 +4039,7 @@ msgstr ""
 
 #: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
+#: lxc/project.go:550 lxc/remote.go:775 lxc/remote.go:780 lxc/remote.go:785
 msgid "NO"
 msgstr ""
 
@@ -4061,8 +4061,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1506
-#: lxc/storage_volume.go:1556
+#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1512
+#: lxc/storage_volume.go:1562
 msgid "Name"
 msgstr ""
 
@@ -4070,7 +4070,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1446
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1452
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4214,7 +4214,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:870 lxc/storage_volume.go:967
+#: lxc/storage_volume.go:876 lxc/storage_volume.go:973
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4230,11 +4230,11 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/storage_volume.go:446 lxc/storage_volume.go:1893
+#: lxc/storage_volume.go:452 lxc/storage_volume.go:1899
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:496 lxc/storage_volume.go:1904
+#: lxc/storage_volume.go:502 lxc/storage_volume.go:1910
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4248,7 +4248,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2012
+#: lxc/storage_volume.go:2018
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4260,15 +4260,15 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2678
+#: lxc/storage_volume.go:2684
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2477
+#: lxc/storage_volume.go:2483
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:336
+#: lxc/remote.go:378
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4276,7 +4276,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1412
+#: lxc/storage_volume.go:1418
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4289,7 +4289,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:693 lxc/storage_volume.go:1560
+#: lxc/info.go:693 lxc/storage_volume.go:1566
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4319,7 +4319,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1756
 msgid "POOL"
 msgstr ""
 
@@ -4335,15 +4335,15 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:213
+#: lxc/list.go:567 lxc/storage_volume.go:1762 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:817
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:752
+#: lxc/image.go:1136 lxc/remote.go:819
 msgid "PUBLIC"
 msgstr ""
 
@@ -4372,7 +4372,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:183
+#: lxc/remote.go:195
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4384,8 +4384,8 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:466
-msgid "Please type 'y', 'n' or the fingerprint:"
+#: lxc/remote.go:536
+msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
 #: lxc/info.go:221
@@ -4409,8 +4409,8 @@ msgstr ""
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1151
-#: lxc/storage_volume.go:1183
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
+#: lxc/storage_volume.go:1189
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4527,7 +4527,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1350
+#: lxc/storage_volume.go:1356
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4541,7 +4541,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1219
+#: lxc/storage_volume.go:1225
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4557,7 +4557,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2224
+#: lxc/storage_volume.go:2230
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4578,7 +4578,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:998
+#: lxc/storage_volume.go:1004
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4587,7 +4587,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2069
+#: lxc/storage_volume.go:2075
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4600,7 +4600,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2345
+#: lxc/storage_volume.go:2351
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4704,33 +4704,33 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:810
+#: lxc/remote.go:877
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
-#: lxc/remote.go:994
+#: lxc/project.go:884 lxc/remote.go:868 lxc/remote.go:949 lxc/remote.go:1013
+#: lxc/remote.go:1061
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:305
+#: lxc/remote.go:345
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:890
+#: lxc/remote.go:957
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:805 lxc/remote.go:886 lxc/remote.go:998
+#: lxc/remote.go:872 lxc/remote.go:953 lxc/remote.go:1065
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:294
+#: lxc/remote.go:319
 msgid "Remote address must not be empty"
 msgstr ""
 
@@ -4738,7 +4738,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:299
+#: lxc/remote.go:339
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4824,7 +4824,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:852 lxc/remote.go:853
+#: lxc/remote.go:919 lxc/remote.go:920
 msgid "Remove remotes"
 msgstr ""
 
@@ -4881,19 +4881,19 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:771 lxc/remote.go:772
+#: lxc/remote.go:838 lxc/remote.go:839
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:1943
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1936
+#: lxc/storage_volume.go:1942
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2025 lxc/storage_volume.go:2045
+#: lxc/storage_volume.go:2031 lxc/storage_volume.go:2051
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4945,7 +4945,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2540 lxc/storage_volume.go:2541
+#: lxc/storage_volume.go:2546 lxc/storage_volume.go:2547
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5026,7 +5026,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:820
 msgid "STATIC"
 msgstr ""
 
@@ -5067,11 +5067,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:464
+#: lxc/remote.go:532
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:616
+#: lxc/remote.go:285 lxc/remote.go:683
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5269,11 +5269,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2063
+#: lxc/storage_volume.go:2069
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2064
+#: lxc/storage_volume.go:2070
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5282,7 +5282,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:964 lxc/remote.go:965
+#: lxc/remote.go:1031 lxc/remote.go:1032
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5358,7 +5358,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2080
+#: lxc/storage_volume.go:2086
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5507,11 +5507,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2221 lxc/storage_volume.go:2222
+#: lxc/storage_volume.go:2227 lxc/storage_volume.go:2228
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1347 lxc/storage_volume.go:1348
+#: lxc/storage_volume.go:1353 lxc/storage_volume.go:1354
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5525,7 +5525,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:647 lxc/remote.go:648
+#: lxc/remote.go:714 lxc/remote.go:715
 msgid "Show the default remote"
 msgstr ""
 
@@ -5579,15 +5579,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2404 lxc/storage_volume.go:2405
+#: lxc/storage_volume.go:2410 lxc/storage_volume.go:2411
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2167
+#: lxc/storage_volume.go:2173
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:607 lxc/storage_volume.go:1485
+#: lxc/info.go:607 lxc/storage_volume.go:1491
 msgid "Snapshots:"
 msgstr ""
 
@@ -5688,21 +5688,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:696
+#: lxc/storage_volume.go:702
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:784
+#: lxc/storage_volume.go:790
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:509
+#: lxc/storage_volume.go:515
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:513
+#: lxc/storage_volume.go:519
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5737,7 +5737,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:916 lxc/remote.go:917
+#: lxc/remote.go:983 lxc/remote.go:984
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5756,11 +5756,11 @@ msgstr ""
 #: lxc/auth.go:818 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
-#: lxc/storage_volume.go:1730 lxc/warning.go:216
+#: lxc/storage_volume.go:1736 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1557
+#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1563
 msgid "Taken at"
 msgstr ""
 
@@ -5770,6 +5770,12 @@ msgstr ""
 
 #: lxc/file.go:1256
 msgid "Target path must be a directory"
+msgstr ""
+
+#: lxc/remote.go:161 lxc/remote.go:334
+msgid ""
+"The --accept-certificate flag is not supported when adding a remote using a "
+"trust token"
 msgstr ""
 
 #: lxc/move.go:181
@@ -5911,15 +5917,20 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1323
+#: lxc/storage_volume.go:1329
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1300
+#: lxc/storage_volume.go:1306
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
+msgstr ""
+
+#: lxc/remote.go:527
+msgid ""
+"The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
 
 #: lxc/info.go:354
@@ -5930,8 +5941,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:875
-#: lxc/storage_volume.go:972
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:881
+#: lxc/storage_volume.go:978
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6006,7 +6017,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1470
+#: lxc/storage_volume.go:1476
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6021,7 +6032,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1847
+#: lxc/storage_volume.go:1853
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6055,7 +6066,15 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:571
+#: lxc/remote.go:329
+msgid "Trust token cannot be used for public remotes"
+msgstr ""
+
+#: lxc/remote.go:324
+msgid "Trust token cannot be used with OIDC authentication"
+msgstr ""
+
+#: lxc/remote.go:639
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6080,7 +6099,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1455
+#: lxc/storage_volume.go:1461
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6098,17 +6117,17 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:193 lxc/remote.go:749
+#: lxc/cluster.go:193 lxc/remote.go:816
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1735
+#: lxc/project.go:995 lxc/storage_volume.go:1741
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1734
+#: lxc/storage.go:724 lxc/storage_volume.go:1740
 msgid "USED BY"
 msgstr ""
 
@@ -6126,7 +6145,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:214 lxc/remote.go:248
+#: lxc/remote.go:226 lxc/remote.go:260
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6140,7 +6159,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1772
+#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1778
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6246,7 +6265,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2342 lxc/storage_volume.go:2343
+#: lxc/storage_volume.go:2348 lxc/storage_volume.go:2349
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6298,7 +6317,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2356
+#: lxc/storage_volume.go:2362
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6342,12 +6361,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1468
+#: lxc/storage_volume.go:1474
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2629
+#: lxc/export.go:42 lxc/storage_volume.go:2635
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6414,7 +6433,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1559
+#: lxc/storage_volume.go:1565
 msgid "Volume Only"
 msgstr ""
 
@@ -6449,7 +6468,7 @@ msgstr ""
 
 #: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
+#: lxc/project.go:552 lxc/remote.go:777 lxc/remote.go:782 lxc/remote.go:787
 msgid "YES"
 msgstr ""
 
@@ -6473,7 +6492,7 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:897
+#: lxc/storage_volume.go:903
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
@@ -6895,7 +6914,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2788
+#: lxc/storage_volume.go:2794
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -6930,13 +6949,13 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:1941
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:799
+#: lxc/storage_volume.go:805
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
@@ -6944,47 +6963,47 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2539
+#: lxc/storage_volume.go:2545
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2622
+#: lxc/storage_volume.go:2628
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2403
+#: lxc/storage_volume.go:2409
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:603
+#: lxc/storage_volume.go:609
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:711
+#: lxc/storage_volume.go:717
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:994 lxc/storage_volume.go:1346
+#: lxc/storage_volume.go:1000 lxc/storage_volume.go:1352
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2341
+#: lxc/storage_volume.go:2347
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2062
+#: lxc/storage_volume.go:2068
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2220
+#: lxc/storage_volume.go:2226
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1215
+#: lxc/storage_volume.go:1221
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1841
+#: lxc/storage_volume.go:1847
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7094,7 +7113,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1584
+#: lxc/storage_volume.go:1590
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7106,7 +7125,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:739
+#: lxc/project.go:557 lxc/remote.go:806
 msgid "current"
 msgstr ""
 
@@ -7566,7 +7585,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:607
+#: lxc/storage_volume.go:613
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7574,13 +7593,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2792
+#: lxc/storage_volume.go:2798
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2407
+#: lxc/storage_volume.go:2413
 msgid ""
 "lxc storage volume snapshot create default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7590,7 +7609,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:531
 msgid "n"
 msgstr ""
 
@@ -7602,7 +7621,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:510
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7639,7 +7658,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:465
+#: lxc/remote.go:519
 msgid "y"
 msgstr ""
 

--- a/po/ber.po
+++ b/po/ber.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-08 07:43+0100\n"
+"POT-Creation-Date: 2024-10-14 13:30+0000\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Berber <https://hosted.weblate.org/projects/linux-containers/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1024
+#: lxc/storage_volume.go:1030
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -515,15 +515,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:850 lxc/remote.go:915
+#: lxc/remote.go:917 lxc/remote.go:982
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:963
+#: lxc/remote.go:1030
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:769
+#: lxc/remote.go:836
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -556,7 +556,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:751
+#: lxc/remote.go:818
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:581
+#: lxc/remote.go:648
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -738,11 +738,11 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1590
+#: lxc/storage_volume.go:1596
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:182
+#: lxc/remote.go:194
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -813,7 +813,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:552
+#: lxc/remote.go:621
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -849,16 +849,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2696
+#: lxc/storage_volume.go:2702
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2773
+#: lxc/export.go:192 lxc/storage_volume.go:2779
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:654 lxc/storage_volume.go:1521
+#: lxc/info.go:654 lxc/storage_volume.go:1527
 msgid "Backups:"
 msgstr ""
 
@@ -879,7 +879,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:679
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:685
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -922,7 +922,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1733
+#: lxc/storage_volume.go:1739
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -991,7 +991,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:894
+#: lxc/remote.go:961
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1007,7 +1007,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1749 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1024,12 +1024,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:486
+#: lxc/storage_volume.go:492
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:440
+#: lxc/storage_volume.go:446
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1057,11 +1057,11 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:509
 msgid "Certificate fingerprint"
 msgstr ""
 
-#: lxc/remote.go:219
+#: lxc/remote.go:231
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
@@ -1076,7 +1076,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:620
+#: lxc/remote.go:687
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1150,13 +1150,13 @@ msgstr ""
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
 #: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
-#: lxc/storage_volume.go:612 lxc/storage_volume.go:717
-#: lxc/storage_volume.go:1005 lxc/storage_volume.go:1231
-#: lxc/storage_volume.go:1360 lxc/storage_volume.go:1848
-#: lxc/storage_volume.go:1940 lxc/storage_volume.go:2079
-#: lxc/storage_volume.go:2239 lxc/storage_volume.go:2355
-#: lxc/storage_volume.go:2416 lxc/storage_volume.go:2543
-#: lxc/storage_volume.go:2631 lxc/storage_volume.go:2795
+#: lxc/storage_volume.go:618 lxc/storage_volume.go:723
+#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1237
+#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1854
+#: lxc/storage_volume.go:1946 lxc/storage_volume.go:2085
+#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2361
+#: lxc/storage_volume.go:2422 lxc/storage_volume.go:2549
+#: lxc/storage_volume.go:2637 lxc/storage_volume.go:2801
 msgid "Cluster member name"
 msgstr ""
 
@@ -1172,7 +1172,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1589
+#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1595
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1216,17 +1216,17 @@ msgstr ""
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1150
-#: lxc/storage_volume.go:1182
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
+#: lxc/storage_volume.go:1188
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:613
+#: lxc/storage_volume.go:619
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1467
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1310,7 +1310,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:508
+#: lxc/storage_volume.go:514
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1324,12 +1324,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:490
+#: lxc/remote.go:559
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:225 lxc/remote.go:474
+#: lxc/remote.go:237 lxc/remote.go:543
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1368,7 +1368,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:485
+#: lxc/remote.go:554
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1437,7 +1437,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:604 lxc/storage_volume.go:605
+#: lxc/storage_volume.go:610 lxc/storage_volume.go:611
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1489,7 +1489,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1475
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1481
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1524,7 +1524,7 @@ msgstr ""
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1732
+#: lxc/storage_volume.go:1738
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1544,7 +1544,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2630
+#: lxc/storage_volume.go:2636
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1640,7 +1640,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:713 lxc/storage_volume.go:714
+#: lxc/storage_volume.go:719 lxc/storage_volume.go:720
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1732,9 +1732,9 @@ msgstr ""
 #: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
 #: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
 #: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:648
-#: lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853 lxc/remote.go:917
-#: lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:715
+#: lxc/remote.go:753 lxc/remote.go:839 lxc/remote.go:920 lxc/remote.go:984
+#: lxc/remote.go:1032 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1746,26 +1746,26 @@ msgstr ""
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
 #: lxc/storage_volume.go:169 lxc/storage_volume.go:283
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:605
-#: lxc/storage_volume.go:714 lxc/storage_volume.go:801
-#: lxc/storage_volume.go:899 lxc/storage_volume.go:996
-#: lxc/storage_volume.go:1217 lxc/storage_volume.go:1348
-#: lxc/storage_volume.go:1507 lxc/storage_volume.go:1591
-#: lxc/storage_volume.go:1844 lxc/storage_volume.go:1937
-#: lxc/storage_volume.go:2064 lxc/storage_volume.go:2222
-#: lxc/storage_volume.go:2343 lxc/storage_volume.go:2405
-#: lxc/storage_volume.go:2541 lxc/storage_volume.go:2624
-#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:611
+#: lxc/storage_volume.go:720 lxc/storage_volume.go:807
+#: lxc/storage_volume.go:905 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:1223 lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1513 lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1850 lxc/storage_volume.go:1943
+#: lxc/storage_volume.go:2070 lxc/storage_volume.go:2228
+#: lxc/storage_volume.go:2349 lxc/storage_volume.go:2411
+#: lxc/storage_volume.go:2547 lxc/storage_volume.go:2630
+#: lxc/storage_volume.go:2796 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1448
+#: lxc/storage_volume.go:1454
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:1849
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:1855
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1777,11 +1777,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:800 lxc/storage_volume.go:801
+#: lxc/storage_volume.go:806 lxc/storage_volume.go:807
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:898 lxc/storage_volume.go:899
+#: lxc/storage_volume.go:904 lxc/storage_volume.go:905
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -2007,7 +2007,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:995 lxc/storage_volume.go:996
+#: lxc/storage_volume.go:1001 lxc/storage_volume.go:1002
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2015,7 +2015,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1766
+#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1772
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2072,7 +2072,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2193
+#: lxc/storage_volume.go:2161 lxc/storage_volume.go:2199
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2086,8 +2086,8 @@ msgstr ""
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2149
-#: lxc/storage_volume.go:2187
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2155
+#: lxc/storage_volume.go:2193
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2129,8 +2129,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1508
-#: lxc/storage_volume.go:1558
+#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1514
+#: lxc/storage_volume.go:1564
 msgid "Expires at"
 msgstr ""
 
@@ -2154,7 +2154,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2623 lxc/storage_volume.go:2624
+#: lxc/storage_volume.go:2629 lxc/storage_volume.go:2630
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2166,11 +2166,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2627
+#: lxc/storage_volume.go:2633
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2756
+#: lxc/export.go:152 lxc/storage_volume.go:2762
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2287,11 +2287,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:191
+#: lxc/remote.go:203
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:242
+#: lxc/remote.go:254
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2301,7 +2301,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:232
+#: lxc/remote.go:244
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2311,12 +2311,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:260
+#: lxc/remote.go:486
 #, c-format
-msgid "Failed to create certificate: %w"
+msgid "Failed to decode trust token: %w"
 msgstr ""
 
-#: lxc/remote.go:267
+#: lxc/remote.go:292
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2341,7 +2341,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:237
+#: lxc/remote.go:249
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2428,9 +2428,9 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:690 lxc/storage.go:657
+#: lxc/project.go:919 lxc/remote.go:757 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1608 lxc/warning.go:94
+#: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2466,7 +2466,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:754
+#: lxc/remote.go:821
 msgid "GLOBAL"
 msgstr ""
 
@@ -2486,7 +2486,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:160 lxc/remote.go:401
+#: lxc/remote.go:165 lxc/remote.go:443
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2554,7 +2554,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1238
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2618,11 +2618,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1216 lxc/storage_volume.go:1217
+#: lxc/storage_volume.go:1222 lxc/storage_volume.go:1223
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:469
+#: lxc/storage_volume.go:475
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2746,7 +2746,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2415
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2421
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2760,7 +2760,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2414
+#: lxc/storage_volume.go:2420
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2810,7 +2810,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2790
+#: lxc/storage_volume.go:2796
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2818,7 +2818,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2789
+#: lxc/storage_volume.go:2795
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2840,11 +2840,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2797
+#: lxc/storage_volume.go:2803
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2871
+#: lxc/storage_volume.go:2877
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2910,7 +2910,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:353
+#: lxc/remote.go:395
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2970,7 +2970,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2000
+#: lxc/move.go:148 lxc/storage_volume.go:2006
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2978,7 +2978,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1996
+#: lxc/storage_volume.go:2002
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2991,14 +2991,14 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:342
+#: lxc/remote.go:384
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1064 lxc/storage_volume.go:1281
-#: lxc/storage_volume.go:1405 lxc/storage_volume.go:1985
-#: lxc/storage_volume.go:2132 lxc/storage_volume.go:2284
+#: lxc/storage_volume.go:1070 lxc/storage_volume.go:1287
+#: lxc/storage_volume.go:1411 lxc/storage_volume.go:1991
+#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2290
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3044,7 +3044,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1739 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1745 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3347,11 +3347,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1586
+#: lxc/storage_volume.go:1592
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1597
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3371,7 +3371,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:685 lxc/remote.go:686
+#: lxc/remote.go:752 lxc/remote.go:753
 msgid "List the available remotes"
 msgstr ""
 
@@ -3410,7 +3410,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1464
+#: lxc/info.go:489 lxc/storage_volume.go:1470
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3874,12 +3874,12 @@ msgstr ""
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:323 lxc/storage_volume.go:643
-#: lxc/storage_volume.go:750 lxc/storage_volume.go:841
-#: lxc/storage_volume.go:939 lxc/storage_volume.go:1053
-#: lxc/storage_volume.go:1270 lxc/storage_volume.go:1974
-#: lxc/storage_volume.go:2115 lxc/storage_volume.go:2273
-#: lxc/storage_volume.go:2464 lxc/storage_volume.go:2581
+#: lxc/storage_volume.go:323 lxc/storage_volume.go:649
+#: lxc/storage_volume.go:756 lxc/storage_volume.go:847
+#: lxc/storage_volume.go:945 lxc/storage_volume.go:1059
+#: lxc/storage_volume.go:1276 lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:2121 lxc/storage_volume.go:2279
+#: lxc/storage_volume.go:2470 lxc/storage_volume.go:2587
 msgid "Missing pool name"
 msgstr ""
 
@@ -3898,11 +3898,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:432 lxc/storage_volume.go:1884
+#: lxc/storage_volume.go:438 lxc/storage_volume.go:1890
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1394
+#: lxc/storage_volume.go:1400
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -3939,8 +3939,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:861
-#: lxc/storage_volume.go:958
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:867
+#: lxc/storage_volume.go:964
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -3977,7 +3977,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1843 lxc/storage_volume.go:1844
+#: lxc/storage_volume.go:1849 lxc/storage_volume.go:1850
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -3985,11 +3985,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1850
+#: lxc/storage_volume.go:1856
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:512
+#: lxc/storage_volume.go:518
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4015,8 +4015,8 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
-#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1731
+#: lxc/remote.go:815 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
 msgstr ""
 
@@ -4042,7 +4042,7 @@ msgstr ""
 
 #: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
+#: lxc/project.go:550 lxc/remote.go:775 lxc/remote.go:780 lxc/remote.go:785
 msgid "NO"
 msgstr ""
 
@@ -4064,8 +4064,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1506
-#: lxc/storage_volume.go:1556
+#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1512
+#: lxc/storage_volume.go:1562
 msgid "Name"
 msgstr ""
 
@@ -4073,7 +4073,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1446
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1452
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4217,7 +4217,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:870 lxc/storage_volume.go:967
+#: lxc/storage_volume.go:876 lxc/storage_volume.go:973
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4233,11 +4233,11 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/storage_volume.go:446 lxc/storage_volume.go:1893
+#: lxc/storage_volume.go:452 lxc/storage_volume.go:1899
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:496 lxc/storage_volume.go:1904
+#: lxc/storage_volume.go:502 lxc/storage_volume.go:1910
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4251,7 +4251,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2012
+#: lxc/storage_volume.go:2018
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4263,15 +4263,15 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2678
+#: lxc/storage_volume.go:2684
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2477
+#: lxc/storage_volume.go:2483
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:336
+#: lxc/remote.go:378
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4279,7 +4279,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1412
+#: lxc/storage_volume.go:1418
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4292,7 +4292,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:693 lxc/storage_volume.go:1560
+#: lxc/info.go:693 lxc/storage_volume.go:1566
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4322,7 +4322,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1756
 msgid "POOL"
 msgstr ""
 
@@ -4338,15 +4338,15 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:213
+#: lxc/list.go:567 lxc/storage_volume.go:1762 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:817
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:752
+#: lxc/image.go:1136 lxc/remote.go:819
 msgid "PUBLIC"
 msgstr ""
 
@@ -4375,7 +4375,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:183
+#: lxc/remote.go:195
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4387,8 +4387,8 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:466
-msgid "Please type 'y', 'n' or the fingerprint:"
+#: lxc/remote.go:536
+msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
 #: lxc/info.go:221
@@ -4412,8 +4412,8 @@ msgstr ""
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1151
-#: lxc/storage_volume.go:1183
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
+#: lxc/storage_volume.go:1189
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4530,7 +4530,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1350
+#: lxc/storage_volume.go:1356
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4544,7 +4544,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1219
+#: lxc/storage_volume.go:1225
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4560,7 +4560,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2224
+#: lxc/storage_volume.go:2230
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4581,7 +4581,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:998
+#: lxc/storage_volume.go:1004
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4590,7 +4590,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2069
+#: lxc/storage_volume.go:2075
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4603,7 +4603,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2345
+#: lxc/storage_volume.go:2351
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4707,33 +4707,33 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:810
+#: lxc/remote.go:877
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
-#: lxc/remote.go:994
+#: lxc/project.go:884 lxc/remote.go:868 lxc/remote.go:949 lxc/remote.go:1013
+#: lxc/remote.go:1061
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:305
+#: lxc/remote.go:345
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:890
+#: lxc/remote.go:957
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:805 lxc/remote.go:886 lxc/remote.go:998
+#: lxc/remote.go:872 lxc/remote.go:953 lxc/remote.go:1065
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:294
+#: lxc/remote.go:319
 msgid "Remote address must not be empty"
 msgstr ""
 
@@ -4741,7 +4741,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:299
+#: lxc/remote.go:339
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4827,7 +4827,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:852 lxc/remote.go:853
+#: lxc/remote.go:919 lxc/remote.go:920
 msgid "Remove remotes"
 msgstr ""
 
@@ -4884,19 +4884,19 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:771 lxc/remote.go:772
+#: lxc/remote.go:838 lxc/remote.go:839
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:1943
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1936
+#: lxc/storage_volume.go:1942
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2025 lxc/storage_volume.go:2045
+#: lxc/storage_volume.go:2031 lxc/storage_volume.go:2051
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4948,7 +4948,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2540 lxc/storage_volume.go:2541
+#: lxc/storage_volume.go:2546 lxc/storage_volume.go:2547
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5029,7 +5029,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:820
 msgid "STATIC"
 msgstr ""
 
@@ -5070,11 +5070,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:464
+#: lxc/remote.go:532
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:616
+#: lxc/remote.go:285 lxc/remote.go:683
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5272,11 +5272,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2063
+#: lxc/storage_volume.go:2069
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2064
+#: lxc/storage_volume.go:2070
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5285,7 +5285,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:964 lxc/remote.go:965
+#: lxc/remote.go:1031 lxc/remote.go:1032
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5361,7 +5361,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2080
+#: lxc/storage_volume.go:2086
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5510,11 +5510,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2221 lxc/storage_volume.go:2222
+#: lxc/storage_volume.go:2227 lxc/storage_volume.go:2228
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1347 lxc/storage_volume.go:1348
+#: lxc/storage_volume.go:1353 lxc/storage_volume.go:1354
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5528,7 +5528,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:647 lxc/remote.go:648
+#: lxc/remote.go:714 lxc/remote.go:715
 msgid "Show the default remote"
 msgstr ""
 
@@ -5582,15 +5582,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2404 lxc/storage_volume.go:2405
+#: lxc/storage_volume.go:2410 lxc/storage_volume.go:2411
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2167
+#: lxc/storage_volume.go:2173
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:607 lxc/storage_volume.go:1485
+#: lxc/info.go:607 lxc/storage_volume.go:1491
 msgid "Snapshots:"
 msgstr ""
 
@@ -5691,21 +5691,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:696
+#: lxc/storage_volume.go:702
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:784
+#: lxc/storage_volume.go:790
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:509
+#: lxc/storage_volume.go:515
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:513
+#: lxc/storage_volume.go:519
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5740,7 +5740,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:916 lxc/remote.go:917
+#: lxc/remote.go:983 lxc/remote.go:984
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5759,11 +5759,11 @@ msgstr ""
 #: lxc/auth.go:818 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
-#: lxc/storage_volume.go:1730 lxc/warning.go:216
+#: lxc/storage_volume.go:1736 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1557
+#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1563
 msgid "Taken at"
 msgstr ""
 
@@ -5773,6 +5773,12 @@ msgstr ""
 
 #: lxc/file.go:1256
 msgid "Target path must be a directory"
+msgstr ""
+
+#: lxc/remote.go:161 lxc/remote.go:334
+msgid ""
+"The --accept-certificate flag is not supported when adding a remote using a "
+"trust token"
 msgstr ""
 
 #: lxc/move.go:181
@@ -5914,15 +5920,20 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1323
+#: lxc/storage_volume.go:1329
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1300
+#: lxc/storage_volume.go:1306
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
+msgstr ""
+
+#: lxc/remote.go:527
+msgid ""
+"The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
 
 #: lxc/info.go:354
@@ -5933,8 +5944,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:875
-#: lxc/storage_volume.go:972
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:881
+#: lxc/storage_volume.go:978
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6009,7 +6020,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1470
+#: lxc/storage_volume.go:1476
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6024,7 +6035,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1847
+#: lxc/storage_volume.go:1853
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6058,7 +6069,15 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:571
+#: lxc/remote.go:329
+msgid "Trust token cannot be used for public remotes"
+msgstr ""
+
+#: lxc/remote.go:324
+msgid "Trust token cannot be used with OIDC authentication"
+msgstr ""
+
+#: lxc/remote.go:639
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6083,7 +6102,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1455
+#: lxc/storage_volume.go:1461
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6101,17 +6120,17 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:193 lxc/remote.go:749
+#: lxc/cluster.go:193 lxc/remote.go:816
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1735
+#: lxc/project.go:995 lxc/storage_volume.go:1741
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1734
+#: lxc/storage.go:724 lxc/storage_volume.go:1740
 msgid "USED BY"
 msgstr ""
 
@@ -6129,7 +6148,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:214 lxc/remote.go:248
+#: lxc/remote.go:226 lxc/remote.go:260
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6143,7 +6162,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1772
+#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1778
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6249,7 +6268,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2342 lxc/storage_volume.go:2343
+#: lxc/storage_volume.go:2348 lxc/storage_volume.go:2349
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6301,7 +6320,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2356
+#: lxc/storage_volume.go:2362
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6345,12 +6364,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1468
+#: lxc/storage_volume.go:1474
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2629
+#: lxc/export.go:42 lxc/storage_volume.go:2635
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6417,7 +6436,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1559
+#: lxc/storage_volume.go:1565
 msgid "Volume Only"
 msgstr ""
 
@@ -6452,7 +6471,7 @@ msgstr ""
 
 #: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
+#: lxc/project.go:552 lxc/remote.go:777 lxc/remote.go:782 lxc/remote.go:787
 msgid "YES"
 msgstr ""
 
@@ -6476,7 +6495,7 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:897
+#: lxc/storage_volume.go:903
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
@@ -6898,7 +6917,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2788
+#: lxc/storage_volume.go:2794
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -6933,13 +6952,13 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:1941
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:799
+#: lxc/storage_volume.go:805
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
@@ -6947,47 +6966,47 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2539
+#: lxc/storage_volume.go:2545
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2622
+#: lxc/storage_volume.go:2628
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2403
+#: lxc/storage_volume.go:2409
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:603
+#: lxc/storage_volume.go:609
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:711
+#: lxc/storage_volume.go:717
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:994 lxc/storage_volume.go:1346
+#: lxc/storage_volume.go:1000 lxc/storage_volume.go:1352
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2341
+#: lxc/storage_volume.go:2347
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2062
+#: lxc/storage_volume.go:2068
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2220
+#: lxc/storage_volume.go:2226
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1215
+#: lxc/storage_volume.go:1221
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1841
+#: lxc/storage_volume.go:1847
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7097,7 +7116,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1584
+#: lxc/storage_volume.go:1590
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7109,7 +7128,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:739
+#: lxc/project.go:557 lxc/remote.go:806
 msgid "current"
 msgstr ""
 
@@ -7569,7 +7588,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:607
+#: lxc/storage_volume.go:613
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7577,13 +7596,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2792
+#: lxc/storage_volume.go:2798
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2407
+#: lxc/storage_volume.go:2413
 msgid ""
 "lxc storage volume snapshot create default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7593,7 +7612,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:531
 msgid "n"
 msgstr ""
 
@@ -7605,7 +7624,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:510
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7642,7 +7661,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:465
+#: lxc/remote.go:519
 msgid "y"
 msgstr ""
 

--- a/po/bg.po
+++ b/po/bg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-08 07:43+0100\n"
+"POT-Creation-Date: 2024-10-14 13:30+0000\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Bulgarian <https://hosted.weblate.org/projects/linux-"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1024
+#: lxc/storage_volume.go:1030
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -515,15 +515,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:850 lxc/remote.go:915
+#: lxc/remote.go:917 lxc/remote.go:982
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:963
+#: lxc/remote.go:1030
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:769
+#: lxc/remote.go:836
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -556,7 +556,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:751
+#: lxc/remote.go:818
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:581
+#: lxc/remote.go:648
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -738,11 +738,11 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1590
+#: lxc/storage_volume.go:1596
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:182
+#: lxc/remote.go:194
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -813,7 +813,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:552
+#: lxc/remote.go:621
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -849,16 +849,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2696
+#: lxc/storage_volume.go:2702
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2773
+#: lxc/export.go:192 lxc/storage_volume.go:2779
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:654 lxc/storage_volume.go:1521
+#: lxc/info.go:654 lxc/storage_volume.go:1527
 msgid "Backups:"
 msgstr ""
 
@@ -879,7 +879,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:679
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:685
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -922,7 +922,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1733
+#: lxc/storage_volume.go:1739
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -991,7 +991,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:894
+#: lxc/remote.go:961
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1007,7 +1007,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1749 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1024,12 +1024,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:486
+#: lxc/storage_volume.go:492
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:440
+#: lxc/storage_volume.go:446
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1057,11 +1057,11 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:509
 msgid "Certificate fingerprint"
 msgstr ""
 
-#: lxc/remote.go:219
+#: lxc/remote.go:231
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
@@ -1076,7 +1076,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:620
+#: lxc/remote.go:687
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1150,13 +1150,13 @@ msgstr ""
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
 #: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
-#: lxc/storage_volume.go:612 lxc/storage_volume.go:717
-#: lxc/storage_volume.go:1005 lxc/storage_volume.go:1231
-#: lxc/storage_volume.go:1360 lxc/storage_volume.go:1848
-#: lxc/storage_volume.go:1940 lxc/storage_volume.go:2079
-#: lxc/storage_volume.go:2239 lxc/storage_volume.go:2355
-#: lxc/storage_volume.go:2416 lxc/storage_volume.go:2543
-#: lxc/storage_volume.go:2631 lxc/storage_volume.go:2795
+#: lxc/storage_volume.go:618 lxc/storage_volume.go:723
+#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1237
+#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1854
+#: lxc/storage_volume.go:1946 lxc/storage_volume.go:2085
+#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2361
+#: lxc/storage_volume.go:2422 lxc/storage_volume.go:2549
+#: lxc/storage_volume.go:2637 lxc/storage_volume.go:2801
 msgid "Cluster member name"
 msgstr ""
 
@@ -1172,7 +1172,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1589
+#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1595
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1216,17 +1216,17 @@ msgstr ""
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1150
-#: lxc/storage_volume.go:1182
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
+#: lxc/storage_volume.go:1188
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:613
+#: lxc/storage_volume.go:619
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1467
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1310,7 +1310,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:508
+#: lxc/storage_volume.go:514
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1324,12 +1324,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:490
+#: lxc/remote.go:559
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:225 lxc/remote.go:474
+#: lxc/remote.go:237 lxc/remote.go:543
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1368,7 +1368,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:485
+#: lxc/remote.go:554
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1437,7 +1437,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:604 lxc/storage_volume.go:605
+#: lxc/storage_volume.go:610 lxc/storage_volume.go:611
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1489,7 +1489,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1475
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1481
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1524,7 +1524,7 @@ msgstr ""
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1732
+#: lxc/storage_volume.go:1738
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1544,7 +1544,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2630
+#: lxc/storage_volume.go:2636
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1640,7 +1640,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:713 lxc/storage_volume.go:714
+#: lxc/storage_volume.go:719 lxc/storage_volume.go:720
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1732,9 +1732,9 @@ msgstr ""
 #: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
 #: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
 #: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:648
-#: lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853 lxc/remote.go:917
-#: lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:715
+#: lxc/remote.go:753 lxc/remote.go:839 lxc/remote.go:920 lxc/remote.go:984
+#: lxc/remote.go:1032 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1746,26 +1746,26 @@ msgstr ""
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
 #: lxc/storage_volume.go:169 lxc/storage_volume.go:283
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:605
-#: lxc/storage_volume.go:714 lxc/storage_volume.go:801
-#: lxc/storage_volume.go:899 lxc/storage_volume.go:996
-#: lxc/storage_volume.go:1217 lxc/storage_volume.go:1348
-#: lxc/storage_volume.go:1507 lxc/storage_volume.go:1591
-#: lxc/storage_volume.go:1844 lxc/storage_volume.go:1937
-#: lxc/storage_volume.go:2064 lxc/storage_volume.go:2222
-#: lxc/storage_volume.go:2343 lxc/storage_volume.go:2405
-#: lxc/storage_volume.go:2541 lxc/storage_volume.go:2624
-#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:611
+#: lxc/storage_volume.go:720 lxc/storage_volume.go:807
+#: lxc/storage_volume.go:905 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:1223 lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1513 lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1850 lxc/storage_volume.go:1943
+#: lxc/storage_volume.go:2070 lxc/storage_volume.go:2228
+#: lxc/storage_volume.go:2349 lxc/storage_volume.go:2411
+#: lxc/storage_volume.go:2547 lxc/storage_volume.go:2630
+#: lxc/storage_volume.go:2796 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1448
+#: lxc/storage_volume.go:1454
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:1849
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:1855
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1777,11 +1777,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:800 lxc/storage_volume.go:801
+#: lxc/storage_volume.go:806 lxc/storage_volume.go:807
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:898 lxc/storage_volume.go:899
+#: lxc/storage_volume.go:904 lxc/storage_volume.go:905
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -2007,7 +2007,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:995 lxc/storage_volume.go:996
+#: lxc/storage_volume.go:1001 lxc/storage_volume.go:1002
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2015,7 +2015,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1766
+#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1772
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2072,7 +2072,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2193
+#: lxc/storage_volume.go:2161 lxc/storage_volume.go:2199
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2086,8 +2086,8 @@ msgstr ""
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2149
-#: lxc/storage_volume.go:2187
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2155
+#: lxc/storage_volume.go:2193
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2129,8 +2129,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1508
-#: lxc/storage_volume.go:1558
+#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1514
+#: lxc/storage_volume.go:1564
 msgid "Expires at"
 msgstr ""
 
@@ -2154,7 +2154,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2623 lxc/storage_volume.go:2624
+#: lxc/storage_volume.go:2629 lxc/storage_volume.go:2630
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2166,11 +2166,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2627
+#: lxc/storage_volume.go:2633
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2756
+#: lxc/export.go:152 lxc/storage_volume.go:2762
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2287,11 +2287,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:191
+#: lxc/remote.go:203
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:242
+#: lxc/remote.go:254
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2301,7 +2301,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:232
+#: lxc/remote.go:244
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2311,12 +2311,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:260
+#: lxc/remote.go:486
 #, c-format
-msgid "Failed to create certificate: %w"
+msgid "Failed to decode trust token: %w"
 msgstr ""
 
-#: lxc/remote.go:267
+#: lxc/remote.go:292
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2341,7 +2341,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:237
+#: lxc/remote.go:249
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2428,9 +2428,9 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:690 lxc/storage.go:657
+#: lxc/project.go:919 lxc/remote.go:757 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1608 lxc/warning.go:94
+#: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2466,7 +2466,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:754
+#: lxc/remote.go:821
 msgid "GLOBAL"
 msgstr ""
 
@@ -2486,7 +2486,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:160 lxc/remote.go:401
+#: lxc/remote.go:165 lxc/remote.go:443
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2554,7 +2554,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1238
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2618,11 +2618,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1216 lxc/storage_volume.go:1217
+#: lxc/storage_volume.go:1222 lxc/storage_volume.go:1223
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:469
+#: lxc/storage_volume.go:475
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2746,7 +2746,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2415
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2421
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2760,7 +2760,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2414
+#: lxc/storage_volume.go:2420
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2810,7 +2810,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2790
+#: lxc/storage_volume.go:2796
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2818,7 +2818,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2789
+#: lxc/storage_volume.go:2795
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2840,11 +2840,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2797
+#: lxc/storage_volume.go:2803
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2871
+#: lxc/storage_volume.go:2877
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2910,7 +2910,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:353
+#: lxc/remote.go:395
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2970,7 +2970,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2000
+#: lxc/move.go:148 lxc/storage_volume.go:2006
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2978,7 +2978,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1996
+#: lxc/storage_volume.go:2002
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2991,14 +2991,14 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:342
+#: lxc/remote.go:384
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1064 lxc/storage_volume.go:1281
-#: lxc/storage_volume.go:1405 lxc/storage_volume.go:1985
-#: lxc/storage_volume.go:2132 lxc/storage_volume.go:2284
+#: lxc/storage_volume.go:1070 lxc/storage_volume.go:1287
+#: lxc/storage_volume.go:1411 lxc/storage_volume.go:1991
+#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2290
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3044,7 +3044,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1739 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1745 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3347,11 +3347,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1586
+#: lxc/storage_volume.go:1592
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1597
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3371,7 +3371,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:685 lxc/remote.go:686
+#: lxc/remote.go:752 lxc/remote.go:753
 msgid "List the available remotes"
 msgstr ""
 
@@ -3410,7 +3410,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1464
+#: lxc/info.go:489 lxc/storage_volume.go:1470
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3874,12 +3874,12 @@ msgstr ""
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:323 lxc/storage_volume.go:643
-#: lxc/storage_volume.go:750 lxc/storage_volume.go:841
-#: lxc/storage_volume.go:939 lxc/storage_volume.go:1053
-#: lxc/storage_volume.go:1270 lxc/storage_volume.go:1974
-#: lxc/storage_volume.go:2115 lxc/storage_volume.go:2273
-#: lxc/storage_volume.go:2464 lxc/storage_volume.go:2581
+#: lxc/storage_volume.go:323 lxc/storage_volume.go:649
+#: lxc/storage_volume.go:756 lxc/storage_volume.go:847
+#: lxc/storage_volume.go:945 lxc/storage_volume.go:1059
+#: lxc/storage_volume.go:1276 lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:2121 lxc/storage_volume.go:2279
+#: lxc/storage_volume.go:2470 lxc/storage_volume.go:2587
 msgid "Missing pool name"
 msgstr ""
 
@@ -3898,11 +3898,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:432 lxc/storage_volume.go:1884
+#: lxc/storage_volume.go:438 lxc/storage_volume.go:1890
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1394
+#: lxc/storage_volume.go:1400
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -3939,8 +3939,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:861
-#: lxc/storage_volume.go:958
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:867
+#: lxc/storage_volume.go:964
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -3977,7 +3977,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1843 lxc/storage_volume.go:1844
+#: lxc/storage_volume.go:1849 lxc/storage_volume.go:1850
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -3985,11 +3985,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1850
+#: lxc/storage_volume.go:1856
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:512
+#: lxc/storage_volume.go:518
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4015,8 +4015,8 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
-#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1731
+#: lxc/remote.go:815 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
 msgstr ""
 
@@ -4042,7 +4042,7 @@ msgstr ""
 
 #: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
+#: lxc/project.go:550 lxc/remote.go:775 lxc/remote.go:780 lxc/remote.go:785
 msgid "NO"
 msgstr ""
 
@@ -4064,8 +4064,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1506
-#: lxc/storage_volume.go:1556
+#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1512
+#: lxc/storage_volume.go:1562
 msgid "Name"
 msgstr ""
 
@@ -4073,7 +4073,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1446
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1452
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4217,7 +4217,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:870 lxc/storage_volume.go:967
+#: lxc/storage_volume.go:876 lxc/storage_volume.go:973
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4233,11 +4233,11 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/storage_volume.go:446 lxc/storage_volume.go:1893
+#: lxc/storage_volume.go:452 lxc/storage_volume.go:1899
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:496 lxc/storage_volume.go:1904
+#: lxc/storage_volume.go:502 lxc/storage_volume.go:1910
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4251,7 +4251,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2012
+#: lxc/storage_volume.go:2018
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4263,15 +4263,15 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2678
+#: lxc/storage_volume.go:2684
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2477
+#: lxc/storage_volume.go:2483
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:336
+#: lxc/remote.go:378
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4279,7 +4279,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1412
+#: lxc/storage_volume.go:1418
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4292,7 +4292,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:693 lxc/storage_volume.go:1560
+#: lxc/info.go:693 lxc/storage_volume.go:1566
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4322,7 +4322,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1756
 msgid "POOL"
 msgstr ""
 
@@ -4338,15 +4338,15 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:213
+#: lxc/list.go:567 lxc/storage_volume.go:1762 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:817
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:752
+#: lxc/image.go:1136 lxc/remote.go:819
 msgid "PUBLIC"
 msgstr ""
 
@@ -4375,7 +4375,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:183
+#: lxc/remote.go:195
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4387,8 +4387,8 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:466
-msgid "Please type 'y', 'n' or the fingerprint:"
+#: lxc/remote.go:536
+msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
 #: lxc/info.go:221
@@ -4412,8 +4412,8 @@ msgstr ""
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1151
-#: lxc/storage_volume.go:1183
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
+#: lxc/storage_volume.go:1189
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4530,7 +4530,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1350
+#: lxc/storage_volume.go:1356
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4544,7 +4544,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1219
+#: lxc/storage_volume.go:1225
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4560,7 +4560,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2224
+#: lxc/storage_volume.go:2230
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4581,7 +4581,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:998
+#: lxc/storage_volume.go:1004
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4590,7 +4590,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2069
+#: lxc/storage_volume.go:2075
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4603,7 +4603,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2345
+#: lxc/storage_volume.go:2351
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4707,33 +4707,33 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:810
+#: lxc/remote.go:877
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
-#: lxc/remote.go:994
+#: lxc/project.go:884 lxc/remote.go:868 lxc/remote.go:949 lxc/remote.go:1013
+#: lxc/remote.go:1061
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:305
+#: lxc/remote.go:345
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:890
+#: lxc/remote.go:957
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:805 lxc/remote.go:886 lxc/remote.go:998
+#: lxc/remote.go:872 lxc/remote.go:953 lxc/remote.go:1065
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:294
+#: lxc/remote.go:319
 msgid "Remote address must not be empty"
 msgstr ""
 
@@ -4741,7 +4741,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:299
+#: lxc/remote.go:339
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4827,7 +4827,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:852 lxc/remote.go:853
+#: lxc/remote.go:919 lxc/remote.go:920
 msgid "Remove remotes"
 msgstr ""
 
@@ -4884,19 +4884,19 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:771 lxc/remote.go:772
+#: lxc/remote.go:838 lxc/remote.go:839
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:1943
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1936
+#: lxc/storage_volume.go:1942
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2025 lxc/storage_volume.go:2045
+#: lxc/storage_volume.go:2031 lxc/storage_volume.go:2051
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4948,7 +4948,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2540 lxc/storage_volume.go:2541
+#: lxc/storage_volume.go:2546 lxc/storage_volume.go:2547
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5029,7 +5029,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:820
 msgid "STATIC"
 msgstr ""
 
@@ -5070,11 +5070,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:464
+#: lxc/remote.go:532
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:616
+#: lxc/remote.go:285 lxc/remote.go:683
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5272,11 +5272,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2063
+#: lxc/storage_volume.go:2069
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2064
+#: lxc/storage_volume.go:2070
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5285,7 +5285,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:964 lxc/remote.go:965
+#: lxc/remote.go:1031 lxc/remote.go:1032
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5361,7 +5361,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2080
+#: lxc/storage_volume.go:2086
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5510,11 +5510,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2221 lxc/storage_volume.go:2222
+#: lxc/storage_volume.go:2227 lxc/storage_volume.go:2228
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1347 lxc/storage_volume.go:1348
+#: lxc/storage_volume.go:1353 lxc/storage_volume.go:1354
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5528,7 +5528,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:647 lxc/remote.go:648
+#: lxc/remote.go:714 lxc/remote.go:715
 msgid "Show the default remote"
 msgstr ""
 
@@ -5582,15 +5582,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2404 lxc/storage_volume.go:2405
+#: lxc/storage_volume.go:2410 lxc/storage_volume.go:2411
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2167
+#: lxc/storage_volume.go:2173
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:607 lxc/storage_volume.go:1485
+#: lxc/info.go:607 lxc/storage_volume.go:1491
 msgid "Snapshots:"
 msgstr ""
 
@@ -5691,21 +5691,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:696
+#: lxc/storage_volume.go:702
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:784
+#: lxc/storage_volume.go:790
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:509
+#: lxc/storage_volume.go:515
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:513
+#: lxc/storage_volume.go:519
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5740,7 +5740,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:916 lxc/remote.go:917
+#: lxc/remote.go:983 lxc/remote.go:984
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5759,11 +5759,11 @@ msgstr ""
 #: lxc/auth.go:818 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
-#: lxc/storage_volume.go:1730 lxc/warning.go:216
+#: lxc/storage_volume.go:1736 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1557
+#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1563
 msgid "Taken at"
 msgstr ""
 
@@ -5773,6 +5773,12 @@ msgstr ""
 
 #: lxc/file.go:1256
 msgid "Target path must be a directory"
+msgstr ""
+
+#: lxc/remote.go:161 lxc/remote.go:334
+msgid ""
+"The --accept-certificate flag is not supported when adding a remote using a "
+"trust token"
 msgstr ""
 
 #: lxc/move.go:181
@@ -5914,15 +5920,20 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1323
+#: lxc/storage_volume.go:1329
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1300
+#: lxc/storage_volume.go:1306
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
+msgstr ""
+
+#: lxc/remote.go:527
+msgid ""
+"The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
 
 #: lxc/info.go:354
@@ -5933,8 +5944,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:875
-#: lxc/storage_volume.go:972
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:881
+#: lxc/storage_volume.go:978
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6009,7 +6020,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1470
+#: lxc/storage_volume.go:1476
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6024,7 +6035,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1847
+#: lxc/storage_volume.go:1853
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6058,7 +6069,15 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:571
+#: lxc/remote.go:329
+msgid "Trust token cannot be used for public remotes"
+msgstr ""
+
+#: lxc/remote.go:324
+msgid "Trust token cannot be used with OIDC authentication"
+msgstr ""
+
+#: lxc/remote.go:639
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6083,7 +6102,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1455
+#: lxc/storage_volume.go:1461
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6101,17 +6120,17 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:193 lxc/remote.go:749
+#: lxc/cluster.go:193 lxc/remote.go:816
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1735
+#: lxc/project.go:995 lxc/storage_volume.go:1741
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1734
+#: lxc/storage.go:724 lxc/storage_volume.go:1740
 msgid "USED BY"
 msgstr ""
 
@@ -6129,7 +6148,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:214 lxc/remote.go:248
+#: lxc/remote.go:226 lxc/remote.go:260
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6143,7 +6162,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1772
+#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1778
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6249,7 +6268,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2342 lxc/storage_volume.go:2343
+#: lxc/storage_volume.go:2348 lxc/storage_volume.go:2349
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6301,7 +6320,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2356
+#: lxc/storage_volume.go:2362
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6345,12 +6364,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1468
+#: lxc/storage_volume.go:1474
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2629
+#: lxc/export.go:42 lxc/storage_volume.go:2635
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6417,7 +6436,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1559
+#: lxc/storage_volume.go:1565
 msgid "Volume Only"
 msgstr ""
 
@@ -6452,7 +6471,7 @@ msgstr ""
 
 #: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
+#: lxc/project.go:552 lxc/remote.go:777 lxc/remote.go:782 lxc/remote.go:787
 msgid "YES"
 msgstr ""
 
@@ -6476,7 +6495,7 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:897
+#: lxc/storage_volume.go:903
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
@@ -6898,7 +6917,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2788
+#: lxc/storage_volume.go:2794
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -6933,13 +6952,13 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:1941
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:799
+#: lxc/storage_volume.go:805
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
@@ -6947,47 +6966,47 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2539
+#: lxc/storage_volume.go:2545
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2622
+#: lxc/storage_volume.go:2628
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2403
+#: lxc/storage_volume.go:2409
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:603
+#: lxc/storage_volume.go:609
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:711
+#: lxc/storage_volume.go:717
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:994 lxc/storage_volume.go:1346
+#: lxc/storage_volume.go:1000 lxc/storage_volume.go:1352
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2341
+#: lxc/storage_volume.go:2347
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2062
+#: lxc/storage_volume.go:2068
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2220
+#: lxc/storage_volume.go:2226
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1215
+#: lxc/storage_volume.go:1221
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1841
+#: lxc/storage_volume.go:1847
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7097,7 +7116,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1584
+#: lxc/storage_volume.go:1590
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7109,7 +7128,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:739
+#: lxc/project.go:557 lxc/remote.go:806
 msgid "current"
 msgstr ""
 
@@ -7569,7 +7588,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:607
+#: lxc/storage_volume.go:613
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7577,13 +7596,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2792
+#: lxc/storage_volume.go:2798
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2407
+#: lxc/storage_volume.go:2413
 msgid ""
 "lxc storage volume snapshot create default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7593,7 +7612,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:531
 msgid "n"
 msgstr ""
 
@@ -7605,7 +7624,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:510
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7642,7 +7661,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:465
+#: lxc/remote.go:519
 msgid "y"
 msgstr ""
 

--- a/po/ca.po
+++ b/po/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-08 07:43+0100\n"
+"POT-Creation-Date: 2024-10-14 13:30+0000\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Catalan <https://hosted.weblate.org/projects/linux-containers/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1024
+#: lxc/storage_volume.go:1030
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -515,15 +515,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:850 lxc/remote.go:915
+#: lxc/remote.go:917 lxc/remote.go:982
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:963
+#: lxc/remote.go:1030
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:769
+#: lxc/remote.go:836
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -556,7 +556,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:751
+#: lxc/remote.go:818
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:581
+#: lxc/remote.go:648
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -738,11 +738,11 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1590
+#: lxc/storage_volume.go:1596
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:182
+#: lxc/remote.go:194
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -813,7 +813,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:552
+#: lxc/remote.go:621
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -849,16 +849,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2696
+#: lxc/storage_volume.go:2702
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2773
+#: lxc/export.go:192 lxc/storage_volume.go:2779
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:654 lxc/storage_volume.go:1521
+#: lxc/info.go:654 lxc/storage_volume.go:1527
 msgid "Backups:"
 msgstr ""
 
@@ -879,7 +879,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:679
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:685
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -922,7 +922,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1733
+#: lxc/storage_volume.go:1739
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -991,7 +991,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:894
+#: lxc/remote.go:961
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1007,7 +1007,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1749 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1024,12 +1024,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:486
+#: lxc/storage_volume.go:492
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:440
+#: lxc/storage_volume.go:446
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1057,11 +1057,11 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:509
 msgid "Certificate fingerprint"
 msgstr ""
 
-#: lxc/remote.go:219
+#: lxc/remote.go:231
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
@@ -1076,7 +1076,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:620
+#: lxc/remote.go:687
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1150,13 +1150,13 @@ msgstr ""
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
 #: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
-#: lxc/storage_volume.go:612 lxc/storage_volume.go:717
-#: lxc/storage_volume.go:1005 lxc/storage_volume.go:1231
-#: lxc/storage_volume.go:1360 lxc/storage_volume.go:1848
-#: lxc/storage_volume.go:1940 lxc/storage_volume.go:2079
-#: lxc/storage_volume.go:2239 lxc/storage_volume.go:2355
-#: lxc/storage_volume.go:2416 lxc/storage_volume.go:2543
-#: lxc/storage_volume.go:2631 lxc/storage_volume.go:2795
+#: lxc/storage_volume.go:618 lxc/storage_volume.go:723
+#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1237
+#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1854
+#: lxc/storage_volume.go:1946 lxc/storage_volume.go:2085
+#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2361
+#: lxc/storage_volume.go:2422 lxc/storage_volume.go:2549
+#: lxc/storage_volume.go:2637 lxc/storage_volume.go:2801
 msgid "Cluster member name"
 msgstr ""
 
@@ -1172,7 +1172,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1589
+#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1595
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1216,17 +1216,17 @@ msgstr ""
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1150
-#: lxc/storage_volume.go:1182
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
+#: lxc/storage_volume.go:1188
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:613
+#: lxc/storage_volume.go:619
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1467
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1310,7 +1310,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:508
+#: lxc/storage_volume.go:514
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1324,12 +1324,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:490
+#: lxc/remote.go:559
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:225 lxc/remote.go:474
+#: lxc/remote.go:237 lxc/remote.go:543
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1368,7 +1368,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:485
+#: lxc/remote.go:554
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1437,7 +1437,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:604 lxc/storage_volume.go:605
+#: lxc/storage_volume.go:610 lxc/storage_volume.go:611
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1489,7 +1489,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1475
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1481
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1524,7 +1524,7 @@ msgstr ""
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1732
+#: lxc/storage_volume.go:1738
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1544,7 +1544,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2630
+#: lxc/storage_volume.go:2636
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1640,7 +1640,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:713 lxc/storage_volume.go:714
+#: lxc/storage_volume.go:719 lxc/storage_volume.go:720
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1732,9 +1732,9 @@ msgstr ""
 #: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
 #: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
 #: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:648
-#: lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853 lxc/remote.go:917
-#: lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:715
+#: lxc/remote.go:753 lxc/remote.go:839 lxc/remote.go:920 lxc/remote.go:984
+#: lxc/remote.go:1032 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1746,26 +1746,26 @@ msgstr ""
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
 #: lxc/storage_volume.go:169 lxc/storage_volume.go:283
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:605
-#: lxc/storage_volume.go:714 lxc/storage_volume.go:801
-#: lxc/storage_volume.go:899 lxc/storage_volume.go:996
-#: lxc/storage_volume.go:1217 lxc/storage_volume.go:1348
-#: lxc/storage_volume.go:1507 lxc/storage_volume.go:1591
-#: lxc/storage_volume.go:1844 lxc/storage_volume.go:1937
-#: lxc/storage_volume.go:2064 lxc/storage_volume.go:2222
-#: lxc/storage_volume.go:2343 lxc/storage_volume.go:2405
-#: lxc/storage_volume.go:2541 lxc/storage_volume.go:2624
-#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:611
+#: lxc/storage_volume.go:720 lxc/storage_volume.go:807
+#: lxc/storage_volume.go:905 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:1223 lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1513 lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1850 lxc/storage_volume.go:1943
+#: lxc/storage_volume.go:2070 lxc/storage_volume.go:2228
+#: lxc/storage_volume.go:2349 lxc/storage_volume.go:2411
+#: lxc/storage_volume.go:2547 lxc/storage_volume.go:2630
+#: lxc/storage_volume.go:2796 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1448
+#: lxc/storage_volume.go:1454
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:1849
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:1855
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1777,11 +1777,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:800 lxc/storage_volume.go:801
+#: lxc/storage_volume.go:806 lxc/storage_volume.go:807
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:898 lxc/storage_volume.go:899
+#: lxc/storage_volume.go:904 lxc/storage_volume.go:905
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -2007,7 +2007,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:995 lxc/storage_volume.go:996
+#: lxc/storage_volume.go:1001 lxc/storage_volume.go:1002
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2015,7 +2015,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1766
+#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1772
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2072,7 +2072,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2193
+#: lxc/storage_volume.go:2161 lxc/storage_volume.go:2199
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2086,8 +2086,8 @@ msgstr ""
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2149
-#: lxc/storage_volume.go:2187
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2155
+#: lxc/storage_volume.go:2193
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2129,8 +2129,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1508
-#: lxc/storage_volume.go:1558
+#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1514
+#: lxc/storage_volume.go:1564
 msgid "Expires at"
 msgstr ""
 
@@ -2154,7 +2154,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2623 lxc/storage_volume.go:2624
+#: lxc/storage_volume.go:2629 lxc/storage_volume.go:2630
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2166,11 +2166,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2627
+#: lxc/storage_volume.go:2633
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2756
+#: lxc/export.go:152 lxc/storage_volume.go:2762
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2287,11 +2287,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:191
+#: lxc/remote.go:203
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:242
+#: lxc/remote.go:254
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2301,7 +2301,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:232
+#: lxc/remote.go:244
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2311,12 +2311,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:260
+#: lxc/remote.go:486
 #, c-format
-msgid "Failed to create certificate: %w"
+msgid "Failed to decode trust token: %w"
 msgstr ""
 
-#: lxc/remote.go:267
+#: lxc/remote.go:292
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2341,7 +2341,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:237
+#: lxc/remote.go:249
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2428,9 +2428,9 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:690 lxc/storage.go:657
+#: lxc/project.go:919 lxc/remote.go:757 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1608 lxc/warning.go:94
+#: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2466,7 +2466,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:754
+#: lxc/remote.go:821
 msgid "GLOBAL"
 msgstr ""
 
@@ -2486,7 +2486,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:160 lxc/remote.go:401
+#: lxc/remote.go:165 lxc/remote.go:443
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2554,7 +2554,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1238
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2618,11 +2618,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1216 lxc/storage_volume.go:1217
+#: lxc/storage_volume.go:1222 lxc/storage_volume.go:1223
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:469
+#: lxc/storage_volume.go:475
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2746,7 +2746,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2415
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2421
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2760,7 +2760,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2414
+#: lxc/storage_volume.go:2420
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2810,7 +2810,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2790
+#: lxc/storage_volume.go:2796
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2818,7 +2818,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2789
+#: lxc/storage_volume.go:2795
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2840,11 +2840,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2797
+#: lxc/storage_volume.go:2803
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2871
+#: lxc/storage_volume.go:2877
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2910,7 +2910,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:353
+#: lxc/remote.go:395
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2970,7 +2970,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2000
+#: lxc/move.go:148 lxc/storage_volume.go:2006
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2978,7 +2978,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1996
+#: lxc/storage_volume.go:2002
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2991,14 +2991,14 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:342
+#: lxc/remote.go:384
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1064 lxc/storage_volume.go:1281
-#: lxc/storage_volume.go:1405 lxc/storage_volume.go:1985
-#: lxc/storage_volume.go:2132 lxc/storage_volume.go:2284
+#: lxc/storage_volume.go:1070 lxc/storage_volume.go:1287
+#: lxc/storage_volume.go:1411 lxc/storage_volume.go:1991
+#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2290
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3044,7 +3044,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1739 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1745 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3347,11 +3347,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1586
+#: lxc/storage_volume.go:1592
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1597
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3371,7 +3371,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:685 lxc/remote.go:686
+#: lxc/remote.go:752 lxc/remote.go:753
 msgid "List the available remotes"
 msgstr ""
 
@@ -3410,7 +3410,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1464
+#: lxc/info.go:489 lxc/storage_volume.go:1470
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3874,12 +3874,12 @@ msgstr ""
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:323 lxc/storage_volume.go:643
-#: lxc/storage_volume.go:750 lxc/storage_volume.go:841
-#: lxc/storage_volume.go:939 lxc/storage_volume.go:1053
-#: lxc/storage_volume.go:1270 lxc/storage_volume.go:1974
-#: lxc/storage_volume.go:2115 lxc/storage_volume.go:2273
-#: lxc/storage_volume.go:2464 lxc/storage_volume.go:2581
+#: lxc/storage_volume.go:323 lxc/storage_volume.go:649
+#: lxc/storage_volume.go:756 lxc/storage_volume.go:847
+#: lxc/storage_volume.go:945 lxc/storage_volume.go:1059
+#: lxc/storage_volume.go:1276 lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:2121 lxc/storage_volume.go:2279
+#: lxc/storage_volume.go:2470 lxc/storage_volume.go:2587
 msgid "Missing pool name"
 msgstr ""
 
@@ -3898,11 +3898,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:432 lxc/storage_volume.go:1884
+#: lxc/storage_volume.go:438 lxc/storage_volume.go:1890
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1394
+#: lxc/storage_volume.go:1400
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -3939,8 +3939,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:861
-#: lxc/storage_volume.go:958
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:867
+#: lxc/storage_volume.go:964
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -3977,7 +3977,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1843 lxc/storage_volume.go:1844
+#: lxc/storage_volume.go:1849 lxc/storage_volume.go:1850
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -3985,11 +3985,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1850
+#: lxc/storage_volume.go:1856
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:512
+#: lxc/storage_volume.go:518
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4015,8 +4015,8 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
-#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1731
+#: lxc/remote.go:815 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
 msgstr ""
 
@@ -4042,7 +4042,7 @@ msgstr ""
 
 #: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
+#: lxc/project.go:550 lxc/remote.go:775 lxc/remote.go:780 lxc/remote.go:785
 msgid "NO"
 msgstr ""
 
@@ -4064,8 +4064,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1506
-#: lxc/storage_volume.go:1556
+#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1512
+#: lxc/storage_volume.go:1562
 msgid "Name"
 msgstr ""
 
@@ -4073,7 +4073,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1446
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1452
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4217,7 +4217,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:870 lxc/storage_volume.go:967
+#: lxc/storage_volume.go:876 lxc/storage_volume.go:973
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4233,11 +4233,11 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/storage_volume.go:446 lxc/storage_volume.go:1893
+#: lxc/storage_volume.go:452 lxc/storage_volume.go:1899
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:496 lxc/storage_volume.go:1904
+#: lxc/storage_volume.go:502 lxc/storage_volume.go:1910
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4251,7 +4251,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2012
+#: lxc/storage_volume.go:2018
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4263,15 +4263,15 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2678
+#: lxc/storage_volume.go:2684
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2477
+#: lxc/storage_volume.go:2483
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:336
+#: lxc/remote.go:378
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4279,7 +4279,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1412
+#: lxc/storage_volume.go:1418
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4292,7 +4292,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:693 lxc/storage_volume.go:1560
+#: lxc/info.go:693 lxc/storage_volume.go:1566
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4322,7 +4322,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1756
 msgid "POOL"
 msgstr ""
 
@@ -4338,15 +4338,15 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:213
+#: lxc/list.go:567 lxc/storage_volume.go:1762 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:817
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:752
+#: lxc/image.go:1136 lxc/remote.go:819
 msgid "PUBLIC"
 msgstr ""
 
@@ -4375,7 +4375,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:183
+#: lxc/remote.go:195
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4387,8 +4387,8 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:466
-msgid "Please type 'y', 'n' or the fingerprint:"
+#: lxc/remote.go:536
+msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
 #: lxc/info.go:221
@@ -4412,8 +4412,8 @@ msgstr ""
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1151
-#: lxc/storage_volume.go:1183
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
+#: lxc/storage_volume.go:1189
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4530,7 +4530,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1350
+#: lxc/storage_volume.go:1356
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4544,7 +4544,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1219
+#: lxc/storage_volume.go:1225
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4560,7 +4560,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2224
+#: lxc/storage_volume.go:2230
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4581,7 +4581,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:998
+#: lxc/storage_volume.go:1004
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4590,7 +4590,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2069
+#: lxc/storage_volume.go:2075
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4603,7 +4603,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2345
+#: lxc/storage_volume.go:2351
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4707,33 +4707,33 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:810
+#: lxc/remote.go:877
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
-#: lxc/remote.go:994
+#: lxc/project.go:884 lxc/remote.go:868 lxc/remote.go:949 lxc/remote.go:1013
+#: lxc/remote.go:1061
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:305
+#: lxc/remote.go:345
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:890
+#: lxc/remote.go:957
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:805 lxc/remote.go:886 lxc/remote.go:998
+#: lxc/remote.go:872 lxc/remote.go:953 lxc/remote.go:1065
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:294
+#: lxc/remote.go:319
 msgid "Remote address must not be empty"
 msgstr ""
 
@@ -4741,7 +4741,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:299
+#: lxc/remote.go:339
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4827,7 +4827,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:852 lxc/remote.go:853
+#: lxc/remote.go:919 lxc/remote.go:920
 msgid "Remove remotes"
 msgstr ""
 
@@ -4884,19 +4884,19 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:771 lxc/remote.go:772
+#: lxc/remote.go:838 lxc/remote.go:839
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:1943
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1936
+#: lxc/storage_volume.go:1942
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2025 lxc/storage_volume.go:2045
+#: lxc/storage_volume.go:2031 lxc/storage_volume.go:2051
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4948,7 +4948,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2540 lxc/storage_volume.go:2541
+#: lxc/storage_volume.go:2546 lxc/storage_volume.go:2547
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5029,7 +5029,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:820
 msgid "STATIC"
 msgstr ""
 
@@ -5070,11 +5070,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:464
+#: lxc/remote.go:532
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:616
+#: lxc/remote.go:285 lxc/remote.go:683
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5272,11 +5272,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2063
+#: lxc/storage_volume.go:2069
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2064
+#: lxc/storage_volume.go:2070
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5285,7 +5285,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:964 lxc/remote.go:965
+#: lxc/remote.go:1031 lxc/remote.go:1032
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5361,7 +5361,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2080
+#: lxc/storage_volume.go:2086
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5510,11 +5510,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2221 lxc/storage_volume.go:2222
+#: lxc/storage_volume.go:2227 lxc/storage_volume.go:2228
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1347 lxc/storage_volume.go:1348
+#: lxc/storage_volume.go:1353 lxc/storage_volume.go:1354
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5528,7 +5528,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:647 lxc/remote.go:648
+#: lxc/remote.go:714 lxc/remote.go:715
 msgid "Show the default remote"
 msgstr ""
 
@@ -5582,15 +5582,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2404 lxc/storage_volume.go:2405
+#: lxc/storage_volume.go:2410 lxc/storage_volume.go:2411
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2167
+#: lxc/storage_volume.go:2173
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:607 lxc/storage_volume.go:1485
+#: lxc/info.go:607 lxc/storage_volume.go:1491
 msgid "Snapshots:"
 msgstr ""
 
@@ -5691,21 +5691,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:696
+#: lxc/storage_volume.go:702
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:784
+#: lxc/storage_volume.go:790
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:509
+#: lxc/storage_volume.go:515
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:513
+#: lxc/storage_volume.go:519
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5740,7 +5740,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:916 lxc/remote.go:917
+#: lxc/remote.go:983 lxc/remote.go:984
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5759,11 +5759,11 @@ msgstr ""
 #: lxc/auth.go:818 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
-#: lxc/storage_volume.go:1730 lxc/warning.go:216
+#: lxc/storage_volume.go:1736 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1557
+#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1563
 msgid "Taken at"
 msgstr ""
 
@@ -5773,6 +5773,12 @@ msgstr ""
 
 #: lxc/file.go:1256
 msgid "Target path must be a directory"
+msgstr ""
+
+#: lxc/remote.go:161 lxc/remote.go:334
+msgid ""
+"The --accept-certificate flag is not supported when adding a remote using a "
+"trust token"
 msgstr ""
 
 #: lxc/move.go:181
@@ -5914,15 +5920,20 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1323
+#: lxc/storage_volume.go:1329
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1300
+#: lxc/storage_volume.go:1306
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
+msgstr ""
+
+#: lxc/remote.go:527
+msgid ""
+"The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
 
 #: lxc/info.go:354
@@ -5933,8 +5944,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:875
-#: lxc/storage_volume.go:972
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:881
+#: lxc/storage_volume.go:978
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6009,7 +6020,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1470
+#: lxc/storage_volume.go:1476
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6024,7 +6035,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1847
+#: lxc/storage_volume.go:1853
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6058,7 +6069,15 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:571
+#: lxc/remote.go:329
+msgid "Trust token cannot be used for public remotes"
+msgstr ""
+
+#: lxc/remote.go:324
+msgid "Trust token cannot be used with OIDC authentication"
+msgstr ""
+
+#: lxc/remote.go:639
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6083,7 +6102,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1455
+#: lxc/storage_volume.go:1461
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6101,17 +6120,17 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:193 lxc/remote.go:749
+#: lxc/cluster.go:193 lxc/remote.go:816
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1735
+#: lxc/project.go:995 lxc/storage_volume.go:1741
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1734
+#: lxc/storage.go:724 lxc/storage_volume.go:1740
 msgid "USED BY"
 msgstr ""
 
@@ -6129,7 +6148,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:214 lxc/remote.go:248
+#: lxc/remote.go:226 lxc/remote.go:260
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6143,7 +6162,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1772
+#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1778
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6249,7 +6268,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2342 lxc/storage_volume.go:2343
+#: lxc/storage_volume.go:2348 lxc/storage_volume.go:2349
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6301,7 +6320,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2356
+#: lxc/storage_volume.go:2362
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6345,12 +6364,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1468
+#: lxc/storage_volume.go:1474
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2629
+#: lxc/export.go:42 lxc/storage_volume.go:2635
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6417,7 +6436,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1559
+#: lxc/storage_volume.go:1565
 msgid "Volume Only"
 msgstr ""
 
@@ -6452,7 +6471,7 @@ msgstr ""
 
 #: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
+#: lxc/project.go:552 lxc/remote.go:777 lxc/remote.go:782 lxc/remote.go:787
 msgid "YES"
 msgstr ""
 
@@ -6476,7 +6495,7 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:897
+#: lxc/storage_volume.go:903
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
@@ -6898,7 +6917,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2788
+#: lxc/storage_volume.go:2794
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -6933,13 +6952,13 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:1941
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:799
+#: lxc/storage_volume.go:805
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
@@ -6947,47 +6966,47 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2539
+#: lxc/storage_volume.go:2545
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2622
+#: lxc/storage_volume.go:2628
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2403
+#: lxc/storage_volume.go:2409
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:603
+#: lxc/storage_volume.go:609
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:711
+#: lxc/storage_volume.go:717
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:994 lxc/storage_volume.go:1346
+#: lxc/storage_volume.go:1000 lxc/storage_volume.go:1352
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2341
+#: lxc/storage_volume.go:2347
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2062
+#: lxc/storage_volume.go:2068
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2220
+#: lxc/storage_volume.go:2226
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1215
+#: lxc/storage_volume.go:1221
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1841
+#: lxc/storage_volume.go:1847
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7097,7 +7116,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1584
+#: lxc/storage_volume.go:1590
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7109,7 +7128,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:739
+#: lxc/project.go:557 lxc/remote.go:806
 msgid "current"
 msgstr ""
 
@@ -7569,7 +7588,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:607
+#: lxc/storage_volume.go:613
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7577,13 +7596,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2792
+#: lxc/storage_volume.go:2798
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2407
+#: lxc/storage_volume.go:2413
 msgid ""
 "lxc storage volume snapshot create default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7593,7 +7612,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:531
 msgid "n"
 msgstr ""
 
@@ -7605,7 +7624,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:510
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7642,7 +7661,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:465
+#: lxc/remote.go:519
 msgid "y"
 msgstr ""
 

--- a/po/cs.po
+++ b/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-08 07:43+0100\n"
+"POT-Creation-Date: 2024-10-14 13:30+0000\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Czech <https://hosted.weblate.org/projects/linux-containers/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1024
+#: lxc/storage_volume.go:1030
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -515,15 +515,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:850 lxc/remote.go:915
+#: lxc/remote.go:917 lxc/remote.go:982
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:963
+#: lxc/remote.go:1030
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:769
+#: lxc/remote.go:836
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -556,7 +556,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:751
+#: lxc/remote.go:818
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:581
+#: lxc/remote.go:648
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -738,11 +738,11 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1590
+#: lxc/storage_volume.go:1596
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:182
+#: lxc/remote.go:194
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -813,7 +813,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:552
+#: lxc/remote.go:621
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -849,16 +849,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2696
+#: lxc/storage_volume.go:2702
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2773
+#: lxc/export.go:192 lxc/storage_volume.go:2779
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:654 lxc/storage_volume.go:1521
+#: lxc/info.go:654 lxc/storage_volume.go:1527
 msgid "Backups:"
 msgstr ""
 
@@ -879,7 +879,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:679
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:685
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -922,7 +922,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1733
+#: lxc/storage_volume.go:1739
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -991,7 +991,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:894
+#: lxc/remote.go:961
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1007,7 +1007,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1749 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1024,12 +1024,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:486
+#: lxc/storage_volume.go:492
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:440
+#: lxc/storage_volume.go:446
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1057,11 +1057,11 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:509
 msgid "Certificate fingerprint"
 msgstr ""
 
-#: lxc/remote.go:219
+#: lxc/remote.go:231
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
@@ -1076,7 +1076,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:620
+#: lxc/remote.go:687
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1150,13 +1150,13 @@ msgstr ""
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
 #: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
-#: lxc/storage_volume.go:612 lxc/storage_volume.go:717
-#: lxc/storage_volume.go:1005 lxc/storage_volume.go:1231
-#: lxc/storage_volume.go:1360 lxc/storage_volume.go:1848
-#: lxc/storage_volume.go:1940 lxc/storage_volume.go:2079
-#: lxc/storage_volume.go:2239 lxc/storage_volume.go:2355
-#: lxc/storage_volume.go:2416 lxc/storage_volume.go:2543
-#: lxc/storage_volume.go:2631 lxc/storage_volume.go:2795
+#: lxc/storage_volume.go:618 lxc/storage_volume.go:723
+#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1237
+#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1854
+#: lxc/storage_volume.go:1946 lxc/storage_volume.go:2085
+#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2361
+#: lxc/storage_volume.go:2422 lxc/storage_volume.go:2549
+#: lxc/storage_volume.go:2637 lxc/storage_volume.go:2801
 msgid "Cluster member name"
 msgstr ""
 
@@ -1172,7 +1172,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1589
+#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1595
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1216,17 +1216,17 @@ msgstr ""
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1150
-#: lxc/storage_volume.go:1182
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
+#: lxc/storage_volume.go:1188
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:613
+#: lxc/storage_volume.go:619
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1467
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1310,7 +1310,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:508
+#: lxc/storage_volume.go:514
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1324,12 +1324,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:490
+#: lxc/remote.go:559
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:225 lxc/remote.go:474
+#: lxc/remote.go:237 lxc/remote.go:543
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1368,7 +1368,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:485
+#: lxc/remote.go:554
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1437,7 +1437,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:604 lxc/storage_volume.go:605
+#: lxc/storage_volume.go:610 lxc/storage_volume.go:611
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1489,7 +1489,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1475
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1481
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1524,7 +1524,7 @@ msgstr ""
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1732
+#: lxc/storage_volume.go:1738
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1544,7 +1544,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2630
+#: lxc/storage_volume.go:2636
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1640,7 +1640,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:713 lxc/storage_volume.go:714
+#: lxc/storage_volume.go:719 lxc/storage_volume.go:720
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1732,9 +1732,9 @@ msgstr ""
 #: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
 #: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
 #: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:648
-#: lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853 lxc/remote.go:917
-#: lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:715
+#: lxc/remote.go:753 lxc/remote.go:839 lxc/remote.go:920 lxc/remote.go:984
+#: lxc/remote.go:1032 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1746,26 +1746,26 @@ msgstr ""
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
 #: lxc/storage_volume.go:169 lxc/storage_volume.go:283
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:605
-#: lxc/storage_volume.go:714 lxc/storage_volume.go:801
-#: lxc/storage_volume.go:899 lxc/storage_volume.go:996
-#: lxc/storage_volume.go:1217 lxc/storage_volume.go:1348
-#: lxc/storage_volume.go:1507 lxc/storage_volume.go:1591
-#: lxc/storage_volume.go:1844 lxc/storage_volume.go:1937
-#: lxc/storage_volume.go:2064 lxc/storage_volume.go:2222
-#: lxc/storage_volume.go:2343 lxc/storage_volume.go:2405
-#: lxc/storage_volume.go:2541 lxc/storage_volume.go:2624
-#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:611
+#: lxc/storage_volume.go:720 lxc/storage_volume.go:807
+#: lxc/storage_volume.go:905 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:1223 lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1513 lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1850 lxc/storage_volume.go:1943
+#: lxc/storage_volume.go:2070 lxc/storage_volume.go:2228
+#: lxc/storage_volume.go:2349 lxc/storage_volume.go:2411
+#: lxc/storage_volume.go:2547 lxc/storage_volume.go:2630
+#: lxc/storage_volume.go:2796 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1448
+#: lxc/storage_volume.go:1454
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:1849
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:1855
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1777,11 +1777,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:800 lxc/storage_volume.go:801
+#: lxc/storage_volume.go:806 lxc/storage_volume.go:807
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:898 lxc/storage_volume.go:899
+#: lxc/storage_volume.go:904 lxc/storage_volume.go:905
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -2007,7 +2007,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:995 lxc/storage_volume.go:996
+#: lxc/storage_volume.go:1001 lxc/storage_volume.go:1002
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2015,7 +2015,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1766
+#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1772
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2072,7 +2072,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2193
+#: lxc/storage_volume.go:2161 lxc/storage_volume.go:2199
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2086,8 +2086,8 @@ msgstr ""
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2149
-#: lxc/storage_volume.go:2187
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2155
+#: lxc/storage_volume.go:2193
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2129,8 +2129,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1508
-#: lxc/storage_volume.go:1558
+#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1514
+#: lxc/storage_volume.go:1564
 msgid "Expires at"
 msgstr ""
 
@@ -2154,7 +2154,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2623 lxc/storage_volume.go:2624
+#: lxc/storage_volume.go:2629 lxc/storage_volume.go:2630
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2166,11 +2166,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2627
+#: lxc/storage_volume.go:2633
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2756
+#: lxc/export.go:152 lxc/storage_volume.go:2762
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2287,11 +2287,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:191
+#: lxc/remote.go:203
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:242
+#: lxc/remote.go:254
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2301,7 +2301,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:232
+#: lxc/remote.go:244
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2311,12 +2311,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:260
+#: lxc/remote.go:486
 #, c-format
-msgid "Failed to create certificate: %w"
+msgid "Failed to decode trust token: %w"
 msgstr ""
 
-#: lxc/remote.go:267
+#: lxc/remote.go:292
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2341,7 +2341,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:237
+#: lxc/remote.go:249
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2428,9 +2428,9 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:690 lxc/storage.go:657
+#: lxc/project.go:919 lxc/remote.go:757 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1608 lxc/warning.go:94
+#: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2466,7 +2466,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:754
+#: lxc/remote.go:821
 msgid "GLOBAL"
 msgstr ""
 
@@ -2486,7 +2486,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:160 lxc/remote.go:401
+#: lxc/remote.go:165 lxc/remote.go:443
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2554,7 +2554,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1238
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2618,11 +2618,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1216 lxc/storage_volume.go:1217
+#: lxc/storage_volume.go:1222 lxc/storage_volume.go:1223
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:469
+#: lxc/storage_volume.go:475
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2746,7 +2746,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2415
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2421
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2760,7 +2760,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2414
+#: lxc/storage_volume.go:2420
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2810,7 +2810,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2790
+#: lxc/storage_volume.go:2796
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2818,7 +2818,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2789
+#: lxc/storage_volume.go:2795
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2840,11 +2840,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2797
+#: lxc/storage_volume.go:2803
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2871
+#: lxc/storage_volume.go:2877
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2910,7 +2910,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:353
+#: lxc/remote.go:395
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2970,7 +2970,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2000
+#: lxc/move.go:148 lxc/storage_volume.go:2006
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2978,7 +2978,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1996
+#: lxc/storage_volume.go:2002
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2991,14 +2991,14 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:342
+#: lxc/remote.go:384
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1064 lxc/storage_volume.go:1281
-#: lxc/storage_volume.go:1405 lxc/storage_volume.go:1985
-#: lxc/storage_volume.go:2132 lxc/storage_volume.go:2284
+#: lxc/storage_volume.go:1070 lxc/storage_volume.go:1287
+#: lxc/storage_volume.go:1411 lxc/storage_volume.go:1991
+#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2290
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3044,7 +3044,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1739 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1745 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3347,11 +3347,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1586
+#: lxc/storage_volume.go:1592
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1597
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3371,7 +3371,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:685 lxc/remote.go:686
+#: lxc/remote.go:752 lxc/remote.go:753
 msgid "List the available remotes"
 msgstr ""
 
@@ -3410,7 +3410,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1464
+#: lxc/info.go:489 lxc/storage_volume.go:1470
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3874,12 +3874,12 @@ msgstr ""
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:323 lxc/storage_volume.go:643
-#: lxc/storage_volume.go:750 lxc/storage_volume.go:841
-#: lxc/storage_volume.go:939 lxc/storage_volume.go:1053
-#: lxc/storage_volume.go:1270 lxc/storage_volume.go:1974
-#: lxc/storage_volume.go:2115 lxc/storage_volume.go:2273
-#: lxc/storage_volume.go:2464 lxc/storage_volume.go:2581
+#: lxc/storage_volume.go:323 lxc/storage_volume.go:649
+#: lxc/storage_volume.go:756 lxc/storage_volume.go:847
+#: lxc/storage_volume.go:945 lxc/storage_volume.go:1059
+#: lxc/storage_volume.go:1276 lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:2121 lxc/storage_volume.go:2279
+#: lxc/storage_volume.go:2470 lxc/storage_volume.go:2587
 msgid "Missing pool name"
 msgstr ""
 
@@ -3898,11 +3898,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:432 lxc/storage_volume.go:1884
+#: lxc/storage_volume.go:438 lxc/storage_volume.go:1890
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1394
+#: lxc/storage_volume.go:1400
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -3939,8 +3939,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:861
-#: lxc/storage_volume.go:958
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:867
+#: lxc/storage_volume.go:964
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -3977,7 +3977,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1843 lxc/storage_volume.go:1844
+#: lxc/storage_volume.go:1849 lxc/storage_volume.go:1850
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -3985,11 +3985,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1850
+#: lxc/storage_volume.go:1856
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:512
+#: lxc/storage_volume.go:518
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4015,8 +4015,8 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
-#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1731
+#: lxc/remote.go:815 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
 msgstr ""
 
@@ -4042,7 +4042,7 @@ msgstr ""
 
 #: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
+#: lxc/project.go:550 lxc/remote.go:775 lxc/remote.go:780 lxc/remote.go:785
 msgid "NO"
 msgstr ""
 
@@ -4064,8 +4064,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1506
-#: lxc/storage_volume.go:1556
+#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1512
+#: lxc/storage_volume.go:1562
 msgid "Name"
 msgstr ""
 
@@ -4073,7 +4073,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1446
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1452
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4217,7 +4217,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:870 lxc/storage_volume.go:967
+#: lxc/storage_volume.go:876 lxc/storage_volume.go:973
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4233,11 +4233,11 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/storage_volume.go:446 lxc/storage_volume.go:1893
+#: lxc/storage_volume.go:452 lxc/storage_volume.go:1899
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:496 lxc/storage_volume.go:1904
+#: lxc/storage_volume.go:502 lxc/storage_volume.go:1910
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4251,7 +4251,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2012
+#: lxc/storage_volume.go:2018
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4263,15 +4263,15 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2678
+#: lxc/storage_volume.go:2684
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2477
+#: lxc/storage_volume.go:2483
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:336
+#: lxc/remote.go:378
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4279,7 +4279,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1412
+#: lxc/storage_volume.go:1418
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4292,7 +4292,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:693 lxc/storage_volume.go:1560
+#: lxc/info.go:693 lxc/storage_volume.go:1566
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4322,7 +4322,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1756
 msgid "POOL"
 msgstr ""
 
@@ -4338,15 +4338,15 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:213
+#: lxc/list.go:567 lxc/storage_volume.go:1762 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:817
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:752
+#: lxc/image.go:1136 lxc/remote.go:819
 msgid "PUBLIC"
 msgstr ""
 
@@ -4375,7 +4375,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:183
+#: lxc/remote.go:195
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4387,8 +4387,8 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:466
-msgid "Please type 'y', 'n' or the fingerprint:"
+#: lxc/remote.go:536
+msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
 #: lxc/info.go:221
@@ -4412,8 +4412,8 @@ msgstr ""
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1151
-#: lxc/storage_volume.go:1183
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
+#: lxc/storage_volume.go:1189
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4530,7 +4530,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1350
+#: lxc/storage_volume.go:1356
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4544,7 +4544,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1219
+#: lxc/storage_volume.go:1225
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4560,7 +4560,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2224
+#: lxc/storage_volume.go:2230
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4581,7 +4581,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:998
+#: lxc/storage_volume.go:1004
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4590,7 +4590,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2069
+#: lxc/storage_volume.go:2075
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4603,7 +4603,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2345
+#: lxc/storage_volume.go:2351
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4707,33 +4707,33 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:810
+#: lxc/remote.go:877
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
-#: lxc/remote.go:994
+#: lxc/project.go:884 lxc/remote.go:868 lxc/remote.go:949 lxc/remote.go:1013
+#: lxc/remote.go:1061
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:305
+#: lxc/remote.go:345
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:890
+#: lxc/remote.go:957
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:805 lxc/remote.go:886 lxc/remote.go:998
+#: lxc/remote.go:872 lxc/remote.go:953 lxc/remote.go:1065
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:294
+#: lxc/remote.go:319
 msgid "Remote address must not be empty"
 msgstr ""
 
@@ -4741,7 +4741,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:299
+#: lxc/remote.go:339
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4827,7 +4827,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:852 lxc/remote.go:853
+#: lxc/remote.go:919 lxc/remote.go:920
 msgid "Remove remotes"
 msgstr ""
 
@@ -4884,19 +4884,19 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:771 lxc/remote.go:772
+#: lxc/remote.go:838 lxc/remote.go:839
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:1943
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1936
+#: lxc/storage_volume.go:1942
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2025 lxc/storage_volume.go:2045
+#: lxc/storage_volume.go:2031 lxc/storage_volume.go:2051
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4948,7 +4948,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2540 lxc/storage_volume.go:2541
+#: lxc/storage_volume.go:2546 lxc/storage_volume.go:2547
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5029,7 +5029,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:820
 msgid "STATIC"
 msgstr ""
 
@@ -5070,11 +5070,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:464
+#: lxc/remote.go:532
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:616
+#: lxc/remote.go:285 lxc/remote.go:683
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5272,11 +5272,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2063
+#: lxc/storage_volume.go:2069
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2064
+#: lxc/storage_volume.go:2070
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5285,7 +5285,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:964 lxc/remote.go:965
+#: lxc/remote.go:1031 lxc/remote.go:1032
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5361,7 +5361,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2080
+#: lxc/storage_volume.go:2086
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5510,11 +5510,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2221 lxc/storage_volume.go:2222
+#: lxc/storage_volume.go:2227 lxc/storage_volume.go:2228
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1347 lxc/storage_volume.go:1348
+#: lxc/storage_volume.go:1353 lxc/storage_volume.go:1354
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5528,7 +5528,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:647 lxc/remote.go:648
+#: lxc/remote.go:714 lxc/remote.go:715
 msgid "Show the default remote"
 msgstr ""
 
@@ -5582,15 +5582,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2404 lxc/storage_volume.go:2405
+#: lxc/storage_volume.go:2410 lxc/storage_volume.go:2411
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2167
+#: lxc/storage_volume.go:2173
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:607 lxc/storage_volume.go:1485
+#: lxc/info.go:607 lxc/storage_volume.go:1491
 msgid "Snapshots:"
 msgstr ""
 
@@ -5691,21 +5691,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:696
+#: lxc/storage_volume.go:702
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:784
+#: lxc/storage_volume.go:790
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:509
+#: lxc/storage_volume.go:515
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:513
+#: lxc/storage_volume.go:519
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5740,7 +5740,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:916 lxc/remote.go:917
+#: lxc/remote.go:983 lxc/remote.go:984
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5759,11 +5759,11 @@ msgstr ""
 #: lxc/auth.go:818 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
-#: lxc/storage_volume.go:1730 lxc/warning.go:216
+#: lxc/storage_volume.go:1736 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1557
+#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1563
 msgid "Taken at"
 msgstr ""
 
@@ -5773,6 +5773,12 @@ msgstr ""
 
 #: lxc/file.go:1256
 msgid "Target path must be a directory"
+msgstr ""
+
+#: lxc/remote.go:161 lxc/remote.go:334
+msgid ""
+"The --accept-certificate flag is not supported when adding a remote using a "
+"trust token"
 msgstr ""
 
 #: lxc/move.go:181
@@ -5914,15 +5920,20 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1323
+#: lxc/storage_volume.go:1329
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1300
+#: lxc/storage_volume.go:1306
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
+msgstr ""
+
+#: lxc/remote.go:527
+msgid ""
+"The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
 
 #: lxc/info.go:354
@@ -5933,8 +5944,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:875
-#: lxc/storage_volume.go:972
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:881
+#: lxc/storage_volume.go:978
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6009,7 +6020,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1470
+#: lxc/storage_volume.go:1476
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6024,7 +6035,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1847
+#: lxc/storage_volume.go:1853
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6058,7 +6069,15 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:571
+#: lxc/remote.go:329
+msgid "Trust token cannot be used for public remotes"
+msgstr ""
+
+#: lxc/remote.go:324
+msgid "Trust token cannot be used with OIDC authentication"
+msgstr ""
+
+#: lxc/remote.go:639
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6083,7 +6102,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1455
+#: lxc/storage_volume.go:1461
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6101,17 +6120,17 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:193 lxc/remote.go:749
+#: lxc/cluster.go:193 lxc/remote.go:816
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1735
+#: lxc/project.go:995 lxc/storage_volume.go:1741
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1734
+#: lxc/storage.go:724 lxc/storage_volume.go:1740
 msgid "USED BY"
 msgstr ""
 
@@ -6129,7 +6148,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:214 lxc/remote.go:248
+#: lxc/remote.go:226 lxc/remote.go:260
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6143,7 +6162,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1772
+#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1778
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6249,7 +6268,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2342 lxc/storage_volume.go:2343
+#: lxc/storage_volume.go:2348 lxc/storage_volume.go:2349
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6301,7 +6320,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2356
+#: lxc/storage_volume.go:2362
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6345,12 +6364,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1468
+#: lxc/storage_volume.go:1474
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2629
+#: lxc/export.go:42 lxc/storage_volume.go:2635
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6417,7 +6436,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1559
+#: lxc/storage_volume.go:1565
 msgid "Volume Only"
 msgstr ""
 
@@ -6452,7 +6471,7 @@ msgstr ""
 
 #: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
+#: lxc/project.go:552 lxc/remote.go:777 lxc/remote.go:782 lxc/remote.go:787
 msgid "YES"
 msgstr ""
 
@@ -6476,7 +6495,7 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:897
+#: lxc/storage_volume.go:903
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
@@ -6898,7 +6917,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2788
+#: lxc/storage_volume.go:2794
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -6933,13 +6952,13 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:1941
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:799
+#: lxc/storage_volume.go:805
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
@@ -6947,47 +6966,47 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2539
+#: lxc/storage_volume.go:2545
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2622
+#: lxc/storage_volume.go:2628
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2403
+#: lxc/storage_volume.go:2409
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:603
+#: lxc/storage_volume.go:609
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:711
+#: lxc/storage_volume.go:717
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:994 lxc/storage_volume.go:1346
+#: lxc/storage_volume.go:1000 lxc/storage_volume.go:1352
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2341
+#: lxc/storage_volume.go:2347
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2062
+#: lxc/storage_volume.go:2068
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2220
+#: lxc/storage_volume.go:2226
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1215
+#: lxc/storage_volume.go:1221
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1841
+#: lxc/storage_volume.go:1847
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7097,7 +7116,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1584
+#: lxc/storage_volume.go:1590
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7109,7 +7128,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:739
+#: lxc/project.go:557 lxc/remote.go:806
 msgid "current"
 msgstr ""
 
@@ -7569,7 +7588,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:607
+#: lxc/storage_volume.go:613
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7577,13 +7596,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2792
+#: lxc/storage_volume.go:2798
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2407
+#: lxc/storage_volume.go:2413
 msgid ""
 "lxc storage volume snapshot create default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7593,7 +7612,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:531
 msgid "n"
 msgstr ""
 
@@ -7605,7 +7624,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:510
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7642,7 +7661,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:465
+#: lxc/remote.go:519
 msgid "y"
 msgstr ""
 

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-08 07:43+0100\n"
+"POT-Creation-Date: 2024-10-14 13:30+0000\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Krombel <krombel@krombel.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/linux-containers/"
@@ -74,7 +74,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/storage_volume.go:1024
+#: lxc/storage_volume.go:1030
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
@@ -774,15 +774,15 @@ msgstr "Ungültiges Ziel %s"
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:850 lxc/remote.go:915
+#: lxc/remote.go:917 lxc/remote.go:982
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:963
+#: lxc/remote.go:1030
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:769
+#: lxc/remote.go:836
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -820,7 +820,7 @@ msgstr "ALIASES"
 msgid "ARCHITECTURE"
 msgstr "ARCHITEKTUR"
 
-#: lxc/remote.go:751
+#: lxc/remote.go:818
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -979,7 +979,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Admin access key: %s"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/remote.go:581
+#: lxc/remote.go:648
 #, fuzzy, c-format
 msgid "Admin password (or token) for %s:"
 msgstr "Administrator Passwort für %s: "
@@ -1013,12 +1013,12 @@ msgstr "entfernte Instanz %s existiert bereits"
 msgid "Aliases:"
 msgstr "Aliasse:\n"
 
-#: lxc/storage_volume.go:1590
+#: lxc/storage_volume.go:1596
 #, fuzzy
 msgid "All projects"
 msgstr "Fehlerhafte Profil URL %s"
 
-#: lxc/remote.go:182
+#: lxc/remote.go:194
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -1096,7 +1096,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:552
+#: lxc/remote.go:621
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -1133,17 +1133,17 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/storage_volume.go:2696
+#: lxc/storage_volume.go:2702
 #, fuzzy, c-format
 msgid "Backing up storage volume: %s"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/export.go:192 lxc/storage_volume.go:2773
+#: lxc/export.go:192 lxc/storage_volume.go:2779
 #, fuzzy
 msgid "Backup exported successfully!"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/info.go:654 lxc/storage_volume.go:1521
+#: lxc/info.go:654 lxc/storage_volume.go:1527
 msgid "Backups:"
 msgstr ""
 
@@ -1164,7 +1164,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:679
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:685
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -1207,7 +1207,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1733
+#: lxc/storage_volume.go:1739
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1287,7 +1287,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:894
+#: lxc/remote.go:961
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1303,7 +1303,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1749 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1320,12 +1320,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:486
+#: lxc/storage_volume.go:492
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:440
+#: lxc/storage_volume.go:446
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1357,12 +1357,12 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: lxc/remote.go:455
+#: lxc/remote.go:509
 #, fuzzy
 msgid "Certificate fingerprint"
 msgstr "Fingerabdruck des Zertifikats: % x\n"
 
-#: lxc/remote.go:219
+#: lxc/remote.go:231
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
@@ -1377,7 +1377,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/remote.go:620
+#: lxc/remote.go:687
 #, fuzzy
 msgid "Client certificate now trusted by server:"
 msgstr "Gespeichertes Nutzerzertifikat auf dem Server: "
@@ -1452,13 +1452,13 @@ msgstr "Gerät %s wurde von %s entfernt\n"
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
 #: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
-#: lxc/storage_volume.go:612 lxc/storage_volume.go:717
-#: lxc/storage_volume.go:1005 lxc/storage_volume.go:1231
-#: lxc/storage_volume.go:1360 lxc/storage_volume.go:1848
-#: lxc/storage_volume.go:1940 lxc/storage_volume.go:2079
-#: lxc/storage_volume.go:2239 lxc/storage_volume.go:2355
-#: lxc/storage_volume.go:2416 lxc/storage_volume.go:2543
-#: lxc/storage_volume.go:2631 lxc/storage_volume.go:2795
+#: lxc/storage_volume.go:618 lxc/storage_volume.go:723
+#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1237
+#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1854
+#: lxc/storage_volume.go:1946 lxc/storage_volume.go:2085
+#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2361
+#: lxc/storage_volume.go:2422 lxc/storage_volume.go:2549
+#: lxc/storage_volume.go:2637 lxc/storage_volume.go:2801
 msgid "Cluster member name"
 msgstr ""
 
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1589
+#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1595
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr "Spalten"
@@ -1521,17 +1521,17 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1150
-#: lxc/storage_volume.go:1182
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
+#: lxc/storage_volume.go:1188
 #, fuzzy, c-format
 msgid "Config parsing error: %s"
 msgstr "YAML Analyse Fehler %v\n"
 
-#: lxc/storage_volume.go:613
+#: lxc/storage_volume.go:619
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1467
 #, fuzzy, c-format
 msgid "Content type: %s"
 msgstr "Erstellt: %s"
@@ -1619,7 +1619,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:508
+#: lxc/storage_volume.go:514
 #, fuzzy, c-format
 msgid "Copying the storage volume: %s"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -1634,12 +1634,12 @@ msgstr "Fehler: %v\n"
 msgid "Cores:"
 msgstr "Fehler: %v\n"
 
-#: lxc/remote.go:490
+#: lxc/remote.go:559
 #, fuzzy, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "Kann Verzeichnis für Zertifikate auf dem Server nicht erstellen"
 
-#: lxc/remote.go:225 lxc/remote.go:474
+#: lxc/remote.go:237 lxc/remote.go:543
 msgid "Could not create server cert dir"
 msgstr "Kann Verzeichnis für Zertifikate auf dem Server nicht erstellen"
 
@@ -1678,7 +1678,7 @@ msgstr "Fingerabdruck des Zertifikats: % x\n"
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:485
+#: lxc/remote.go:554
 #, fuzzy, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "Kann Verzeichnis für Zertifikate auf dem Server nicht erstellen"
@@ -1757,7 +1757,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Create new custom storage buckets"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/storage_volume.go:604 lxc/storage_volume.go:605
+#: lxc/storage_volume.go:610 lxc/storage_volume.go:611
 #, fuzzy
 msgid "Create new custom storage volumes"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -1820,7 +1820,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Create the instance with no profiles applied"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1475
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1481
 #, c-format
 msgid "Created: %s"
 msgstr "Erstellt: %s"
@@ -1856,7 +1856,7 @@ msgstr ""
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1732
+#: lxc/storage_volume.go:1738
 msgid "DESCRIPTION"
 msgstr "BESCHREIBUNG"
 
@@ -1876,7 +1876,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2630
+#: lxc/storage_volume.go:2636
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1982,7 +1982,7 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:713 lxc/storage_volume.go:714
+#: lxc/storage_volume.go:719 lxc/storage_volume.go:720
 #, fuzzy
 msgid "Delete storage volumes"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -2075,9 +2075,9 @@ msgstr ""
 #: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
 #: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
 #: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:648
-#: lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853 lxc/remote.go:917
-#: lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:715
+#: lxc/remote.go:753 lxc/remote.go:839 lxc/remote.go:920 lxc/remote.go:984
+#: lxc/remote.go:1032 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -2089,26 +2089,26 @@ msgstr ""
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
 #: lxc/storage_volume.go:169 lxc/storage_volume.go:283
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:605
-#: lxc/storage_volume.go:714 lxc/storage_volume.go:801
-#: lxc/storage_volume.go:899 lxc/storage_volume.go:996
-#: lxc/storage_volume.go:1217 lxc/storage_volume.go:1348
-#: lxc/storage_volume.go:1507 lxc/storage_volume.go:1591
-#: lxc/storage_volume.go:1844 lxc/storage_volume.go:1937
-#: lxc/storage_volume.go:2064 lxc/storage_volume.go:2222
-#: lxc/storage_volume.go:2343 lxc/storage_volume.go:2405
-#: lxc/storage_volume.go:2541 lxc/storage_volume.go:2624
-#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:611
+#: lxc/storage_volume.go:720 lxc/storage_volume.go:807
+#: lxc/storage_volume.go:905 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:1223 lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1513 lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1850 lxc/storage_volume.go:1943
+#: lxc/storage_volume.go:2070 lxc/storage_volume.go:2228
+#: lxc/storage_volume.go:2349 lxc/storage_volume.go:2411
+#: lxc/storage_volume.go:2547 lxc/storage_volume.go:2630
+#: lxc/storage_volume.go:2796 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1448
+#: lxc/storage_volume.go:1454
 #, fuzzy, c-format
 msgid "Description: %s"
 msgstr "Fingerabdruck: %s\n"
 
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:1849
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:1855
 #, fuzzy
 msgid "Destination cluster member name"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -2122,12 +2122,12 @@ msgstr "Netzwerkschnittstellen an Container anbinden"
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:800 lxc/storage_volume.go:801
+#: lxc/storage_volume.go:806 lxc/storage_volume.go:807
 #, fuzzy
 msgid "Detach storage volumes from instances"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/storage_volume.go:898 lxc/storage_volume.go:899
+#: lxc/storage_volume.go:904 lxc/storage_volume.go:905
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -2380,7 +2380,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:995 lxc/storage_volume.go:996
+#: lxc/storage_volume.go:1001 lxc/storage_volume.go:1002
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2389,7 +2389,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1766
+#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1772
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2447,7 +2447,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2193
+#: lxc/storage_volume.go:2161 lxc/storage_volume.go:2199
 #, fuzzy, c-format
 msgid "Error setting properties: %v"
 msgstr "Fehler beim hinzufügen des Alias %s\n"
@@ -2461,8 +2461,8 @@ msgstr "Fehler beim hinzufügen des Alias %s\n"
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2149
-#: lxc/storage_volume.go:2187
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2155
+#: lxc/storage_volume.go:2193
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2513,8 +2513,8 @@ msgstr ""
 "\n"
 "lxc exec <Container> [--env EDITOR=/usr/bin/vim]... <Befehl>\n"
 
-#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1508
-#: lxc/storage_volume.go:1558
+#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1514
+#: lxc/storage_volume.go:1564
 msgid "Expires at"
 msgstr ""
 
@@ -2538,7 +2538,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2623 lxc/storage_volume.go:2624
+#: lxc/storage_volume.go:2629 lxc/storage_volume.go:2630
 #, fuzzy
 msgid "Export custom storage volume"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -2553,12 +2553,12 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Export instances as backup tarballs."
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/storage_volume.go:2627
+#: lxc/storage_volume.go:2633
 #, fuzzy
 msgid "Export the volume without its snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/export.go:152 lxc/storage_volume.go:2756
+#: lxc/export.go:152 lxc/storage_volume.go:2762
 #, fuzzy, c-format
 msgid "Exporting the backup: %s"
 msgstr "Herunterfahren des Containers erzwingen."
@@ -2675,11 +2675,11 @@ msgstr "Akzeptiere Zertifikat"
 msgid "Failed to accept incoming connection: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/remote.go:191
+#: lxc/remote.go:203
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:242
+#: lxc/remote.go:254
 #, fuzzy, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr "Akzeptiere Zertifikat"
@@ -2689,7 +2689,7 @@ msgstr "Akzeptiere Zertifikat"
 msgid "Failed to connect to cluster member: %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/remote.go:232
+#: lxc/remote.go:244
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2699,12 +2699,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/remote.go:260
+#: lxc/remote.go:486
 #, fuzzy, c-format
-msgid "Failed to create certificate: %w"
-msgstr "Akzeptiere Zertifikat"
+msgid "Failed to decode trust token: %w"
+msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/remote.go:267
+#: lxc/remote.go:292
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2729,7 +2729,7 @@ msgstr "Akzeptiere Zertifikat"
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:237
+#: lxc/remote.go:249
 #, fuzzy, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr "Akzeptiere Zertifikat"
@@ -2820,9 +2820,9 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:690 lxc/storage.go:657
+#: lxc/project.go:919 lxc/remote.go:757 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1608 lxc/warning.go:94
+#: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2858,7 +2858,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:754
+#: lxc/remote.go:821
 msgid "GLOBAL"
 msgstr ""
 
@@ -2878,7 +2878,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:160 lxc/remote.go:401
+#: lxc/remote.go:165 lxc/remote.go:443
 #, fuzzy
 msgid "Generating a client certificate. This may take a minute..."
 msgstr "Generiere Nutzerzertifikat. Dies kann wenige Minuten dauern...\n"
@@ -2955,7 +2955,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Get the key as a storage property"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1238
 #, fuzzy
 msgid "Get the key as a storage volume property"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -3031,11 +3031,11 @@ msgstr "Profil %s erstellt\n"
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1216 lxc/storage_volume.go:1217
+#: lxc/storage_volume.go:1222 lxc/storage_volume.go:1223
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:469
+#: lxc/storage_volume.go:475
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -3162,7 +3162,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2415
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2421
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -3176,7 +3176,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2414
+#: lxc/storage_volume.go:2420
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -3228,7 +3228,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/storage_volume.go:2790
+#: lxc/storage_volume.go:2796
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -3236,7 +3236,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2789
+#: lxc/storage_volume.go:2795
 #, fuzzy
 msgid "Import custom storage volumes"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -3260,11 +3260,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/storage_volume.go:2797
+#: lxc/storage_volume.go:2803
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2871
+#: lxc/storage_volume.go:2877
 #, fuzzy, c-format
 msgid "Importing custom volume: %s"
 msgstr "Herunterfahren des Containers erzwingen."
@@ -3331,7 +3331,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:353
+#: lxc/remote.go:395
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3392,7 +3392,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2000
+#: lxc/move.go:148 lxc/storage_volume.go:2006
 #, fuzzy
 msgid "Invalid new snapshot name"
 msgstr "'/' ist kein gültiges Zeichen im Namen eines Sicherungspunktes\n"
@@ -3401,7 +3401,7 @@ msgstr "'/' ist kein gültiges Zeichen im Namen eines Sicherungspunktes\n"
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1996
+#: lxc/storage_volume.go:2002
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3415,14 +3415,14 @@ msgstr "ungültiges Argument %s"
 msgid "Invalid path %s"
 msgstr "Ungültiges Ziel %s"
 
-#: lxc/remote.go:342
+#: lxc/remote.go:384
 #, fuzzy, c-format
 msgid "Invalid protocol: %s"
 msgstr "Ungültiges Ziel %s"
 
-#: lxc/storage_volume.go:1064 lxc/storage_volume.go:1281
-#: lxc/storage_volume.go:1405 lxc/storage_volume.go:1985
-#: lxc/storage_volume.go:2132 lxc/storage_volume.go:2284
+#: lxc/storage_volume.go:1070 lxc/storage_volume.go:1287
+#: lxc/storage_volume.go:1411 lxc/storage_volume.go:1991
+#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2290
 #, fuzzy
 msgid "Invalid snapshot name"
 msgstr "Ungültige Quelle %s"
@@ -3473,7 +3473,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1739 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1745 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3806,12 +3806,12 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "List storage buckets"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/storage_volume.go:1586
+#: lxc/storage_volume.go:1592
 #, fuzzy
 msgid "List storage volumes"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1597
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3831,7 +3831,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:685 lxc/remote.go:686
+#: lxc/remote.go:752 lxc/remote.go:753
 msgid "List the available remotes"
 msgstr ""
 
@@ -3871,7 +3871,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1464
+#: lxc/info.go:489 lxc/storage_volume.go:1470
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -4393,12 +4393,12 @@ msgstr "Fehlende Zusammenfassung."
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:323 lxc/storage_volume.go:643
-#: lxc/storage_volume.go:750 lxc/storage_volume.go:841
-#: lxc/storage_volume.go:939 lxc/storage_volume.go:1053
-#: lxc/storage_volume.go:1270 lxc/storage_volume.go:1974
-#: lxc/storage_volume.go:2115 lxc/storage_volume.go:2273
-#: lxc/storage_volume.go:2464 lxc/storage_volume.go:2581
+#: lxc/storage_volume.go:323 lxc/storage_volume.go:649
+#: lxc/storage_volume.go:756 lxc/storage_volume.go:847
+#: lxc/storage_volume.go:945 lxc/storage_volume.go:1059
+#: lxc/storage_volume.go:1276 lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:2121 lxc/storage_volume.go:2279
+#: lxc/storage_volume.go:2470 lxc/storage_volume.go:2587
 #, fuzzy
 msgid "Missing pool name"
 msgstr "Profilname kann nicht geändert werden"
@@ -4419,12 +4419,12 @@ msgstr "Profilname kann nicht geändert werden"
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:432 lxc/storage_volume.go:1884
+#: lxc/storage_volume.go:438 lxc/storage_volume.go:1890
 #, fuzzy
 msgid "Missing source volume name"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/storage_volume.go:1394
+#: lxc/storage_volume.go:1400
 #, fuzzy
 msgid "Missing storage pool name"
 msgstr "Profilname kann nicht geändert werden"
@@ -4463,8 +4463,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:861
-#: lxc/storage_volume.go:958
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:867
+#: lxc/storage_volume.go:964
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4504,7 +4504,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1843 lxc/storage_volume.go:1844
+#: lxc/storage_volume.go:1849 lxc/storage_volume.go:1850
 #, fuzzy
 msgid "Move storage volumes between pools"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -4514,11 +4514,11 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Move the instance without its snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/storage_volume.go:1850
+#: lxc/storage_volume.go:1856
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:512
+#: lxc/storage_volume.go:518
 #, fuzzy, c-format
 msgid "Moving the storage volume: %s"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -4545,8 +4545,8 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
-#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1731
+#: lxc/remote.go:815 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
 msgstr ""
 
@@ -4572,7 +4572,7 @@ msgstr ""
 
 #: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
+#: lxc/project.go:550 lxc/remote.go:775 lxc/remote.go:780 lxc/remote.go:785
 msgid "NO"
 msgstr ""
 
@@ -4594,8 +4594,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1506
-#: lxc/storage_volume.go:1556
+#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1512
+#: lxc/storage_volume.go:1562
 msgid "Name"
 msgstr ""
 
@@ -4603,7 +4603,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1446
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1452
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4751,7 +4751,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/storage_volume.go:870 lxc/storage_volume.go:967
+#: lxc/storage_volume.go:876 lxc/storage_volume.go:973
 #, fuzzy
 msgid "No device found for this storage volume"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -4768,11 +4768,11 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/storage_volume.go:446 lxc/storage_volume.go:1893
+#: lxc/storage_volume.go:452 lxc/storage_volume.go:1899
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:496 lxc/storage_volume.go:1904
+#: lxc/storage_volume.go:502 lxc/storage_volume.go:1910
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4786,7 +4786,7 @@ msgstr "kein Wert in %q gefunden\n"
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2012
+#: lxc/storage_volume.go:2018
 #, fuzzy
 msgid "Not a snapshot name"
 msgstr "'/' ist kein gültiges Zeichen im Namen eines Sicherungspunktes\n"
@@ -4799,15 +4799,15 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2678
+#: lxc/storage_volume.go:2684
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2477
+#: lxc/storage_volume.go:2483
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:336
+#: lxc/remote.go:378
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4815,7 +4815,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1412
+#: lxc/storage_volume.go:1418
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4828,7 +4828,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: lxc/info.go:693 lxc/storage_volume.go:1560
+#: lxc/info.go:693 lxc/storage_volume.go:1566
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4858,7 +4858,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1756
 msgid "POOL"
 msgstr ""
 
@@ -4874,15 +4874,15 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:213
+#: lxc/list.go:567 lxc/storage_volume.go:1762 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:817
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:752
+#: lxc/image.go:1136 lxc/remote.go:819
 msgid "PUBLIC"
 msgstr ""
 
@@ -4912,7 +4912,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:183
+#: lxc/remote.go:195
 #, fuzzy
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr "Alternatives config Verzeichnis."
@@ -4926,9 +4926,10 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/remote.go:466
-msgid "Please type 'y', 'n' or the fingerprint:"
-msgstr ""
+#: lxc/remote.go:536
+#, fuzzy
+msgid "Please type 'y', 'n' or the fingerprint: "
+msgstr "Abbild mit Fingerabdruck %s importiert\n"
 
 #: lxc/info.go:221
 #, fuzzy, c-format
@@ -4951,8 +4952,8 @@ msgstr ""
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1151
-#: lxc/storage_volume.go:1183
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
+#: lxc/storage_volume.go:1189
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -5075,7 +5076,7 @@ msgstr "Eigenschaften:\n"
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1350
+#: lxc/storage_volume.go:1356
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -5089,7 +5090,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1219
+#: lxc/storage_volume.go:1225
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5105,7 +5106,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2224
+#: lxc/storage_volume.go:2230
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5126,7 +5127,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:998
+#: lxc/storage_volume.go:1004
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5135,7 +5136,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2069
+#: lxc/storage_volume.go:2075
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5148,7 +5149,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2345
+#: lxc/storage_volume.go:2351
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5258,33 +5259,33 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:810
+#: lxc/remote.go:877
 #, fuzzy, c-format
 msgid "Remote %s already exists"
 msgstr "entfernte Instanz %s existiert bereits"
 
-#: lxc/project.go:884 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
-#: lxc/remote.go:994
+#: lxc/project.go:884 lxc/remote.go:868 lxc/remote.go:949 lxc/remote.go:1013
+#: lxc/remote.go:1061
 #, fuzzy, c-format
 msgid "Remote %s doesn't exist"
 msgstr "entfernte Instanz %s existiert nicht"
 
-#: lxc/remote.go:305
+#: lxc/remote.go:345
 #, fuzzy, c-format
 msgid "Remote %s exists as <%s>"
 msgstr "entfernte Instanz %s existiert als <%s>"
 
-#: lxc/remote.go:890
+#: lxc/remote.go:957
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:805 lxc/remote.go:886 lxc/remote.go:998
+#: lxc/remote.go:872 lxc/remote.go:953 lxc/remote.go:1065
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:294
+#: lxc/remote.go:319
 msgid "Remote address must not be empty"
 msgstr ""
 
@@ -5292,7 +5293,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr "Entferntes Administrator Passwort"
 
-#: lxc/remote.go:299
+#: lxc/remote.go:339
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -5391,7 +5392,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Remove profiles from instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/remote.go:852 lxc/remote.go:853
+#: lxc/remote.go:919 lxc/remote.go:920
 msgid "Remove remotes"
 msgstr ""
 
@@ -5455,21 +5456,21 @@ msgstr "Fehlerhafte Profil URL %s"
 msgid "Rename projects"
 msgstr "Fehlerhafte Profil URL %s"
 
-#: lxc/remote.go:771 lxc/remote.go:772
+#: lxc/remote.go:838 lxc/remote.go:839
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:1943
 #, fuzzy
 msgid "Rename storage volumes"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/storage_volume.go:1936
+#: lxc/storage_volume.go:1942
 #, fuzzy
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/storage_volume.go:2025 lxc/storage_volume.go:2045
+#: lxc/storage_volume.go:2031 lxc/storage_volume.go:2051
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5524,7 +5525,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2540 lxc/storage_volume.go:2541
+#: lxc/storage_volume.go:2546 lxc/storage_volume.go:2547
 #, fuzzy
 msgid "Restore storage volume snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
@@ -5610,7 +5611,7 @@ msgstr "Entferntes Administrator Passwort"
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:820
 msgid "STATIC"
 msgstr ""
 
@@ -5651,11 +5652,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:464
+#: lxc/remote.go:532
 msgid "Server certificate NACKed by user"
 msgstr "Server Zertifikat vom Benutzer nicht akzeptiert"
 
-#: lxc/remote.go:616
+#: lxc/remote.go:285 lxc/remote.go:683
 #, fuzzy
 msgid "Server doesn't trust us after authentication"
 msgstr ""
@@ -5868,12 +5869,12 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2063
+#: lxc/storage_volume.go:2069
 #, fuzzy
 msgid "Set storage volume configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/storage_volume.go:2064
+#: lxc/storage_volume.go:2070
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5882,7 +5883,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:964 lxc/remote.go:965
+#: lxc/remote.go:1031 lxc/remote.go:1032
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5968,7 +5969,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Set the key as a storage property"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/storage_volume.go:2080
+#: lxc/storage_volume.go:2086
 #, fuzzy
 msgid "Set the key as a storage volume property"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -6136,12 +6137,12 @@ msgstr "Profil %s erstellt\n"
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2221 lxc/storage_volume.go:2222
+#: lxc/storage_volume.go:2227 lxc/storage_volume.go:2228
 #, fuzzy
 msgid "Show storage volume configurations"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/storage_volume.go:1347 lxc/storage_volume.go:1348
+#: lxc/storage_volume.go:1353 lxc/storage_volume.go:1354
 #, fuzzy
 msgid "Show storage volume state information"
 msgstr "Profil %s erstellt\n"
@@ -6156,7 +6157,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:647 lxc/remote.go:648
+#: lxc/remote.go:714 lxc/remote.go:715
 msgid "Show the default remote"
 msgstr ""
 
@@ -6213,16 +6214,16 @@ msgstr "Größe: %.2vMB\n"
 msgid "Size: %s"
 msgstr "Erstellt: %s"
 
-#: lxc/storage_volume.go:2404 lxc/storage_volume.go:2405
+#: lxc/storage_volume.go:2410 lxc/storage_volume.go:2411
 #, fuzzy
 msgid "Snapshot storage volumes"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/storage_volume.go:2167
+#: lxc/storage_volume.go:2173
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:607 lxc/storage_volume.go:1485
+#: lxc/info.go:607 lxc/storage_volume.go:1491
 msgid "Snapshots:"
 msgstr ""
 
@@ -6328,22 +6329,22 @@ msgstr "Profil %s erstellt\n"
 msgid "Storage pool name"
 msgstr "Profilname kann nicht geändert werden"
 
-#: lxc/storage_volume.go:696
+#: lxc/storage_volume.go:702
 #, fuzzy, c-format
 msgid "Storage volume %s created"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/storage_volume.go:784
+#: lxc/storage_volume.go:790
 #, fuzzy, c-format
 msgid "Storage volume %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: lxc/storage_volume.go:509
+#: lxc/storage_volume.go:515
 #, fuzzy
 msgid "Storage volume copied successfully!"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/storage_volume.go:513
+#: lxc/storage_volume.go:519
 #, fuzzy
 msgid "Storage volume moved successfully!"
 msgstr "Profil %s erstellt\n"
@@ -6380,7 +6381,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:916 lxc/remote.go:917
+#: lxc/remote.go:983 lxc/remote.go:984
 msgid "Switch the default remote"
 msgstr ""
 
@@ -6399,11 +6400,11 @@ msgstr ""
 #: lxc/auth.go:818 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
-#: lxc/storage_volume.go:1730 lxc/warning.go:216
+#: lxc/storage_volume.go:1736 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1557
+#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1563
 msgid "Taken at"
 msgstr ""
 
@@ -6414,6 +6415,12 @@ msgstr "--refresh kann nur mit Containern verwendet werden"
 
 #: lxc/file.go:1256
 msgid "Target path must be a directory"
+msgstr ""
+
+#: lxc/remote.go:161 lxc/remote.go:334
+msgid ""
+"The --accept-certificate flag is not supported when adding a remote using a "
+"trust token"
 msgstr ""
 
 #: lxc/move.go:181
@@ -6560,15 +6567,20 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/storage_volume.go:1323
+#: lxc/storage_volume.go:1329
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/storage_volume.go:1300
+#: lxc/storage_volume.go:1306
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
+msgstr ""
+
+#: lxc/remote.go:527
+msgid ""
+"The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
 
 #: lxc/info.go:354
@@ -6579,8 +6591,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:875
-#: lxc/storage_volume.go:972
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:881
+#: lxc/storage_volume.go:978
 #, fuzzy
 msgid "The specified device doesn't exist"
 msgstr "entfernte Instanz %s existiert nicht"
@@ -6660,7 +6672,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1470
+#: lxc/storage_volume.go:1476
 #, fuzzy, c-format
 msgid "Total: %s"
 msgstr "Erstellt: %s"
@@ -6675,7 +6687,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr "unbekannter entfernter Instanz Name: %q"
 
-#: lxc/storage_volume.go:1847
+#: lxc/storage_volume.go:1853
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6709,7 +6721,16 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:571
+#: lxc/remote.go:329
+msgid "Trust token cannot be used for public remotes"
+msgstr ""
+
+#: lxc/remote.go:324
+#, fuzzy
+msgid "Trust token cannot be used with OIDC authentication"
+msgstr "--refresh kann nur mit Containern verwendet werden"
+
+#: lxc/remote.go:639
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6735,7 +6756,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1455
+#: lxc/storage_volume.go:1461
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6753,17 +6774,17 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:193 lxc/remote.go:749
+#: lxc/cluster.go:193 lxc/remote.go:816
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1735
+#: lxc/project.go:995 lxc/storage_volume.go:1741
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1734
+#: lxc/storage.go:724 lxc/storage_volume.go:1740
 msgid "USED BY"
 msgstr ""
 
@@ -6781,7 +6802,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:214 lxc/remote.go:248
+#: lxc/remote.go:226 lxc/remote.go:260
 #, fuzzy
 msgid "Unavailable remote server"
 msgstr "Neue entfernte Server hinzufügen"
@@ -6796,7 +6817,7 @@ msgstr "Unbekannter Befehl %s für Abbild"
 msgid "Unknown channel type for client %q: %s"
 msgstr "Unbekannter Befehl %s für Abbild"
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1772
+#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1778
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6918,7 +6939,7 @@ msgstr "Alternatives config Verzeichnis."
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2342 lxc/storage_volume.go:2343
+#: lxc/storage_volume.go:2348 lxc/storage_volume.go:2349
 #, fuzzy
 msgid "Unset storage volume configuration keys"
 msgstr "Alternatives config Verzeichnis."
@@ -6979,7 +7000,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Unset the key as a storage property"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/storage_volume.go:2356
+#: lxc/storage_volume.go:2362
 #, fuzzy
 msgid "Unset the key as a storage volume property"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -7026,12 +7047,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/storage_volume.go:1468
+#: lxc/storage_volume.go:1474
 #, fuzzy, c-format
 msgid "Usage: %s"
 msgstr "Erstellt: %s"
 
-#: lxc/export.go:42 lxc/storage_volume.go:2629
+#: lxc/export.go:42 lxc/storage_volume.go:2635
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -7102,7 +7123,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1559
+#: lxc/storage_volume.go:1565
 msgid "Volume Only"
 msgstr ""
 
@@ -7142,7 +7163,7 @@ msgstr ""
 
 #: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
+#: lxc/project.go:552 lxc/remote.go:777 lxc/remote.go:782 lxc/remote.go:787
 msgid "YES"
 msgstr ""
 
@@ -7170,7 +7191,7 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 msgid "You need to specify an image name or use --empty"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/storage_volume.go:897
+#: lxc/storage_volume.go:903
 #, fuzzy
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
@@ -7997,7 +8018,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_volume.go:2788
+#: lxc/storage_volume.go:2794
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
@@ -8064,7 +8085,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:1941
 #, fuzzy
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
@@ -8075,7 +8096,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/storage_volume.go:799
+#: lxc/storage_volume.go:805
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
@@ -8091,7 +8112,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_volume.go:2539
+#: lxc/storage_volume.go:2545
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
@@ -8100,7 +8121,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/storage_volume.go:2622
+#: lxc/storage_volume.go:2628
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
@@ -8109,7 +8130,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/storage_volume.go:2403
+#: lxc/storage_volume.go:2409
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
@@ -8118,7 +8139,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/storage_volume.go:603
+#: lxc/storage_volume.go:609
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
@@ -8126,7 +8147,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_volume.go:711
+#: lxc/storage_volume.go:717
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
@@ -8135,7 +8156,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/storage_volume.go:994 lxc/storage_volume.go:1346
+#: lxc/storage_volume.go:1000 lxc/storage_volume.go:1352
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
@@ -8143,7 +8164,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_volume.go:2341
+#: lxc/storage_volume.go:2347
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
@@ -8151,7 +8172,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_volume.go:2062
+#: lxc/storage_volume.go:2068
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
@@ -8159,7 +8180,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_volume.go:2220
+#: lxc/storage_volume.go:2226
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
@@ -8168,7 +8189,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/storage_volume.go:1215
+#: lxc/storage_volume.go:1221
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
@@ -8177,7 +8198,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/storage_volume.go:1841
+#: lxc/storage_volume.go:1847
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
@@ -8399,7 +8420,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_volume.go:1584
+#: lxc/storage_volume.go:1590
 #, fuzzy
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
@@ -8424,7 +8445,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/project.go:557 lxc/remote.go:739
+#: lxc/project.go:557 lxc/remote.go:806
 msgid "current"
 msgstr ""
 
@@ -8888,7 +8909,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:607
+#: lxc/storage_volume.go:613
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -8896,13 +8917,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2792
+#: lxc/storage_volume.go:2798
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2407
+#: lxc/storage_volume.go:2413
 msgid ""
 "lxc storage volume snapshot create default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -8912,7 +8933,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:531
 msgid "n"
 msgstr ""
 
@@ -8924,7 +8945,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:510
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -8961,7 +8982,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:465
+#: lxc/remote.go:519
 msgid "y"
 msgstr ""
 
@@ -8969,6 +8990,10 @@ msgstr ""
 #: lxc/image.go:1194
 msgid "yes"
 msgstr ""
+
+#, fuzzy, c-format
+#~ msgid "Failed to create certificate: %w"
+#~ msgstr "Akzeptiere Zertifikat"
 
 #, fuzzy
 #~ msgid "Make the image public"

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-08 07:43+0100\n"
+"POT-Creation-Date: 2024-10-14 13:30+0000\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/linux-containers/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1024
+#: lxc/storage_volume.go:1030
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -515,15 +515,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:850 lxc/remote.go:915
+#: lxc/remote.go:917 lxc/remote.go:982
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:963
+#: lxc/remote.go:1030
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:769
+#: lxc/remote.go:836
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -556,7 +556,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:751
+#: lxc/remote.go:818
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -708,7 +708,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:581
+#: lxc/remote.go:648
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -741,11 +741,11 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1590
+#: lxc/storage_volume.go:1596
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:182
+#: lxc/remote.go:194
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -816,7 +816,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:552
+#: lxc/remote.go:621
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -852,16 +852,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2696
+#: lxc/storage_volume.go:2702
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2773
+#: lxc/export.go:192 lxc/storage_volume.go:2779
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:654 lxc/storage_volume.go:1521
+#: lxc/info.go:654 lxc/storage_volume.go:1527
 msgid "Backups:"
 msgstr ""
 
@@ -882,7 +882,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:679
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:685
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -925,7 +925,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1733
+#: lxc/storage_volume.go:1739
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -995,7 +995,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:894
+#: lxc/remote.go:961
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1011,7 +1011,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1749 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1028,12 +1028,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:486
+#: lxc/storage_volume.go:492
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:440
+#: lxc/storage_volume.go:446
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1061,11 +1061,11 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/remote.go:455
+#: lxc/remote.go:509
 msgid "Certificate fingerprint"
 msgstr ""
 
-#: lxc/remote.go:219
+#: lxc/remote.go:231
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/remote.go:620
+#: lxc/remote.go:687
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1154,13 +1154,13 @@ msgstr ""
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
 #: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
-#: lxc/storage_volume.go:612 lxc/storage_volume.go:717
-#: lxc/storage_volume.go:1005 lxc/storage_volume.go:1231
-#: lxc/storage_volume.go:1360 lxc/storage_volume.go:1848
-#: lxc/storage_volume.go:1940 lxc/storage_volume.go:2079
-#: lxc/storage_volume.go:2239 lxc/storage_volume.go:2355
-#: lxc/storage_volume.go:2416 lxc/storage_volume.go:2543
-#: lxc/storage_volume.go:2631 lxc/storage_volume.go:2795
+#: lxc/storage_volume.go:618 lxc/storage_volume.go:723
+#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1237
+#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1854
+#: lxc/storage_volume.go:1946 lxc/storage_volume.go:2085
+#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2361
+#: lxc/storage_volume.go:2422 lxc/storage_volume.go:2549
+#: lxc/storage_volume.go:2637 lxc/storage_volume.go:2801
 msgid "Cluster member name"
 msgstr ""
 
@@ -1176,7 +1176,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1589
+#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1595
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1220,17 +1220,17 @@ msgstr ""
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1150
-#: lxc/storage_volume.go:1182
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
+#: lxc/storage_volume.go:1188
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:613
+#: lxc/storage_volume.go:619
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1467
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1314,7 +1314,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:508
+#: lxc/storage_volume.go:514
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1328,12 +1328,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:490
+#: lxc/remote.go:559
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:225 lxc/remote.go:474
+#: lxc/remote.go:237 lxc/remote.go:543
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1372,7 +1372,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:485
+#: lxc/remote.go:554
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1442,7 +1442,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/storage_volume.go:604 lxc/storage_volume.go:605
+#: lxc/storage_volume.go:610 lxc/storage_volume.go:611
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1496,7 +1496,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1475
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1481
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1531,7 +1531,7 @@ msgstr ""
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1732
+#: lxc/storage_volume.go:1738
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1551,7 +1551,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2630
+#: lxc/storage_volume.go:2636
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1652,7 +1652,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:713 lxc/storage_volume.go:714
+#: lxc/storage_volume.go:719 lxc/storage_volume.go:720
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1744,9 +1744,9 @@ msgstr ""
 #: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
 #: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
 #: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:648
-#: lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853 lxc/remote.go:917
-#: lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:715
+#: lxc/remote.go:753 lxc/remote.go:839 lxc/remote.go:920 lxc/remote.go:984
+#: lxc/remote.go:1032 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1758,26 +1758,26 @@ msgstr ""
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
 #: lxc/storage_volume.go:169 lxc/storage_volume.go:283
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:605
-#: lxc/storage_volume.go:714 lxc/storage_volume.go:801
-#: lxc/storage_volume.go:899 lxc/storage_volume.go:996
-#: lxc/storage_volume.go:1217 lxc/storage_volume.go:1348
-#: lxc/storage_volume.go:1507 lxc/storage_volume.go:1591
-#: lxc/storage_volume.go:1844 lxc/storage_volume.go:1937
-#: lxc/storage_volume.go:2064 lxc/storage_volume.go:2222
-#: lxc/storage_volume.go:2343 lxc/storage_volume.go:2405
-#: lxc/storage_volume.go:2541 lxc/storage_volume.go:2624
-#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:611
+#: lxc/storage_volume.go:720 lxc/storage_volume.go:807
+#: lxc/storage_volume.go:905 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:1223 lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1513 lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1850 lxc/storage_volume.go:1943
+#: lxc/storage_volume.go:2070 lxc/storage_volume.go:2228
+#: lxc/storage_volume.go:2349 lxc/storage_volume.go:2411
+#: lxc/storage_volume.go:2547 lxc/storage_volume.go:2630
+#: lxc/storage_volume.go:2796 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1448
+#: lxc/storage_volume.go:1454
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:1849
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:1855
 #, fuzzy
 msgid "Destination cluster member name"
 msgstr "  Χρήση δικτύου:"
@@ -1790,11 +1790,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:800 lxc/storage_volume.go:801
+#: lxc/storage_volume.go:806 lxc/storage_volume.go:807
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:898 lxc/storage_volume.go:899
+#: lxc/storage_volume.go:904 lxc/storage_volume.go:905
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -2029,7 +2029,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:995 lxc/storage_volume.go:996
+#: lxc/storage_volume.go:1001 lxc/storage_volume.go:1002
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2037,7 +2037,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1766
+#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1772
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2094,7 +2094,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2193
+#: lxc/storage_volume.go:2161 lxc/storage_volume.go:2199
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2108,8 +2108,8 @@ msgstr ""
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2149
-#: lxc/storage_volume.go:2187
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2155
+#: lxc/storage_volume.go:2193
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2151,8 +2151,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1508
-#: lxc/storage_volume.go:1558
+#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1514
+#: lxc/storage_volume.go:1564
 msgid "Expires at"
 msgstr ""
 
@@ -2176,7 +2176,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2623 lxc/storage_volume.go:2624
+#: lxc/storage_volume.go:2629 lxc/storage_volume.go:2630
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2188,11 +2188,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2627
+#: lxc/storage_volume.go:2633
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2756
+#: lxc/export.go:152 lxc/storage_volume.go:2762
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2309,11 +2309,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:191
+#: lxc/remote.go:203
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:242
+#: lxc/remote.go:254
 #, fuzzy, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr "  Χρήση δικτύου:"
@@ -2323,7 +2323,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Failed to connect to cluster member: %w"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/remote.go:232
+#: lxc/remote.go:244
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2333,12 +2333,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:260
-#, c-format
-msgid "Failed to create certificate: %w"
-msgstr ""
+#: lxc/remote.go:486
+#, fuzzy, c-format
+msgid "Failed to decode trust token: %w"
+msgstr "  Χρήση δικτύου:"
 
-#: lxc/remote.go:267
+#: lxc/remote.go:292
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2363,7 +2363,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:237
+#: lxc/remote.go:249
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2450,9 +2450,9 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:690 lxc/storage.go:657
+#: lxc/project.go:919 lxc/remote.go:757 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1608 lxc/warning.go:94
+#: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2488,7 +2488,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:754
+#: lxc/remote.go:821
 msgid "GLOBAL"
 msgstr ""
 
@@ -2508,7 +2508,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:160 lxc/remote.go:401
+#: lxc/remote.go:165 lxc/remote.go:443
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2582,7 +2582,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1238
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2653,11 +2653,11 @@ msgstr "  Χρήση δικτύου:"
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1216 lxc/storage_volume.go:1217
+#: lxc/storage_volume.go:1222 lxc/storage_volume.go:1223
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:469
+#: lxc/storage_volume.go:475
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2781,7 +2781,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2415
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2421
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2795,7 +2795,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2414
+#: lxc/storage_volume.go:2420
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2845,7 +2845,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2790
+#: lxc/storage_volume.go:2796
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2853,7 +2853,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2789
+#: lxc/storage_volume.go:2795
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2875,11 +2875,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2797
+#: lxc/storage_volume.go:2803
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2871
+#: lxc/storage_volume.go:2877
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2945,7 +2945,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:353
+#: lxc/remote.go:395
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3005,7 +3005,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2000
+#: lxc/move.go:148 lxc/storage_volume.go:2006
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -3013,7 +3013,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1996
+#: lxc/storage_volume.go:2002
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3026,14 +3026,14 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:342
+#: lxc/remote.go:384
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1064 lxc/storage_volume.go:1281
-#: lxc/storage_volume.go:1405 lxc/storage_volume.go:1985
-#: lxc/storage_volume.go:2132 lxc/storage_volume.go:2284
+#: lxc/storage_volume.go:1070 lxc/storage_volume.go:1287
+#: lxc/storage_volume.go:1411 lxc/storage_volume.go:1991
+#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2290
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3079,7 +3079,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1739 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1745 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3384,11 +3384,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1586
+#: lxc/storage_volume.go:1592
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1597
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3408,7 +3408,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:685 lxc/remote.go:686
+#: lxc/remote.go:752 lxc/remote.go:753
 msgid "List the available remotes"
 msgstr ""
 
@@ -3447,7 +3447,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1464
+#: lxc/info.go:489 lxc/storage_volume.go:1470
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3935,12 +3935,12 @@ msgstr ""
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:323 lxc/storage_volume.go:643
-#: lxc/storage_volume.go:750 lxc/storage_volume.go:841
-#: lxc/storage_volume.go:939 lxc/storage_volume.go:1053
-#: lxc/storage_volume.go:1270 lxc/storage_volume.go:1974
-#: lxc/storage_volume.go:2115 lxc/storage_volume.go:2273
-#: lxc/storage_volume.go:2464 lxc/storage_volume.go:2581
+#: lxc/storage_volume.go:323 lxc/storage_volume.go:649
+#: lxc/storage_volume.go:756 lxc/storage_volume.go:847
+#: lxc/storage_volume.go:945 lxc/storage_volume.go:1059
+#: lxc/storage_volume.go:1276 lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:2121 lxc/storage_volume.go:2279
+#: lxc/storage_volume.go:2470 lxc/storage_volume.go:2587
 msgid "Missing pool name"
 msgstr ""
 
@@ -3959,11 +3959,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:432 lxc/storage_volume.go:1884
+#: lxc/storage_volume.go:438 lxc/storage_volume.go:1890
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1394
+#: lxc/storage_volume.go:1400
 #, fuzzy
 msgid "Missing storage pool name"
 msgstr "  Χρήση δικτύου:"
@@ -4001,8 +4001,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:861
-#: lxc/storage_volume.go:958
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:867
+#: lxc/storage_volume.go:964
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4039,7 +4039,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1843 lxc/storage_volume.go:1844
+#: lxc/storage_volume.go:1849 lxc/storage_volume.go:1850
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4047,11 +4047,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1850
+#: lxc/storage_volume.go:1856
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:512
+#: lxc/storage_volume.go:518
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4077,8 +4077,8 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
-#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1731
+#: lxc/remote.go:815 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
 msgstr ""
 
@@ -4104,7 +4104,7 @@ msgstr ""
 
 #: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
+#: lxc/project.go:550 lxc/remote.go:775 lxc/remote.go:780 lxc/remote.go:785
 msgid "NO"
 msgstr ""
 
@@ -4126,8 +4126,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1506
-#: lxc/storage_volume.go:1556
+#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1512
+#: lxc/storage_volume.go:1562
 msgid "Name"
 msgstr ""
 
@@ -4135,7 +4135,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1446
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1452
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4281,7 +4281,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:870 lxc/storage_volume.go:967
+#: lxc/storage_volume.go:876 lxc/storage_volume.go:973
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4297,11 +4297,11 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/storage_volume.go:446 lxc/storage_volume.go:1893
+#: lxc/storage_volume.go:452 lxc/storage_volume.go:1899
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:496 lxc/storage_volume.go:1904
+#: lxc/storage_volume.go:502 lxc/storage_volume.go:1910
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4315,7 +4315,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2012
+#: lxc/storage_volume.go:2018
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4327,15 +4327,15 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2678
+#: lxc/storage_volume.go:2684
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2477
+#: lxc/storage_volume.go:2483
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:336
+#: lxc/remote.go:378
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4343,7 +4343,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1412
+#: lxc/storage_volume.go:1418
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4356,7 +4356,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:693 lxc/storage_volume.go:1560
+#: lxc/info.go:693 lxc/storage_volume.go:1566
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4386,7 +4386,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1756
 msgid "POOL"
 msgstr ""
 
@@ -4402,15 +4402,15 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:213
+#: lxc/list.go:567 lxc/storage_volume.go:1762 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:817
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:752
+#: lxc/image.go:1136 lxc/remote.go:819
 msgid "PUBLIC"
 msgstr ""
 
@@ -4439,7 +4439,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:183
+#: lxc/remote.go:195
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4452,8 +4452,8 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/remote.go:466
-msgid "Please type 'y', 'n' or the fingerprint:"
+#: lxc/remote.go:536
+msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
 #: lxc/info.go:221
@@ -4477,8 +4477,8 @@ msgstr ""
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1151
-#: lxc/storage_volume.go:1183
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
+#: lxc/storage_volume.go:1189
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4595,7 +4595,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1350
+#: lxc/storage_volume.go:1356
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4609,7 +4609,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1219
+#: lxc/storage_volume.go:1225
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4625,7 +4625,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2224
+#: lxc/storage_volume.go:2230
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4646,7 +4646,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:998
+#: lxc/storage_volume.go:1004
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4655,7 +4655,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2069
+#: lxc/storage_volume.go:2075
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4668,7 +4668,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2345
+#: lxc/storage_volume.go:2351
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4772,33 +4772,33 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:810
+#: lxc/remote.go:877
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
-#: lxc/remote.go:994
+#: lxc/project.go:884 lxc/remote.go:868 lxc/remote.go:949 lxc/remote.go:1013
+#: lxc/remote.go:1061
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:305
+#: lxc/remote.go:345
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:890
+#: lxc/remote.go:957
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:805 lxc/remote.go:886 lxc/remote.go:998
+#: lxc/remote.go:872 lxc/remote.go:953 lxc/remote.go:1065
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:294
+#: lxc/remote.go:319
 msgid "Remote address must not be empty"
 msgstr ""
 
@@ -4806,7 +4806,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:299
+#: lxc/remote.go:339
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4896,7 +4896,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:852 lxc/remote.go:853
+#: lxc/remote.go:919 lxc/remote.go:920
 msgid "Remove remotes"
 msgstr ""
 
@@ -4954,19 +4954,19 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:771 lxc/remote.go:772
+#: lxc/remote.go:838 lxc/remote.go:839
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:1943
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1936
+#: lxc/storage_volume.go:1942
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2025 lxc/storage_volume.go:2045
+#: lxc/storage_volume.go:2031 lxc/storage_volume.go:2051
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5018,7 +5018,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2540 lxc/storage_volume.go:2541
+#: lxc/storage_volume.go:2546 lxc/storage_volume.go:2547
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5100,7 +5100,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:820
 msgid "STATIC"
 msgstr ""
 
@@ -5141,11 +5141,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:464
+#: lxc/remote.go:532
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:616
+#: lxc/remote.go:285 lxc/remote.go:683
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5350,11 +5350,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2063
+#: lxc/storage_volume.go:2069
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2064
+#: lxc/storage_volume.go:2070
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5363,7 +5363,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:964 lxc/remote.go:965
+#: lxc/remote.go:1031 lxc/remote.go:1032
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5445,7 +5445,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2080
+#: lxc/storage_volume.go:2086
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5604,11 +5604,11 @@ msgstr "  Χρήση δικτύου:"
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2221 lxc/storage_volume.go:2222
+#: lxc/storage_volume.go:2227 lxc/storage_volume.go:2228
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1347 lxc/storage_volume.go:1348
+#: lxc/storage_volume.go:1353 lxc/storage_volume.go:1354
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5622,7 +5622,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:647 lxc/remote.go:648
+#: lxc/remote.go:714 lxc/remote.go:715
 msgid "Show the default remote"
 msgstr ""
 
@@ -5677,15 +5677,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2404 lxc/storage_volume.go:2405
+#: lxc/storage_volume.go:2410 lxc/storage_volume.go:2411
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2167
+#: lxc/storage_volume.go:2173
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:607 lxc/storage_volume.go:1485
+#: lxc/info.go:607 lxc/storage_volume.go:1491
 msgid "Snapshots:"
 msgstr ""
 
@@ -5786,21 +5786,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:696
+#: lxc/storage_volume.go:702
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:784
+#: lxc/storage_volume.go:790
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:509
+#: lxc/storage_volume.go:515
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:513
+#: lxc/storage_volume.go:519
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5835,7 +5835,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:916 lxc/remote.go:917
+#: lxc/remote.go:983 lxc/remote.go:984
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5854,11 +5854,11 @@ msgstr ""
 #: lxc/auth.go:818 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
-#: lxc/storage_volume.go:1730 lxc/warning.go:216
+#: lxc/storage_volume.go:1736 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1557
+#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1563
 msgid "Taken at"
 msgstr ""
 
@@ -5868,6 +5868,12 @@ msgstr ""
 
 #: lxc/file.go:1256
 msgid "Target path must be a directory"
+msgstr ""
+
+#: lxc/remote.go:161 lxc/remote.go:334
+msgid ""
+"The --accept-certificate flag is not supported when adding a remote using a "
+"trust token"
 msgstr ""
 
 #: lxc/move.go:181
@@ -6009,15 +6015,20 @@ msgstr "  Χρήση δικτύου:"
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/storage_volume.go:1323
+#: lxc/storage_volume.go:1329
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/storage_volume.go:1300
+#: lxc/storage_volume.go:1306
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
+msgstr ""
+
+#: lxc/remote.go:527
+msgid ""
+"The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
 
 #: lxc/info.go:354
@@ -6028,8 +6039,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:875
-#: lxc/storage_volume.go:972
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:881
+#: lxc/storage_volume.go:978
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6105,7 +6116,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1470
+#: lxc/storage_volume.go:1476
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6120,7 +6131,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1847
+#: lxc/storage_volume.go:1853
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6154,7 +6165,15 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:571
+#: lxc/remote.go:329
+msgid "Trust token cannot be used for public remotes"
+msgstr ""
+
+#: lxc/remote.go:324
+msgid "Trust token cannot be used with OIDC authentication"
+msgstr ""
+
+#: lxc/remote.go:639
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6179,7 +6198,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1455
+#: lxc/storage_volume.go:1461
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6197,17 +6216,17 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:193 lxc/remote.go:749
+#: lxc/cluster.go:193 lxc/remote.go:816
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1735
+#: lxc/project.go:995 lxc/storage_volume.go:1741
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1734
+#: lxc/storage.go:724 lxc/storage_volume.go:1740
 msgid "USED BY"
 msgstr ""
 
@@ -6225,7 +6244,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:214 lxc/remote.go:248
+#: lxc/remote.go:226 lxc/remote.go:260
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6239,7 +6258,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1772
+#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1778
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6355,7 +6374,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2342 lxc/storage_volume.go:2343
+#: lxc/storage_volume.go:2348 lxc/storage_volume.go:2349
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6414,7 +6433,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2356
+#: lxc/storage_volume.go:2362
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6458,12 +6477,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1468
+#: lxc/storage_volume.go:1474
 #, fuzzy, c-format
 msgid "Usage: %s"
 msgstr "  Χρήση CPU:"
 
-#: lxc/export.go:42 lxc/storage_volume.go:2629
+#: lxc/export.go:42 lxc/storage_volume.go:2635
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6530,7 +6549,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1559
+#: lxc/storage_volume.go:1565
 msgid "Volume Only"
 msgstr ""
 
@@ -6565,7 +6584,7 @@ msgstr ""
 
 #: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
+#: lxc/project.go:552 lxc/remote.go:777 lxc/remote.go:782 lxc/remote.go:787
 msgid "YES"
 msgstr ""
 
@@ -6589,7 +6608,7 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:897
+#: lxc/storage_volume.go:903
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
@@ -7011,7 +7030,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2788
+#: lxc/storage_volume.go:2794
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7046,13 +7065,13 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:1941
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:799
+#: lxc/storage_volume.go:805
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
@@ -7060,47 +7079,47 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2539
+#: lxc/storage_volume.go:2545
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2622
+#: lxc/storage_volume.go:2628
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2403
+#: lxc/storage_volume.go:2409
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:603
+#: lxc/storage_volume.go:609
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:711
+#: lxc/storage_volume.go:717
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:994 lxc/storage_volume.go:1346
+#: lxc/storage_volume.go:1000 lxc/storage_volume.go:1352
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2341
+#: lxc/storage_volume.go:2347
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2062
+#: lxc/storage_volume.go:2068
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2220
+#: lxc/storage_volume.go:2226
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1215
+#: lxc/storage_volume.go:1221
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1841
+#: lxc/storage_volume.go:1847
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7210,7 +7229,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1584
+#: lxc/storage_volume.go:1590
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7222,7 +7241,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:739
+#: lxc/project.go:557 lxc/remote.go:806
 msgid "current"
 msgstr ""
 
@@ -7682,7 +7701,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:607
+#: lxc/storage_volume.go:613
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7690,13 +7709,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2792
+#: lxc/storage_volume.go:2798
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2407
+#: lxc/storage_volume.go:2413
 msgid ""
 "lxc storage volume snapshot create default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7706,7 +7725,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:531
 msgid "n"
 msgstr ""
 
@@ -7718,7 +7737,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:510
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7755,7 +7774,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:465
+#: lxc/remote.go:519
 msgid "y"
 msgstr ""
 

--- a/po/eo.po
+++ b/po/eo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-08 07:43+0100\n"
+"POT-Creation-Date: 2024-10-14 13:30+0000\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Esperanto <https://hosted.weblate.org/projects/linux-"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1024
+#: lxc/storage_volume.go:1030
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -515,15 +515,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:850 lxc/remote.go:915
+#: lxc/remote.go:917 lxc/remote.go:982
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:963
+#: lxc/remote.go:1030
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:769
+#: lxc/remote.go:836
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -556,7 +556,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:751
+#: lxc/remote.go:818
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:581
+#: lxc/remote.go:648
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -738,11 +738,11 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1590
+#: lxc/storage_volume.go:1596
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:182
+#: lxc/remote.go:194
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -813,7 +813,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:552
+#: lxc/remote.go:621
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -849,16 +849,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2696
+#: lxc/storage_volume.go:2702
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2773
+#: lxc/export.go:192 lxc/storage_volume.go:2779
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:654 lxc/storage_volume.go:1521
+#: lxc/info.go:654 lxc/storage_volume.go:1527
 msgid "Backups:"
 msgstr ""
 
@@ -879,7 +879,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:679
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:685
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -922,7 +922,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1733
+#: lxc/storage_volume.go:1739
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -991,7 +991,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:894
+#: lxc/remote.go:961
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1007,7 +1007,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1749 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1024,12 +1024,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:486
+#: lxc/storage_volume.go:492
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:440
+#: lxc/storage_volume.go:446
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1057,11 +1057,11 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:509
 msgid "Certificate fingerprint"
 msgstr ""
 
-#: lxc/remote.go:219
+#: lxc/remote.go:231
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
@@ -1076,7 +1076,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:620
+#: lxc/remote.go:687
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1150,13 +1150,13 @@ msgstr ""
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
 #: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
-#: lxc/storage_volume.go:612 lxc/storage_volume.go:717
-#: lxc/storage_volume.go:1005 lxc/storage_volume.go:1231
-#: lxc/storage_volume.go:1360 lxc/storage_volume.go:1848
-#: lxc/storage_volume.go:1940 lxc/storage_volume.go:2079
-#: lxc/storage_volume.go:2239 lxc/storage_volume.go:2355
-#: lxc/storage_volume.go:2416 lxc/storage_volume.go:2543
-#: lxc/storage_volume.go:2631 lxc/storage_volume.go:2795
+#: lxc/storage_volume.go:618 lxc/storage_volume.go:723
+#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1237
+#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1854
+#: lxc/storage_volume.go:1946 lxc/storage_volume.go:2085
+#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2361
+#: lxc/storage_volume.go:2422 lxc/storage_volume.go:2549
+#: lxc/storage_volume.go:2637 lxc/storage_volume.go:2801
 msgid "Cluster member name"
 msgstr ""
 
@@ -1172,7 +1172,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1589
+#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1595
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1216,17 +1216,17 @@ msgstr ""
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1150
-#: lxc/storage_volume.go:1182
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
+#: lxc/storage_volume.go:1188
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:613
+#: lxc/storage_volume.go:619
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1467
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1310,7 +1310,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:508
+#: lxc/storage_volume.go:514
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1324,12 +1324,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:490
+#: lxc/remote.go:559
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:225 lxc/remote.go:474
+#: lxc/remote.go:237 lxc/remote.go:543
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1368,7 +1368,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:485
+#: lxc/remote.go:554
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1437,7 +1437,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:604 lxc/storage_volume.go:605
+#: lxc/storage_volume.go:610 lxc/storage_volume.go:611
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1489,7 +1489,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1475
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1481
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1524,7 +1524,7 @@ msgstr ""
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1732
+#: lxc/storage_volume.go:1738
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1544,7 +1544,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2630
+#: lxc/storage_volume.go:2636
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1640,7 +1640,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:713 lxc/storage_volume.go:714
+#: lxc/storage_volume.go:719 lxc/storage_volume.go:720
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1732,9 +1732,9 @@ msgstr ""
 #: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
 #: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
 #: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:648
-#: lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853 lxc/remote.go:917
-#: lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:715
+#: lxc/remote.go:753 lxc/remote.go:839 lxc/remote.go:920 lxc/remote.go:984
+#: lxc/remote.go:1032 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1746,26 +1746,26 @@ msgstr ""
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
 #: lxc/storage_volume.go:169 lxc/storage_volume.go:283
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:605
-#: lxc/storage_volume.go:714 lxc/storage_volume.go:801
-#: lxc/storage_volume.go:899 lxc/storage_volume.go:996
-#: lxc/storage_volume.go:1217 lxc/storage_volume.go:1348
-#: lxc/storage_volume.go:1507 lxc/storage_volume.go:1591
-#: lxc/storage_volume.go:1844 lxc/storage_volume.go:1937
-#: lxc/storage_volume.go:2064 lxc/storage_volume.go:2222
-#: lxc/storage_volume.go:2343 lxc/storage_volume.go:2405
-#: lxc/storage_volume.go:2541 lxc/storage_volume.go:2624
-#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:611
+#: lxc/storage_volume.go:720 lxc/storage_volume.go:807
+#: lxc/storage_volume.go:905 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:1223 lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1513 lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1850 lxc/storage_volume.go:1943
+#: lxc/storage_volume.go:2070 lxc/storage_volume.go:2228
+#: lxc/storage_volume.go:2349 lxc/storage_volume.go:2411
+#: lxc/storage_volume.go:2547 lxc/storage_volume.go:2630
+#: lxc/storage_volume.go:2796 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1448
+#: lxc/storage_volume.go:1454
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:1849
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:1855
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1777,11 +1777,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:800 lxc/storage_volume.go:801
+#: lxc/storage_volume.go:806 lxc/storage_volume.go:807
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:898 lxc/storage_volume.go:899
+#: lxc/storage_volume.go:904 lxc/storage_volume.go:905
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -2007,7 +2007,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:995 lxc/storage_volume.go:996
+#: lxc/storage_volume.go:1001 lxc/storage_volume.go:1002
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2015,7 +2015,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1766
+#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1772
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2072,7 +2072,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2193
+#: lxc/storage_volume.go:2161 lxc/storage_volume.go:2199
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2086,8 +2086,8 @@ msgstr ""
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2149
-#: lxc/storage_volume.go:2187
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2155
+#: lxc/storage_volume.go:2193
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2129,8 +2129,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1508
-#: lxc/storage_volume.go:1558
+#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1514
+#: lxc/storage_volume.go:1564
 msgid "Expires at"
 msgstr ""
 
@@ -2154,7 +2154,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2623 lxc/storage_volume.go:2624
+#: lxc/storage_volume.go:2629 lxc/storage_volume.go:2630
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2166,11 +2166,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2627
+#: lxc/storage_volume.go:2633
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2756
+#: lxc/export.go:152 lxc/storage_volume.go:2762
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2287,11 +2287,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:191
+#: lxc/remote.go:203
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:242
+#: lxc/remote.go:254
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2301,7 +2301,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:232
+#: lxc/remote.go:244
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2311,12 +2311,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:260
+#: lxc/remote.go:486
 #, c-format
-msgid "Failed to create certificate: %w"
+msgid "Failed to decode trust token: %w"
 msgstr ""
 
-#: lxc/remote.go:267
+#: lxc/remote.go:292
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2341,7 +2341,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:237
+#: lxc/remote.go:249
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2428,9 +2428,9 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:690 lxc/storage.go:657
+#: lxc/project.go:919 lxc/remote.go:757 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1608 lxc/warning.go:94
+#: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2466,7 +2466,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:754
+#: lxc/remote.go:821
 msgid "GLOBAL"
 msgstr ""
 
@@ -2486,7 +2486,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:160 lxc/remote.go:401
+#: lxc/remote.go:165 lxc/remote.go:443
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2554,7 +2554,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1238
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2618,11 +2618,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1216 lxc/storage_volume.go:1217
+#: lxc/storage_volume.go:1222 lxc/storage_volume.go:1223
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:469
+#: lxc/storage_volume.go:475
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2746,7 +2746,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2415
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2421
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2760,7 +2760,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2414
+#: lxc/storage_volume.go:2420
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2810,7 +2810,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2790
+#: lxc/storage_volume.go:2796
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2818,7 +2818,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2789
+#: lxc/storage_volume.go:2795
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2840,11 +2840,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2797
+#: lxc/storage_volume.go:2803
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2871
+#: lxc/storage_volume.go:2877
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2910,7 +2910,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:353
+#: lxc/remote.go:395
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2970,7 +2970,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2000
+#: lxc/move.go:148 lxc/storage_volume.go:2006
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2978,7 +2978,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1996
+#: lxc/storage_volume.go:2002
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2991,14 +2991,14 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:342
+#: lxc/remote.go:384
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1064 lxc/storage_volume.go:1281
-#: lxc/storage_volume.go:1405 lxc/storage_volume.go:1985
-#: lxc/storage_volume.go:2132 lxc/storage_volume.go:2284
+#: lxc/storage_volume.go:1070 lxc/storage_volume.go:1287
+#: lxc/storage_volume.go:1411 lxc/storage_volume.go:1991
+#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2290
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3044,7 +3044,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1739 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1745 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3347,11 +3347,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1586
+#: lxc/storage_volume.go:1592
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1597
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3371,7 +3371,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:685 lxc/remote.go:686
+#: lxc/remote.go:752 lxc/remote.go:753
 msgid "List the available remotes"
 msgstr ""
 
@@ -3410,7 +3410,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1464
+#: lxc/info.go:489 lxc/storage_volume.go:1470
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3874,12 +3874,12 @@ msgstr ""
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:323 lxc/storage_volume.go:643
-#: lxc/storage_volume.go:750 lxc/storage_volume.go:841
-#: lxc/storage_volume.go:939 lxc/storage_volume.go:1053
-#: lxc/storage_volume.go:1270 lxc/storage_volume.go:1974
-#: lxc/storage_volume.go:2115 lxc/storage_volume.go:2273
-#: lxc/storage_volume.go:2464 lxc/storage_volume.go:2581
+#: lxc/storage_volume.go:323 lxc/storage_volume.go:649
+#: lxc/storage_volume.go:756 lxc/storage_volume.go:847
+#: lxc/storage_volume.go:945 lxc/storage_volume.go:1059
+#: lxc/storage_volume.go:1276 lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:2121 lxc/storage_volume.go:2279
+#: lxc/storage_volume.go:2470 lxc/storage_volume.go:2587
 msgid "Missing pool name"
 msgstr ""
 
@@ -3898,11 +3898,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:432 lxc/storage_volume.go:1884
+#: lxc/storage_volume.go:438 lxc/storage_volume.go:1890
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1394
+#: lxc/storage_volume.go:1400
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -3939,8 +3939,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:861
-#: lxc/storage_volume.go:958
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:867
+#: lxc/storage_volume.go:964
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -3977,7 +3977,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1843 lxc/storage_volume.go:1844
+#: lxc/storage_volume.go:1849 lxc/storage_volume.go:1850
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -3985,11 +3985,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1850
+#: lxc/storage_volume.go:1856
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:512
+#: lxc/storage_volume.go:518
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4015,8 +4015,8 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
-#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1731
+#: lxc/remote.go:815 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
 msgstr ""
 
@@ -4042,7 +4042,7 @@ msgstr ""
 
 #: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
+#: lxc/project.go:550 lxc/remote.go:775 lxc/remote.go:780 lxc/remote.go:785
 msgid "NO"
 msgstr ""
 
@@ -4064,8 +4064,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1506
-#: lxc/storage_volume.go:1556
+#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1512
+#: lxc/storage_volume.go:1562
 msgid "Name"
 msgstr ""
 
@@ -4073,7 +4073,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1446
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1452
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4217,7 +4217,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:870 lxc/storage_volume.go:967
+#: lxc/storage_volume.go:876 lxc/storage_volume.go:973
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4233,11 +4233,11 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/storage_volume.go:446 lxc/storage_volume.go:1893
+#: lxc/storage_volume.go:452 lxc/storage_volume.go:1899
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:496 lxc/storage_volume.go:1904
+#: lxc/storage_volume.go:502 lxc/storage_volume.go:1910
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4251,7 +4251,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2012
+#: lxc/storage_volume.go:2018
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4263,15 +4263,15 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2678
+#: lxc/storage_volume.go:2684
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2477
+#: lxc/storage_volume.go:2483
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:336
+#: lxc/remote.go:378
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4279,7 +4279,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1412
+#: lxc/storage_volume.go:1418
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4292,7 +4292,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:693 lxc/storage_volume.go:1560
+#: lxc/info.go:693 lxc/storage_volume.go:1566
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4322,7 +4322,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1756
 msgid "POOL"
 msgstr ""
 
@@ -4338,15 +4338,15 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:213
+#: lxc/list.go:567 lxc/storage_volume.go:1762 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:817
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:752
+#: lxc/image.go:1136 lxc/remote.go:819
 msgid "PUBLIC"
 msgstr ""
 
@@ -4375,7 +4375,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:183
+#: lxc/remote.go:195
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4387,8 +4387,8 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:466
-msgid "Please type 'y', 'n' or the fingerprint:"
+#: lxc/remote.go:536
+msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
 #: lxc/info.go:221
@@ -4412,8 +4412,8 @@ msgstr ""
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1151
-#: lxc/storage_volume.go:1183
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
+#: lxc/storage_volume.go:1189
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4530,7 +4530,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1350
+#: lxc/storage_volume.go:1356
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4544,7 +4544,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1219
+#: lxc/storage_volume.go:1225
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4560,7 +4560,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2224
+#: lxc/storage_volume.go:2230
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4581,7 +4581,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:998
+#: lxc/storage_volume.go:1004
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4590,7 +4590,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2069
+#: lxc/storage_volume.go:2075
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4603,7 +4603,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2345
+#: lxc/storage_volume.go:2351
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4707,33 +4707,33 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:810
+#: lxc/remote.go:877
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
-#: lxc/remote.go:994
+#: lxc/project.go:884 lxc/remote.go:868 lxc/remote.go:949 lxc/remote.go:1013
+#: lxc/remote.go:1061
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:305
+#: lxc/remote.go:345
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:890
+#: lxc/remote.go:957
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:805 lxc/remote.go:886 lxc/remote.go:998
+#: lxc/remote.go:872 lxc/remote.go:953 lxc/remote.go:1065
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:294
+#: lxc/remote.go:319
 msgid "Remote address must not be empty"
 msgstr ""
 
@@ -4741,7 +4741,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:299
+#: lxc/remote.go:339
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4827,7 +4827,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:852 lxc/remote.go:853
+#: lxc/remote.go:919 lxc/remote.go:920
 msgid "Remove remotes"
 msgstr ""
 
@@ -4884,19 +4884,19 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:771 lxc/remote.go:772
+#: lxc/remote.go:838 lxc/remote.go:839
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:1943
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1936
+#: lxc/storage_volume.go:1942
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2025 lxc/storage_volume.go:2045
+#: lxc/storage_volume.go:2031 lxc/storage_volume.go:2051
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4948,7 +4948,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2540 lxc/storage_volume.go:2541
+#: lxc/storage_volume.go:2546 lxc/storage_volume.go:2547
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5029,7 +5029,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:820
 msgid "STATIC"
 msgstr ""
 
@@ -5070,11 +5070,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:464
+#: lxc/remote.go:532
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:616
+#: lxc/remote.go:285 lxc/remote.go:683
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5272,11 +5272,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2063
+#: lxc/storage_volume.go:2069
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2064
+#: lxc/storage_volume.go:2070
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5285,7 +5285,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:964 lxc/remote.go:965
+#: lxc/remote.go:1031 lxc/remote.go:1032
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5361,7 +5361,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2080
+#: lxc/storage_volume.go:2086
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5510,11 +5510,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2221 lxc/storage_volume.go:2222
+#: lxc/storage_volume.go:2227 lxc/storage_volume.go:2228
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1347 lxc/storage_volume.go:1348
+#: lxc/storage_volume.go:1353 lxc/storage_volume.go:1354
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5528,7 +5528,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:647 lxc/remote.go:648
+#: lxc/remote.go:714 lxc/remote.go:715
 msgid "Show the default remote"
 msgstr ""
 
@@ -5582,15 +5582,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2404 lxc/storage_volume.go:2405
+#: lxc/storage_volume.go:2410 lxc/storage_volume.go:2411
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2167
+#: lxc/storage_volume.go:2173
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:607 lxc/storage_volume.go:1485
+#: lxc/info.go:607 lxc/storage_volume.go:1491
 msgid "Snapshots:"
 msgstr ""
 
@@ -5691,21 +5691,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:696
+#: lxc/storage_volume.go:702
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:784
+#: lxc/storage_volume.go:790
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:509
+#: lxc/storage_volume.go:515
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:513
+#: lxc/storage_volume.go:519
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5740,7 +5740,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:916 lxc/remote.go:917
+#: lxc/remote.go:983 lxc/remote.go:984
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5759,11 +5759,11 @@ msgstr ""
 #: lxc/auth.go:818 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
-#: lxc/storage_volume.go:1730 lxc/warning.go:216
+#: lxc/storage_volume.go:1736 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1557
+#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1563
 msgid "Taken at"
 msgstr ""
 
@@ -5773,6 +5773,12 @@ msgstr ""
 
 #: lxc/file.go:1256
 msgid "Target path must be a directory"
+msgstr ""
+
+#: lxc/remote.go:161 lxc/remote.go:334
+msgid ""
+"The --accept-certificate flag is not supported when adding a remote using a "
+"trust token"
 msgstr ""
 
 #: lxc/move.go:181
@@ -5914,15 +5920,20 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1323
+#: lxc/storage_volume.go:1329
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1300
+#: lxc/storage_volume.go:1306
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
+msgstr ""
+
+#: lxc/remote.go:527
+msgid ""
+"The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
 
 #: lxc/info.go:354
@@ -5933,8 +5944,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:875
-#: lxc/storage_volume.go:972
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:881
+#: lxc/storage_volume.go:978
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6009,7 +6020,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1470
+#: lxc/storage_volume.go:1476
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6024,7 +6035,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1847
+#: lxc/storage_volume.go:1853
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6058,7 +6069,15 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:571
+#: lxc/remote.go:329
+msgid "Trust token cannot be used for public remotes"
+msgstr ""
+
+#: lxc/remote.go:324
+msgid "Trust token cannot be used with OIDC authentication"
+msgstr ""
+
+#: lxc/remote.go:639
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6083,7 +6102,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1455
+#: lxc/storage_volume.go:1461
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6101,17 +6120,17 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:193 lxc/remote.go:749
+#: lxc/cluster.go:193 lxc/remote.go:816
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1735
+#: lxc/project.go:995 lxc/storage_volume.go:1741
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1734
+#: lxc/storage.go:724 lxc/storage_volume.go:1740
 msgid "USED BY"
 msgstr ""
 
@@ -6129,7 +6148,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:214 lxc/remote.go:248
+#: lxc/remote.go:226 lxc/remote.go:260
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6143,7 +6162,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1772
+#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1778
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6249,7 +6268,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2342 lxc/storage_volume.go:2343
+#: lxc/storage_volume.go:2348 lxc/storage_volume.go:2349
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6301,7 +6320,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2356
+#: lxc/storage_volume.go:2362
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6345,12 +6364,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1468
+#: lxc/storage_volume.go:1474
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2629
+#: lxc/export.go:42 lxc/storage_volume.go:2635
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6417,7 +6436,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1559
+#: lxc/storage_volume.go:1565
 msgid "Volume Only"
 msgstr ""
 
@@ -6452,7 +6471,7 @@ msgstr ""
 
 #: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
+#: lxc/project.go:552 lxc/remote.go:777 lxc/remote.go:782 lxc/remote.go:787
 msgid "YES"
 msgstr ""
 
@@ -6476,7 +6495,7 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:897
+#: lxc/storage_volume.go:903
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
@@ -6898,7 +6917,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2788
+#: lxc/storage_volume.go:2794
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -6933,13 +6952,13 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:1941
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:799
+#: lxc/storage_volume.go:805
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
@@ -6947,47 +6966,47 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2539
+#: lxc/storage_volume.go:2545
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2622
+#: lxc/storage_volume.go:2628
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2403
+#: lxc/storage_volume.go:2409
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:603
+#: lxc/storage_volume.go:609
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:711
+#: lxc/storage_volume.go:717
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:994 lxc/storage_volume.go:1346
+#: lxc/storage_volume.go:1000 lxc/storage_volume.go:1352
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2341
+#: lxc/storage_volume.go:2347
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2062
+#: lxc/storage_volume.go:2068
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2220
+#: lxc/storage_volume.go:2226
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1215
+#: lxc/storage_volume.go:1221
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1841
+#: lxc/storage_volume.go:1847
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7097,7 +7116,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1584
+#: lxc/storage_volume.go:1590
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7109,7 +7128,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:739
+#: lxc/project.go:557 lxc/remote.go:806
 msgid "current"
 msgstr ""
 
@@ -7569,7 +7588,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:607
+#: lxc/storage_volume.go:613
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7577,13 +7596,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2792
+#: lxc/storage_volume.go:2798
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2407
+#: lxc/storage_volume.go:2413
 msgid ""
 "lxc storage volume snapshot create default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7593,7 +7612,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:531
 msgid "n"
 msgstr ""
 
@@ -7605,7 +7624,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:510
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7642,7 +7661,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:465
+#: lxc/remote.go:519
 msgid "y"
 msgstr ""
 

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-08 07:43+0100\n"
+"POT-Creation-Date: 2024-10-14 13:30+0000\n"
 "PO-Revision-Date: 2023-06-16 20:55+0000\n"
 "Last-Translator: Francisco Serrador <fserrador@gmail.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -79,7 +79,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/storage_volume.go:1024
+#: lxc/storage_volume.go:1030
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
@@ -757,15 +757,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:850 lxc/remote.go:915
+#: lxc/remote.go:917 lxc/remote.go:982
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:963
+#: lxc/remote.go:1030
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:769
+#: lxc/remote.go:836
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -799,7 +799,7 @@ msgstr "ALIASES"
 msgid "ARCHITECTURE"
 msgstr "ARQUITECTURA"
 
-#: lxc/remote.go:751
+#: lxc/remote.go:818
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -952,7 +952,7 @@ msgstr "Expira: %s"
 msgid "Admin access key: %s"
 msgstr "Expira: %s"
 
-#: lxc/remote.go:581
+#: lxc/remote.go:648
 #, fuzzy, c-format
 msgid "Admin password (or token) for %s:"
 msgstr "Contraseña admin para %s: "
@@ -985,11 +985,11 @@ msgstr "El dispostivo ya existe: %s"
 msgid "Aliases:"
 msgstr "Aliases:"
 
-#: lxc/storage_volume.go:1590
+#: lxc/storage_volume.go:1596
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:182
+#: lxc/remote.go:194
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -1062,7 +1062,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:552
+#: lxc/remote.go:621
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr "Tipo de autenticación %s no está soportada por el servidor"
@@ -1098,16 +1098,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:2696
+#: lxc/storage_volume.go:2702
 #, fuzzy, c-format
 msgid "Backing up storage volume: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/export.go:192 lxc/storage_volume.go:2773
+#: lxc/export.go:192 lxc/storage_volume.go:2779
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:654 lxc/storage_volume.go:1521
+#: lxc/info.go:654 lxc/storage_volume.go:1527
 msgid "Backups:"
 msgstr ""
 
@@ -1128,7 +1128,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:679
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:685
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -1172,7 +1172,7 @@ msgstr "CANCELABLE"
 msgid "COMMON NAME"
 msgstr "NOMBRE COMÚN"
 
-#: lxc/storage_volume.go:1733
+#: lxc/storage_volume.go:1739
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1244,7 +1244,7 @@ msgstr "No se puede jalar un directorio sin - recursivo"
 msgid "Can't read from stdin: %w"
 msgstr "No se peude leer desde stdin: %s"
 
-#: lxc/remote.go:894
+#: lxc/remote.go:961
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1261,7 +1261,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr "No se puede especificar un remote diferente para renombrar."
 
-#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1749 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1278,12 +1278,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:486
+#: lxc/storage_volume.go:492
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:440
+#: lxc/storage_volume.go:446
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1311,12 +1311,12 @@ msgstr "Cacheado: %s"
 msgid "Certificate add token for %s deleted"
 msgstr "Perfil %s eliminado"
 
-#: lxc/remote.go:455
+#: lxc/remote.go:509
 #, fuzzy
 msgid "Certificate fingerprint"
 msgstr "Certificado de la huella digital: %s"
 
-#: lxc/remote.go:219
+#: lxc/remote.go:231
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
@@ -1331,7 +1331,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/remote.go:620
+#: lxc/remote.go:687
 #, fuzzy
 msgid "Client certificate now trusted by server:"
 msgstr "Certificado del cliente almacenado en el servidor: "
@@ -1406,13 +1406,13 @@ msgstr "Perfil %s eliminado de %s"
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
 #: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
-#: lxc/storage_volume.go:612 lxc/storage_volume.go:717
-#: lxc/storage_volume.go:1005 lxc/storage_volume.go:1231
-#: lxc/storage_volume.go:1360 lxc/storage_volume.go:1848
-#: lxc/storage_volume.go:1940 lxc/storage_volume.go:2079
-#: lxc/storage_volume.go:2239 lxc/storage_volume.go:2355
-#: lxc/storage_volume.go:2416 lxc/storage_volume.go:2543
-#: lxc/storage_volume.go:2631 lxc/storage_volume.go:2795
+#: lxc/storage_volume.go:618 lxc/storage_volume.go:723
+#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1237
+#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1854
+#: lxc/storage_volume.go:1946 lxc/storage_volume.go:2085
+#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2361
+#: lxc/storage_volume.go:2422 lxc/storage_volume.go:2549
+#: lxc/storage_volume.go:2637 lxc/storage_volume.go:2801
 msgid "Cluster member name"
 msgstr "Nombre del Miembro del Cluster"
 
@@ -1428,7 +1428,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1589
+#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1595
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr "Columnas"
@@ -1474,17 +1474,17 @@ msgstr "Perfil para aplicar al nuevo contenedor"
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1150
-#: lxc/storage_volume.go:1182
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
+#: lxc/storage_volume.go:1188
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:613
+#: lxc/storage_volume.go:619
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1467
 #, fuzzy, c-format
 msgid "Content type: %s"
 msgstr "Auto actualización: %s"
@@ -1569,7 +1569,7 @@ msgstr "Copiando la imagen: %s"
 msgid "Copying the image: %s"
 msgstr "Copiando la imagen: %s"
 
-#: lxc/storage_volume.go:508
+#: lxc/storage_volume.go:514
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1584,12 +1584,12 @@ msgstr "Expira: %s"
 msgid "Cores:"
 msgstr "Expira: %s"
 
-#: lxc/remote.go:490
+#: lxc/remote.go:559
 #, fuzzy, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "Certificado de la huella digital: %s"
 
-#: lxc/remote.go:225 lxc/remote.go:474
+#: lxc/remote.go:237 lxc/remote.go:543
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1628,7 +1628,7 @@ msgstr "Certificado de la huella digital: %s"
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:485
+#: lxc/remote.go:554
 #, fuzzy, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "Certificado de la huella digital: %s"
@@ -1703,7 +1703,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr "Perfil %s creado"
 
-#: lxc/storage_volume.go:604 lxc/storage_volume.go:605
+#: lxc/storage_volume.go:610 lxc/storage_volume.go:611
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1757,7 +1757,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1475
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1481
 #, c-format
 msgid "Created: %s"
 msgstr "Creado: %s"
@@ -1793,7 +1793,7 @@ msgstr ""
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1732
+#: lxc/storage_volume.go:1738
 msgid "DESCRIPTION"
 msgstr "DESCRIPCIÓN"
 
@@ -1813,7 +1813,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2630
+#: lxc/storage_volume.go:2636
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1915,7 +1915,7 @@ msgstr "Perfil %s creado"
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:713 lxc/storage_volume.go:714
+#: lxc/storage_volume.go:719 lxc/storage_volume.go:720
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -2007,9 +2007,9 @@ msgstr ""
 #: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
 #: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
 #: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:648
-#: lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853 lxc/remote.go:917
-#: lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:715
+#: lxc/remote.go:753 lxc/remote.go:839 lxc/remote.go:920 lxc/remote.go:984
+#: lxc/remote.go:1032 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -2021,26 +2021,26 @@ msgstr ""
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
 #: lxc/storage_volume.go:169 lxc/storage_volume.go:283
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:605
-#: lxc/storage_volume.go:714 lxc/storage_volume.go:801
-#: lxc/storage_volume.go:899 lxc/storage_volume.go:996
-#: lxc/storage_volume.go:1217 lxc/storage_volume.go:1348
-#: lxc/storage_volume.go:1507 lxc/storage_volume.go:1591
-#: lxc/storage_volume.go:1844 lxc/storage_volume.go:1937
-#: lxc/storage_volume.go:2064 lxc/storage_volume.go:2222
-#: lxc/storage_volume.go:2343 lxc/storage_volume.go:2405
-#: lxc/storage_volume.go:2541 lxc/storage_volume.go:2624
-#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:611
+#: lxc/storage_volume.go:720 lxc/storage_volume.go:807
+#: lxc/storage_volume.go:905 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:1223 lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1513 lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1850 lxc/storage_volume.go:1943
+#: lxc/storage_volume.go:2070 lxc/storage_volume.go:2228
+#: lxc/storage_volume.go:2349 lxc/storage_volume.go:2411
+#: lxc/storage_volume.go:2547 lxc/storage_volume.go:2630
+#: lxc/storage_volume.go:2796 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr "Descripción"
 
-#: lxc/storage_volume.go:1448
+#: lxc/storage_volume.go:1454
 #, fuzzy, c-format
 msgid "Description: %s"
 msgstr "Huella dactilar: %s"
 
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:1849
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:1855
 #, fuzzy
 msgid "Destination cluster member name"
 msgstr "Nombre del Miembro del Cluster"
@@ -2053,11 +2053,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:800 lxc/storage_volume.go:801
+#: lxc/storage_volume.go:806 lxc/storage_volume.go:807
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:898 lxc/storage_volume.go:899
+#: lxc/storage_volume.go:904 lxc/storage_volume.go:905
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -2292,7 +2292,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:995 lxc/storage_volume.go:996
+#: lxc/storage_volume.go:1001 lxc/storage_volume.go:1002
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2300,7 +2300,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1766
+#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1772
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2357,7 +2357,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2193
+#: lxc/storage_volume.go:2161 lxc/storage_volume.go:2199
 #, fuzzy, c-format
 msgid "Error setting properties: %v"
 msgstr "Error actualizando el archivo de plantilla: %s"
@@ -2371,8 +2371,8 @@ msgstr "Error actualizando el archivo de plantilla: %s"
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2149
-#: lxc/storage_volume.go:2187
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2155
+#: lxc/storage_volume.go:2193
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2415,8 +2415,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1508
-#: lxc/storage_volume.go:1558
+#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1514
+#: lxc/storage_volume.go:1564
 #, fuzzy
 msgid "Expires at"
 msgstr "Expira: %s"
@@ -2441,7 +2441,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2623 lxc/storage_volume.go:2624
+#: lxc/storage_volume.go:2629 lxc/storage_volume.go:2630
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2455,11 +2455,11 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "Export instances as backup tarballs."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:2627
+#: lxc/storage_volume.go:2633
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2756
+#: lxc/export.go:152 lxc/storage_volume.go:2762
 #, fuzzy, c-format
 msgid "Exporting the backup: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -2576,11 +2576,11 @@ msgstr "Acepta certificado"
 msgid "Failed to accept incoming connection: %w"
 msgstr "Acepta certificado"
 
-#: lxc/remote.go:191
+#: lxc/remote.go:203
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:242
+#: lxc/remote.go:254
 #, fuzzy, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr "Acepta certificado"
@@ -2590,7 +2590,7 @@ msgstr "Acepta certificado"
 msgid "Failed to connect to cluster member: %w"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/remote.go:232
+#: lxc/remote.go:244
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2600,12 +2600,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr "Acepta certificado"
 
-#: lxc/remote.go:260
+#: lxc/remote.go:486
 #, fuzzy, c-format
-msgid "Failed to create certificate: %w"
-msgstr "Acepta certificado"
+msgid "Failed to decode trust token: %w"
+msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/remote.go:267
+#: lxc/remote.go:292
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2630,7 +2630,7 @@ msgstr "Acepta certificado"
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:237
+#: lxc/remote.go:249
 #, fuzzy, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr "Acepta certificado"
@@ -2718,9 +2718,9 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:690 lxc/storage.go:657
+#: lxc/project.go:919 lxc/remote.go:757 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1608 lxc/warning.go:94
+#: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2756,7 +2756,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:754
+#: lxc/remote.go:821
 msgid "GLOBAL"
 msgstr ""
 
@@ -2776,7 +2776,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:160 lxc/remote.go:401
+#: lxc/remote.go:165 lxc/remote.go:443
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2851,7 +2851,7 @@ msgstr "Perfil %s creado"
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1238
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2922,11 +2922,11 @@ msgstr "Perfil %s creado"
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1216 lxc/storage_volume.go:1217
+#: lxc/storage_volume.go:1222 lxc/storage_volume.go:1223
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:469
+#: lxc/storage_volume.go:475
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -3053,7 +3053,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2415
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2421
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -3067,7 +3067,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2414
+#: lxc/storage_volume.go:2420
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -3117,7 +3117,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2790
+#: lxc/storage_volume.go:2796
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -3125,7 +3125,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2789
+#: lxc/storage_volume.go:2795
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -3148,11 +3148,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:2797
+#: lxc/storage_volume.go:2803
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2871
+#: lxc/storage_volume.go:2877
 #, fuzzy, c-format
 msgid "Importing custom volume: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -3221,7 +3221,7 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:353
+#: lxc/remote.go:395
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3281,7 +3281,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2000
+#: lxc/move.go:148 lxc/storage_volume.go:2006
 #, fuzzy
 msgid "Invalid new snapshot name"
 msgstr "Nombre del contenedor es: %s"
@@ -3290,7 +3290,7 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1996
+#: lxc/storage_volume.go:2002
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3303,14 +3303,14 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:342
+#: lxc/remote.go:384
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1064 lxc/storage_volume.go:1281
-#: lxc/storage_volume.go:1405 lxc/storage_volume.go:1985
-#: lxc/storage_volume.go:2132 lxc/storage_volume.go:2284
+#: lxc/storage_volume.go:1070 lxc/storage_volume.go:1287
+#: lxc/storage_volume.go:1411 lxc/storage_volume.go:1991
+#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2290
 #, fuzzy
 msgid "Invalid snapshot name"
 msgstr "Nombre del contenedor es: %s"
@@ -3357,7 +3357,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1739 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1745 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3673,11 +3673,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr "Aliases:"
 
-#: lxc/storage_volume.go:1586
+#: lxc/storage_volume.go:1592
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1597
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3697,7 +3697,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:685 lxc/remote.go:686
+#: lxc/remote.go:752 lxc/remote.go:753
 msgid "List the available remotes"
 msgstr ""
 
@@ -3737,7 +3737,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1464
+#: lxc/info.go:489 lxc/storage_volume.go:1470
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -4232,12 +4232,12 @@ msgstr "Nombre del contenedor es: %s"
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:323 lxc/storage_volume.go:643
-#: lxc/storage_volume.go:750 lxc/storage_volume.go:841
-#: lxc/storage_volume.go:939 lxc/storage_volume.go:1053
-#: lxc/storage_volume.go:1270 lxc/storage_volume.go:1974
-#: lxc/storage_volume.go:2115 lxc/storage_volume.go:2273
-#: lxc/storage_volume.go:2464 lxc/storage_volume.go:2581
+#: lxc/storage_volume.go:323 lxc/storage_volume.go:649
+#: lxc/storage_volume.go:756 lxc/storage_volume.go:847
+#: lxc/storage_volume.go:945 lxc/storage_volume.go:1059
+#: lxc/storage_volume.go:1276 lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:2121 lxc/storage_volume.go:2279
+#: lxc/storage_volume.go:2470 lxc/storage_volume.go:2587
 msgid "Missing pool name"
 msgstr ""
 
@@ -4257,11 +4257,11 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:432 lxc/storage_volume.go:1884
+#: lxc/storage_volume.go:438 lxc/storage_volume.go:1890
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1394
+#: lxc/storage_volume.go:1400
 #, fuzzy
 msgid "Missing storage pool name"
 msgstr "Nombre del contenedor es: %s"
@@ -4301,8 +4301,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:861
-#: lxc/storage_volume.go:958
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:867
+#: lxc/storage_volume.go:964
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4340,7 +4340,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1843 lxc/storage_volume.go:1844
+#: lxc/storage_volume.go:1849 lxc/storage_volume.go:1850
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4348,11 +4348,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1850
+#: lxc/storage_volume.go:1856
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:512
+#: lxc/storage_volume.go:518
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4378,8 +4378,8 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
-#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1731
+#: lxc/remote.go:815 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
 msgstr ""
 
@@ -4405,7 +4405,7 @@ msgstr ""
 
 #: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
+#: lxc/project.go:550 lxc/remote.go:775 lxc/remote.go:780 lxc/remote.go:785
 msgid "NO"
 msgstr ""
 
@@ -4427,8 +4427,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1506
-#: lxc/storage_volume.go:1556
+#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1512
+#: lxc/storage_volume.go:1562
 msgid "Name"
 msgstr ""
 
@@ -4436,7 +4436,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1446
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1452
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4580,7 +4580,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:870 lxc/storage_volume.go:967
+#: lxc/storage_volume.go:876 lxc/storage_volume.go:973
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4596,11 +4596,11 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/storage_volume.go:446 lxc/storage_volume.go:1893
+#: lxc/storage_volume.go:452 lxc/storage_volume.go:1899
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:496 lxc/storage_volume.go:1904
+#: lxc/storage_volume.go:502 lxc/storage_volume.go:1910
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4614,7 +4614,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2012
+#: lxc/storage_volume.go:2018
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4626,15 +4626,15 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2678
+#: lxc/storage_volume.go:2684
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2477
+#: lxc/storage_volume.go:2483
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:336
+#: lxc/remote.go:378
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4642,7 +4642,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1412
+#: lxc/storage_volume.go:1418
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4655,7 +4655,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:693 lxc/storage_volume.go:1560
+#: lxc/info.go:693 lxc/storage_volume.go:1566
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4685,7 +4685,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1756
 msgid "POOL"
 msgstr ""
 
@@ -4701,15 +4701,15 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:213
+#: lxc/list.go:567 lxc/storage_volume.go:1762 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:817
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:752
+#: lxc/image.go:1136 lxc/remote.go:819
 msgid "PUBLIC"
 msgstr ""
 
@@ -4738,7 +4738,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:183
+#: lxc/remote.go:195
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4751,8 +4751,8 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/remote.go:466
-msgid "Please type 'y', 'n' or the fingerprint:"
+#: lxc/remote.go:536
+msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
 #: lxc/info.go:221
@@ -4776,8 +4776,8 @@ msgstr ""
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1151
-#: lxc/storage_volume.go:1183
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
+#: lxc/storage_volume.go:1189
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4898,7 +4898,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1350
+#: lxc/storage_volume.go:1356
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4912,7 +4912,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1219
+#: lxc/storage_volume.go:1225
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4928,7 +4928,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2224
+#: lxc/storage_volume.go:2230
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4949,7 +4949,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:998
+#: lxc/storage_volume.go:1004
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4958,7 +4958,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2069
+#: lxc/storage_volume.go:2075
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4971,7 +4971,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2345
+#: lxc/storage_volume.go:2351
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5077,33 +5077,33 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "Refreshing the image: %s"
 msgstr "Refrescando la imagen: %s"
 
-#: lxc/remote.go:810
+#: lxc/remote.go:877
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
-#: lxc/remote.go:994
+#: lxc/project.go:884 lxc/remote.go:868 lxc/remote.go:949 lxc/remote.go:1013
+#: lxc/remote.go:1061
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:305
+#: lxc/remote.go:345
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:890
+#: lxc/remote.go:957
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:805 lxc/remote.go:886 lxc/remote.go:998
+#: lxc/remote.go:872 lxc/remote.go:953 lxc/remote.go:1065
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:294
+#: lxc/remote.go:319
 msgid "Remote address must not be empty"
 msgstr ""
 
@@ -5112,7 +5112,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr "Contraseña admin para %s: "
 
-#: lxc/remote.go:299
+#: lxc/remote.go:339
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -5203,7 +5203,7 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:852 lxc/remote.go:853
+#: lxc/remote.go:919 lxc/remote.go:920
 msgid "Remove remotes"
 msgstr ""
 
@@ -5262,19 +5262,19 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:771 lxc/remote.go:772
+#: lxc/remote.go:838 lxc/remote.go:839
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:1943
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1936
+#: lxc/storage_volume.go:1942
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2025 lxc/storage_volume.go:2045
+#: lxc/storage_volume.go:2031 lxc/storage_volume.go:2051
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5329,7 +5329,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2540 lxc/storage_volume.go:2541
+#: lxc/storage_volume.go:2546 lxc/storage_volume.go:2547
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5413,7 +5413,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:820
 msgid "STATIC"
 msgstr ""
 
@@ -5454,11 +5454,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:464
+#: lxc/remote.go:532
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:616
+#: lxc/remote.go:285 lxc/remote.go:683
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5664,11 +5664,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2063
+#: lxc/storage_volume.go:2069
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2064
+#: lxc/storage_volume.go:2070
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5677,7 +5677,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:964 lxc/remote.go:965
+#: lxc/remote.go:1031 lxc/remote.go:1032
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5759,7 +5759,7 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2080
+#: lxc/storage_volume.go:2086
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5919,11 +5919,11 @@ msgstr "Perfil %s creado"
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2221 lxc/storage_volume.go:2222
+#: lxc/storage_volume.go:2227 lxc/storage_volume.go:2228
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1347 lxc/storage_volume.go:1348
+#: lxc/storage_volume.go:1353 lxc/storage_volume.go:1354
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5937,7 +5937,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:647 lxc/remote.go:648
+#: lxc/remote.go:714 lxc/remote.go:715
 msgid "Show the default remote"
 msgstr ""
 
@@ -5992,15 +5992,15 @@ msgstr "Auto actualización: %s"
 msgid "Size: %s"
 msgstr "Auto actualización: %s"
 
-#: lxc/storage_volume.go:2404 lxc/storage_volume.go:2405
+#: lxc/storage_volume.go:2410 lxc/storage_volume.go:2411
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2167
+#: lxc/storage_volume.go:2173
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:607 lxc/storage_volume.go:1485
+#: lxc/info.go:607 lxc/storage_volume.go:1491
 msgid "Snapshots:"
 msgstr ""
 
@@ -6102,21 +6102,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:696
+#: lxc/storage_volume.go:702
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:784
+#: lxc/storage_volume.go:790
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:509
+#: lxc/storage_volume.go:515
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:513
+#: lxc/storage_volume.go:519
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -6151,7 +6151,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:916 lxc/remote.go:917
+#: lxc/remote.go:983 lxc/remote.go:984
 msgid "Switch the default remote"
 msgstr ""
 
@@ -6170,11 +6170,11 @@ msgstr ""
 #: lxc/auth.go:818 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
-#: lxc/storage_volume.go:1730 lxc/warning.go:216
+#: lxc/storage_volume.go:1736 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1557
+#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1563
 msgid "Taken at"
 msgstr ""
 
@@ -6184,6 +6184,12 @@ msgstr ""
 
 #: lxc/file.go:1256
 msgid "Target path must be a directory"
+msgstr ""
+
+#: lxc/remote.go:161 lxc/remote.go:334
+msgid ""
+"The --accept-certificate flag is not supported when adding a remote using a "
+"trust token"
 msgstr ""
 
 #: lxc/move.go:181
@@ -6327,15 +6333,20 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/storage_volume.go:1323
+#: lxc/storage_volume.go:1329
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/storage_volume.go:1300
+#: lxc/storage_volume.go:1306
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
+msgstr ""
+
+#: lxc/remote.go:527
+msgid ""
+"The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
 
 #: lxc/info.go:354
@@ -6346,8 +6357,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:875
-#: lxc/storage_volume.go:972
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:881
+#: lxc/storage_volume.go:978
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6424,7 +6435,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1470
+#: lxc/storage_volume.go:1476
 #, fuzzy, c-format
 msgid "Total: %s"
 msgstr "Auto actualización: %s"
@@ -6439,7 +6450,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1847
+#: lxc/storage_volume.go:1853
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6473,7 +6484,15 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:571
+#: lxc/remote.go:329
+msgid "Trust token cannot be used for public remotes"
+msgstr ""
+
+#: lxc/remote.go:324
+msgid "Trust token cannot be used with OIDC authentication"
+msgstr ""
+
+#: lxc/remote.go:639
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6500,7 +6519,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1455
+#: lxc/storage_volume.go:1461
 #, fuzzy, c-format
 msgid "Type: %s"
 msgstr "Expira: %s"
@@ -6518,17 +6537,17 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:193 lxc/remote.go:749
+#: lxc/cluster.go:193 lxc/remote.go:816
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1735
+#: lxc/project.go:995 lxc/storage_volume.go:1741
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1734
+#: lxc/storage.go:724 lxc/storage_volume.go:1740
 msgid "USED BY"
 msgstr ""
 
@@ -6546,7 +6565,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:214 lxc/remote.go:248
+#: lxc/remote.go:226 lxc/remote.go:260
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6560,7 +6579,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1772
+#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1778
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6677,7 +6696,7 @@ msgstr "Perfil %s creado"
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2342 lxc/storage_volume.go:2343
+#: lxc/storage_volume.go:2348 lxc/storage_volume.go:2349
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6736,7 +6755,7 @@ msgstr "Perfil %s creado"
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2356
+#: lxc/storage_volume.go:2362
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6781,12 +6800,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1468
+#: lxc/storage_volume.go:1474
 #, fuzzy, c-format
 msgid "Usage: %s"
 msgstr "Auto actualización: %s"
 
-#: lxc/export.go:42 lxc/storage_volume.go:2629
+#: lxc/export.go:42 lxc/storage_volume.go:2635
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6853,7 +6872,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1559
+#: lxc/storage_volume.go:1565
 msgid "Volume Only"
 msgstr ""
 
@@ -6888,7 +6907,7 @@ msgstr ""
 
 #: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
+#: lxc/project.go:552 lxc/remote.go:777 lxc/remote.go:782 lxc/remote.go:787
 msgid "YES"
 msgstr ""
 
@@ -6912,7 +6931,7 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:897
+#: lxc/storage_volume.go:903
 #, fuzzy
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7427,7 +7446,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<pool>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:2788
+#: lxc/storage_volume.go:2794
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7470,14 +7489,14 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:1941
 #, fuzzy
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:799
+#: lxc/storage_volume.go:805
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7487,57 +7506,57 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:2539
+#: lxc/storage_volume.go:2545
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:2622
+#: lxc/storage_volume.go:2628
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:2403
+#: lxc/storage_volume.go:2409
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:603
+#: lxc/storage_volume.go:609
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:711
+#: lxc/storage_volume.go:717
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:994 lxc/storage_volume.go:1346
+#: lxc/storage_volume.go:1000 lxc/storage_volume.go:1352
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:2341
+#: lxc/storage_volume.go:2347
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:2062
+#: lxc/storage_volume.go:2068
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:2220
+#: lxc/storage_volume.go:2226
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:1215
+#: lxc/storage_volume.go:1221
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:1841
+#: lxc/storage_volume.go:1847
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7674,7 +7693,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:1584
+#: lxc/storage_volume.go:1590
 #, fuzzy
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7689,7 +7708,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[[<remote>:]<member>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/project.go:557 lxc/remote.go:739
+#: lxc/project.go:557 lxc/remote.go:806
 msgid "current"
 msgstr ""
 
@@ -8149,7 +8168,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:607
+#: lxc/storage_volume.go:613
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -8157,13 +8176,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2792
+#: lxc/storage_volume.go:2798
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2407
+#: lxc/storage_volume.go:2413
 msgid ""
 "lxc storage volume snapshot create default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -8173,7 +8192,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:531
 msgid "n"
 msgstr ""
 
@@ -8185,7 +8204,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:510
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -8222,7 +8241,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:465
+#: lxc/remote.go:519
 msgid "y"
 msgstr ""
 
@@ -8230,6 +8249,10 @@ msgstr ""
 #: lxc/image.go:1194
 msgid "yes"
 msgstr ""
+
+#, fuzzy, c-format
+#~ msgid "Failed to create certificate: %w"
+#~ msgstr "Acepta certificado"
 
 #, fuzzy
 #~ msgid "[<remote>:]<cluster member>"

--- a/po/fa.po
+++ b/po/fa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-08 07:43+0100\n"
+"POT-Creation-Date: 2024-10-14 13:30+0000\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Persian <https://hosted.weblate.org/projects/linux-containers/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1024
+#: lxc/storage_volume.go:1030
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -515,15 +515,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:850 lxc/remote.go:915
+#: lxc/remote.go:917 lxc/remote.go:982
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:963
+#: lxc/remote.go:1030
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:769
+#: lxc/remote.go:836
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -556,7 +556,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:751
+#: lxc/remote.go:818
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:581
+#: lxc/remote.go:648
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -738,11 +738,11 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1590
+#: lxc/storage_volume.go:1596
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:182
+#: lxc/remote.go:194
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -813,7 +813,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:552
+#: lxc/remote.go:621
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -849,16 +849,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2696
+#: lxc/storage_volume.go:2702
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2773
+#: lxc/export.go:192 lxc/storage_volume.go:2779
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:654 lxc/storage_volume.go:1521
+#: lxc/info.go:654 lxc/storage_volume.go:1527
 msgid "Backups:"
 msgstr ""
 
@@ -879,7 +879,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:679
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:685
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -922,7 +922,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1733
+#: lxc/storage_volume.go:1739
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -991,7 +991,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:894
+#: lxc/remote.go:961
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1007,7 +1007,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1749 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1024,12 +1024,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:486
+#: lxc/storage_volume.go:492
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:440
+#: lxc/storage_volume.go:446
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1057,11 +1057,11 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:509
 msgid "Certificate fingerprint"
 msgstr ""
 
-#: lxc/remote.go:219
+#: lxc/remote.go:231
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
@@ -1076,7 +1076,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:620
+#: lxc/remote.go:687
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1150,13 +1150,13 @@ msgstr ""
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
 #: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
-#: lxc/storage_volume.go:612 lxc/storage_volume.go:717
-#: lxc/storage_volume.go:1005 lxc/storage_volume.go:1231
-#: lxc/storage_volume.go:1360 lxc/storage_volume.go:1848
-#: lxc/storage_volume.go:1940 lxc/storage_volume.go:2079
-#: lxc/storage_volume.go:2239 lxc/storage_volume.go:2355
-#: lxc/storage_volume.go:2416 lxc/storage_volume.go:2543
-#: lxc/storage_volume.go:2631 lxc/storage_volume.go:2795
+#: lxc/storage_volume.go:618 lxc/storage_volume.go:723
+#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1237
+#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1854
+#: lxc/storage_volume.go:1946 lxc/storage_volume.go:2085
+#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2361
+#: lxc/storage_volume.go:2422 lxc/storage_volume.go:2549
+#: lxc/storage_volume.go:2637 lxc/storage_volume.go:2801
 msgid "Cluster member name"
 msgstr ""
 
@@ -1172,7 +1172,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1589
+#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1595
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1216,17 +1216,17 @@ msgstr ""
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1150
-#: lxc/storage_volume.go:1182
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
+#: lxc/storage_volume.go:1188
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:613
+#: lxc/storage_volume.go:619
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1467
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1310,7 +1310,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:508
+#: lxc/storage_volume.go:514
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1324,12 +1324,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:490
+#: lxc/remote.go:559
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:225 lxc/remote.go:474
+#: lxc/remote.go:237 lxc/remote.go:543
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1368,7 +1368,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:485
+#: lxc/remote.go:554
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1437,7 +1437,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:604 lxc/storage_volume.go:605
+#: lxc/storage_volume.go:610 lxc/storage_volume.go:611
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1489,7 +1489,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1475
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1481
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1524,7 +1524,7 @@ msgstr ""
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1732
+#: lxc/storage_volume.go:1738
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1544,7 +1544,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2630
+#: lxc/storage_volume.go:2636
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1640,7 +1640,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:713 lxc/storage_volume.go:714
+#: lxc/storage_volume.go:719 lxc/storage_volume.go:720
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1732,9 +1732,9 @@ msgstr ""
 #: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
 #: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
 #: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:648
-#: lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853 lxc/remote.go:917
-#: lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:715
+#: lxc/remote.go:753 lxc/remote.go:839 lxc/remote.go:920 lxc/remote.go:984
+#: lxc/remote.go:1032 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1746,26 +1746,26 @@ msgstr ""
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
 #: lxc/storage_volume.go:169 lxc/storage_volume.go:283
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:605
-#: lxc/storage_volume.go:714 lxc/storage_volume.go:801
-#: lxc/storage_volume.go:899 lxc/storage_volume.go:996
-#: lxc/storage_volume.go:1217 lxc/storage_volume.go:1348
-#: lxc/storage_volume.go:1507 lxc/storage_volume.go:1591
-#: lxc/storage_volume.go:1844 lxc/storage_volume.go:1937
-#: lxc/storage_volume.go:2064 lxc/storage_volume.go:2222
-#: lxc/storage_volume.go:2343 lxc/storage_volume.go:2405
-#: lxc/storage_volume.go:2541 lxc/storage_volume.go:2624
-#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:611
+#: lxc/storage_volume.go:720 lxc/storage_volume.go:807
+#: lxc/storage_volume.go:905 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:1223 lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1513 lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1850 lxc/storage_volume.go:1943
+#: lxc/storage_volume.go:2070 lxc/storage_volume.go:2228
+#: lxc/storage_volume.go:2349 lxc/storage_volume.go:2411
+#: lxc/storage_volume.go:2547 lxc/storage_volume.go:2630
+#: lxc/storage_volume.go:2796 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1448
+#: lxc/storage_volume.go:1454
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:1849
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:1855
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1777,11 +1777,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:800 lxc/storage_volume.go:801
+#: lxc/storage_volume.go:806 lxc/storage_volume.go:807
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:898 lxc/storage_volume.go:899
+#: lxc/storage_volume.go:904 lxc/storage_volume.go:905
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -2007,7 +2007,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:995 lxc/storage_volume.go:996
+#: lxc/storage_volume.go:1001 lxc/storage_volume.go:1002
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2015,7 +2015,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1766
+#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1772
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2072,7 +2072,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2193
+#: lxc/storage_volume.go:2161 lxc/storage_volume.go:2199
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2086,8 +2086,8 @@ msgstr ""
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2149
-#: lxc/storage_volume.go:2187
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2155
+#: lxc/storage_volume.go:2193
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2129,8 +2129,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1508
-#: lxc/storage_volume.go:1558
+#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1514
+#: lxc/storage_volume.go:1564
 msgid "Expires at"
 msgstr ""
 
@@ -2154,7 +2154,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2623 lxc/storage_volume.go:2624
+#: lxc/storage_volume.go:2629 lxc/storage_volume.go:2630
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2166,11 +2166,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2627
+#: lxc/storage_volume.go:2633
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2756
+#: lxc/export.go:152 lxc/storage_volume.go:2762
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2287,11 +2287,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:191
+#: lxc/remote.go:203
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:242
+#: lxc/remote.go:254
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2301,7 +2301,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:232
+#: lxc/remote.go:244
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2311,12 +2311,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:260
+#: lxc/remote.go:486
 #, c-format
-msgid "Failed to create certificate: %w"
+msgid "Failed to decode trust token: %w"
 msgstr ""
 
-#: lxc/remote.go:267
+#: lxc/remote.go:292
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2341,7 +2341,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:237
+#: lxc/remote.go:249
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2428,9 +2428,9 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:690 lxc/storage.go:657
+#: lxc/project.go:919 lxc/remote.go:757 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1608 lxc/warning.go:94
+#: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2466,7 +2466,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:754
+#: lxc/remote.go:821
 msgid "GLOBAL"
 msgstr ""
 
@@ -2486,7 +2486,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:160 lxc/remote.go:401
+#: lxc/remote.go:165 lxc/remote.go:443
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2554,7 +2554,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1238
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2618,11 +2618,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1216 lxc/storage_volume.go:1217
+#: lxc/storage_volume.go:1222 lxc/storage_volume.go:1223
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:469
+#: lxc/storage_volume.go:475
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2746,7 +2746,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2415
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2421
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2760,7 +2760,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2414
+#: lxc/storage_volume.go:2420
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2810,7 +2810,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2790
+#: lxc/storage_volume.go:2796
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2818,7 +2818,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2789
+#: lxc/storage_volume.go:2795
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2840,11 +2840,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2797
+#: lxc/storage_volume.go:2803
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2871
+#: lxc/storage_volume.go:2877
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2910,7 +2910,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:353
+#: lxc/remote.go:395
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2970,7 +2970,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2000
+#: lxc/move.go:148 lxc/storage_volume.go:2006
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2978,7 +2978,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1996
+#: lxc/storage_volume.go:2002
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2991,14 +2991,14 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:342
+#: lxc/remote.go:384
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1064 lxc/storage_volume.go:1281
-#: lxc/storage_volume.go:1405 lxc/storage_volume.go:1985
-#: lxc/storage_volume.go:2132 lxc/storage_volume.go:2284
+#: lxc/storage_volume.go:1070 lxc/storage_volume.go:1287
+#: lxc/storage_volume.go:1411 lxc/storage_volume.go:1991
+#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2290
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3044,7 +3044,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1739 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1745 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3347,11 +3347,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1586
+#: lxc/storage_volume.go:1592
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1597
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3371,7 +3371,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:685 lxc/remote.go:686
+#: lxc/remote.go:752 lxc/remote.go:753
 msgid "List the available remotes"
 msgstr ""
 
@@ -3410,7 +3410,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1464
+#: lxc/info.go:489 lxc/storage_volume.go:1470
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3874,12 +3874,12 @@ msgstr ""
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:323 lxc/storage_volume.go:643
-#: lxc/storage_volume.go:750 lxc/storage_volume.go:841
-#: lxc/storage_volume.go:939 lxc/storage_volume.go:1053
-#: lxc/storage_volume.go:1270 lxc/storage_volume.go:1974
-#: lxc/storage_volume.go:2115 lxc/storage_volume.go:2273
-#: lxc/storage_volume.go:2464 lxc/storage_volume.go:2581
+#: lxc/storage_volume.go:323 lxc/storage_volume.go:649
+#: lxc/storage_volume.go:756 lxc/storage_volume.go:847
+#: lxc/storage_volume.go:945 lxc/storage_volume.go:1059
+#: lxc/storage_volume.go:1276 lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:2121 lxc/storage_volume.go:2279
+#: lxc/storage_volume.go:2470 lxc/storage_volume.go:2587
 msgid "Missing pool name"
 msgstr ""
 
@@ -3898,11 +3898,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:432 lxc/storage_volume.go:1884
+#: lxc/storage_volume.go:438 lxc/storage_volume.go:1890
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1394
+#: lxc/storage_volume.go:1400
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -3939,8 +3939,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:861
-#: lxc/storage_volume.go:958
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:867
+#: lxc/storage_volume.go:964
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -3977,7 +3977,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1843 lxc/storage_volume.go:1844
+#: lxc/storage_volume.go:1849 lxc/storage_volume.go:1850
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -3985,11 +3985,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1850
+#: lxc/storage_volume.go:1856
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:512
+#: lxc/storage_volume.go:518
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4015,8 +4015,8 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
-#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1731
+#: lxc/remote.go:815 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
 msgstr ""
 
@@ -4042,7 +4042,7 @@ msgstr ""
 
 #: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
+#: lxc/project.go:550 lxc/remote.go:775 lxc/remote.go:780 lxc/remote.go:785
 msgid "NO"
 msgstr ""
 
@@ -4064,8 +4064,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1506
-#: lxc/storage_volume.go:1556
+#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1512
+#: lxc/storage_volume.go:1562
 msgid "Name"
 msgstr ""
 
@@ -4073,7 +4073,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1446
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1452
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4217,7 +4217,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:870 lxc/storage_volume.go:967
+#: lxc/storage_volume.go:876 lxc/storage_volume.go:973
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4233,11 +4233,11 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/storage_volume.go:446 lxc/storage_volume.go:1893
+#: lxc/storage_volume.go:452 lxc/storage_volume.go:1899
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:496 lxc/storage_volume.go:1904
+#: lxc/storage_volume.go:502 lxc/storage_volume.go:1910
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4251,7 +4251,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2012
+#: lxc/storage_volume.go:2018
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4263,15 +4263,15 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2678
+#: lxc/storage_volume.go:2684
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2477
+#: lxc/storage_volume.go:2483
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:336
+#: lxc/remote.go:378
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4279,7 +4279,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1412
+#: lxc/storage_volume.go:1418
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4292,7 +4292,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:693 lxc/storage_volume.go:1560
+#: lxc/info.go:693 lxc/storage_volume.go:1566
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4322,7 +4322,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1756
 msgid "POOL"
 msgstr ""
 
@@ -4338,15 +4338,15 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:213
+#: lxc/list.go:567 lxc/storage_volume.go:1762 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:817
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:752
+#: lxc/image.go:1136 lxc/remote.go:819
 msgid "PUBLIC"
 msgstr ""
 
@@ -4375,7 +4375,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:183
+#: lxc/remote.go:195
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4387,8 +4387,8 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:466
-msgid "Please type 'y', 'n' or the fingerprint:"
+#: lxc/remote.go:536
+msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
 #: lxc/info.go:221
@@ -4412,8 +4412,8 @@ msgstr ""
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1151
-#: lxc/storage_volume.go:1183
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
+#: lxc/storage_volume.go:1189
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4530,7 +4530,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1350
+#: lxc/storage_volume.go:1356
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4544,7 +4544,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1219
+#: lxc/storage_volume.go:1225
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4560,7 +4560,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2224
+#: lxc/storage_volume.go:2230
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4581,7 +4581,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:998
+#: lxc/storage_volume.go:1004
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4590,7 +4590,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2069
+#: lxc/storage_volume.go:2075
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4603,7 +4603,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2345
+#: lxc/storage_volume.go:2351
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4707,33 +4707,33 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:810
+#: lxc/remote.go:877
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
-#: lxc/remote.go:994
+#: lxc/project.go:884 lxc/remote.go:868 lxc/remote.go:949 lxc/remote.go:1013
+#: lxc/remote.go:1061
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:305
+#: lxc/remote.go:345
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:890
+#: lxc/remote.go:957
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:805 lxc/remote.go:886 lxc/remote.go:998
+#: lxc/remote.go:872 lxc/remote.go:953 lxc/remote.go:1065
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:294
+#: lxc/remote.go:319
 msgid "Remote address must not be empty"
 msgstr ""
 
@@ -4741,7 +4741,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:299
+#: lxc/remote.go:339
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4827,7 +4827,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:852 lxc/remote.go:853
+#: lxc/remote.go:919 lxc/remote.go:920
 msgid "Remove remotes"
 msgstr ""
 
@@ -4884,19 +4884,19 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:771 lxc/remote.go:772
+#: lxc/remote.go:838 lxc/remote.go:839
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:1943
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1936
+#: lxc/storage_volume.go:1942
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2025 lxc/storage_volume.go:2045
+#: lxc/storage_volume.go:2031 lxc/storage_volume.go:2051
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4948,7 +4948,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2540 lxc/storage_volume.go:2541
+#: lxc/storage_volume.go:2546 lxc/storage_volume.go:2547
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5029,7 +5029,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:820
 msgid "STATIC"
 msgstr ""
 
@@ -5070,11 +5070,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:464
+#: lxc/remote.go:532
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:616
+#: lxc/remote.go:285 lxc/remote.go:683
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5272,11 +5272,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2063
+#: lxc/storage_volume.go:2069
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2064
+#: lxc/storage_volume.go:2070
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5285,7 +5285,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:964 lxc/remote.go:965
+#: lxc/remote.go:1031 lxc/remote.go:1032
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5361,7 +5361,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2080
+#: lxc/storage_volume.go:2086
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5510,11 +5510,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2221 lxc/storage_volume.go:2222
+#: lxc/storage_volume.go:2227 lxc/storage_volume.go:2228
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1347 lxc/storage_volume.go:1348
+#: lxc/storage_volume.go:1353 lxc/storage_volume.go:1354
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5528,7 +5528,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:647 lxc/remote.go:648
+#: lxc/remote.go:714 lxc/remote.go:715
 msgid "Show the default remote"
 msgstr ""
 
@@ -5582,15 +5582,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2404 lxc/storage_volume.go:2405
+#: lxc/storage_volume.go:2410 lxc/storage_volume.go:2411
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2167
+#: lxc/storage_volume.go:2173
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:607 lxc/storage_volume.go:1485
+#: lxc/info.go:607 lxc/storage_volume.go:1491
 msgid "Snapshots:"
 msgstr ""
 
@@ -5691,21 +5691,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:696
+#: lxc/storage_volume.go:702
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:784
+#: lxc/storage_volume.go:790
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:509
+#: lxc/storage_volume.go:515
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:513
+#: lxc/storage_volume.go:519
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5740,7 +5740,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:916 lxc/remote.go:917
+#: lxc/remote.go:983 lxc/remote.go:984
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5759,11 +5759,11 @@ msgstr ""
 #: lxc/auth.go:818 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
-#: lxc/storage_volume.go:1730 lxc/warning.go:216
+#: lxc/storage_volume.go:1736 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1557
+#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1563
 msgid "Taken at"
 msgstr ""
 
@@ -5773,6 +5773,12 @@ msgstr ""
 
 #: lxc/file.go:1256
 msgid "Target path must be a directory"
+msgstr ""
+
+#: lxc/remote.go:161 lxc/remote.go:334
+msgid ""
+"The --accept-certificate flag is not supported when adding a remote using a "
+"trust token"
 msgstr ""
 
 #: lxc/move.go:181
@@ -5914,15 +5920,20 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1323
+#: lxc/storage_volume.go:1329
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1300
+#: lxc/storage_volume.go:1306
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
+msgstr ""
+
+#: lxc/remote.go:527
+msgid ""
+"The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
 
 #: lxc/info.go:354
@@ -5933,8 +5944,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:875
-#: lxc/storage_volume.go:972
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:881
+#: lxc/storage_volume.go:978
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6009,7 +6020,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1470
+#: lxc/storage_volume.go:1476
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6024,7 +6035,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1847
+#: lxc/storage_volume.go:1853
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6058,7 +6069,15 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:571
+#: lxc/remote.go:329
+msgid "Trust token cannot be used for public remotes"
+msgstr ""
+
+#: lxc/remote.go:324
+msgid "Trust token cannot be used with OIDC authentication"
+msgstr ""
+
+#: lxc/remote.go:639
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6083,7 +6102,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1455
+#: lxc/storage_volume.go:1461
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6101,17 +6120,17 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:193 lxc/remote.go:749
+#: lxc/cluster.go:193 lxc/remote.go:816
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1735
+#: lxc/project.go:995 lxc/storage_volume.go:1741
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1734
+#: lxc/storage.go:724 lxc/storage_volume.go:1740
 msgid "USED BY"
 msgstr ""
 
@@ -6129,7 +6148,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:214 lxc/remote.go:248
+#: lxc/remote.go:226 lxc/remote.go:260
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6143,7 +6162,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1772
+#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1778
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6249,7 +6268,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2342 lxc/storage_volume.go:2343
+#: lxc/storage_volume.go:2348 lxc/storage_volume.go:2349
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6301,7 +6320,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2356
+#: lxc/storage_volume.go:2362
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6345,12 +6364,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1468
+#: lxc/storage_volume.go:1474
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2629
+#: lxc/export.go:42 lxc/storage_volume.go:2635
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6417,7 +6436,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1559
+#: lxc/storage_volume.go:1565
 msgid "Volume Only"
 msgstr ""
 
@@ -6452,7 +6471,7 @@ msgstr ""
 
 #: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
+#: lxc/project.go:552 lxc/remote.go:777 lxc/remote.go:782 lxc/remote.go:787
 msgid "YES"
 msgstr ""
 
@@ -6476,7 +6495,7 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:897
+#: lxc/storage_volume.go:903
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
@@ -6898,7 +6917,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2788
+#: lxc/storage_volume.go:2794
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -6933,13 +6952,13 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:1941
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:799
+#: lxc/storage_volume.go:805
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
@@ -6947,47 +6966,47 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2539
+#: lxc/storage_volume.go:2545
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2622
+#: lxc/storage_volume.go:2628
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2403
+#: lxc/storage_volume.go:2409
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:603
+#: lxc/storage_volume.go:609
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:711
+#: lxc/storage_volume.go:717
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:994 lxc/storage_volume.go:1346
+#: lxc/storage_volume.go:1000 lxc/storage_volume.go:1352
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2341
+#: lxc/storage_volume.go:2347
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2062
+#: lxc/storage_volume.go:2068
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2220
+#: lxc/storage_volume.go:2226
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1215
+#: lxc/storage_volume.go:1221
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1841
+#: lxc/storage_volume.go:1847
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7097,7 +7116,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1584
+#: lxc/storage_volume.go:1590
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7109,7 +7128,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:739
+#: lxc/project.go:557 lxc/remote.go:806
 msgid "current"
 msgstr ""
 
@@ -7569,7 +7588,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:607
+#: lxc/storage_volume.go:613
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7577,13 +7596,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2792
+#: lxc/storage_volume.go:2798
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2407
+#: lxc/storage_volume.go:2413
 msgid ""
 "lxc storage volume snapshot create default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7593,7 +7612,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:531
 msgid "n"
 msgstr ""
 
@@ -7605,7 +7624,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:510
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7642,7 +7661,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:465
+#: lxc/remote.go:519
 msgid "y"
 msgstr ""
 

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-08 07:43+0100\n"
+"POT-Creation-Date: 2024-10-14 13:30+0000\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/linux-containers/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1024
+#: lxc/storage_volume.go:1030
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -515,15 +515,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:850 lxc/remote.go:915
+#: lxc/remote.go:917 lxc/remote.go:982
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:963
+#: lxc/remote.go:1030
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:769
+#: lxc/remote.go:836
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -556,7 +556,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:751
+#: lxc/remote.go:818
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:581
+#: lxc/remote.go:648
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -738,11 +738,11 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1590
+#: lxc/storage_volume.go:1596
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:182
+#: lxc/remote.go:194
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -813,7 +813,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:552
+#: lxc/remote.go:621
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -849,16 +849,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2696
+#: lxc/storage_volume.go:2702
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2773
+#: lxc/export.go:192 lxc/storage_volume.go:2779
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:654 lxc/storage_volume.go:1521
+#: lxc/info.go:654 lxc/storage_volume.go:1527
 msgid "Backups:"
 msgstr ""
 
@@ -879,7 +879,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:679
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:685
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -922,7 +922,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1733
+#: lxc/storage_volume.go:1739
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -991,7 +991,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:894
+#: lxc/remote.go:961
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1007,7 +1007,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1749 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1024,12 +1024,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:486
+#: lxc/storage_volume.go:492
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:440
+#: lxc/storage_volume.go:446
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1057,11 +1057,11 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:509
 msgid "Certificate fingerprint"
 msgstr ""
 
-#: lxc/remote.go:219
+#: lxc/remote.go:231
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
@@ -1076,7 +1076,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:620
+#: lxc/remote.go:687
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1150,13 +1150,13 @@ msgstr ""
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
 #: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
-#: lxc/storage_volume.go:612 lxc/storage_volume.go:717
-#: lxc/storage_volume.go:1005 lxc/storage_volume.go:1231
-#: lxc/storage_volume.go:1360 lxc/storage_volume.go:1848
-#: lxc/storage_volume.go:1940 lxc/storage_volume.go:2079
-#: lxc/storage_volume.go:2239 lxc/storage_volume.go:2355
-#: lxc/storage_volume.go:2416 lxc/storage_volume.go:2543
-#: lxc/storage_volume.go:2631 lxc/storage_volume.go:2795
+#: lxc/storage_volume.go:618 lxc/storage_volume.go:723
+#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1237
+#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1854
+#: lxc/storage_volume.go:1946 lxc/storage_volume.go:2085
+#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2361
+#: lxc/storage_volume.go:2422 lxc/storage_volume.go:2549
+#: lxc/storage_volume.go:2637 lxc/storage_volume.go:2801
 msgid "Cluster member name"
 msgstr ""
 
@@ -1172,7 +1172,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1589
+#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1595
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1216,17 +1216,17 @@ msgstr ""
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1150
-#: lxc/storage_volume.go:1182
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
+#: lxc/storage_volume.go:1188
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:613
+#: lxc/storage_volume.go:619
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1467
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1310,7 +1310,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:508
+#: lxc/storage_volume.go:514
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1324,12 +1324,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:490
+#: lxc/remote.go:559
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:225 lxc/remote.go:474
+#: lxc/remote.go:237 lxc/remote.go:543
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1368,7 +1368,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:485
+#: lxc/remote.go:554
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1437,7 +1437,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:604 lxc/storage_volume.go:605
+#: lxc/storage_volume.go:610 lxc/storage_volume.go:611
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1489,7 +1489,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1475
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1481
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1524,7 +1524,7 @@ msgstr ""
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1732
+#: lxc/storage_volume.go:1738
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1544,7 +1544,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2630
+#: lxc/storage_volume.go:2636
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1640,7 +1640,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:713 lxc/storage_volume.go:714
+#: lxc/storage_volume.go:719 lxc/storage_volume.go:720
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1732,9 +1732,9 @@ msgstr ""
 #: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
 #: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
 #: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:648
-#: lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853 lxc/remote.go:917
-#: lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:715
+#: lxc/remote.go:753 lxc/remote.go:839 lxc/remote.go:920 lxc/remote.go:984
+#: lxc/remote.go:1032 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1746,26 +1746,26 @@ msgstr ""
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
 #: lxc/storage_volume.go:169 lxc/storage_volume.go:283
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:605
-#: lxc/storage_volume.go:714 lxc/storage_volume.go:801
-#: lxc/storage_volume.go:899 lxc/storage_volume.go:996
-#: lxc/storage_volume.go:1217 lxc/storage_volume.go:1348
-#: lxc/storage_volume.go:1507 lxc/storage_volume.go:1591
-#: lxc/storage_volume.go:1844 lxc/storage_volume.go:1937
-#: lxc/storage_volume.go:2064 lxc/storage_volume.go:2222
-#: lxc/storage_volume.go:2343 lxc/storage_volume.go:2405
-#: lxc/storage_volume.go:2541 lxc/storage_volume.go:2624
-#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:611
+#: lxc/storage_volume.go:720 lxc/storage_volume.go:807
+#: lxc/storage_volume.go:905 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:1223 lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1513 lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1850 lxc/storage_volume.go:1943
+#: lxc/storage_volume.go:2070 lxc/storage_volume.go:2228
+#: lxc/storage_volume.go:2349 lxc/storage_volume.go:2411
+#: lxc/storage_volume.go:2547 lxc/storage_volume.go:2630
+#: lxc/storage_volume.go:2796 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1448
+#: lxc/storage_volume.go:1454
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:1849
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:1855
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1777,11 +1777,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:800 lxc/storage_volume.go:801
+#: lxc/storage_volume.go:806 lxc/storage_volume.go:807
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:898 lxc/storage_volume.go:899
+#: lxc/storage_volume.go:904 lxc/storage_volume.go:905
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -2007,7 +2007,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:995 lxc/storage_volume.go:996
+#: lxc/storage_volume.go:1001 lxc/storage_volume.go:1002
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2015,7 +2015,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1766
+#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1772
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2072,7 +2072,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2193
+#: lxc/storage_volume.go:2161 lxc/storage_volume.go:2199
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2086,8 +2086,8 @@ msgstr ""
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2149
-#: lxc/storage_volume.go:2187
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2155
+#: lxc/storage_volume.go:2193
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2129,8 +2129,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1508
-#: lxc/storage_volume.go:1558
+#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1514
+#: lxc/storage_volume.go:1564
 msgid "Expires at"
 msgstr ""
 
@@ -2154,7 +2154,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2623 lxc/storage_volume.go:2624
+#: lxc/storage_volume.go:2629 lxc/storage_volume.go:2630
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2166,11 +2166,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2627
+#: lxc/storage_volume.go:2633
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2756
+#: lxc/export.go:152 lxc/storage_volume.go:2762
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2287,11 +2287,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:191
+#: lxc/remote.go:203
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:242
+#: lxc/remote.go:254
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2301,7 +2301,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:232
+#: lxc/remote.go:244
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2311,12 +2311,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:260
+#: lxc/remote.go:486
 #, c-format
-msgid "Failed to create certificate: %w"
+msgid "Failed to decode trust token: %w"
 msgstr ""
 
-#: lxc/remote.go:267
+#: lxc/remote.go:292
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2341,7 +2341,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:237
+#: lxc/remote.go:249
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2428,9 +2428,9 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:690 lxc/storage.go:657
+#: lxc/project.go:919 lxc/remote.go:757 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1608 lxc/warning.go:94
+#: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2466,7 +2466,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:754
+#: lxc/remote.go:821
 msgid "GLOBAL"
 msgstr ""
 
@@ -2486,7 +2486,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:160 lxc/remote.go:401
+#: lxc/remote.go:165 lxc/remote.go:443
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2554,7 +2554,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1238
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2618,11 +2618,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1216 lxc/storage_volume.go:1217
+#: lxc/storage_volume.go:1222 lxc/storage_volume.go:1223
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:469
+#: lxc/storage_volume.go:475
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2746,7 +2746,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2415
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2421
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2760,7 +2760,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2414
+#: lxc/storage_volume.go:2420
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2810,7 +2810,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2790
+#: lxc/storage_volume.go:2796
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2818,7 +2818,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2789
+#: lxc/storage_volume.go:2795
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2840,11 +2840,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2797
+#: lxc/storage_volume.go:2803
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2871
+#: lxc/storage_volume.go:2877
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2910,7 +2910,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:353
+#: lxc/remote.go:395
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2970,7 +2970,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2000
+#: lxc/move.go:148 lxc/storage_volume.go:2006
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2978,7 +2978,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1996
+#: lxc/storage_volume.go:2002
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2991,14 +2991,14 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:342
+#: lxc/remote.go:384
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1064 lxc/storage_volume.go:1281
-#: lxc/storage_volume.go:1405 lxc/storage_volume.go:1985
-#: lxc/storage_volume.go:2132 lxc/storage_volume.go:2284
+#: lxc/storage_volume.go:1070 lxc/storage_volume.go:1287
+#: lxc/storage_volume.go:1411 lxc/storage_volume.go:1991
+#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2290
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3044,7 +3044,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1739 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1745 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3347,11 +3347,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1586
+#: lxc/storage_volume.go:1592
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1597
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3371,7 +3371,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:685 lxc/remote.go:686
+#: lxc/remote.go:752 lxc/remote.go:753
 msgid "List the available remotes"
 msgstr ""
 
@@ -3410,7 +3410,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1464
+#: lxc/info.go:489 lxc/storage_volume.go:1470
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3874,12 +3874,12 @@ msgstr ""
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:323 lxc/storage_volume.go:643
-#: lxc/storage_volume.go:750 lxc/storage_volume.go:841
-#: lxc/storage_volume.go:939 lxc/storage_volume.go:1053
-#: lxc/storage_volume.go:1270 lxc/storage_volume.go:1974
-#: lxc/storage_volume.go:2115 lxc/storage_volume.go:2273
-#: lxc/storage_volume.go:2464 lxc/storage_volume.go:2581
+#: lxc/storage_volume.go:323 lxc/storage_volume.go:649
+#: lxc/storage_volume.go:756 lxc/storage_volume.go:847
+#: lxc/storage_volume.go:945 lxc/storage_volume.go:1059
+#: lxc/storage_volume.go:1276 lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:2121 lxc/storage_volume.go:2279
+#: lxc/storage_volume.go:2470 lxc/storage_volume.go:2587
 msgid "Missing pool name"
 msgstr ""
 
@@ -3898,11 +3898,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:432 lxc/storage_volume.go:1884
+#: lxc/storage_volume.go:438 lxc/storage_volume.go:1890
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1394
+#: lxc/storage_volume.go:1400
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -3939,8 +3939,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:861
-#: lxc/storage_volume.go:958
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:867
+#: lxc/storage_volume.go:964
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -3977,7 +3977,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1843 lxc/storage_volume.go:1844
+#: lxc/storage_volume.go:1849 lxc/storage_volume.go:1850
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -3985,11 +3985,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1850
+#: lxc/storage_volume.go:1856
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:512
+#: lxc/storage_volume.go:518
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4015,8 +4015,8 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
-#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1731
+#: lxc/remote.go:815 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
 msgstr ""
 
@@ -4042,7 +4042,7 @@ msgstr ""
 
 #: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
+#: lxc/project.go:550 lxc/remote.go:775 lxc/remote.go:780 lxc/remote.go:785
 msgid "NO"
 msgstr ""
 
@@ -4064,8 +4064,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1506
-#: lxc/storage_volume.go:1556
+#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1512
+#: lxc/storage_volume.go:1562
 msgid "Name"
 msgstr ""
 
@@ -4073,7 +4073,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1446
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1452
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4217,7 +4217,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:870 lxc/storage_volume.go:967
+#: lxc/storage_volume.go:876 lxc/storage_volume.go:973
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4233,11 +4233,11 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/storage_volume.go:446 lxc/storage_volume.go:1893
+#: lxc/storage_volume.go:452 lxc/storage_volume.go:1899
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:496 lxc/storage_volume.go:1904
+#: lxc/storage_volume.go:502 lxc/storage_volume.go:1910
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4251,7 +4251,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2012
+#: lxc/storage_volume.go:2018
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4263,15 +4263,15 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2678
+#: lxc/storage_volume.go:2684
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2477
+#: lxc/storage_volume.go:2483
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:336
+#: lxc/remote.go:378
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4279,7 +4279,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1412
+#: lxc/storage_volume.go:1418
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4292,7 +4292,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:693 lxc/storage_volume.go:1560
+#: lxc/info.go:693 lxc/storage_volume.go:1566
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4322,7 +4322,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1756
 msgid "POOL"
 msgstr ""
 
@@ -4338,15 +4338,15 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:213
+#: lxc/list.go:567 lxc/storage_volume.go:1762 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:817
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:752
+#: lxc/image.go:1136 lxc/remote.go:819
 msgid "PUBLIC"
 msgstr ""
 
@@ -4375,7 +4375,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:183
+#: lxc/remote.go:195
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4387,8 +4387,8 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:466
-msgid "Please type 'y', 'n' or the fingerprint:"
+#: lxc/remote.go:536
+msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
 #: lxc/info.go:221
@@ -4412,8 +4412,8 @@ msgstr ""
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1151
-#: lxc/storage_volume.go:1183
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
+#: lxc/storage_volume.go:1189
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4530,7 +4530,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1350
+#: lxc/storage_volume.go:1356
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4544,7 +4544,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1219
+#: lxc/storage_volume.go:1225
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4560,7 +4560,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2224
+#: lxc/storage_volume.go:2230
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4581,7 +4581,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:998
+#: lxc/storage_volume.go:1004
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4590,7 +4590,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2069
+#: lxc/storage_volume.go:2075
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4603,7 +4603,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2345
+#: lxc/storage_volume.go:2351
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4707,33 +4707,33 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:810
+#: lxc/remote.go:877
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
-#: lxc/remote.go:994
+#: lxc/project.go:884 lxc/remote.go:868 lxc/remote.go:949 lxc/remote.go:1013
+#: lxc/remote.go:1061
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:305
+#: lxc/remote.go:345
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:890
+#: lxc/remote.go:957
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:805 lxc/remote.go:886 lxc/remote.go:998
+#: lxc/remote.go:872 lxc/remote.go:953 lxc/remote.go:1065
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:294
+#: lxc/remote.go:319
 msgid "Remote address must not be empty"
 msgstr ""
 
@@ -4741,7 +4741,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:299
+#: lxc/remote.go:339
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4827,7 +4827,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:852 lxc/remote.go:853
+#: lxc/remote.go:919 lxc/remote.go:920
 msgid "Remove remotes"
 msgstr ""
 
@@ -4884,19 +4884,19 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:771 lxc/remote.go:772
+#: lxc/remote.go:838 lxc/remote.go:839
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:1943
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1936
+#: lxc/storage_volume.go:1942
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2025 lxc/storage_volume.go:2045
+#: lxc/storage_volume.go:2031 lxc/storage_volume.go:2051
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4948,7 +4948,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2540 lxc/storage_volume.go:2541
+#: lxc/storage_volume.go:2546 lxc/storage_volume.go:2547
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5029,7 +5029,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:820
 msgid "STATIC"
 msgstr ""
 
@@ -5070,11 +5070,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:464
+#: lxc/remote.go:532
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:616
+#: lxc/remote.go:285 lxc/remote.go:683
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5272,11 +5272,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2063
+#: lxc/storage_volume.go:2069
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2064
+#: lxc/storage_volume.go:2070
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5285,7 +5285,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:964 lxc/remote.go:965
+#: lxc/remote.go:1031 lxc/remote.go:1032
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5361,7 +5361,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2080
+#: lxc/storage_volume.go:2086
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5510,11 +5510,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2221 lxc/storage_volume.go:2222
+#: lxc/storage_volume.go:2227 lxc/storage_volume.go:2228
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1347 lxc/storage_volume.go:1348
+#: lxc/storage_volume.go:1353 lxc/storage_volume.go:1354
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5528,7 +5528,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:647 lxc/remote.go:648
+#: lxc/remote.go:714 lxc/remote.go:715
 msgid "Show the default remote"
 msgstr ""
 
@@ -5582,15 +5582,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2404 lxc/storage_volume.go:2405
+#: lxc/storage_volume.go:2410 lxc/storage_volume.go:2411
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2167
+#: lxc/storage_volume.go:2173
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:607 lxc/storage_volume.go:1485
+#: lxc/info.go:607 lxc/storage_volume.go:1491
 msgid "Snapshots:"
 msgstr ""
 
@@ -5691,21 +5691,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:696
+#: lxc/storage_volume.go:702
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:784
+#: lxc/storage_volume.go:790
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:509
+#: lxc/storage_volume.go:515
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:513
+#: lxc/storage_volume.go:519
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5740,7 +5740,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:916 lxc/remote.go:917
+#: lxc/remote.go:983 lxc/remote.go:984
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5759,11 +5759,11 @@ msgstr ""
 #: lxc/auth.go:818 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
-#: lxc/storage_volume.go:1730 lxc/warning.go:216
+#: lxc/storage_volume.go:1736 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1557
+#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1563
 msgid "Taken at"
 msgstr ""
 
@@ -5773,6 +5773,12 @@ msgstr ""
 
 #: lxc/file.go:1256
 msgid "Target path must be a directory"
+msgstr ""
+
+#: lxc/remote.go:161 lxc/remote.go:334
+msgid ""
+"The --accept-certificate flag is not supported when adding a remote using a "
+"trust token"
 msgstr ""
 
 #: lxc/move.go:181
@@ -5914,15 +5920,20 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1323
+#: lxc/storage_volume.go:1329
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1300
+#: lxc/storage_volume.go:1306
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
+msgstr ""
+
+#: lxc/remote.go:527
+msgid ""
+"The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
 
 #: lxc/info.go:354
@@ -5933,8 +5944,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:875
-#: lxc/storage_volume.go:972
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:881
+#: lxc/storage_volume.go:978
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6009,7 +6020,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1470
+#: lxc/storage_volume.go:1476
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6024,7 +6035,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1847
+#: lxc/storage_volume.go:1853
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6058,7 +6069,15 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:571
+#: lxc/remote.go:329
+msgid "Trust token cannot be used for public remotes"
+msgstr ""
+
+#: lxc/remote.go:324
+msgid "Trust token cannot be used with OIDC authentication"
+msgstr ""
+
+#: lxc/remote.go:639
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6083,7 +6102,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1455
+#: lxc/storage_volume.go:1461
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6101,17 +6120,17 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:193 lxc/remote.go:749
+#: lxc/cluster.go:193 lxc/remote.go:816
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1735
+#: lxc/project.go:995 lxc/storage_volume.go:1741
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1734
+#: lxc/storage.go:724 lxc/storage_volume.go:1740
 msgid "USED BY"
 msgstr ""
 
@@ -6129,7 +6148,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:214 lxc/remote.go:248
+#: lxc/remote.go:226 lxc/remote.go:260
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6143,7 +6162,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1772
+#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1778
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6249,7 +6268,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2342 lxc/storage_volume.go:2343
+#: lxc/storage_volume.go:2348 lxc/storage_volume.go:2349
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6301,7 +6320,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2356
+#: lxc/storage_volume.go:2362
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6345,12 +6364,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1468
+#: lxc/storage_volume.go:1474
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2629
+#: lxc/export.go:42 lxc/storage_volume.go:2635
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6417,7 +6436,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1559
+#: lxc/storage_volume.go:1565
 msgid "Volume Only"
 msgstr ""
 
@@ -6452,7 +6471,7 @@ msgstr ""
 
 #: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
+#: lxc/project.go:552 lxc/remote.go:777 lxc/remote.go:782 lxc/remote.go:787
 msgid "YES"
 msgstr ""
 
@@ -6476,7 +6495,7 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:897
+#: lxc/storage_volume.go:903
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
@@ -6898,7 +6917,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2788
+#: lxc/storage_volume.go:2794
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -6933,13 +6952,13 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:1941
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:799
+#: lxc/storage_volume.go:805
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
@@ -6947,47 +6966,47 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2539
+#: lxc/storage_volume.go:2545
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2622
+#: lxc/storage_volume.go:2628
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2403
+#: lxc/storage_volume.go:2409
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:603
+#: lxc/storage_volume.go:609
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:711
+#: lxc/storage_volume.go:717
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:994 lxc/storage_volume.go:1346
+#: lxc/storage_volume.go:1000 lxc/storage_volume.go:1352
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2341
+#: lxc/storage_volume.go:2347
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2062
+#: lxc/storage_volume.go:2068
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2220
+#: lxc/storage_volume.go:2226
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1215
+#: lxc/storage_volume.go:1221
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1841
+#: lxc/storage_volume.go:1847
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7097,7 +7116,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1584
+#: lxc/storage_volume.go:1590
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7109,7 +7128,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:739
+#: lxc/project.go:557 lxc/remote.go:806
 msgid "current"
 msgstr ""
 
@@ -7569,7 +7588,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:607
+#: lxc/storage_volume.go:613
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7577,13 +7596,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2792
+#: lxc/storage_volume.go:2798
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2407
+#: lxc/storage_volume.go:2413
 msgid ""
 "lxc storage volume snapshot create default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7593,7 +7612,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:531
 msgid "n"
 msgstr ""
 
@@ -7605,7 +7624,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:510
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7642,7 +7661,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:465
+#: lxc/remote.go:519
 msgid "y"
 msgstr ""
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-08 07:43+0100\n"
+"POT-Creation-Date: 2024-10-14 13:30+0000\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Wivik <seb+weblate@zedas.fr>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/linux-containers/"
@@ -75,7 +75,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/storage_volume.go:1024
+#: lxc/storage_volume.go:1030
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -764,17 +764,17 @@ msgstr "Cible invalide %s"
 msgid "<old alias> <new alias>"
 msgstr "<ancien alias> <nouvel alias>"
 
-#: lxc/remote.go:850 lxc/remote.go:915
+#: lxc/remote.go:917 lxc/remote.go:982
 #, fuzzy
 msgid "<remote>"
 msgstr "Serveur distant : %s"
 
-#: lxc/remote.go:963
+#: lxc/remote.go:1030
 #, fuzzy
 msgid "<remote> <URL>"
 msgstr "Serveur distant : %s"
 
-#: lxc/remote.go:769
+#: lxc/remote.go:836
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -817,7 +817,7 @@ msgstr "ALIAS"
 msgid "ARCHITECTURE"
 msgstr "ARCHITECTURE"
 
-#: lxc/remote.go:751
+#: lxc/remote.go:818
 #, fuzzy
 msgid "AUTH TYPE"
 msgstr "TYPE"
@@ -984,7 +984,7 @@ msgstr "Expire : %s"
 msgid "Admin access key: %s"
 msgstr "Expire : %s"
 
-#: lxc/remote.go:581
+#: lxc/remote.go:648
 #, fuzzy, c-format
 msgid "Admin password (or token) for %s:"
 msgstr "Mot de passe administrateur pour %s : "
@@ -1017,12 +1017,12 @@ msgstr "le serveur distant %s existe déjà"
 msgid "Aliases:"
 msgstr "Alias :"
 
-#: lxc/storage_volume.go:1590
+#: lxc/storage_volume.go:1596
 #, fuzzy
 msgid "All projects"
 msgstr "Rendre l'image publique"
 
-#: lxc/remote.go:182
+#: lxc/remote.go:194
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -1099,7 +1099,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:552
+#: lxc/remote.go:621
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr "Le type d'authentification '%s' n'est pas supporté par le serveur"
@@ -1136,17 +1136,17 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
 
-#: lxc/storage_volume.go:2696
+#: lxc/storage_volume.go:2702
 #, fuzzy, c-format
 msgid "Backing up storage volume: %s"
 msgstr "Copie de l'image : %s"
 
-#: lxc/export.go:192 lxc/storage_volume.go:2773
+#: lxc/export.go:192 lxc/storage_volume.go:2779
 #, fuzzy
 msgid "Backup exported successfully!"
 msgstr "Image copiée avec succès !"
 
-#: lxc/info.go:654 lxc/storage_volume.go:1521
+#: lxc/info.go:654 lxc/storage_volume.go:1527
 msgid "Backups:"
 msgstr ""
 
@@ -1167,7 +1167,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr "Clé de configuration invalide"
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:679
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:685
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -1210,7 +1210,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr "COMMON NAME"
 
-#: lxc/storage_volume.go:1733
+#: lxc/storage_volume.go:1739
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1282,7 +1282,7 @@ msgstr "impossible de récupérer un répertoire sans --recursive"
 msgid "Can't read from stdin: %w"
 msgstr "Impossible de lire depuis stdin : %s"
 
-#: lxc/remote.go:894
+#: lxc/remote.go:961
 #, fuzzy
 msgid "Can't remove the default remote"
 msgstr "impossible de supprimer le serveur distant par défaut"
@@ -1299,7 +1299,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1749 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1318,12 +1318,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:486
+#: lxc/storage_volume.go:492
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:440
+#: lxc/storage_volume.go:446
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1351,12 +1351,12 @@ msgstr "Créé : %s"
 msgid "Certificate add token for %s deleted"
 msgstr "Le réseau %s a été supprimé"
 
-#: lxc/remote.go:455
+#: lxc/remote.go:509
 #, fuzzy
 msgid "Certificate fingerprint"
 msgstr "Empreinte du certificat : %s"
 
-#: lxc/remote.go:219
+#: lxc/remote.go:231
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
@@ -1371,7 +1371,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/remote.go:620
+#: lxc/remote.go:687
 #, fuzzy
 msgid "Client certificate now trusted by server:"
 msgstr "Certificat client enregistré sur le serveur : "
@@ -1446,13 +1446,13 @@ msgstr "Périphérique %s retiré de %s"
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
 #: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
-#: lxc/storage_volume.go:612 lxc/storage_volume.go:717
-#: lxc/storage_volume.go:1005 lxc/storage_volume.go:1231
-#: lxc/storage_volume.go:1360 lxc/storage_volume.go:1848
-#: lxc/storage_volume.go:1940 lxc/storage_volume.go:2079
-#: lxc/storage_volume.go:2239 lxc/storage_volume.go:2355
-#: lxc/storage_volume.go:2416 lxc/storage_volume.go:2543
-#: lxc/storage_volume.go:2631 lxc/storage_volume.go:2795
+#: lxc/storage_volume.go:618 lxc/storage_volume.go:723
+#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1237
+#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1854
+#: lxc/storage_volume.go:1946 lxc/storage_volume.go:2085
+#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2361
+#: lxc/storage_volume.go:2422 lxc/storage_volume.go:2549
+#: lxc/storage_volume.go:2637 lxc/storage_volume.go:2801
 msgid "Cluster member name"
 msgstr ""
 
@@ -1468,7 +1468,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1589
+#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1595
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr "Colonnes"
@@ -1523,17 +1523,17 @@ msgstr "Clé/valeur de configuration à appliquer au nouveau conteneur"
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1150
-#: lxc/storage_volume.go:1182
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
+#: lxc/storage_volume.go:1188
 #, c-format
 msgid "Config parsing error: %s"
 msgstr "Erreur lors de la lecture de la configuration : %s"
 
-#: lxc/storage_volume.go:613
+#: lxc/storage_volume.go:619
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1467
 #, fuzzy, c-format
 msgid "Content type: %s"
 msgstr "État : %s"
@@ -1622,7 +1622,7 @@ msgstr "Copie de l'image : %s"
 msgid "Copying the image: %s"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:508
+#: lxc/storage_volume.go:514
 #, fuzzy, c-format
 msgid "Copying the storage volume: %s"
 msgstr "Copie de l'image : %s"
@@ -1637,12 +1637,12 @@ msgstr "erreur : %v"
 msgid "Cores:"
 msgstr "erreur : %v"
 
-#: lxc/remote.go:490
+#: lxc/remote.go:559
 #, fuzzy, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "Impossible de créer le dossier de stockage des certificats serveurs"
 
-#: lxc/remote.go:225 lxc/remote.go:474
+#: lxc/remote.go:237 lxc/remote.go:543
 msgid "Could not create server cert dir"
 msgstr "Impossible de créer le dossier de stockage des certificats serveurs"
 
@@ -1681,7 +1681,7 @@ msgstr "Impossible d'assainir le chemin %s"
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:485
+#: lxc/remote.go:554
 #, fuzzy, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "Impossible de créer le dossier de stockage des certificats serveurs"
@@ -1776,7 +1776,7 @@ msgstr "Copie de l'image : %s"
 msgid "Create new custom storage buckets"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:604 lxc/storage_volume.go:605
+#: lxc/storage_volume.go:610 lxc/storage_volume.go:611
 #, fuzzy
 msgid "Create new custom storage volumes"
 msgstr "Copie de l'image : %s"
@@ -1839,7 +1839,7 @@ msgstr "Copie de l'image : %s"
 msgid "Create the instance with no profiles applied"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1475
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1481
 #, c-format
 msgid "Created: %s"
 msgstr "Créé : %s"
@@ -1875,7 +1875,7 @@ msgstr ""
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1732
+#: lxc/storage_volume.go:1738
 msgid "DESCRIPTION"
 msgstr "DESCRIPTION"
 
@@ -1895,7 +1895,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2630
+#: lxc/storage_volume.go:2636
 #, fuzzy
 msgid "Define a compression algorithm: for backup or none"
 msgstr "Définir un algorithme de compression : pour image ou aucun"
@@ -2006,7 +2006,7 @@ msgstr "Copie de l'image : %s"
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:713 lxc/storage_volume.go:714
+#: lxc/storage_volume.go:719 lxc/storage_volume.go:720
 #, fuzzy
 msgid "Delete storage volumes"
 msgstr "Copie de l'image : %s"
@@ -2100,9 +2100,9 @@ msgstr "Récupération de l'image : %s"
 #: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
 #: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
 #: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:648
-#: lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853 lxc/remote.go:917
-#: lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:715
+#: lxc/remote.go:753 lxc/remote.go:839 lxc/remote.go:920 lxc/remote.go:984
+#: lxc/remote.go:1032 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -2114,26 +2114,26 @@ msgstr "Récupération de l'image : %s"
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
 #: lxc/storage_volume.go:169 lxc/storage_volume.go:283
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:605
-#: lxc/storage_volume.go:714 lxc/storage_volume.go:801
-#: lxc/storage_volume.go:899 lxc/storage_volume.go:996
-#: lxc/storage_volume.go:1217 lxc/storage_volume.go:1348
-#: lxc/storage_volume.go:1507 lxc/storage_volume.go:1591
-#: lxc/storage_volume.go:1844 lxc/storage_volume.go:1937
-#: lxc/storage_volume.go:2064 lxc/storage_volume.go:2222
-#: lxc/storage_volume.go:2343 lxc/storage_volume.go:2405
-#: lxc/storage_volume.go:2541 lxc/storage_volume.go:2624
-#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:611
+#: lxc/storage_volume.go:720 lxc/storage_volume.go:807
+#: lxc/storage_volume.go:905 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:1223 lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1513 lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1850 lxc/storage_volume.go:1943
+#: lxc/storage_volume.go:2070 lxc/storage_volume.go:2228
+#: lxc/storage_volume.go:2349 lxc/storage_volume.go:2411
+#: lxc/storage_volume.go:2547 lxc/storage_volume.go:2630
+#: lxc/storage_volume.go:2796 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1448
+#: lxc/storage_volume.go:1454
 #, fuzzy, c-format
 msgid "Description: %s"
 msgstr "Empreinte : %s"
 
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:1849
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:1855
 #, fuzzy
 msgid "Destination cluster member name"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -2146,12 +2146,12 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:800 lxc/storage_volume.go:801
+#: lxc/storage_volume.go:806 lxc/storage_volume.go:807
 #, fuzzy
 msgid "Detach storage volumes from instances"
 msgstr "Clé de configuration invalide"
 
-#: lxc/storage_volume.go:898 lxc/storage_volume.go:899
+#: lxc/storage_volume.go:904 lxc/storage_volume.go:905
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -2401,7 +2401,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:995 lxc/storage_volume.go:996
+#: lxc/storage_volume.go:1001 lxc/storage_volume.go:1002
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2410,7 +2410,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr "Clé de configuration invalide"
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1766
+#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1772
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2468,7 +2468,7 @@ msgstr "Récupération de l'image : %s"
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2193
+#: lxc/storage_volume.go:2161 lxc/storage_volume.go:2199
 #, fuzzy, c-format
 msgid "Error setting properties: %v"
 msgstr "Récupération de l'image : %s"
@@ -2482,8 +2482,8 @@ msgstr "Récupération de l'image : %s"
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2149
-#: lxc/storage_volume.go:2187
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2155
+#: lxc/storage_volume.go:2193
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2542,8 +2542,8 @@ msgstr ""
 "sélectionné si à la fois stdin et stdout sont des terminaux (stderr\n"
 "est ignoré)."
 
-#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1508
-#: lxc/storage_volume.go:1558
+#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1514
+#: lxc/storage_volume.go:1564
 #, fuzzy
 msgid "Expires at"
 msgstr "Expire : %s"
@@ -2569,7 +2569,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2623 lxc/storage_volume.go:2624
+#: lxc/storage_volume.go:2629 lxc/storage_volume.go:2630
 #, fuzzy
 msgid "Export custom storage volume"
 msgstr "Copie de l'image : %s"
@@ -2584,12 +2584,12 @@ msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
 msgid "Export instances as backup tarballs."
 msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
 
-#: lxc/storage_volume.go:2627
+#: lxc/storage_volume.go:2633
 #, fuzzy
 msgid "Export the volume without its snapshots"
 msgstr "Copiez le conteneur sans ses instantanés"
 
-#: lxc/export.go:152 lxc/storage_volume.go:2756
+#: lxc/export.go:152 lxc/storage_volume.go:2762
 #, fuzzy, c-format
 msgid "Exporting the backup: %s"
 msgstr "Import de l'image : %s"
@@ -2707,12 +2707,12 @@ msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 msgid "Failed to accept incoming connection: %w"
 msgstr "Échec lors de la génération de 'lxc.1': %v"
 
-#: lxc/remote.go:191
+#: lxc/remote.go:203
 #, fuzzy
 msgid "Failed to add remote"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
-#: lxc/remote.go:242
+#: lxc/remote.go:254
 #, fuzzy, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
@@ -2722,7 +2722,7 @@ msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 msgid "Failed to connect to cluster member: %w"
 msgstr "Profil à appliquer au nouveau conteneur"
 
-#: lxc/remote.go:232
+#: lxc/remote.go:244
 #, fuzzy, c-format
 msgid "Failed to create %q: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
@@ -2732,12 +2732,12 @@ msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 msgid "Failed to create alias %s: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
-#: lxc/remote.go:260
+#: lxc/remote.go:486
 #, fuzzy, c-format
-msgid "Failed to create certificate: %w"
-msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
+msgid "Failed to decode trust token: %w"
+msgstr "Profil à appliquer au nouveau conteneur"
 
-#: lxc/remote.go:267
+#: lxc/remote.go:292
 #, fuzzy, c-format
 msgid "Failed to find project: %w"
 msgstr "Échec lors de la génération de 'lxc.1': %v"
@@ -2762,7 +2762,7 @@ msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:237
+#: lxc/remote.go:249
 #, fuzzy, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
@@ -2854,9 +2854,9 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:690 lxc/storage.go:657
+#: lxc/project.go:919 lxc/remote.go:757 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1608 lxc/warning.go:94
+#: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2892,7 +2892,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:754
+#: lxc/remote.go:821
 msgid "GLOBAL"
 msgstr ""
 
@@ -2912,7 +2912,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:160 lxc/remote.go:401
+#: lxc/remote.go:165 lxc/remote.go:443
 msgid "Generating a client certificate. This may take a minute..."
 msgstr "Génération d'un certificat client. Ceci peut prendre une minute…"
 
@@ -2988,7 +2988,7 @@ msgstr "Copie de l'image : %s"
 msgid "Get the key as a storage property"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1238
 #, fuzzy
 msgid "Get the key as a storage volume property"
 msgstr "Copie de l'image : %s"
@@ -3066,11 +3066,11 @@ msgstr "Clé de configuration invalide"
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1216 lxc/storage_volume.go:1217
+#: lxc/storage_volume.go:1222 lxc/storage_volume.go:1223
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:469
+#: lxc/storage_volume.go:475
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -3199,7 +3199,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2415
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2421
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -3216,7 +3216,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2414
+#: lxc/storage_volume.go:2420
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -3270,7 +3270,7 @@ msgstr "Image copiée avec succès !"
 msgid "Immediately attach to the console"
 msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
 
-#: lxc/storage_volume.go:2790
+#: lxc/storage_volume.go:2796
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -3278,7 +3278,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2789
+#: lxc/storage_volume.go:2795
 #, fuzzy
 msgid "Import custom storage volumes"
 msgstr "Copie de l'image : %s"
@@ -3303,11 +3303,11 @@ msgstr "Import de l'image : %s"
 msgid "Import instance backups"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
 
-#: lxc/storage_volume.go:2797
+#: lxc/storage_volume.go:2803
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2871
+#: lxc/storage_volume.go:2877
 #, fuzzy, c-format
 msgid "Importing custom volume: %s"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
@@ -3377,7 +3377,7 @@ msgstr "Le nom du conteneur est : %s"
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:353
+#: lxc/remote.go:395
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr "Schème d'URL invalide \"%s\" in \"%s\""
@@ -3437,7 +3437,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2000
+#: lxc/move.go:148 lxc/storage_volume.go:2006
 #, fuzzy
 msgid "Invalid new snapshot name"
 msgstr "'/' n'est pas autorisé dans le nom d'un instantané"
@@ -3446,7 +3446,7 @@ msgstr "'/' n'est pas autorisé dans le nom d'un instantané"
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1996
+#: lxc/storage_volume.go:2002
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3460,14 +3460,14 @@ msgstr "nombre d'arguments incorrect pour la sous-comande"
 msgid "Invalid path %s"
 msgstr "Cible invalide %s"
 
-#: lxc/remote.go:342
+#: lxc/remote.go:384
 #, fuzzy, c-format
 msgid "Invalid protocol: %s"
 msgstr "Cible invalide %s"
 
-#: lxc/storage_volume.go:1064 lxc/storage_volume.go:1281
-#: lxc/storage_volume.go:1405 lxc/storage_volume.go:1985
-#: lxc/storage_volume.go:2132 lxc/storage_volume.go:2284
+#: lxc/storage_volume.go:1070 lxc/storage_volume.go:1287
+#: lxc/storage_volume.go:1411 lxc/storage_volume.go:1991
+#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2290
 #, fuzzy
 msgid "Invalid snapshot name"
 msgstr "Le nom du conteneur est : %s"
@@ -3515,7 +3515,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1739 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1745 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3894,12 +3894,12 @@ msgstr "Copie de l'image : %s"
 msgid "List storage buckets"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:1586
+#: lxc/storage_volume.go:1592
 #, fuzzy
 msgid "List storage volumes"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1597
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3919,7 +3919,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:685 lxc/remote.go:686
+#: lxc/remote.go:752 lxc/remote.go:753
 msgid "List the available remotes"
 msgstr ""
 
@@ -3959,7 +3959,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1464
+#: lxc/info.go:489 lxc/storage_volume.go:1470
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -4479,12 +4479,12 @@ msgstr "Résumé manquant."
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:323 lxc/storage_volume.go:643
-#: lxc/storage_volume.go:750 lxc/storage_volume.go:841
-#: lxc/storage_volume.go:939 lxc/storage_volume.go:1053
-#: lxc/storage_volume.go:1270 lxc/storage_volume.go:1974
-#: lxc/storage_volume.go:2115 lxc/storage_volume.go:2273
-#: lxc/storage_volume.go:2464 lxc/storage_volume.go:2581
+#: lxc/storage_volume.go:323 lxc/storage_volume.go:649
+#: lxc/storage_volume.go:756 lxc/storage_volume.go:847
+#: lxc/storage_volume.go:945 lxc/storage_volume.go:1059
+#: lxc/storage_volume.go:1276 lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:2121 lxc/storage_volume.go:2279
+#: lxc/storage_volume.go:2470 lxc/storage_volume.go:2587
 #, fuzzy
 msgid "Missing pool name"
 msgstr "Nom de l'ensemble de stockage"
@@ -4505,12 +4505,12 @@ msgstr "Nom de l'ensemble de stockage"
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:432 lxc/storage_volume.go:1884
+#: lxc/storage_volume.go:438 lxc/storage_volume.go:1890
 #, fuzzy
 msgid "Missing source volume name"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:1394
+#: lxc/storage_volume.go:1400
 #, fuzzy
 msgid "Missing storage pool name"
 msgstr "Nom de l'ensemble de stockage"
@@ -4551,8 +4551,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:861
-#: lxc/storage_volume.go:958
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:867
+#: lxc/storage_volume.go:964
 #, fuzzy
 msgid "More than one device matches, specify the device name"
 msgstr "Plus d'un périphérique correspond, spécifier le nom du périphérique."
@@ -4593,7 +4593,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1843 lxc/storage_volume.go:1844
+#: lxc/storage_volume.go:1849 lxc/storage_volume.go:1850
 #, fuzzy
 msgid "Move storage volumes between pools"
 msgstr "Copie de l'image : %s"
@@ -4603,11 +4603,11 @@ msgstr "Copie de l'image : %s"
 msgid "Move the instance without its snapshots"
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: lxc/storage_volume.go:1850
+#: lxc/storage_volume.go:1856
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:512
+#: lxc/storage_volume.go:518
 #, fuzzy, c-format
 msgid "Moving the storage volume: %s"
 msgstr "Copie de l'image : %s"
@@ -4634,8 +4634,8 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
-#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1731
+#: lxc/remote.go:815 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
 msgstr "NOM"
 
@@ -4661,7 +4661,7 @@ msgstr ""
 
 #: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
+#: lxc/project.go:550 lxc/remote.go:775 lxc/remote.go:780 lxc/remote.go:785
 msgid "NO"
 msgstr "NON"
 
@@ -4683,8 +4683,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1506
-#: lxc/storage_volume.go:1556
+#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1512
+#: lxc/storage_volume.go:1562
 #, fuzzy
 msgid "Name"
 msgstr "Nom : %s"
@@ -4693,7 +4693,7 @@ msgstr "Nom : %s"
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1446
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1452
 #, c-format
 msgid "Name: %s"
 msgstr "Nom : %s"
@@ -4841,7 +4841,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr "Aucun périphérique existant pour ce réseau"
 
-#: lxc/storage_volume.go:870 lxc/storage_volume.go:967
+#: lxc/storage_volume.go:876 lxc/storage_volume.go:973
 #, fuzzy
 msgid "No device found for this storage volume"
 msgstr "Aucun périphérique existant pour ce réseau"
@@ -4858,11 +4858,11 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/storage_volume.go:446 lxc/storage_volume.go:1893
+#: lxc/storage_volume.go:452 lxc/storage_volume.go:1899
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:496 lxc/storage_volume.go:1904
+#: lxc/storage_volume.go:502 lxc/storage_volume.go:1910
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4876,7 +4876,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2012
+#: lxc/storage_volume.go:2018
 #, fuzzy
 msgid "Not a snapshot name"
 msgstr "'/' n'est pas autorisé dans le nom d'un instantané"
@@ -4891,19 +4891,19 @@ msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 "Seuls les volumes \"personnalisés\" peuvent être attachés aux conteneurs."
 
-#: lxc/storage_volume.go:2678
+#: lxc/storage_volume.go:2684
 #, fuzzy
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 "Seuls les volumes \"personnalisés\" peuvent être attachés aux conteneurs."
 
-#: lxc/storage_volume.go:2477
+#: lxc/storage_volume.go:2483
 #, fuzzy
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 "Seuls les volumes \"personnalisés\" peuvent être attachés aux conteneurs."
 
-#: lxc/remote.go:336
+#: lxc/remote.go:378
 msgid "Only https URLs are supported for simplestreams"
 msgstr "Seules les URLs https sont supportées par simplestreams"
 
@@ -4912,7 +4912,7 @@ msgstr "Seules les URLs https sont supportées par simplestreams"
 msgid "Only https:// is supported for remote image import"
 msgstr "Seul https:// est supporté par l'import d'images distantes."
 
-#: lxc/storage_volume.go:1412
+#: lxc/storage_volume.go:1418
 #, fuzzy
 msgid "Only instance or custom volumes are supported"
 msgstr ""
@@ -4928,7 +4928,7 @@ msgstr "Seuls les réseaux gérés par LXD peuvent être modifiés."
 msgid "Operation %s deleted"
 msgstr "Le réseau %s a été supprimé"
 
-#: lxc/info.go:693 lxc/storage_volume.go:1560
+#: lxc/info.go:693 lxc/storage_volume.go:1566
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4959,7 +4959,7 @@ msgstr "PID"
 msgid "PID: %d"
 msgstr "Pid : %d"
 
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1756
 msgid "POOL"
 msgstr ""
 
@@ -4975,15 +4975,15 @@ msgstr ""
 msgid "PROFILES"
 msgstr "PROFILS"
 
-#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:213
+#: lxc/list.go:567 lxc/storage_volume.go:1762 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:817
 msgid "PROTOCOL"
 msgstr "PROTOCOLE"
 
-#: lxc/image.go:1136 lxc/remote.go:752
+#: lxc/image.go:1136 lxc/remote.go:819
 msgid "PUBLIC"
 msgstr "PUBLIC"
 
@@ -5014,7 +5014,7 @@ msgstr "Création du conteneur"
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:183
+#: lxc/remote.go:195
 #, fuzzy
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr "Chemin vers un dossier de configuration serveur alternatif"
@@ -5028,9 +5028,10 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/remote.go:466
-msgid "Please type 'y', 'n' or the fingerprint:"
-msgstr ""
+#: lxc/remote.go:536
+#, fuzzy
+msgid "Please type 'y', 'n' or the fingerprint: "
+msgstr "Image importée avec l'empreinte : %s"
 
 #: lxc/info.go:221
 #, fuzzy, c-format
@@ -5053,8 +5054,8 @@ msgstr ""
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1151
-#: lxc/storage_volume.go:1183
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
+#: lxc/storage_volume.go:1189
 #, fuzzy
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr "Appuyer sur Entrée pour ouvrir à nouveau l'éditeur"
@@ -5177,7 +5178,7 @@ msgstr "Propriétés :"
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1350
+#: lxc/storage_volume.go:1356
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -5191,7 +5192,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1219
+#: lxc/storage_volume.go:1225
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5207,7 +5208,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2224
+#: lxc/storage_volume.go:2230
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5228,7 +5229,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:998
+#: lxc/storage_volume.go:1004
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5237,7 +5238,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2069
+#: lxc/storage_volume.go:2075
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5250,7 +5251,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2345
+#: lxc/storage_volume.go:2351
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5363,33 +5364,33 @@ msgstr "Ignorer l'état du conteneur (seulement pour start)"
 msgid "Refreshing the image: %s"
 msgstr "Récupération de l'image : %s"
 
-#: lxc/remote.go:810
+#: lxc/remote.go:877
 #, fuzzy, c-format
 msgid "Remote %s already exists"
 msgstr "le serveur distant %s existe déjà"
 
-#: lxc/project.go:884 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
-#: lxc/remote.go:994
+#: lxc/project.go:884 lxc/remote.go:868 lxc/remote.go:949 lxc/remote.go:1013
+#: lxc/remote.go:1061
 #, fuzzy, c-format
 msgid "Remote %s doesn't exist"
 msgstr "le serveur distant %s n'existe pas"
 
-#: lxc/remote.go:305
+#: lxc/remote.go:345
 #, fuzzy, c-format
 msgid "Remote %s exists as <%s>"
 msgstr "le serveur distant %s existe en tant que <%s>"
 
-#: lxc/remote.go:890
+#: lxc/remote.go:957
 #, fuzzy, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr "le serveur distant %s est statique et ne peut être modifié"
 
-#: lxc/remote.go:805 lxc/remote.go:886 lxc/remote.go:998
+#: lxc/remote.go:872 lxc/remote.go:953 lxc/remote.go:1065
 #, fuzzy, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr "le serveur distant %s est statique et ne peut être modifié"
 
-#: lxc/remote.go:294
+#: lxc/remote.go:319
 msgid "Remote address must not be empty"
 msgstr ""
 
@@ -5397,7 +5398,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr "Mot de passe de l'administrateur distant"
 
-#: lxc/remote.go:299
+#: lxc/remote.go:339
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -5497,7 +5498,7 @@ msgstr "Création du conteneur"
 msgid "Remove profiles from instances"
 msgstr "Création du conteneur"
 
-#: lxc/remote.go:852 lxc/remote.go:853
+#: lxc/remote.go:919 lxc/remote.go:920
 msgid "Remove remotes"
 msgstr ""
 
@@ -5561,21 +5562,21 @@ msgstr ""
 msgid "Rename projects"
 msgstr "Créé : %s"
 
-#: lxc/remote.go:771 lxc/remote.go:772
+#: lxc/remote.go:838 lxc/remote.go:839
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:1943
 #, fuzzy
 msgid "Rename storage volumes"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:1936
+#: lxc/storage_volume.go:1942
 #, fuzzy
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:2025 lxc/storage_volume.go:2045
+#: lxc/storage_volume.go:2031 lxc/storage_volume.go:2051
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5647,7 +5648,7 @@ msgstr ""
 "Exemple :\n"
 "    lxc snapshot u1 snap0"
 
-#: lxc/storage_volume.go:2540 lxc/storage_volume.go:2541
+#: lxc/storage_volume.go:2546 lxc/storage_volume.go:2547
 #, fuzzy
 msgid "Restore storage volume snapshots"
 msgstr "Forcer le conteneur à s'arrêter"
@@ -5733,7 +5734,7 @@ msgstr "Mot de passe de l'administrateur distant"
 msgid "STATE"
 msgstr "ÉTAT"
 
-#: lxc/remote.go:753
+#: lxc/remote.go:820
 msgid "STATIC"
 msgstr "STATIQUE"
 
@@ -5777,11 +5778,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:464
+#: lxc/remote.go:532
 msgid "Server certificate NACKed by user"
 msgstr "Certificat serveur rejeté par l'utilisateur"
 
-#: lxc/remote.go:616
+#: lxc/remote.go:285 lxc/remote.go:683
 #, fuzzy
 msgid "Server doesn't trust us after authentication"
 msgstr ""
@@ -5996,12 +5997,12 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2063
+#: lxc/storage_volume.go:2069
 #, fuzzy
 msgid "Set storage volume configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/storage_volume.go:2064
+#: lxc/storage_volume.go:2070
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -6010,7 +6011,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:964 lxc/remote.go:965
+#: lxc/remote.go:1031 lxc/remote.go:1032
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -6096,7 +6097,7 @@ msgstr "Copie de l'image : %s"
 msgid "Set the key as a storage property"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:2080
+#: lxc/storage_volume.go:2086
 #, fuzzy
 msgid "Set the key as a storage volume property"
 msgstr "Copie de l'image : %s"
@@ -6269,12 +6270,12 @@ msgstr "Afficher la configuration étendue"
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2221 lxc/storage_volume.go:2222
+#: lxc/storage_volume.go:2227 lxc/storage_volume.go:2228
 #, fuzzy
 msgid "Show storage volume configurations"
 msgstr "Afficher la configuration étendue"
 
-#: lxc/storage_volume.go:1347 lxc/storage_volume.go:1348
+#: lxc/storage_volume.go:1353 lxc/storage_volume.go:1354
 #, fuzzy
 msgid "Show storage volume state information"
 msgstr "Afficher la configuration étendue"
@@ -6289,7 +6290,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:647 lxc/remote.go:648
+#: lxc/remote.go:714 lxc/remote.go:715
 #, fuzzy
 msgid "Show the default remote"
 msgstr "impossible de supprimer le serveur distant par défaut"
@@ -6347,16 +6348,16 @@ msgstr "Taille : %.2f Mo"
 msgid "Size: %s"
 msgstr "État : %s"
 
-#: lxc/storage_volume.go:2404 lxc/storage_volume.go:2405
+#: lxc/storage_volume.go:2410 lxc/storage_volume.go:2411
 #, fuzzy
 msgid "Snapshot storage volumes"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:2167
+#: lxc/storage_volume.go:2173
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:607 lxc/storage_volume.go:1485
+#: lxc/info.go:607 lxc/storage_volume.go:1491
 msgid "Snapshots:"
 msgstr "Instantanés :"
 
@@ -6463,22 +6464,22 @@ msgstr "Le réseau %s a été créé"
 msgid "Storage pool name"
 msgstr "Nom de l'ensemble de stockage"
 
-#: lxc/storage_volume.go:696
+#: lxc/storage_volume.go:702
 #, fuzzy, c-format
 msgid "Storage volume %s created"
 msgstr "Profil %s créé"
 
-#: lxc/storage_volume.go:784
+#: lxc/storage_volume.go:790
 #, fuzzy, c-format
 msgid "Storage volume %s deleted"
 msgstr "Profil %s supprimé"
 
-#: lxc/storage_volume.go:509
+#: lxc/storage_volume.go:515
 #, fuzzy
 msgid "Storage volume copied successfully!"
 msgstr "Image copiée avec succès !"
 
-#: lxc/storage_volume.go:513
+#: lxc/storage_volume.go:519
 #, fuzzy
 msgid "Storage volume moved successfully!"
 msgstr "Image copiée avec succès !"
@@ -6516,7 +6517,7 @@ msgstr "Swap (pointe)"
 msgid "Switch the current project"
 msgstr "impossible de supprimer le serveur distant par défaut"
 
-#: lxc/remote.go:916 lxc/remote.go:917
+#: lxc/remote.go:983 lxc/remote.go:984
 #, fuzzy
 msgid "Switch the default remote"
 msgstr "impossible de supprimer le serveur distant par défaut"
@@ -6536,11 +6537,11 @@ msgstr ""
 #: lxc/auth.go:818 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
-#: lxc/storage_volume.go:1730 lxc/warning.go:216
+#: lxc/storage_volume.go:1736 lxc/warning.go:216
 msgid "TYPE"
 msgstr "TYPE"
 
-#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1557
+#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1563
 #, fuzzy
 msgid "Taken at"
 msgstr "pris à %s"
@@ -6551,6 +6552,12 @@ msgstr ""
 
 #: lxc/file.go:1256
 msgid "Target path must be a directory"
+msgstr ""
+
+#: lxc/remote.go:161 lxc/remote.go:334
+msgid ""
+"The --accept-certificate flag is not supported when adding a remote using a "
+"trust token"
 msgstr ""
 
 #: lxc/move.go:181
@@ -6701,15 +6708,20 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/storage_volume.go:1323
+#: lxc/storage_volume.go:1329
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/storage_volume.go:1300
+#: lxc/storage_volume.go:1306
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
+msgstr ""
+
+#: lxc/remote.go:527
+msgid ""
+"The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
 
 #: lxc/info.go:354
@@ -6720,8 +6732,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:875
-#: lxc/storage_volume.go:972
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:881
+#: lxc/storage_volume.go:978
 msgid "The specified device doesn't exist"
 msgstr "Le périphérique indiqué n'existe pas"
 
@@ -6802,7 +6814,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1470
+#: lxc/storage_volume.go:1476
 #, fuzzy, c-format
 msgid "Total: %s"
 msgstr "Publié : %s"
@@ -6817,7 +6829,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr "Transfert de l'image : %s"
 
-#: lxc/storage_volume.go:1847
+#: lxc/storage_volume.go:1853
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6851,7 +6863,16 @@ msgstr "Transfert de l'image : %s"
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:571
+#: lxc/remote.go:329
+msgid "Trust token cannot be used for public remotes"
+msgstr ""
+
+#: lxc/remote.go:324
+#, fuzzy
+msgid "Trust token cannot be used with OIDC authentication"
+msgstr "--project ne peut pas être utilisé avec la commande query"
+
+#: lxc/remote.go:639
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6878,7 +6899,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1455
+#: lxc/storage_volume.go:1461
 #, fuzzy, c-format
 msgid "Type: %s"
 msgstr "Expire : %s"
@@ -6896,17 +6917,17 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr "DATE DE PUBLICATION"
 
-#: lxc/cluster.go:193 lxc/remote.go:749
+#: lxc/cluster.go:193 lxc/remote.go:816
 msgid "URL"
 msgstr "URL"
 
-#: lxc/project.go:995 lxc/storage_volume.go:1735
+#: lxc/project.go:995 lxc/storage_volume.go:1741
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1734
+#: lxc/storage.go:724 lxc/storage_volume.go:1740
 msgid "USED BY"
 msgstr "UTILISÉ PAR"
 
@@ -6924,7 +6945,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:214 lxc/remote.go:248
+#: lxc/remote.go:226 lxc/remote.go:260
 #, fuzzy
 msgid "Unavailable remote server"
 msgstr "Ajouter de nouveaux serveurs distants"
@@ -6939,7 +6960,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1772
+#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1778
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -7064,7 +7085,7 @@ msgstr "Clé de configuration invalide"
 msgid "Unset storage pool configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/storage_volume.go:2342 lxc/storage_volume.go:2343
+#: lxc/storage_volume.go:2348 lxc/storage_volume.go:2349
 #, fuzzy
 msgid "Unset storage volume configuration keys"
 msgstr "Clé de configuration invalide"
@@ -7125,7 +7146,7 @@ msgstr "Copie de l'image : %s"
 msgid "Unset the key as a storage property"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:2356
+#: lxc/storage_volume.go:2362
 #, fuzzy
 msgid "Unset the key as a storage volume property"
 msgstr "Copie de l'image : %s"
@@ -7172,12 +7193,12 @@ msgstr "Publié : %s"
 msgid "Upper devices"
 msgstr "Création du conteneur"
 
-#: lxc/storage_volume.go:1468
+#: lxc/storage_volume.go:1474
 #, c-format
 msgid "Usage: %s"
 msgstr "Utilisation : %s"
 
-#: lxc/export.go:42 lxc/storage_volume.go:2629
+#: lxc/export.go:42 lxc/storage_volume.go:2635
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -7246,7 +7267,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr "impossible de supprimer le serveur distant par défaut"
 
-#: lxc/storage_volume.go:1559
+#: lxc/storage_volume.go:1565
 msgid "Volume Only"
 msgstr ""
 
@@ -7286,7 +7307,7 @@ msgstr ""
 
 #: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
+#: lxc/project.go:552 lxc/remote.go:777 lxc/remote.go:782 lxc/remote.go:787
 msgid "YES"
 msgstr "OUI"
 
@@ -7314,7 +7335,7 @@ msgstr "vous devez spécifier un nom de conteneur source"
 msgid "You need to specify an image name or use --empty"
 msgstr "vous devez spécifier un nom de conteneur source"
 
-#: lxc/storage_volume.go:897
+#: lxc/storage_volume.go:903
 #, fuzzy
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
@@ -8219,7 +8240,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:2788
+#: lxc/storage_volume.go:2794
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
@@ -8286,7 +8307,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:1941
 #, fuzzy
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
@@ -8300,7 +8321,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/storage_volume.go:799
+#: lxc/storage_volume.go:805
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
@@ -8316,7 +8337,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:2539
+#: lxc/storage_volume.go:2545
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
@@ -8328,7 +8349,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/storage_volume.go:2622
+#: lxc/storage_volume.go:2628
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
@@ -8340,7 +8361,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/storage_volume.go:2403
+#: lxc/storage_volume.go:2409
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
@@ -8352,7 +8373,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/storage_volume.go:603
+#: lxc/storage_volume.go:609
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
@@ -8360,7 +8381,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:711
+#: lxc/storage_volume.go:717
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
@@ -8372,7 +8393,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/storage_volume.go:994 lxc/storage_volume.go:1346
+#: lxc/storage_volume.go:1000 lxc/storage_volume.go:1352
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
@@ -8380,7 +8401,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:2341
+#: lxc/storage_volume.go:2347
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
@@ -8388,7 +8409,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:2062
+#: lxc/storage_volume.go:2068
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
@@ -8396,7 +8417,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:2220
+#: lxc/storage_volume.go:2226
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
@@ -8408,7 +8429,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/storage_volume.go:1215
+#: lxc/storage_volume.go:1221
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
@@ -8420,7 +8441,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/storage_volume.go:1841
+#: lxc/storage_volume.go:1847
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
@@ -8654,7 +8675,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:1584
+#: lxc/storage_volume.go:1590
 #, fuzzy
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
@@ -8682,7 +8703,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/project.go:557 lxc/remote.go:739
+#: lxc/project.go:557 lxc/remote.go:806
 #, fuzzy
 msgid "current"
 msgstr "Swap (courant)"
@@ -9165,7 +9186,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:607
+#: lxc/storage_volume.go:613
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -9173,13 +9194,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2792
+#: lxc/storage_volume.go:2798
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2407
+#: lxc/storage_volume.go:2413
 msgid ""
 "lxc storage volume snapshot create default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -9189,7 +9210,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:531
 #, fuzzy
 msgid "n"
 msgstr "non"
@@ -9202,7 +9223,7 @@ msgstr ""
 msgid "no"
 msgstr "non"
 
-#: lxc/remote.go:456
+#: lxc/remote.go:510
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -9239,7 +9260,7 @@ msgstr "inaccessible"
 msgid "used by"
 msgstr "utilisé par"
 
-#: lxc/remote.go:465
+#: lxc/remote.go:519
 msgid "y"
 msgstr "o"
 
@@ -9247,6 +9268,10 @@ msgstr "o"
 #: lxc/image.go:1194
 msgid "yes"
 msgstr "oui"
+
+#, fuzzy, c-format
+#~ msgid "Failed to create certificate: %w"
+#~ msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
 #~ msgid "Make the image public"
 #~ msgstr "Rendre l'image publique"

--- a/po/he.po
+++ b/po/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-08 07:43+0100\n"
+"POT-Creation-Date: 2024-10-14 13:30+0000\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hebrew <https://hosted.weblate.org/projects/linux-containers/"
@@ -50,7 +50,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1024
+#: lxc/storage_volume.go:1030
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -516,15 +516,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:850 lxc/remote.go:915
+#: lxc/remote.go:917 lxc/remote.go:982
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:963
+#: lxc/remote.go:1030
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:769
+#: lxc/remote.go:836
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -557,7 +557,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:751
+#: lxc/remote.go:818
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -706,7 +706,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:581
+#: lxc/remote.go:648
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -739,11 +739,11 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1590
+#: lxc/storage_volume.go:1596
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:182
+#: lxc/remote.go:194
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -814,7 +814,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:552
+#: lxc/remote.go:621
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -850,16 +850,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2696
+#: lxc/storage_volume.go:2702
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2773
+#: lxc/export.go:192 lxc/storage_volume.go:2779
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:654 lxc/storage_volume.go:1521
+#: lxc/info.go:654 lxc/storage_volume.go:1527
 msgid "Backups:"
 msgstr ""
 
@@ -880,7 +880,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:679
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:685
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -923,7 +923,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1733
+#: lxc/storage_volume.go:1739
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -992,7 +992,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:894
+#: lxc/remote.go:961
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1008,7 +1008,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1749 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1025,12 +1025,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:486
+#: lxc/storage_volume.go:492
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:440
+#: lxc/storage_volume.go:446
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1058,11 +1058,11 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:509
 msgid "Certificate fingerprint"
 msgstr ""
 
-#: lxc/remote.go:219
+#: lxc/remote.go:231
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:620
+#: lxc/remote.go:687
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1151,13 +1151,13 @@ msgstr ""
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
 #: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
-#: lxc/storage_volume.go:612 lxc/storage_volume.go:717
-#: lxc/storage_volume.go:1005 lxc/storage_volume.go:1231
-#: lxc/storage_volume.go:1360 lxc/storage_volume.go:1848
-#: lxc/storage_volume.go:1940 lxc/storage_volume.go:2079
-#: lxc/storage_volume.go:2239 lxc/storage_volume.go:2355
-#: lxc/storage_volume.go:2416 lxc/storage_volume.go:2543
-#: lxc/storage_volume.go:2631 lxc/storage_volume.go:2795
+#: lxc/storage_volume.go:618 lxc/storage_volume.go:723
+#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1237
+#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1854
+#: lxc/storage_volume.go:1946 lxc/storage_volume.go:2085
+#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2361
+#: lxc/storage_volume.go:2422 lxc/storage_volume.go:2549
+#: lxc/storage_volume.go:2637 lxc/storage_volume.go:2801
 msgid "Cluster member name"
 msgstr ""
 
@@ -1173,7 +1173,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1589
+#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1595
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1217,17 +1217,17 @@ msgstr ""
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1150
-#: lxc/storage_volume.go:1182
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
+#: lxc/storage_volume.go:1188
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:613
+#: lxc/storage_volume.go:619
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1467
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1311,7 +1311,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:508
+#: lxc/storage_volume.go:514
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1325,12 +1325,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:490
+#: lxc/remote.go:559
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:225 lxc/remote.go:474
+#: lxc/remote.go:237 lxc/remote.go:543
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1369,7 +1369,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:485
+#: lxc/remote.go:554
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1438,7 +1438,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:604 lxc/storage_volume.go:605
+#: lxc/storage_volume.go:610 lxc/storage_volume.go:611
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1490,7 +1490,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1475
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1481
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1525,7 +1525,7 @@ msgstr ""
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1732
+#: lxc/storage_volume.go:1738
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1545,7 +1545,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2630
+#: lxc/storage_volume.go:2636
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1641,7 +1641,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:713 lxc/storage_volume.go:714
+#: lxc/storage_volume.go:719 lxc/storage_volume.go:720
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1733,9 +1733,9 @@ msgstr ""
 #: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
 #: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
 #: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:648
-#: lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853 lxc/remote.go:917
-#: lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:715
+#: lxc/remote.go:753 lxc/remote.go:839 lxc/remote.go:920 lxc/remote.go:984
+#: lxc/remote.go:1032 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1747,26 +1747,26 @@ msgstr ""
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
 #: lxc/storage_volume.go:169 lxc/storage_volume.go:283
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:605
-#: lxc/storage_volume.go:714 lxc/storage_volume.go:801
-#: lxc/storage_volume.go:899 lxc/storage_volume.go:996
-#: lxc/storage_volume.go:1217 lxc/storage_volume.go:1348
-#: lxc/storage_volume.go:1507 lxc/storage_volume.go:1591
-#: lxc/storage_volume.go:1844 lxc/storage_volume.go:1937
-#: lxc/storage_volume.go:2064 lxc/storage_volume.go:2222
-#: lxc/storage_volume.go:2343 lxc/storage_volume.go:2405
-#: lxc/storage_volume.go:2541 lxc/storage_volume.go:2624
-#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:611
+#: lxc/storage_volume.go:720 lxc/storage_volume.go:807
+#: lxc/storage_volume.go:905 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:1223 lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1513 lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1850 lxc/storage_volume.go:1943
+#: lxc/storage_volume.go:2070 lxc/storage_volume.go:2228
+#: lxc/storage_volume.go:2349 lxc/storage_volume.go:2411
+#: lxc/storage_volume.go:2547 lxc/storage_volume.go:2630
+#: lxc/storage_volume.go:2796 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1448
+#: lxc/storage_volume.go:1454
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:1849
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:1855
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1778,11 +1778,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:800 lxc/storage_volume.go:801
+#: lxc/storage_volume.go:806 lxc/storage_volume.go:807
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:898 lxc/storage_volume.go:899
+#: lxc/storage_volume.go:904 lxc/storage_volume.go:905
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -2008,7 +2008,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:995 lxc/storage_volume.go:996
+#: lxc/storage_volume.go:1001 lxc/storage_volume.go:1002
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2016,7 +2016,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1766
+#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1772
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2073,7 +2073,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2193
+#: lxc/storage_volume.go:2161 lxc/storage_volume.go:2199
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2087,8 +2087,8 @@ msgstr ""
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2149
-#: lxc/storage_volume.go:2187
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2155
+#: lxc/storage_volume.go:2193
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2130,8 +2130,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1508
-#: lxc/storage_volume.go:1558
+#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1514
+#: lxc/storage_volume.go:1564
 msgid "Expires at"
 msgstr ""
 
@@ -2155,7 +2155,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2623 lxc/storage_volume.go:2624
+#: lxc/storage_volume.go:2629 lxc/storage_volume.go:2630
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2167,11 +2167,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2627
+#: lxc/storage_volume.go:2633
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2756
+#: lxc/export.go:152 lxc/storage_volume.go:2762
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2288,11 +2288,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:191
+#: lxc/remote.go:203
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:242
+#: lxc/remote.go:254
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2302,7 +2302,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:232
+#: lxc/remote.go:244
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2312,12 +2312,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:260
+#: lxc/remote.go:486
 #, c-format
-msgid "Failed to create certificate: %w"
+msgid "Failed to decode trust token: %w"
 msgstr ""
 
-#: lxc/remote.go:267
+#: lxc/remote.go:292
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2342,7 +2342,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:237
+#: lxc/remote.go:249
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2429,9 +2429,9 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:690 lxc/storage.go:657
+#: lxc/project.go:919 lxc/remote.go:757 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1608 lxc/warning.go:94
+#: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2467,7 +2467,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:754
+#: lxc/remote.go:821
 msgid "GLOBAL"
 msgstr ""
 
@@ -2487,7 +2487,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:160 lxc/remote.go:401
+#: lxc/remote.go:165 lxc/remote.go:443
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2555,7 +2555,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1238
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2619,11 +2619,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1216 lxc/storage_volume.go:1217
+#: lxc/storage_volume.go:1222 lxc/storage_volume.go:1223
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:469
+#: lxc/storage_volume.go:475
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2747,7 +2747,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2415
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2421
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2761,7 +2761,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2414
+#: lxc/storage_volume.go:2420
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2811,7 +2811,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2790
+#: lxc/storage_volume.go:2796
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2819,7 +2819,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2789
+#: lxc/storage_volume.go:2795
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2841,11 +2841,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2797
+#: lxc/storage_volume.go:2803
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2871
+#: lxc/storage_volume.go:2877
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2911,7 +2911,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:353
+#: lxc/remote.go:395
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2971,7 +2971,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2000
+#: lxc/move.go:148 lxc/storage_volume.go:2006
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2979,7 +2979,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1996
+#: lxc/storage_volume.go:2002
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2992,14 +2992,14 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:342
+#: lxc/remote.go:384
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1064 lxc/storage_volume.go:1281
-#: lxc/storage_volume.go:1405 lxc/storage_volume.go:1985
-#: lxc/storage_volume.go:2132 lxc/storage_volume.go:2284
+#: lxc/storage_volume.go:1070 lxc/storage_volume.go:1287
+#: lxc/storage_volume.go:1411 lxc/storage_volume.go:1991
+#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2290
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3045,7 +3045,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1739 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1745 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3348,11 +3348,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1586
+#: lxc/storage_volume.go:1592
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1597
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3372,7 +3372,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:685 lxc/remote.go:686
+#: lxc/remote.go:752 lxc/remote.go:753
 msgid "List the available remotes"
 msgstr ""
 
@@ -3411,7 +3411,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1464
+#: lxc/info.go:489 lxc/storage_volume.go:1470
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3875,12 +3875,12 @@ msgstr ""
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:323 lxc/storage_volume.go:643
-#: lxc/storage_volume.go:750 lxc/storage_volume.go:841
-#: lxc/storage_volume.go:939 lxc/storage_volume.go:1053
-#: lxc/storage_volume.go:1270 lxc/storage_volume.go:1974
-#: lxc/storage_volume.go:2115 lxc/storage_volume.go:2273
-#: lxc/storage_volume.go:2464 lxc/storage_volume.go:2581
+#: lxc/storage_volume.go:323 lxc/storage_volume.go:649
+#: lxc/storage_volume.go:756 lxc/storage_volume.go:847
+#: lxc/storage_volume.go:945 lxc/storage_volume.go:1059
+#: lxc/storage_volume.go:1276 lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:2121 lxc/storage_volume.go:2279
+#: lxc/storage_volume.go:2470 lxc/storage_volume.go:2587
 msgid "Missing pool name"
 msgstr ""
 
@@ -3899,11 +3899,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:432 lxc/storage_volume.go:1884
+#: lxc/storage_volume.go:438 lxc/storage_volume.go:1890
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1394
+#: lxc/storage_volume.go:1400
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -3940,8 +3940,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:861
-#: lxc/storage_volume.go:958
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:867
+#: lxc/storage_volume.go:964
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -3978,7 +3978,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1843 lxc/storage_volume.go:1844
+#: lxc/storage_volume.go:1849 lxc/storage_volume.go:1850
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -3986,11 +3986,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1850
+#: lxc/storage_volume.go:1856
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:512
+#: lxc/storage_volume.go:518
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4016,8 +4016,8 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
-#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1731
+#: lxc/remote.go:815 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
 msgstr ""
 
@@ -4043,7 +4043,7 @@ msgstr ""
 
 #: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
+#: lxc/project.go:550 lxc/remote.go:775 lxc/remote.go:780 lxc/remote.go:785
 msgid "NO"
 msgstr ""
 
@@ -4065,8 +4065,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1506
-#: lxc/storage_volume.go:1556
+#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1512
+#: lxc/storage_volume.go:1562
 msgid "Name"
 msgstr ""
 
@@ -4074,7 +4074,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1446
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1452
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4218,7 +4218,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:870 lxc/storage_volume.go:967
+#: lxc/storage_volume.go:876 lxc/storage_volume.go:973
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4234,11 +4234,11 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/storage_volume.go:446 lxc/storage_volume.go:1893
+#: lxc/storage_volume.go:452 lxc/storage_volume.go:1899
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:496 lxc/storage_volume.go:1904
+#: lxc/storage_volume.go:502 lxc/storage_volume.go:1910
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4252,7 +4252,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2012
+#: lxc/storage_volume.go:2018
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4264,15 +4264,15 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2678
+#: lxc/storage_volume.go:2684
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2477
+#: lxc/storage_volume.go:2483
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:336
+#: lxc/remote.go:378
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4280,7 +4280,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1412
+#: lxc/storage_volume.go:1418
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4293,7 +4293,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:693 lxc/storage_volume.go:1560
+#: lxc/info.go:693 lxc/storage_volume.go:1566
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4323,7 +4323,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1756
 msgid "POOL"
 msgstr ""
 
@@ -4339,15 +4339,15 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:213
+#: lxc/list.go:567 lxc/storage_volume.go:1762 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:817
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:752
+#: lxc/image.go:1136 lxc/remote.go:819
 msgid "PUBLIC"
 msgstr ""
 
@@ -4376,7 +4376,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:183
+#: lxc/remote.go:195
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4388,8 +4388,8 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:466
-msgid "Please type 'y', 'n' or the fingerprint:"
+#: lxc/remote.go:536
+msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
 #: lxc/info.go:221
@@ -4413,8 +4413,8 @@ msgstr ""
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1151
-#: lxc/storage_volume.go:1183
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
+#: lxc/storage_volume.go:1189
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4531,7 +4531,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1350
+#: lxc/storage_volume.go:1356
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4545,7 +4545,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1219
+#: lxc/storage_volume.go:1225
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4561,7 +4561,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2224
+#: lxc/storage_volume.go:2230
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4582,7 +4582,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:998
+#: lxc/storage_volume.go:1004
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4591,7 +4591,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2069
+#: lxc/storage_volume.go:2075
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4604,7 +4604,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2345
+#: lxc/storage_volume.go:2351
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4708,33 +4708,33 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:810
+#: lxc/remote.go:877
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
-#: lxc/remote.go:994
+#: lxc/project.go:884 lxc/remote.go:868 lxc/remote.go:949 lxc/remote.go:1013
+#: lxc/remote.go:1061
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:305
+#: lxc/remote.go:345
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:890
+#: lxc/remote.go:957
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:805 lxc/remote.go:886 lxc/remote.go:998
+#: lxc/remote.go:872 lxc/remote.go:953 lxc/remote.go:1065
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:294
+#: lxc/remote.go:319
 msgid "Remote address must not be empty"
 msgstr ""
 
@@ -4742,7 +4742,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:299
+#: lxc/remote.go:339
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4828,7 +4828,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:852 lxc/remote.go:853
+#: lxc/remote.go:919 lxc/remote.go:920
 msgid "Remove remotes"
 msgstr ""
 
@@ -4885,19 +4885,19 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:771 lxc/remote.go:772
+#: lxc/remote.go:838 lxc/remote.go:839
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:1943
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1936
+#: lxc/storage_volume.go:1942
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2025 lxc/storage_volume.go:2045
+#: lxc/storage_volume.go:2031 lxc/storage_volume.go:2051
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4949,7 +4949,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2540 lxc/storage_volume.go:2541
+#: lxc/storage_volume.go:2546 lxc/storage_volume.go:2547
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5030,7 +5030,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:820
 msgid "STATIC"
 msgstr ""
 
@@ -5071,11 +5071,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:464
+#: lxc/remote.go:532
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:616
+#: lxc/remote.go:285 lxc/remote.go:683
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5273,11 +5273,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2063
+#: lxc/storage_volume.go:2069
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2064
+#: lxc/storage_volume.go:2070
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5286,7 +5286,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:964 lxc/remote.go:965
+#: lxc/remote.go:1031 lxc/remote.go:1032
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5362,7 +5362,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2080
+#: lxc/storage_volume.go:2086
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5511,11 +5511,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2221 lxc/storage_volume.go:2222
+#: lxc/storage_volume.go:2227 lxc/storage_volume.go:2228
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1347 lxc/storage_volume.go:1348
+#: lxc/storage_volume.go:1353 lxc/storage_volume.go:1354
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5529,7 +5529,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:647 lxc/remote.go:648
+#: lxc/remote.go:714 lxc/remote.go:715
 msgid "Show the default remote"
 msgstr ""
 
@@ -5583,15 +5583,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2404 lxc/storage_volume.go:2405
+#: lxc/storage_volume.go:2410 lxc/storage_volume.go:2411
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2167
+#: lxc/storage_volume.go:2173
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:607 lxc/storage_volume.go:1485
+#: lxc/info.go:607 lxc/storage_volume.go:1491
 msgid "Snapshots:"
 msgstr ""
 
@@ -5692,21 +5692,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:696
+#: lxc/storage_volume.go:702
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:784
+#: lxc/storage_volume.go:790
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:509
+#: lxc/storage_volume.go:515
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:513
+#: lxc/storage_volume.go:519
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5741,7 +5741,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:916 lxc/remote.go:917
+#: lxc/remote.go:983 lxc/remote.go:984
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5760,11 +5760,11 @@ msgstr ""
 #: lxc/auth.go:818 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
-#: lxc/storage_volume.go:1730 lxc/warning.go:216
+#: lxc/storage_volume.go:1736 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1557
+#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1563
 msgid "Taken at"
 msgstr ""
 
@@ -5774,6 +5774,12 @@ msgstr ""
 
 #: lxc/file.go:1256
 msgid "Target path must be a directory"
+msgstr ""
+
+#: lxc/remote.go:161 lxc/remote.go:334
+msgid ""
+"The --accept-certificate flag is not supported when adding a remote using a "
+"trust token"
 msgstr ""
 
 #: lxc/move.go:181
@@ -5915,15 +5921,20 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1323
+#: lxc/storage_volume.go:1329
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1300
+#: lxc/storage_volume.go:1306
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
+msgstr ""
+
+#: lxc/remote.go:527
+msgid ""
+"The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
 
 #: lxc/info.go:354
@@ -5934,8 +5945,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:875
-#: lxc/storage_volume.go:972
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:881
+#: lxc/storage_volume.go:978
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6010,7 +6021,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1470
+#: lxc/storage_volume.go:1476
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6025,7 +6036,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1847
+#: lxc/storage_volume.go:1853
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6059,7 +6070,15 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:571
+#: lxc/remote.go:329
+msgid "Trust token cannot be used for public remotes"
+msgstr ""
+
+#: lxc/remote.go:324
+msgid "Trust token cannot be used with OIDC authentication"
+msgstr ""
+
+#: lxc/remote.go:639
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6084,7 +6103,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1455
+#: lxc/storage_volume.go:1461
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6102,17 +6121,17 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:193 lxc/remote.go:749
+#: lxc/cluster.go:193 lxc/remote.go:816
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1735
+#: lxc/project.go:995 lxc/storage_volume.go:1741
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1734
+#: lxc/storage.go:724 lxc/storage_volume.go:1740
 msgid "USED BY"
 msgstr ""
 
@@ -6130,7 +6149,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:214 lxc/remote.go:248
+#: lxc/remote.go:226 lxc/remote.go:260
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6144,7 +6163,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1772
+#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1778
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6250,7 +6269,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2342 lxc/storage_volume.go:2343
+#: lxc/storage_volume.go:2348 lxc/storage_volume.go:2349
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6302,7 +6321,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2356
+#: lxc/storage_volume.go:2362
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6346,12 +6365,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1468
+#: lxc/storage_volume.go:1474
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2629
+#: lxc/export.go:42 lxc/storage_volume.go:2635
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6418,7 +6437,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1559
+#: lxc/storage_volume.go:1565
 msgid "Volume Only"
 msgstr ""
 
@@ -6453,7 +6472,7 @@ msgstr ""
 
 #: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
+#: lxc/project.go:552 lxc/remote.go:777 lxc/remote.go:782 lxc/remote.go:787
 msgid "YES"
 msgstr ""
 
@@ -6477,7 +6496,7 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:897
+#: lxc/storage_volume.go:903
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
@@ -6899,7 +6918,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2788
+#: lxc/storage_volume.go:2794
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -6934,13 +6953,13 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:1941
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:799
+#: lxc/storage_volume.go:805
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
@@ -6948,47 +6967,47 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2539
+#: lxc/storage_volume.go:2545
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2622
+#: lxc/storage_volume.go:2628
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2403
+#: lxc/storage_volume.go:2409
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:603
+#: lxc/storage_volume.go:609
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:711
+#: lxc/storage_volume.go:717
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:994 lxc/storage_volume.go:1346
+#: lxc/storage_volume.go:1000 lxc/storage_volume.go:1352
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2341
+#: lxc/storage_volume.go:2347
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2062
+#: lxc/storage_volume.go:2068
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2220
+#: lxc/storage_volume.go:2226
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1215
+#: lxc/storage_volume.go:1221
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1841
+#: lxc/storage_volume.go:1847
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7098,7 +7117,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1584
+#: lxc/storage_volume.go:1590
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7110,7 +7129,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:739
+#: lxc/project.go:557 lxc/remote.go:806
 msgid "current"
 msgstr ""
 
@@ -7570,7 +7589,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:607
+#: lxc/storage_volume.go:613
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7578,13 +7597,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2792
+#: lxc/storage_volume.go:2798
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2407
+#: lxc/storage_volume.go:2413
 msgid ""
 "lxc storage volume snapshot create default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7594,7 +7613,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:531
 msgid "n"
 msgstr ""
 
@@ -7606,7 +7625,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:510
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7643,7 +7662,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:465
+#: lxc/remote.go:519
 msgid "y"
 msgstr ""
 

--- a/po/hi.po
+++ b/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-08 07:43+0100\n"
+"POT-Creation-Date: 2024-10-14 13:30+0000\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hindi <https://hosted.weblate.org/projects/linux-containers/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1024
+#: lxc/storage_volume.go:1030
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -515,15 +515,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:850 lxc/remote.go:915
+#: lxc/remote.go:917 lxc/remote.go:982
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:963
+#: lxc/remote.go:1030
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:769
+#: lxc/remote.go:836
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -556,7 +556,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:751
+#: lxc/remote.go:818
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:581
+#: lxc/remote.go:648
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -738,11 +738,11 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1590
+#: lxc/storage_volume.go:1596
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:182
+#: lxc/remote.go:194
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -813,7 +813,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:552
+#: lxc/remote.go:621
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -849,16 +849,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2696
+#: lxc/storage_volume.go:2702
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2773
+#: lxc/export.go:192 lxc/storage_volume.go:2779
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:654 lxc/storage_volume.go:1521
+#: lxc/info.go:654 lxc/storage_volume.go:1527
 msgid "Backups:"
 msgstr ""
 
@@ -879,7 +879,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:679
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:685
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -922,7 +922,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1733
+#: lxc/storage_volume.go:1739
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -991,7 +991,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:894
+#: lxc/remote.go:961
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1007,7 +1007,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1749 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1024,12 +1024,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:486
+#: lxc/storage_volume.go:492
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:440
+#: lxc/storage_volume.go:446
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1057,11 +1057,11 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:509
 msgid "Certificate fingerprint"
 msgstr ""
 
-#: lxc/remote.go:219
+#: lxc/remote.go:231
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
@@ -1076,7 +1076,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:620
+#: lxc/remote.go:687
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1150,13 +1150,13 @@ msgstr ""
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
 #: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
-#: lxc/storage_volume.go:612 lxc/storage_volume.go:717
-#: lxc/storage_volume.go:1005 lxc/storage_volume.go:1231
-#: lxc/storage_volume.go:1360 lxc/storage_volume.go:1848
-#: lxc/storage_volume.go:1940 lxc/storage_volume.go:2079
-#: lxc/storage_volume.go:2239 lxc/storage_volume.go:2355
-#: lxc/storage_volume.go:2416 lxc/storage_volume.go:2543
-#: lxc/storage_volume.go:2631 lxc/storage_volume.go:2795
+#: lxc/storage_volume.go:618 lxc/storage_volume.go:723
+#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1237
+#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1854
+#: lxc/storage_volume.go:1946 lxc/storage_volume.go:2085
+#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2361
+#: lxc/storage_volume.go:2422 lxc/storage_volume.go:2549
+#: lxc/storage_volume.go:2637 lxc/storage_volume.go:2801
 msgid "Cluster member name"
 msgstr ""
 
@@ -1172,7 +1172,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1589
+#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1595
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1216,17 +1216,17 @@ msgstr ""
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1150
-#: lxc/storage_volume.go:1182
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
+#: lxc/storage_volume.go:1188
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:613
+#: lxc/storage_volume.go:619
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1467
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1310,7 +1310,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:508
+#: lxc/storage_volume.go:514
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1324,12 +1324,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:490
+#: lxc/remote.go:559
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:225 lxc/remote.go:474
+#: lxc/remote.go:237 lxc/remote.go:543
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1368,7 +1368,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:485
+#: lxc/remote.go:554
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1437,7 +1437,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:604 lxc/storage_volume.go:605
+#: lxc/storage_volume.go:610 lxc/storage_volume.go:611
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1489,7 +1489,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1475
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1481
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1524,7 +1524,7 @@ msgstr ""
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1732
+#: lxc/storage_volume.go:1738
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1544,7 +1544,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2630
+#: lxc/storage_volume.go:2636
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1640,7 +1640,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:713 lxc/storage_volume.go:714
+#: lxc/storage_volume.go:719 lxc/storage_volume.go:720
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1732,9 +1732,9 @@ msgstr ""
 #: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
 #: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
 #: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:648
-#: lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853 lxc/remote.go:917
-#: lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:715
+#: lxc/remote.go:753 lxc/remote.go:839 lxc/remote.go:920 lxc/remote.go:984
+#: lxc/remote.go:1032 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1746,26 +1746,26 @@ msgstr ""
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
 #: lxc/storage_volume.go:169 lxc/storage_volume.go:283
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:605
-#: lxc/storage_volume.go:714 lxc/storage_volume.go:801
-#: lxc/storage_volume.go:899 lxc/storage_volume.go:996
-#: lxc/storage_volume.go:1217 lxc/storage_volume.go:1348
-#: lxc/storage_volume.go:1507 lxc/storage_volume.go:1591
-#: lxc/storage_volume.go:1844 lxc/storage_volume.go:1937
-#: lxc/storage_volume.go:2064 lxc/storage_volume.go:2222
-#: lxc/storage_volume.go:2343 lxc/storage_volume.go:2405
-#: lxc/storage_volume.go:2541 lxc/storage_volume.go:2624
-#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:611
+#: lxc/storage_volume.go:720 lxc/storage_volume.go:807
+#: lxc/storage_volume.go:905 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:1223 lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1513 lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1850 lxc/storage_volume.go:1943
+#: lxc/storage_volume.go:2070 lxc/storage_volume.go:2228
+#: lxc/storage_volume.go:2349 lxc/storage_volume.go:2411
+#: lxc/storage_volume.go:2547 lxc/storage_volume.go:2630
+#: lxc/storage_volume.go:2796 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1448
+#: lxc/storage_volume.go:1454
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:1849
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:1855
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1777,11 +1777,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:800 lxc/storage_volume.go:801
+#: lxc/storage_volume.go:806 lxc/storage_volume.go:807
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:898 lxc/storage_volume.go:899
+#: lxc/storage_volume.go:904 lxc/storage_volume.go:905
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -2007,7 +2007,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:995 lxc/storage_volume.go:996
+#: lxc/storage_volume.go:1001 lxc/storage_volume.go:1002
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2015,7 +2015,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1766
+#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1772
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2072,7 +2072,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2193
+#: lxc/storage_volume.go:2161 lxc/storage_volume.go:2199
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2086,8 +2086,8 @@ msgstr ""
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2149
-#: lxc/storage_volume.go:2187
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2155
+#: lxc/storage_volume.go:2193
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2129,8 +2129,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1508
-#: lxc/storage_volume.go:1558
+#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1514
+#: lxc/storage_volume.go:1564
 msgid "Expires at"
 msgstr ""
 
@@ -2154,7 +2154,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2623 lxc/storage_volume.go:2624
+#: lxc/storage_volume.go:2629 lxc/storage_volume.go:2630
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2166,11 +2166,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2627
+#: lxc/storage_volume.go:2633
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2756
+#: lxc/export.go:152 lxc/storage_volume.go:2762
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2287,11 +2287,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:191
+#: lxc/remote.go:203
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:242
+#: lxc/remote.go:254
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2301,7 +2301,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:232
+#: lxc/remote.go:244
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2311,12 +2311,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:260
+#: lxc/remote.go:486
 #, c-format
-msgid "Failed to create certificate: %w"
+msgid "Failed to decode trust token: %w"
 msgstr ""
 
-#: lxc/remote.go:267
+#: lxc/remote.go:292
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2341,7 +2341,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:237
+#: lxc/remote.go:249
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2428,9 +2428,9 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:690 lxc/storage.go:657
+#: lxc/project.go:919 lxc/remote.go:757 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1608 lxc/warning.go:94
+#: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2466,7 +2466,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:754
+#: lxc/remote.go:821
 msgid "GLOBAL"
 msgstr ""
 
@@ -2486,7 +2486,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:160 lxc/remote.go:401
+#: lxc/remote.go:165 lxc/remote.go:443
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2554,7 +2554,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1238
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2618,11 +2618,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1216 lxc/storage_volume.go:1217
+#: lxc/storage_volume.go:1222 lxc/storage_volume.go:1223
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:469
+#: lxc/storage_volume.go:475
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2746,7 +2746,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2415
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2421
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2760,7 +2760,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2414
+#: lxc/storage_volume.go:2420
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2810,7 +2810,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2790
+#: lxc/storage_volume.go:2796
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2818,7 +2818,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2789
+#: lxc/storage_volume.go:2795
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2840,11 +2840,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2797
+#: lxc/storage_volume.go:2803
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2871
+#: lxc/storage_volume.go:2877
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2910,7 +2910,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:353
+#: lxc/remote.go:395
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2970,7 +2970,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2000
+#: lxc/move.go:148 lxc/storage_volume.go:2006
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2978,7 +2978,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1996
+#: lxc/storage_volume.go:2002
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2991,14 +2991,14 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:342
+#: lxc/remote.go:384
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1064 lxc/storage_volume.go:1281
-#: lxc/storage_volume.go:1405 lxc/storage_volume.go:1985
-#: lxc/storage_volume.go:2132 lxc/storage_volume.go:2284
+#: lxc/storage_volume.go:1070 lxc/storage_volume.go:1287
+#: lxc/storage_volume.go:1411 lxc/storage_volume.go:1991
+#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2290
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3044,7 +3044,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1739 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1745 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3347,11 +3347,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1586
+#: lxc/storage_volume.go:1592
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1597
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3371,7 +3371,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:685 lxc/remote.go:686
+#: lxc/remote.go:752 lxc/remote.go:753
 msgid "List the available remotes"
 msgstr ""
 
@@ -3410,7 +3410,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1464
+#: lxc/info.go:489 lxc/storage_volume.go:1470
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3874,12 +3874,12 @@ msgstr ""
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:323 lxc/storage_volume.go:643
-#: lxc/storage_volume.go:750 lxc/storage_volume.go:841
-#: lxc/storage_volume.go:939 lxc/storage_volume.go:1053
-#: lxc/storage_volume.go:1270 lxc/storage_volume.go:1974
-#: lxc/storage_volume.go:2115 lxc/storage_volume.go:2273
-#: lxc/storage_volume.go:2464 lxc/storage_volume.go:2581
+#: lxc/storage_volume.go:323 lxc/storage_volume.go:649
+#: lxc/storage_volume.go:756 lxc/storage_volume.go:847
+#: lxc/storage_volume.go:945 lxc/storage_volume.go:1059
+#: lxc/storage_volume.go:1276 lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:2121 lxc/storage_volume.go:2279
+#: lxc/storage_volume.go:2470 lxc/storage_volume.go:2587
 msgid "Missing pool name"
 msgstr ""
 
@@ -3898,11 +3898,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:432 lxc/storage_volume.go:1884
+#: lxc/storage_volume.go:438 lxc/storage_volume.go:1890
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1394
+#: lxc/storage_volume.go:1400
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -3939,8 +3939,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:861
-#: lxc/storage_volume.go:958
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:867
+#: lxc/storage_volume.go:964
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -3977,7 +3977,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1843 lxc/storage_volume.go:1844
+#: lxc/storage_volume.go:1849 lxc/storage_volume.go:1850
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -3985,11 +3985,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1850
+#: lxc/storage_volume.go:1856
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:512
+#: lxc/storage_volume.go:518
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4015,8 +4015,8 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
-#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1731
+#: lxc/remote.go:815 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
 msgstr ""
 
@@ -4042,7 +4042,7 @@ msgstr ""
 
 #: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
+#: lxc/project.go:550 lxc/remote.go:775 lxc/remote.go:780 lxc/remote.go:785
 msgid "NO"
 msgstr ""
 
@@ -4064,8 +4064,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1506
-#: lxc/storage_volume.go:1556
+#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1512
+#: lxc/storage_volume.go:1562
 msgid "Name"
 msgstr ""
 
@@ -4073,7 +4073,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1446
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1452
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4217,7 +4217,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:870 lxc/storage_volume.go:967
+#: lxc/storage_volume.go:876 lxc/storage_volume.go:973
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4233,11 +4233,11 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/storage_volume.go:446 lxc/storage_volume.go:1893
+#: lxc/storage_volume.go:452 lxc/storage_volume.go:1899
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:496 lxc/storage_volume.go:1904
+#: lxc/storage_volume.go:502 lxc/storage_volume.go:1910
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4251,7 +4251,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2012
+#: lxc/storage_volume.go:2018
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4263,15 +4263,15 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2678
+#: lxc/storage_volume.go:2684
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2477
+#: lxc/storage_volume.go:2483
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:336
+#: lxc/remote.go:378
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4279,7 +4279,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1412
+#: lxc/storage_volume.go:1418
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4292,7 +4292,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:693 lxc/storage_volume.go:1560
+#: lxc/info.go:693 lxc/storage_volume.go:1566
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4322,7 +4322,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1756
 msgid "POOL"
 msgstr ""
 
@@ -4338,15 +4338,15 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:213
+#: lxc/list.go:567 lxc/storage_volume.go:1762 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:817
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:752
+#: lxc/image.go:1136 lxc/remote.go:819
 msgid "PUBLIC"
 msgstr ""
 
@@ -4375,7 +4375,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:183
+#: lxc/remote.go:195
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4387,8 +4387,8 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:466
-msgid "Please type 'y', 'n' or the fingerprint:"
+#: lxc/remote.go:536
+msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
 #: lxc/info.go:221
@@ -4412,8 +4412,8 @@ msgstr ""
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1151
-#: lxc/storage_volume.go:1183
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
+#: lxc/storage_volume.go:1189
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4530,7 +4530,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1350
+#: lxc/storage_volume.go:1356
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4544,7 +4544,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1219
+#: lxc/storage_volume.go:1225
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4560,7 +4560,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2224
+#: lxc/storage_volume.go:2230
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4581,7 +4581,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:998
+#: lxc/storage_volume.go:1004
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4590,7 +4590,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2069
+#: lxc/storage_volume.go:2075
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4603,7 +4603,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2345
+#: lxc/storage_volume.go:2351
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4707,33 +4707,33 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:810
+#: lxc/remote.go:877
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
-#: lxc/remote.go:994
+#: lxc/project.go:884 lxc/remote.go:868 lxc/remote.go:949 lxc/remote.go:1013
+#: lxc/remote.go:1061
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:305
+#: lxc/remote.go:345
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:890
+#: lxc/remote.go:957
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:805 lxc/remote.go:886 lxc/remote.go:998
+#: lxc/remote.go:872 lxc/remote.go:953 lxc/remote.go:1065
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:294
+#: lxc/remote.go:319
 msgid "Remote address must not be empty"
 msgstr ""
 
@@ -4741,7 +4741,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:299
+#: lxc/remote.go:339
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4827,7 +4827,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:852 lxc/remote.go:853
+#: lxc/remote.go:919 lxc/remote.go:920
 msgid "Remove remotes"
 msgstr ""
 
@@ -4884,19 +4884,19 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:771 lxc/remote.go:772
+#: lxc/remote.go:838 lxc/remote.go:839
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:1943
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1936
+#: lxc/storage_volume.go:1942
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2025 lxc/storage_volume.go:2045
+#: lxc/storage_volume.go:2031 lxc/storage_volume.go:2051
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4948,7 +4948,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2540 lxc/storage_volume.go:2541
+#: lxc/storage_volume.go:2546 lxc/storage_volume.go:2547
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5029,7 +5029,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:820
 msgid "STATIC"
 msgstr ""
 
@@ -5070,11 +5070,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:464
+#: lxc/remote.go:532
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:616
+#: lxc/remote.go:285 lxc/remote.go:683
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5272,11 +5272,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2063
+#: lxc/storage_volume.go:2069
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2064
+#: lxc/storage_volume.go:2070
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5285,7 +5285,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:964 lxc/remote.go:965
+#: lxc/remote.go:1031 lxc/remote.go:1032
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5361,7 +5361,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2080
+#: lxc/storage_volume.go:2086
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5510,11 +5510,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2221 lxc/storage_volume.go:2222
+#: lxc/storage_volume.go:2227 lxc/storage_volume.go:2228
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1347 lxc/storage_volume.go:1348
+#: lxc/storage_volume.go:1353 lxc/storage_volume.go:1354
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5528,7 +5528,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:647 lxc/remote.go:648
+#: lxc/remote.go:714 lxc/remote.go:715
 msgid "Show the default remote"
 msgstr ""
 
@@ -5582,15 +5582,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2404 lxc/storage_volume.go:2405
+#: lxc/storage_volume.go:2410 lxc/storage_volume.go:2411
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2167
+#: lxc/storage_volume.go:2173
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:607 lxc/storage_volume.go:1485
+#: lxc/info.go:607 lxc/storage_volume.go:1491
 msgid "Snapshots:"
 msgstr ""
 
@@ -5691,21 +5691,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:696
+#: lxc/storage_volume.go:702
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:784
+#: lxc/storage_volume.go:790
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:509
+#: lxc/storage_volume.go:515
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:513
+#: lxc/storage_volume.go:519
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5740,7 +5740,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:916 lxc/remote.go:917
+#: lxc/remote.go:983 lxc/remote.go:984
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5759,11 +5759,11 @@ msgstr ""
 #: lxc/auth.go:818 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
-#: lxc/storage_volume.go:1730 lxc/warning.go:216
+#: lxc/storage_volume.go:1736 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1557
+#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1563
 msgid "Taken at"
 msgstr ""
 
@@ -5773,6 +5773,12 @@ msgstr ""
 
 #: lxc/file.go:1256
 msgid "Target path must be a directory"
+msgstr ""
+
+#: lxc/remote.go:161 lxc/remote.go:334
+msgid ""
+"The --accept-certificate flag is not supported when adding a remote using a "
+"trust token"
 msgstr ""
 
 #: lxc/move.go:181
@@ -5914,15 +5920,20 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1323
+#: lxc/storage_volume.go:1329
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1300
+#: lxc/storage_volume.go:1306
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
+msgstr ""
+
+#: lxc/remote.go:527
+msgid ""
+"The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
 
 #: lxc/info.go:354
@@ -5933,8 +5944,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:875
-#: lxc/storage_volume.go:972
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:881
+#: lxc/storage_volume.go:978
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6009,7 +6020,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1470
+#: lxc/storage_volume.go:1476
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6024,7 +6035,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1847
+#: lxc/storage_volume.go:1853
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6058,7 +6069,15 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:571
+#: lxc/remote.go:329
+msgid "Trust token cannot be used for public remotes"
+msgstr ""
+
+#: lxc/remote.go:324
+msgid "Trust token cannot be used with OIDC authentication"
+msgstr ""
+
+#: lxc/remote.go:639
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6083,7 +6102,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1455
+#: lxc/storage_volume.go:1461
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6101,17 +6120,17 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:193 lxc/remote.go:749
+#: lxc/cluster.go:193 lxc/remote.go:816
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1735
+#: lxc/project.go:995 lxc/storage_volume.go:1741
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1734
+#: lxc/storage.go:724 lxc/storage_volume.go:1740
 msgid "USED BY"
 msgstr ""
 
@@ -6129,7 +6148,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:214 lxc/remote.go:248
+#: lxc/remote.go:226 lxc/remote.go:260
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6143,7 +6162,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1772
+#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1778
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6249,7 +6268,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2342 lxc/storage_volume.go:2343
+#: lxc/storage_volume.go:2348 lxc/storage_volume.go:2349
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6301,7 +6320,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2356
+#: lxc/storage_volume.go:2362
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6345,12 +6364,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1468
+#: lxc/storage_volume.go:1474
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2629
+#: lxc/export.go:42 lxc/storage_volume.go:2635
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6417,7 +6436,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1559
+#: lxc/storage_volume.go:1565
 msgid "Volume Only"
 msgstr ""
 
@@ -6452,7 +6471,7 @@ msgstr ""
 
 #: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
+#: lxc/project.go:552 lxc/remote.go:777 lxc/remote.go:782 lxc/remote.go:787
 msgid "YES"
 msgstr ""
 
@@ -6476,7 +6495,7 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:897
+#: lxc/storage_volume.go:903
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
@@ -6898,7 +6917,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2788
+#: lxc/storage_volume.go:2794
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -6933,13 +6952,13 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:1941
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:799
+#: lxc/storage_volume.go:805
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
@@ -6947,47 +6966,47 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2539
+#: lxc/storage_volume.go:2545
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2622
+#: lxc/storage_volume.go:2628
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2403
+#: lxc/storage_volume.go:2409
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:603
+#: lxc/storage_volume.go:609
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:711
+#: lxc/storage_volume.go:717
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:994 lxc/storage_volume.go:1346
+#: lxc/storage_volume.go:1000 lxc/storage_volume.go:1352
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2341
+#: lxc/storage_volume.go:2347
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2062
+#: lxc/storage_volume.go:2068
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2220
+#: lxc/storage_volume.go:2226
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1215
+#: lxc/storage_volume.go:1221
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1841
+#: lxc/storage_volume.go:1847
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7097,7 +7116,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1584
+#: lxc/storage_volume.go:1590
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7109,7 +7128,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:739
+#: lxc/project.go:557 lxc/remote.go:806
 msgid "current"
 msgstr ""
 
@@ -7569,7 +7588,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:607
+#: lxc/storage_volume.go:613
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7577,13 +7596,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2792
+#: lxc/storage_volume.go:2798
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2407
+#: lxc/storage_volume.go:2413
 msgid ""
 "lxc storage volume snapshot create default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7593,7 +7612,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:531
 msgid "n"
 msgstr ""
 
@@ -7605,7 +7624,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:510
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7642,7 +7661,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:465
+#: lxc/remote.go:519
 msgid "y"
 msgstr ""
 

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-08 07:43+0100\n"
+"POT-Creation-Date: 2024-10-14 13:30+0000\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Indonesian <https://hosted.weblate.org/projects/linux-"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1024
+#: lxc/storage_volume.go:1030
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -515,15 +515,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:850 lxc/remote.go:915
+#: lxc/remote.go:917 lxc/remote.go:982
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:963
+#: lxc/remote.go:1030
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:769
+#: lxc/remote.go:836
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -556,7 +556,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:751
+#: lxc/remote.go:818
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:581
+#: lxc/remote.go:648
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -738,11 +738,11 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1590
+#: lxc/storage_volume.go:1596
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:182
+#: lxc/remote.go:194
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -813,7 +813,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:552
+#: lxc/remote.go:621
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -849,16 +849,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2696
+#: lxc/storage_volume.go:2702
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2773
+#: lxc/export.go:192 lxc/storage_volume.go:2779
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:654 lxc/storage_volume.go:1521
+#: lxc/info.go:654 lxc/storage_volume.go:1527
 msgid "Backups:"
 msgstr ""
 
@@ -879,7 +879,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:679
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:685
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -922,7 +922,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1733
+#: lxc/storage_volume.go:1739
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -991,7 +991,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:894
+#: lxc/remote.go:961
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1007,7 +1007,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1749 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1024,12 +1024,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:486
+#: lxc/storage_volume.go:492
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:440
+#: lxc/storage_volume.go:446
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1057,11 +1057,11 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:509
 msgid "Certificate fingerprint"
 msgstr ""
 
-#: lxc/remote.go:219
+#: lxc/remote.go:231
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
@@ -1076,7 +1076,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:620
+#: lxc/remote.go:687
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1150,13 +1150,13 @@ msgstr ""
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
 #: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
-#: lxc/storage_volume.go:612 lxc/storage_volume.go:717
-#: lxc/storage_volume.go:1005 lxc/storage_volume.go:1231
-#: lxc/storage_volume.go:1360 lxc/storage_volume.go:1848
-#: lxc/storage_volume.go:1940 lxc/storage_volume.go:2079
-#: lxc/storage_volume.go:2239 lxc/storage_volume.go:2355
-#: lxc/storage_volume.go:2416 lxc/storage_volume.go:2543
-#: lxc/storage_volume.go:2631 lxc/storage_volume.go:2795
+#: lxc/storage_volume.go:618 lxc/storage_volume.go:723
+#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1237
+#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1854
+#: lxc/storage_volume.go:1946 lxc/storage_volume.go:2085
+#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2361
+#: lxc/storage_volume.go:2422 lxc/storage_volume.go:2549
+#: lxc/storage_volume.go:2637 lxc/storage_volume.go:2801
 msgid "Cluster member name"
 msgstr ""
 
@@ -1172,7 +1172,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1589
+#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1595
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1216,17 +1216,17 @@ msgstr ""
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1150
-#: lxc/storage_volume.go:1182
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
+#: lxc/storage_volume.go:1188
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:613
+#: lxc/storage_volume.go:619
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1467
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1310,7 +1310,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:508
+#: lxc/storage_volume.go:514
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1324,12 +1324,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:490
+#: lxc/remote.go:559
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:225 lxc/remote.go:474
+#: lxc/remote.go:237 lxc/remote.go:543
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1368,7 +1368,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:485
+#: lxc/remote.go:554
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1437,7 +1437,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:604 lxc/storage_volume.go:605
+#: lxc/storage_volume.go:610 lxc/storage_volume.go:611
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1489,7 +1489,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1475
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1481
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1524,7 +1524,7 @@ msgstr ""
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1732
+#: lxc/storage_volume.go:1738
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1544,7 +1544,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2630
+#: lxc/storage_volume.go:2636
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1640,7 +1640,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:713 lxc/storage_volume.go:714
+#: lxc/storage_volume.go:719 lxc/storage_volume.go:720
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1732,9 +1732,9 @@ msgstr ""
 #: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
 #: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
 #: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:648
-#: lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853 lxc/remote.go:917
-#: lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:715
+#: lxc/remote.go:753 lxc/remote.go:839 lxc/remote.go:920 lxc/remote.go:984
+#: lxc/remote.go:1032 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1746,26 +1746,26 @@ msgstr ""
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
 #: lxc/storage_volume.go:169 lxc/storage_volume.go:283
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:605
-#: lxc/storage_volume.go:714 lxc/storage_volume.go:801
-#: lxc/storage_volume.go:899 lxc/storage_volume.go:996
-#: lxc/storage_volume.go:1217 lxc/storage_volume.go:1348
-#: lxc/storage_volume.go:1507 lxc/storage_volume.go:1591
-#: lxc/storage_volume.go:1844 lxc/storage_volume.go:1937
-#: lxc/storage_volume.go:2064 lxc/storage_volume.go:2222
-#: lxc/storage_volume.go:2343 lxc/storage_volume.go:2405
-#: lxc/storage_volume.go:2541 lxc/storage_volume.go:2624
-#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:611
+#: lxc/storage_volume.go:720 lxc/storage_volume.go:807
+#: lxc/storage_volume.go:905 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:1223 lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1513 lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1850 lxc/storage_volume.go:1943
+#: lxc/storage_volume.go:2070 lxc/storage_volume.go:2228
+#: lxc/storage_volume.go:2349 lxc/storage_volume.go:2411
+#: lxc/storage_volume.go:2547 lxc/storage_volume.go:2630
+#: lxc/storage_volume.go:2796 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1448
+#: lxc/storage_volume.go:1454
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:1849
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:1855
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1777,11 +1777,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:800 lxc/storage_volume.go:801
+#: lxc/storage_volume.go:806 lxc/storage_volume.go:807
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:898 lxc/storage_volume.go:899
+#: lxc/storage_volume.go:904 lxc/storage_volume.go:905
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -2007,7 +2007,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:995 lxc/storage_volume.go:996
+#: lxc/storage_volume.go:1001 lxc/storage_volume.go:1002
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2015,7 +2015,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1766
+#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1772
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2072,7 +2072,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2193
+#: lxc/storage_volume.go:2161 lxc/storage_volume.go:2199
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2086,8 +2086,8 @@ msgstr ""
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2149
-#: lxc/storage_volume.go:2187
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2155
+#: lxc/storage_volume.go:2193
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2129,8 +2129,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1508
-#: lxc/storage_volume.go:1558
+#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1514
+#: lxc/storage_volume.go:1564
 msgid "Expires at"
 msgstr ""
 
@@ -2154,7 +2154,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2623 lxc/storage_volume.go:2624
+#: lxc/storage_volume.go:2629 lxc/storage_volume.go:2630
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2166,11 +2166,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2627
+#: lxc/storage_volume.go:2633
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2756
+#: lxc/export.go:152 lxc/storage_volume.go:2762
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2287,11 +2287,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:191
+#: lxc/remote.go:203
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:242
+#: lxc/remote.go:254
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2301,7 +2301,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:232
+#: lxc/remote.go:244
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2311,12 +2311,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:260
+#: lxc/remote.go:486
 #, c-format
-msgid "Failed to create certificate: %w"
+msgid "Failed to decode trust token: %w"
 msgstr ""
 
-#: lxc/remote.go:267
+#: lxc/remote.go:292
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2341,7 +2341,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:237
+#: lxc/remote.go:249
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2428,9 +2428,9 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:690 lxc/storage.go:657
+#: lxc/project.go:919 lxc/remote.go:757 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1608 lxc/warning.go:94
+#: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2466,7 +2466,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:754
+#: lxc/remote.go:821
 msgid "GLOBAL"
 msgstr ""
 
@@ -2486,7 +2486,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:160 lxc/remote.go:401
+#: lxc/remote.go:165 lxc/remote.go:443
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2554,7 +2554,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1238
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2618,11 +2618,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1216 lxc/storage_volume.go:1217
+#: lxc/storage_volume.go:1222 lxc/storage_volume.go:1223
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:469
+#: lxc/storage_volume.go:475
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2746,7 +2746,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2415
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2421
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2760,7 +2760,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2414
+#: lxc/storage_volume.go:2420
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2810,7 +2810,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2790
+#: lxc/storage_volume.go:2796
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2818,7 +2818,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2789
+#: lxc/storage_volume.go:2795
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2840,11 +2840,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2797
+#: lxc/storage_volume.go:2803
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2871
+#: lxc/storage_volume.go:2877
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2910,7 +2910,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:353
+#: lxc/remote.go:395
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2970,7 +2970,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2000
+#: lxc/move.go:148 lxc/storage_volume.go:2006
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2978,7 +2978,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1996
+#: lxc/storage_volume.go:2002
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2991,14 +2991,14 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:342
+#: lxc/remote.go:384
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1064 lxc/storage_volume.go:1281
-#: lxc/storage_volume.go:1405 lxc/storage_volume.go:1985
-#: lxc/storage_volume.go:2132 lxc/storage_volume.go:2284
+#: lxc/storage_volume.go:1070 lxc/storage_volume.go:1287
+#: lxc/storage_volume.go:1411 lxc/storage_volume.go:1991
+#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2290
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3044,7 +3044,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1739 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1745 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3347,11 +3347,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1586
+#: lxc/storage_volume.go:1592
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1597
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3371,7 +3371,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:685 lxc/remote.go:686
+#: lxc/remote.go:752 lxc/remote.go:753
 msgid "List the available remotes"
 msgstr ""
 
@@ -3410,7 +3410,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1464
+#: lxc/info.go:489 lxc/storage_volume.go:1470
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3874,12 +3874,12 @@ msgstr ""
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:323 lxc/storage_volume.go:643
-#: lxc/storage_volume.go:750 lxc/storage_volume.go:841
-#: lxc/storage_volume.go:939 lxc/storage_volume.go:1053
-#: lxc/storage_volume.go:1270 lxc/storage_volume.go:1974
-#: lxc/storage_volume.go:2115 lxc/storage_volume.go:2273
-#: lxc/storage_volume.go:2464 lxc/storage_volume.go:2581
+#: lxc/storage_volume.go:323 lxc/storage_volume.go:649
+#: lxc/storage_volume.go:756 lxc/storage_volume.go:847
+#: lxc/storage_volume.go:945 lxc/storage_volume.go:1059
+#: lxc/storage_volume.go:1276 lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:2121 lxc/storage_volume.go:2279
+#: lxc/storage_volume.go:2470 lxc/storage_volume.go:2587
 msgid "Missing pool name"
 msgstr ""
 
@@ -3898,11 +3898,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:432 lxc/storage_volume.go:1884
+#: lxc/storage_volume.go:438 lxc/storage_volume.go:1890
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1394
+#: lxc/storage_volume.go:1400
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -3939,8 +3939,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:861
-#: lxc/storage_volume.go:958
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:867
+#: lxc/storage_volume.go:964
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -3977,7 +3977,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1843 lxc/storage_volume.go:1844
+#: lxc/storage_volume.go:1849 lxc/storage_volume.go:1850
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -3985,11 +3985,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1850
+#: lxc/storage_volume.go:1856
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:512
+#: lxc/storage_volume.go:518
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4015,8 +4015,8 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
-#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1731
+#: lxc/remote.go:815 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
 msgstr ""
 
@@ -4042,7 +4042,7 @@ msgstr ""
 
 #: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
+#: lxc/project.go:550 lxc/remote.go:775 lxc/remote.go:780 lxc/remote.go:785
 msgid "NO"
 msgstr ""
 
@@ -4064,8 +4064,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1506
-#: lxc/storage_volume.go:1556
+#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1512
+#: lxc/storage_volume.go:1562
 msgid "Name"
 msgstr ""
 
@@ -4073,7 +4073,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1446
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1452
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4217,7 +4217,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:870 lxc/storage_volume.go:967
+#: lxc/storage_volume.go:876 lxc/storage_volume.go:973
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4233,11 +4233,11 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/storage_volume.go:446 lxc/storage_volume.go:1893
+#: lxc/storage_volume.go:452 lxc/storage_volume.go:1899
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:496 lxc/storage_volume.go:1904
+#: lxc/storage_volume.go:502 lxc/storage_volume.go:1910
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4251,7 +4251,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2012
+#: lxc/storage_volume.go:2018
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4263,15 +4263,15 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2678
+#: lxc/storage_volume.go:2684
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2477
+#: lxc/storage_volume.go:2483
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:336
+#: lxc/remote.go:378
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4279,7 +4279,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1412
+#: lxc/storage_volume.go:1418
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4292,7 +4292,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:693 lxc/storage_volume.go:1560
+#: lxc/info.go:693 lxc/storage_volume.go:1566
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4322,7 +4322,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1756
 msgid "POOL"
 msgstr ""
 
@@ -4338,15 +4338,15 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:213
+#: lxc/list.go:567 lxc/storage_volume.go:1762 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:817
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:752
+#: lxc/image.go:1136 lxc/remote.go:819
 msgid "PUBLIC"
 msgstr ""
 
@@ -4375,7 +4375,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:183
+#: lxc/remote.go:195
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4387,8 +4387,8 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:466
-msgid "Please type 'y', 'n' or the fingerprint:"
+#: lxc/remote.go:536
+msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
 #: lxc/info.go:221
@@ -4412,8 +4412,8 @@ msgstr ""
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1151
-#: lxc/storage_volume.go:1183
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
+#: lxc/storage_volume.go:1189
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4530,7 +4530,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1350
+#: lxc/storage_volume.go:1356
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4544,7 +4544,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1219
+#: lxc/storage_volume.go:1225
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4560,7 +4560,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2224
+#: lxc/storage_volume.go:2230
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4581,7 +4581,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:998
+#: lxc/storage_volume.go:1004
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4590,7 +4590,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2069
+#: lxc/storage_volume.go:2075
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4603,7 +4603,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2345
+#: lxc/storage_volume.go:2351
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4707,33 +4707,33 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:810
+#: lxc/remote.go:877
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
-#: lxc/remote.go:994
+#: lxc/project.go:884 lxc/remote.go:868 lxc/remote.go:949 lxc/remote.go:1013
+#: lxc/remote.go:1061
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:305
+#: lxc/remote.go:345
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:890
+#: lxc/remote.go:957
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:805 lxc/remote.go:886 lxc/remote.go:998
+#: lxc/remote.go:872 lxc/remote.go:953 lxc/remote.go:1065
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:294
+#: lxc/remote.go:319
 msgid "Remote address must not be empty"
 msgstr ""
 
@@ -4741,7 +4741,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:299
+#: lxc/remote.go:339
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4827,7 +4827,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:852 lxc/remote.go:853
+#: lxc/remote.go:919 lxc/remote.go:920
 msgid "Remove remotes"
 msgstr ""
 
@@ -4884,19 +4884,19 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:771 lxc/remote.go:772
+#: lxc/remote.go:838 lxc/remote.go:839
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:1943
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1936
+#: lxc/storage_volume.go:1942
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2025 lxc/storage_volume.go:2045
+#: lxc/storage_volume.go:2031 lxc/storage_volume.go:2051
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4948,7 +4948,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2540 lxc/storage_volume.go:2541
+#: lxc/storage_volume.go:2546 lxc/storage_volume.go:2547
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5029,7 +5029,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:820
 msgid "STATIC"
 msgstr ""
 
@@ -5070,11 +5070,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:464
+#: lxc/remote.go:532
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:616
+#: lxc/remote.go:285 lxc/remote.go:683
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5272,11 +5272,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2063
+#: lxc/storage_volume.go:2069
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2064
+#: lxc/storage_volume.go:2070
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5285,7 +5285,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:964 lxc/remote.go:965
+#: lxc/remote.go:1031 lxc/remote.go:1032
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5361,7 +5361,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2080
+#: lxc/storage_volume.go:2086
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5510,11 +5510,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2221 lxc/storage_volume.go:2222
+#: lxc/storage_volume.go:2227 lxc/storage_volume.go:2228
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1347 lxc/storage_volume.go:1348
+#: lxc/storage_volume.go:1353 lxc/storage_volume.go:1354
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5528,7 +5528,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:647 lxc/remote.go:648
+#: lxc/remote.go:714 lxc/remote.go:715
 msgid "Show the default remote"
 msgstr ""
 
@@ -5582,15 +5582,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2404 lxc/storage_volume.go:2405
+#: lxc/storage_volume.go:2410 lxc/storage_volume.go:2411
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2167
+#: lxc/storage_volume.go:2173
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:607 lxc/storage_volume.go:1485
+#: lxc/info.go:607 lxc/storage_volume.go:1491
 msgid "Snapshots:"
 msgstr ""
 
@@ -5691,21 +5691,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:696
+#: lxc/storage_volume.go:702
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:784
+#: lxc/storage_volume.go:790
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:509
+#: lxc/storage_volume.go:515
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:513
+#: lxc/storage_volume.go:519
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5740,7 +5740,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:916 lxc/remote.go:917
+#: lxc/remote.go:983 lxc/remote.go:984
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5759,11 +5759,11 @@ msgstr ""
 #: lxc/auth.go:818 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
-#: lxc/storage_volume.go:1730 lxc/warning.go:216
+#: lxc/storage_volume.go:1736 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1557
+#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1563
 msgid "Taken at"
 msgstr ""
 
@@ -5773,6 +5773,12 @@ msgstr ""
 
 #: lxc/file.go:1256
 msgid "Target path must be a directory"
+msgstr ""
+
+#: lxc/remote.go:161 lxc/remote.go:334
+msgid ""
+"The --accept-certificate flag is not supported when adding a remote using a "
+"trust token"
 msgstr ""
 
 #: lxc/move.go:181
@@ -5914,15 +5920,20 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1323
+#: lxc/storage_volume.go:1329
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1300
+#: lxc/storage_volume.go:1306
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
+msgstr ""
+
+#: lxc/remote.go:527
+msgid ""
+"The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
 
 #: lxc/info.go:354
@@ -5933,8 +5944,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:875
-#: lxc/storage_volume.go:972
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:881
+#: lxc/storage_volume.go:978
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6009,7 +6020,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1470
+#: lxc/storage_volume.go:1476
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6024,7 +6035,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1847
+#: lxc/storage_volume.go:1853
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6058,7 +6069,15 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:571
+#: lxc/remote.go:329
+msgid "Trust token cannot be used for public remotes"
+msgstr ""
+
+#: lxc/remote.go:324
+msgid "Trust token cannot be used with OIDC authentication"
+msgstr ""
+
+#: lxc/remote.go:639
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6083,7 +6102,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1455
+#: lxc/storage_volume.go:1461
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6101,17 +6120,17 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:193 lxc/remote.go:749
+#: lxc/cluster.go:193 lxc/remote.go:816
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1735
+#: lxc/project.go:995 lxc/storage_volume.go:1741
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1734
+#: lxc/storage.go:724 lxc/storage_volume.go:1740
 msgid "USED BY"
 msgstr ""
 
@@ -6129,7 +6148,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:214 lxc/remote.go:248
+#: lxc/remote.go:226 lxc/remote.go:260
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6143,7 +6162,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1772
+#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1778
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6249,7 +6268,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2342 lxc/storage_volume.go:2343
+#: lxc/storage_volume.go:2348 lxc/storage_volume.go:2349
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6301,7 +6320,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2356
+#: lxc/storage_volume.go:2362
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6345,12 +6364,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1468
+#: lxc/storage_volume.go:1474
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2629
+#: lxc/export.go:42 lxc/storage_volume.go:2635
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6417,7 +6436,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1559
+#: lxc/storage_volume.go:1565
 msgid "Volume Only"
 msgstr ""
 
@@ -6452,7 +6471,7 @@ msgstr ""
 
 #: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
+#: lxc/project.go:552 lxc/remote.go:777 lxc/remote.go:782 lxc/remote.go:787
 msgid "YES"
 msgstr ""
 
@@ -6476,7 +6495,7 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:897
+#: lxc/storage_volume.go:903
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
@@ -6898,7 +6917,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2788
+#: lxc/storage_volume.go:2794
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -6933,13 +6952,13 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:1941
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:799
+#: lxc/storage_volume.go:805
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
@@ -6947,47 +6966,47 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2539
+#: lxc/storage_volume.go:2545
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2622
+#: lxc/storage_volume.go:2628
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2403
+#: lxc/storage_volume.go:2409
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:603
+#: lxc/storage_volume.go:609
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:711
+#: lxc/storage_volume.go:717
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:994 lxc/storage_volume.go:1346
+#: lxc/storage_volume.go:1000 lxc/storage_volume.go:1352
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2341
+#: lxc/storage_volume.go:2347
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2062
+#: lxc/storage_volume.go:2068
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2220
+#: lxc/storage_volume.go:2226
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1215
+#: lxc/storage_volume.go:1221
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1841
+#: lxc/storage_volume.go:1847
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7097,7 +7116,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1584
+#: lxc/storage_volume.go:1590
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7109,7 +7128,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:739
+#: lxc/project.go:557 lxc/remote.go:806
 msgid "current"
 msgstr ""
 
@@ -7569,7 +7588,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:607
+#: lxc/storage_volume.go:613
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7577,13 +7596,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2792
+#: lxc/storage_volume.go:2798
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2407
+#: lxc/storage_volume.go:2413
 msgid ""
 "lxc storage volume snapshot create default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7593,7 +7612,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:531
 msgid "n"
 msgstr ""
 
@@ -7605,7 +7624,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:510
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7642,7 +7661,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:465
+#: lxc/remote.go:519
 msgid "y"
 msgstr ""
 

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-08 07:43+0100\n"
+"POT-Creation-Date: 2024-10-14 13:30+0000\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Luigi Operoso <brokenpip3@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/linux-containers/"
@@ -79,7 +79,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/storage_volume.go:1024
+#: lxc/storage_volume.go:1030
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
@@ -759,15 +759,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:850 lxc/remote.go:915
+#: lxc/remote.go:917 lxc/remote.go:982
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:963
+#: lxc/remote.go:1030
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:769
+#: lxc/remote.go:836
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -801,7 +801,7 @@ msgstr "ALIAS"
 msgid "ARCHITECTURE"
 msgstr "ARCHITETTURA"
 
-#: lxc/remote.go:751
+#: lxc/remote.go:818
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -954,7 +954,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr "Password amministratore per %s: "
 
-#: lxc/remote.go:581
+#: lxc/remote.go:648
 #, fuzzy, c-format
 msgid "Admin password (or token) for %s:"
 msgstr "Password amministratore per %s: "
@@ -987,11 +987,11 @@ msgstr "il remote %s esiste già"
 msgid "Aliases:"
 msgstr "Alias:"
 
-#: lxc/storage_volume.go:1590
+#: lxc/storage_volume.go:1596
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:182
+#: lxc/remote.go:194
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -1064,7 +1064,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:552
+#: lxc/remote.go:621
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -1100,16 +1100,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:2696
+#: lxc/storage_volume.go:2702
 #, fuzzy, c-format
 msgid "Backing up storage volume: %s"
 msgstr "Creazione del container in corso"
 
-#: lxc/export.go:192 lxc/storage_volume.go:2773
+#: lxc/export.go:192 lxc/storage_volume.go:2779
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:654 lxc/storage_volume.go:1521
+#: lxc/info.go:654 lxc/storage_volume.go:1527
 msgid "Backups:"
 msgstr ""
 
@@ -1130,7 +1130,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr "Proprietà errata: %s"
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:679
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:685
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -1173,7 +1173,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr "NOME COMUNE"
 
-#: lxc/storage_volume.go:1733
+#: lxc/storage_volume.go:1739
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1243,7 +1243,7 @@ msgstr "Impossibile effettuare il pull di una directory senza --recursive"
 msgid "Can't read from stdin: %w"
 msgstr "Impossible leggere da stdin: %s"
 
-#: lxc/remote.go:894
+#: lxc/remote.go:961
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1259,7 +1259,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1749 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1276,12 +1276,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:486
+#: lxc/storage_volume.go:492
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:440
+#: lxc/storage_volume.go:446
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1309,12 +1309,12 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr "Il nome del container è: %s"
 
-#: lxc/remote.go:455
+#: lxc/remote.go:509
 #, fuzzy
 msgid "Certificate fingerprint"
 msgstr "Creazione del container in corso"
 
-#: lxc/remote.go:219
+#: lxc/remote.go:231
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
@@ -1329,7 +1329,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr "Il nome del container è: %s"
 
-#: lxc/remote.go:620
+#: lxc/remote.go:687
 #, fuzzy
 msgid "Client certificate now trusted by server:"
 msgstr "Certificato del client salvato dal server: "
@@ -1404,13 +1404,13 @@ msgstr ""
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
 #: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
-#: lxc/storage_volume.go:612 lxc/storage_volume.go:717
-#: lxc/storage_volume.go:1005 lxc/storage_volume.go:1231
-#: lxc/storage_volume.go:1360 lxc/storage_volume.go:1848
-#: lxc/storage_volume.go:1940 lxc/storage_volume.go:2079
-#: lxc/storage_volume.go:2239 lxc/storage_volume.go:2355
-#: lxc/storage_volume.go:2416 lxc/storage_volume.go:2543
-#: lxc/storage_volume.go:2631 lxc/storage_volume.go:2795
+#: lxc/storage_volume.go:618 lxc/storage_volume.go:723
+#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1237
+#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1854
+#: lxc/storage_volume.go:1946 lxc/storage_volume.go:2085
+#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2361
+#: lxc/storage_volume.go:2422 lxc/storage_volume.go:2549
+#: lxc/storage_volume.go:2637 lxc/storage_volume.go:2801
 msgid "Cluster member name"
 msgstr ""
 
@@ -1426,7 +1426,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1589
+#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1595
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr "Colonne"
@@ -1470,17 +1470,17 @@ msgstr ""
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1150
-#: lxc/storage_volume.go:1182
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
+#: lxc/storage_volume.go:1188
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:613
+#: lxc/storage_volume.go:619
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1467
 #, fuzzy, c-format
 msgid "Content type: %s"
 msgstr "Aggiornamento automatico: %s"
@@ -1564,7 +1564,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:508
+#: lxc/storage_volume.go:514
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1578,12 +1578,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:490
+#: lxc/remote.go:559
 #, fuzzy, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "Certificato del client salvato dal server: "
 
-#: lxc/remote.go:225 lxc/remote.go:474
+#: lxc/remote.go:237 lxc/remote.go:543
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1622,7 +1622,7 @@ msgstr "Certificato del client salvato dal server: "
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:485
+#: lxc/remote.go:554
 #, fuzzy, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "Certificato del client salvato dal server: "
@@ -1698,7 +1698,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:604 lxc/storage_volume.go:605
+#: lxc/storage_volume.go:610 lxc/storage_volume.go:611
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1753,7 +1753,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1475
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1481
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1789,7 +1789,7 @@ msgstr ""
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1732
+#: lxc/storage_volume.go:1738
 msgid "DESCRIPTION"
 msgstr "DESCRIZIONE"
 
@@ -1809,7 +1809,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2630
+#: lxc/storage_volume.go:2636
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1910,7 +1910,7 @@ msgstr "Il nome del container è: %s"
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:713 lxc/storage_volume.go:714
+#: lxc/storage_volume.go:719 lxc/storage_volume.go:720
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -2002,9 +2002,9 @@ msgstr ""
 #: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
 #: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
 #: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:648
-#: lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853 lxc/remote.go:917
-#: lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:715
+#: lxc/remote.go:753 lxc/remote.go:839 lxc/remote.go:920 lxc/remote.go:984
+#: lxc/remote.go:1032 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -2016,26 +2016,26 @@ msgstr ""
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
 #: lxc/storage_volume.go:169 lxc/storage_volume.go:283
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:605
-#: lxc/storage_volume.go:714 lxc/storage_volume.go:801
-#: lxc/storage_volume.go:899 lxc/storage_volume.go:996
-#: lxc/storage_volume.go:1217 lxc/storage_volume.go:1348
-#: lxc/storage_volume.go:1507 lxc/storage_volume.go:1591
-#: lxc/storage_volume.go:1844 lxc/storage_volume.go:1937
-#: lxc/storage_volume.go:2064 lxc/storage_volume.go:2222
-#: lxc/storage_volume.go:2343 lxc/storage_volume.go:2405
-#: lxc/storage_volume.go:2541 lxc/storage_volume.go:2624
-#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:611
+#: lxc/storage_volume.go:720 lxc/storage_volume.go:807
+#: lxc/storage_volume.go:905 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:1223 lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1513 lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1850 lxc/storage_volume.go:1943
+#: lxc/storage_volume.go:2070 lxc/storage_volume.go:2228
+#: lxc/storage_volume.go:2349 lxc/storage_volume.go:2411
+#: lxc/storage_volume.go:2547 lxc/storage_volume.go:2630
+#: lxc/storage_volume.go:2796 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1448
+#: lxc/storage_volume.go:1454
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:1849
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:1855
 #, fuzzy
 msgid "Destination cluster member name"
 msgstr "Il nome del container è: %s"
@@ -2048,11 +2048,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:800 lxc/storage_volume.go:801
+#: lxc/storage_volume.go:806 lxc/storage_volume.go:807
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:898 lxc/storage_volume.go:899
+#: lxc/storage_volume.go:904 lxc/storage_volume.go:905
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -2289,7 +2289,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:995 lxc/storage_volume.go:996
+#: lxc/storage_volume.go:1001 lxc/storage_volume.go:1002
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2297,7 +2297,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1766
+#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1772
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2354,7 +2354,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2193
+#: lxc/storage_volume.go:2161 lxc/storage_volume.go:2199
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2368,8 +2368,8 @@ msgstr ""
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2149
-#: lxc/storage_volume.go:2187
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2155
+#: lxc/storage_volume.go:2193
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2412,8 +2412,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1508
-#: lxc/storage_volume.go:1558
+#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1514
+#: lxc/storage_volume.go:1564
 msgid "Expires at"
 msgstr ""
 
@@ -2437,7 +2437,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2623 lxc/storage_volume.go:2624
+#: lxc/storage_volume.go:2629 lxc/storage_volume.go:2630
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2451,11 +2451,11 @@ msgstr "Creazione del container in corso"
 msgid "Export instances as backup tarballs."
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:2627
+#: lxc/storage_volume.go:2633
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2756
+#: lxc/export.go:152 lxc/storage_volume.go:2762
 #, fuzzy, c-format
 msgid "Exporting the backup: %s"
 msgstr "Creazione del container in corso"
@@ -2572,11 +2572,11 @@ msgstr "Accetta certificato"
 msgid "Failed to accept incoming connection: %w"
 msgstr "Accetta certificato"
 
-#: lxc/remote.go:191
+#: lxc/remote.go:203
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:242
+#: lxc/remote.go:254
 #, fuzzy, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr "Accetta certificato"
@@ -2586,7 +2586,7 @@ msgstr "Accetta certificato"
 msgid "Failed to connect to cluster member: %w"
 msgstr "Il nome del container è: %s"
 
-#: lxc/remote.go:232
+#: lxc/remote.go:244
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2596,12 +2596,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr "Accetta certificato"
 
-#: lxc/remote.go:260
+#: lxc/remote.go:486
 #, fuzzy, c-format
-msgid "Failed to create certificate: %w"
-msgstr "Accetta certificato"
+msgid "Failed to decode trust token: %w"
+msgstr "Il nome del container è: %s"
 
-#: lxc/remote.go:267
+#: lxc/remote.go:292
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2626,7 +2626,7 @@ msgstr "Accetta certificato"
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:237
+#: lxc/remote.go:249
 #, fuzzy, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr "Accetta certificato"
@@ -2715,9 +2715,9 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:690 lxc/storage.go:657
+#: lxc/project.go:919 lxc/remote.go:757 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1608 lxc/warning.go:94
+#: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2753,7 +2753,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:754
+#: lxc/remote.go:821
 msgid "GLOBAL"
 msgstr ""
 
@@ -2773,7 +2773,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:160 lxc/remote.go:401
+#: lxc/remote.go:165 lxc/remote.go:443
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2846,7 +2846,7 @@ msgstr "Il nome del container è: %s"
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1238
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2916,11 +2916,11 @@ msgstr "Il nome del container è: %s"
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1216 lxc/storage_volume.go:1217
+#: lxc/storage_volume.go:1222 lxc/storage_volume.go:1223
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:469
+#: lxc/storage_volume.go:475
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -3045,7 +3045,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2415
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2421
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -3059,7 +3059,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2414
+#: lxc/storage_volume.go:2420
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -3110,7 +3110,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2790
+#: lxc/storage_volume.go:2796
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -3118,7 +3118,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2789
+#: lxc/storage_volume.go:2795
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -3141,11 +3141,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:2797
+#: lxc/storage_volume.go:2803
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2871
+#: lxc/storage_volume.go:2877
 #, fuzzy, c-format
 msgid "Importing custom volume: %s"
 msgstr "Creazione del container in corso"
@@ -3213,7 +3213,7 @@ msgstr "Il nome del container è: %s"
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:353
+#: lxc/remote.go:395
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3273,7 +3273,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2000
+#: lxc/move.go:148 lxc/storage_volume.go:2006
 #, fuzzy
 msgid "Invalid new snapshot name"
 msgstr "'/' non è permesso nel nome di uno snapshot"
@@ -3282,7 +3282,7 @@ msgstr "'/' non è permesso nel nome di uno snapshot"
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1996
+#: lxc/storage_volume.go:2002
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3296,14 +3296,14 @@ msgstr "numero errato di argomenti del sottocomando"
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:342
+#: lxc/remote.go:384
 #, fuzzy, c-format
 msgid "Invalid protocol: %s"
 msgstr "Proprietà errata: %s"
 
-#: lxc/storage_volume.go:1064 lxc/storage_volume.go:1281
-#: lxc/storage_volume.go:1405 lxc/storage_volume.go:1985
-#: lxc/storage_volume.go:2132 lxc/storage_volume.go:2284
+#: lxc/storage_volume.go:1070 lxc/storage_volume.go:1287
+#: lxc/storage_volume.go:1411 lxc/storage_volume.go:1991
+#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2290
 #, fuzzy
 msgid "Invalid snapshot name"
 msgstr "Il nome del container è: %s"
@@ -3350,7 +3350,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1739 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1745 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3667,11 +3667,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:1586
+#: lxc/storage_volume.go:1592
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1597
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3691,7 +3691,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:685 lxc/remote.go:686
+#: lxc/remote.go:752 lxc/remote.go:753
 msgid "List the available remotes"
 msgstr ""
 
@@ -3731,7 +3731,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1464
+#: lxc/info.go:489 lxc/storage_volume.go:1470
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -4231,12 +4231,12 @@ msgstr "Il nome del container è: %s"
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:323 lxc/storage_volume.go:643
-#: lxc/storage_volume.go:750 lxc/storage_volume.go:841
-#: lxc/storage_volume.go:939 lxc/storage_volume.go:1053
-#: lxc/storage_volume.go:1270 lxc/storage_volume.go:1974
-#: lxc/storage_volume.go:2115 lxc/storage_volume.go:2273
-#: lxc/storage_volume.go:2464 lxc/storage_volume.go:2581
+#: lxc/storage_volume.go:323 lxc/storage_volume.go:649
+#: lxc/storage_volume.go:756 lxc/storage_volume.go:847
+#: lxc/storage_volume.go:945 lxc/storage_volume.go:1059
+#: lxc/storage_volume.go:1276 lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:2121 lxc/storage_volume.go:2279
+#: lxc/storage_volume.go:2470 lxc/storage_volume.go:2587
 msgid "Missing pool name"
 msgstr ""
 
@@ -4256,11 +4256,11 @@ msgstr "Il nome del container è: %s"
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:432 lxc/storage_volume.go:1884
+#: lxc/storage_volume.go:438 lxc/storage_volume.go:1890
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1394
+#: lxc/storage_volume.go:1400
 #, fuzzy
 msgid "Missing storage pool name"
 msgstr "Il nome del container è: %s"
@@ -4299,8 +4299,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:861
-#: lxc/storage_volume.go:958
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:867
+#: lxc/storage_volume.go:964
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4338,7 +4338,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1843 lxc/storage_volume.go:1844
+#: lxc/storage_volume.go:1849 lxc/storage_volume.go:1850
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4346,11 +4346,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1850
+#: lxc/storage_volume.go:1856
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:512
+#: lxc/storage_volume.go:518
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4376,8 +4376,8 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
-#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1731
+#: lxc/remote.go:815 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
 msgstr ""
 
@@ -4403,7 +4403,7 @@ msgstr ""
 
 #: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
+#: lxc/project.go:550 lxc/remote.go:775 lxc/remote.go:780 lxc/remote.go:785
 msgid "NO"
 msgstr ""
 
@@ -4425,8 +4425,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1506
-#: lxc/storage_volume.go:1556
+#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1512
+#: lxc/storage_volume.go:1562
 msgid "Name"
 msgstr ""
 
@@ -4434,7 +4434,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1446
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1452
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4578,7 +4578,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:870 lxc/storage_volume.go:967
+#: lxc/storage_volume.go:876 lxc/storage_volume.go:973
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4594,11 +4594,11 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/storage_volume.go:446 lxc/storage_volume.go:1893
+#: lxc/storage_volume.go:452 lxc/storage_volume.go:1899
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:496 lxc/storage_volume.go:1904
+#: lxc/storage_volume.go:502 lxc/storage_volume.go:1910
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4612,7 +4612,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2012
+#: lxc/storage_volume.go:2018
 #, fuzzy
 msgid "Not a snapshot name"
 msgstr "'/' non è permesso nel nome di uno snapshot"
@@ -4625,15 +4625,15 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2678
+#: lxc/storage_volume.go:2684
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2477
+#: lxc/storage_volume.go:2483
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:336
+#: lxc/remote.go:378
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4641,7 +4641,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1412
+#: lxc/storage_volume.go:1418
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4654,7 +4654,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:693 lxc/storage_volume.go:1560
+#: lxc/info.go:693 lxc/storage_volume.go:1566
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4684,7 +4684,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1756
 msgid "POOL"
 msgstr ""
 
@@ -4700,15 +4700,15 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:213
+#: lxc/list.go:567 lxc/storage_volume.go:1762 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:817
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:752
+#: lxc/image.go:1136 lxc/remote.go:819
 msgid "PUBLIC"
 msgstr ""
 
@@ -4738,7 +4738,7 @@ msgstr "Creazione del container in corso"
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:183
+#: lxc/remote.go:195
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4751,8 +4751,8 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr "Il nome del container è: %s"
 
-#: lxc/remote.go:466
-msgid "Please type 'y', 'n' or the fingerprint:"
+#: lxc/remote.go:536
+msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
 #: lxc/info.go:221
@@ -4776,8 +4776,8 @@ msgstr ""
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1151
-#: lxc/storage_volume.go:1183
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
+#: lxc/storage_volume.go:1189
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4896,7 +4896,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1350
+#: lxc/storage_volume.go:1356
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4910,7 +4910,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1219
+#: lxc/storage_volume.go:1225
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4926,7 +4926,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2224
+#: lxc/storage_volume.go:2230
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4947,7 +4947,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:998
+#: lxc/storage_volume.go:1004
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4956,7 +4956,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2069
+#: lxc/storage_volume.go:2075
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4969,7 +4969,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2345
+#: lxc/storage_volume.go:2351
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5076,33 +5076,33 @@ msgstr "Creazione del container in corso"
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:810
+#: lxc/remote.go:877
 #, fuzzy, c-format
 msgid "Remote %s already exists"
 msgstr "il remote %s esiste già"
 
-#: lxc/project.go:884 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
-#: lxc/remote.go:994
+#: lxc/project.go:884 lxc/remote.go:868 lxc/remote.go:949 lxc/remote.go:1013
+#: lxc/remote.go:1061
 #, fuzzy, c-format
 msgid "Remote %s doesn't exist"
 msgstr "il remote %s non esiste"
 
-#: lxc/remote.go:305
+#: lxc/remote.go:345
 #, fuzzy, c-format
 msgid "Remote %s exists as <%s>"
 msgstr "il remote %s esiste come %s"
 
-#: lxc/remote.go:890
+#: lxc/remote.go:957
 #, fuzzy, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr "il remote %s è statico e non può essere modificato"
 
-#: lxc/remote.go:805 lxc/remote.go:886 lxc/remote.go:998
+#: lxc/remote.go:872 lxc/remote.go:953 lxc/remote.go:1065
 #, fuzzy, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr "il remote %s è statico e non può essere modificato"
 
-#: lxc/remote.go:294
+#: lxc/remote.go:319
 msgid "Remote address must not be empty"
 msgstr ""
 
@@ -5111,7 +5111,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr "Password amministratore per %s: "
 
-#: lxc/remote.go:299
+#: lxc/remote.go:339
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -5203,7 +5203,7 @@ msgstr "Il nome del container è: %s"
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:852 lxc/remote.go:853
+#: lxc/remote.go:919 lxc/remote.go:920
 msgid "Remove remotes"
 msgstr ""
 
@@ -5262,19 +5262,19 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:771 lxc/remote.go:772
+#: lxc/remote.go:838 lxc/remote.go:839
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:1943
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1936
+#: lxc/storage_volume.go:1942
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2025 lxc/storage_volume.go:2045
+#: lxc/storage_volume.go:2031 lxc/storage_volume.go:2051
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5329,7 +5329,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2540 lxc/storage_volume.go:2541
+#: lxc/storage_volume.go:2546 lxc/storage_volume.go:2547
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5413,7 +5413,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:820
 msgid "STATIC"
 msgstr ""
 
@@ -5454,11 +5454,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:464
+#: lxc/remote.go:532
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:616
+#: lxc/remote.go:285 lxc/remote.go:683
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5662,11 +5662,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2063
+#: lxc/storage_volume.go:2069
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2064
+#: lxc/storage_volume.go:2070
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5675,7 +5675,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:964 lxc/remote.go:965
+#: lxc/remote.go:1031 lxc/remote.go:1032
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5755,7 +5755,7 @@ msgstr "Creazione del container in corso"
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2080
+#: lxc/storage_volume.go:2086
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5915,11 +5915,11 @@ msgstr "Il nome del container è: %s"
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2221 lxc/storage_volume.go:2222
+#: lxc/storage_volume.go:2227 lxc/storage_volume.go:2228
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1347 lxc/storage_volume.go:1348
+#: lxc/storage_volume.go:1353 lxc/storage_volume.go:1354
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5933,7 +5933,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:647 lxc/remote.go:648
+#: lxc/remote.go:714 lxc/remote.go:715
 msgid "Show the default remote"
 msgstr ""
 
@@ -5988,15 +5988,15 @@ msgstr "Aggiornamento automatico: %s"
 msgid "Size: %s"
 msgstr "Aggiornamento automatico: %s"
 
-#: lxc/storage_volume.go:2404 lxc/storage_volume.go:2405
+#: lxc/storage_volume.go:2410 lxc/storage_volume.go:2411
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2167
+#: lxc/storage_volume.go:2173
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:607 lxc/storage_volume.go:1485
+#: lxc/info.go:607 lxc/storage_volume.go:1491
 msgid "Snapshots:"
 msgstr ""
 
@@ -6099,21 +6099,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:696
+#: lxc/storage_volume.go:702
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:784
+#: lxc/storage_volume.go:790
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:509
+#: lxc/storage_volume.go:515
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:513
+#: lxc/storage_volume.go:519
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -6149,7 +6149,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:916 lxc/remote.go:917
+#: lxc/remote.go:983 lxc/remote.go:984
 msgid "Switch the default remote"
 msgstr ""
 
@@ -6168,11 +6168,11 @@ msgstr ""
 #: lxc/auth.go:818 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
-#: lxc/storage_volume.go:1730 lxc/warning.go:216
+#: lxc/storage_volume.go:1736 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1557
+#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1563
 #, fuzzy
 msgid "Taken at"
 msgstr "salvato alle %s"
@@ -6183,6 +6183,12 @@ msgstr ""
 
 #: lxc/file.go:1256
 msgid "Target path must be a directory"
+msgstr ""
+
+#: lxc/remote.go:161 lxc/remote.go:334
+msgid ""
+"The --accept-certificate flag is not supported when adding a remote using a "
+"trust token"
 msgstr ""
 
 #: lxc/move.go:181
@@ -6325,15 +6331,20 @@ msgstr "Il nome del container è: %s"
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr "Il nome del container è: %s"
 
-#: lxc/storage_volume.go:1323
+#: lxc/storage_volume.go:1329
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr "Il nome del container è: %s"
 
-#: lxc/storage_volume.go:1300
+#: lxc/storage_volume.go:1306
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
+msgstr ""
+
+#: lxc/remote.go:527
+msgid ""
+"The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
 
 #: lxc/info.go:354
@@ -6344,8 +6355,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:875
-#: lxc/storage_volume.go:972
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:881
+#: lxc/storage_volume.go:978
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6422,7 +6433,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1470
+#: lxc/storage_volume.go:1476
 #, fuzzy, c-format
 msgid "Total: %s"
 msgstr "Aggiornamento automatico: %s"
@@ -6437,7 +6448,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1847
+#: lxc/storage_volume.go:1853
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6471,7 +6482,15 @@ msgstr "Creazione del container in corso"
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:571
+#: lxc/remote.go:329
+msgid "Trust token cannot be used for public remotes"
+msgstr ""
+
+#: lxc/remote.go:324
+msgid "Trust token cannot be used with OIDC authentication"
+msgstr ""
+
+#: lxc/remote.go:639
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6497,7 +6516,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1455
+#: lxc/storage_volume.go:1461
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6515,17 +6534,17 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:193 lxc/remote.go:749
+#: lxc/cluster.go:193 lxc/remote.go:816
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1735
+#: lxc/project.go:995 lxc/storage_volume.go:1741
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1734
+#: lxc/storage.go:724 lxc/storage_volume.go:1740
 msgid "USED BY"
 msgstr ""
 
@@ -6543,7 +6562,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:214 lxc/remote.go:248
+#: lxc/remote.go:226 lxc/remote.go:260
 #, fuzzy
 msgid "Unavailable remote server"
 msgstr "Aggiungi un nuovo server remoto"
@@ -6558,7 +6577,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1772
+#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1778
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6673,7 +6692,7 @@ msgstr "Il nome del container è: %s"
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2342 lxc/storage_volume.go:2343
+#: lxc/storage_volume.go:2348 lxc/storage_volume.go:2349
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6729,7 +6748,7 @@ msgstr "Il nome del container è: %s"
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2356
+#: lxc/storage_volume.go:2362
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6775,12 +6794,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:1468
+#: lxc/storage_volume.go:1474
 #, fuzzy, c-format
 msgid "Usage: %s"
 msgstr "Aggiornamento automatico: %s"
 
-#: lxc/export.go:42 lxc/storage_volume.go:2629
+#: lxc/export.go:42 lxc/storage_volume.go:2635
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6847,7 +6866,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1559
+#: lxc/storage_volume.go:1565
 msgid "Volume Only"
 msgstr ""
 
@@ -6882,7 +6901,7 @@ msgstr ""
 
 #: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
+#: lxc/project.go:552 lxc/remote.go:777 lxc/remote.go:782 lxc/remote.go:787
 msgid "YES"
 msgstr ""
 
@@ -6909,7 +6928,7 @@ msgstr "Occorre specificare un nome di container come origine"
 msgid "You need to specify an image name or use --empty"
 msgstr "Occorre specificare un nome di container come origine"
 
-#: lxc/storage_volume.go:897
+#: lxc/storage_volume.go:903
 #, fuzzy
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr "Creazione del container in corso"
@@ -7424,7 +7443,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<pool>"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:2788
+#: lxc/storage_volume.go:2794
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr "Creazione del container in corso"
@@ -7467,14 +7486,14 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:1941
 #, fuzzy
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:799
+#: lxc/storage_volume.go:805
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr "Creazione del container in corso"
@@ -7484,57 +7503,57 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:2539
+#: lxc/storage_volume.go:2545
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:2622
+#: lxc/storage_volume.go:2628
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:2403
+#: lxc/storage_volume.go:2409
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:603
+#: lxc/storage_volume.go:609
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:711
+#: lxc/storage_volume.go:717
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:994 lxc/storage_volume.go:1346
+#: lxc/storage_volume.go:1000 lxc/storage_volume.go:1352
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:2341
+#: lxc/storage_volume.go:2347
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:2062
+#: lxc/storage_volume.go:2068
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:2220
+#: lxc/storage_volume.go:2226
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:1215
+#: lxc/storage_volume.go:1221
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:1841
+#: lxc/storage_volume.go:1847
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr "Creazione del container in corso"
@@ -7671,7 +7690,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:1584
+#: lxc/storage_volume.go:1590
 #, fuzzy
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr "Creazione del container in corso"
@@ -7686,7 +7705,7 @@ msgstr "Creazione del container in corso"
 msgid "[[<remote>:]<member>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/project.go:557 lxc/remote.go:739
+#: lxc/project.go:557 lxc/remote.go:806
 msgid "current"
 msgstr ""
 
@@ -8146,7 +8165,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:607
+#: lxc/storage_volume.go:613
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -8154,13 +8173,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2792
+#: lxc/storage_volume.go:2798
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2407
+#: lxc/storage_volume.go:2413
 msgid ""
 "lxc storage volume snapshot create default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -8170,7 +8189,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:531
 #, fuzzy
 msgid "n"
 msgstr "no"
@@ -8183,7 +8202,7 @@ msgstr ""
 msgid "no"
 msgstr "no"
 
-#: lxc/remote.go:456
+#: lxc/remote.go:510
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -8220,7 +8239,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:465
+#: lxc/remote.go:519
 msgid "y"
 msgstr ""
 
@@ -8228,6 +8247,10 @@ msgstr ""
 #: lxc/image.go:1194
 msgid "yes"
 msgstr "si"
+
+#, fuzzy, c-format
+#~ msgid "Failed to create certificate: %w"
+#~ msgstr "Accetta certificato"
 
 #, fuzzy
 #~ msgid "[<remote>:]<cluster member>"

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-08 07:43+0100\n"
+"POT-Creation-Date: 2024-10-14 13:30+0000\n"
 "PO-Revision-Date: 2023-03-10 15:14+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/linux-"
@@ -71,7 +71,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/storage_volume.go:1024
+#: lxc/storage_volume.go:1030
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -749,15 +749,15 @@ msgstr "<alias> <target>"
 msgid "<old alias> <new alias>"
 msgstr "<old alias> <new alias>"
 
-#: lxc/remote.go:850 lxc/remote.go:915
+#: lxc/remote.go:917 lxc/remote.go:982
 msgid "<remote>"
 msgstr "<remote>"
 
-#: lxc/remote.go:963
+#: lxc/remote.go:1030
 msgid "<remote> <URL>"
 msgstr "<remote> <URL>"
 
-#: lxc/remote.go:769
+#: lxc/remote.go:836
 msgid "<remote> <new-name>"
 msgstr "<remote> <new-name>"
 
@@ -792,7 +792,7 @@ msgstr "ALIASES"
 msgid "ARCHITECTURE"
 msgstr "ARCHITECTURE"
 
-#: lxc/remote.go:751
+#: lxc/remote.go:818
 msgid "AUTH TYPE"
 msgstr "AUTH TYPE"
 
@@ -962,7 +962,7 @@ msgstr "アドレス: %s"
 msgid "Admin access key: %s"
 msgstr "管理者アクセスキー: %s"
 
-#: lxc/remote.go:581
+#: lxc/remote.go:648
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr "%s の管理者パスワード（もしくはトークン）:"
@@ -995,11 +995,11 @@ msgstr "エイリアス %s は既に存在します"
 msgid "Aliases:"
 msgstr "エイリアス:"
 
-#: lxc/storage_volume.go:1590
+#: lxc/storage_volume.go:1596
 msgid "All projects"
 msgstr "すべてのプロジェクト"
 
-#: lxc/remote.go:182
+#: lxc/remote.go:194
 msgid "All server addresses are unavailable"
 msgstr "すべてのサーバーアドレスが利用できません"
 
@@ -1075,7 +1075,7 @@ msgstr ""
 "このコマンドはインスタンスのブートコンソールに接続できます。\n"
 "そしてそこから過去のログエントリを取り出すことができます。"
 
-#: lxc/remote.go:552
+#: lxc/remote.go:621
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr "認証タイプ '%s' はサーバではサポートされていません"
@@ -1111,16 +1111,16 @@ msgstr "BASE IMAGE"
 msgid "Backing up instance: %s"
 msgstr "インスタンスのバックアップ中: %s"
 
-#: lxc/storage_volume.go:2696
+#: lxc/storage_volume.go:2702
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr "ストレージボリュームのバックアップ中: %s"
 
-#: lxc/export.go:192 lxc/storage_volume.go:2773
+#: lxc/export.go:192 lxc/storage_volume.go:2779
 msgid "Backup exported successfully!"
 msgstr "バックアップのエクスポートが成功しました!"
 
-#: lxc/info.go:654 lxc/storage_volume.go:1521
+#: lxc/info.go:654 lxc/storage_volume.go:1527
 msgid "Backups:"
 msgstr "バックアップ:"
 
@@ -1143,7 +1143,7 @@ msgstr "不適切なキー/値のペア: %s"
 msgid "Bad key=value pair: %q"
 msgstr "不適切な キー=値 のペア: %s"
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:679
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:685
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr "不適切な キー=値 のペア: %s"
@@ -1186,7 +1186,7 @@ msgstr "CANCELABLE"
 msgid "COMMON NAME"
 msgstr "COMMON NAME"
 
-#: lxc/storage_volume.go:1733
+#: lxc/storage_volume.go:1739
 msgid "CONTENT-TYPE"
 msgstr "CONTENT-TYPE"
 
@@ -1256,7 +1256,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr "標準入力から読み込めません: %w"
 
-#: lxc/remote.go:894
+#: lxc/remote.go:961
 msgid "Can't remove the default remote"
 msgstr "デフォルトのリモートは削除できません"
 
@@ -1272,7 +1272,7 @@ msgstr "--project と --all-project は同時に指定できません"
 msgid "Can't specify a different remote for rename"
 msgstr "リネームの場合は異なるリモートを指定できません"
 
-#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1749 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr "クラスタでない場合はカラムとして L は指定できません"
 
@@ -1289,14 +1289,14 @@ msgstr "キー '%s' が設定されていないので削除できません"
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:486
+#: lxc/storage_volume.go:492
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 "コピー先のサーバーがクラスターに属していない場合は --destination-target は指"
 "定できません"
 
-#: lxc/storage_volume.go:440
+#: lxc/storage_volume.go:446
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 "コピー元のサーバーがクラスターに属していない場合は --target は指定できません"
@@ -1325,12 +1325,12 @@ msgstr "カード: %s (%s)"
 msgid "Certificate add token for %s deleted"
 msgstr "%s に対する証明書追加トークンが削除されました"
 
-#: lxc/remote.go:455
+#: lxc/remote.go:509
 #, fuzzy
 msgid "Certificate fingerprint"
 msgstr "証明書のフィンガープリント: %s"
 
-#: lxc/remote.go:219
+#: lxc/remote.go:231
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
@@ -1346,7 +1346,7 @@ msgstr "Chassis"
 msgid "Client %s certificate add token:"
 msgstr "クライアント %s の証明書追加トークン:"
 
-#: lxc/remote.go:620
+#: lxc/remote.go:687
 msgid "Client certificate now trusted by server:"
 msgstr "クライアント証明書がサーバに信頼されました:"
 
@@ -1420,13 +1420,13 @@ msgstr "クラスターメンバー %s がグループ %s から削除されま�
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
 #: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
-#: lxc/storage_volume.go:612 lxc/storage_volume.go:717
-#: lxc/storage_volume.go:1005 lxc/storage_volume.go:1231
-#: lxc/storage_volume.go:1360 lxc/storage_volume.go:1848
-#: lxc/storage_volume.go:1940 lxc/storage_volume.go:2079
-#: lxc/storage_volume.go:2239 lxc/storage_volume.go:2355
-#: lxc/storage_volume.go:2416 lxc/storage_volume.go:2543
-#: lxc/storage_volume.go:2631 lxc/storage_volume.go:2795
+#: lxc/storage_volume.go:618 lxc/storage_volume.go:723
+#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1237
+#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1854
+#: lxc/storage_volume.go:1946 lxc/storage_volume.go:2085
+#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2361
+#: lxc/storage_volume.go:2422 lxc/storage_volume.go:2549
+#: lxc/storage_volume.go:2637 lxc/storage_volume.go:2801
 msgid "Cluster member name"
 msgstr "クラスタメンバ名"
 
@@ -1442,7 +1442,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr "クラスタリングが有効になりました"
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1589
+#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1595
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr "カラムレイアウト"
@@ -1490,17 +1490,17 @@ msgstr "移動先のインスタンスに適用するキー/値の設定"
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1150
-#: lxc/storage_volume.go:1182
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
+#: lxc/storage_volume.go:1188
 #, c-format
 msgid "Config parsing error: %s"
 msgstr "設定の構文エラー: %s"
 
-#: lxc/storage_volume.go:613
+#: lxc/storage_volume.go:619
 msgid "Content type, block or filesystem"
 msgstr "ストレージボリュームのタイプ、block もしくは filesystem"
 
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1467
 #, c-format
 msgid "Content type: %s"
 msgstr "コンテンツタイプ: %s"
@@ -1599,7 +1599,7 @@ msgstr "仮想マシンイメージをコピーします"
 msgid "Copying the image: %s"
 msgstr "イメージのコピー中: %s"
 
-#: lxc/storage_volume.go:508
+#: lxc/storage_volume.go:514
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr "ストレージボリュームのコピー中: %s"
@@ -1613,12 +1613,12 @@ msgstr "コア %d"
 msgid "Cores:"
 msgstr "コア:"
 
-#: lxc/remote.go:490
+#: lxc/remote.go:559
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "サーバ証明書ファイル %q をクローズできません: %w"
 
-#: lxc/remote.go:225 lxc/remote.go:474
+#: lxc/remote.go:237 lxc/remote.go:543
 msgid "Could not create server cert dir"
 msgstr "サーバ証明書格納用のディレクトリを作成できません"
 
@@ -1657,7 +1657,7 @@ msgstr "秘密鍵ファイル %s をエラーで読み込めません: %v"
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr "リモート '%s' に対する新しいリモート証明書がエラーで書き込めません: %v"
 
-#: lxc/remote.go:485
+#: lxc/remote.go:554
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "サーバ証明書ファイル %q を書き込めません: %w"
@@ -1733,7 +1733,7 @@ msgstr "ストレージバケットに対する鍵を作成します"
 msgid "Create new custom storage buckets"
 msgstr "新たにカスタムストレージバケットを作成します"
 
-#: lxc/storage_volume.go:604 lxc/storage_volume.go:605
+#: lxc/storage_volume.go:610 lxc/storage_volume.go:611
 msgid "Create new custom storage volumes"
 msgstr "新たにカスタムストレージボリュームを作成します"
 
@@ -1785,7 +1785,7 @@ msgstr "ストレージプールを作成します"
 msgid "Create the instance with no profiles applied"
 msgstr "プロファイルを適用しないインスタンスを作成します"
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1475
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1481
 #, c-format
 msgid "Created: %s"
 msgstr "作成日時: %s"
@@ -1820,7 +1820,7 @@ msgstr "DEFAULT TARGET ADDRESS"
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1732
+#: lxc/storage_volume.go:1738
 msgid "DESCRIPTION"
 msgstr "DESCRIPTION"
 
@@ -1840,7 +1840,7 @@ msgstr "DRM:"
 msgid "Default VLAN ID"
 msgstr "デフォルト VLAN ID"
 
-#: lxc/storage_volume.go:2630
+#: lxc/storage_volume.go:2636
 msgid "Define a compression algorithm: for backup or none"
 msgstr "圧縮アルゴリズムを指定します: backup or none"
 
@@ -1939,7 +1939,7 @@ msgstr "ストレージバケットを削除します"
 msgid "Delete storage pools"
 msgstr "ストレージプールを削除します"
 
-#: lxc/storage_volume.go:713 lxc/storage_volume.go:714
+#: lxc/storage_volume.go:719 lxc/storage_volume.go:720
 msgid "Delete storage volumes"
 msgstr "ストレージボリュームを削除します"
 
@@ -2031,9 +2031,9 @@ msgstr "警告を削除します"
 #: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
 #: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
 #: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:648
-#: lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853 lxc/remote.go:917
-#: lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:715
+#: lxc/remote.go:753 lxc/remote.go:839 lxc/remote.go:920 lxc/remote.go:984
+#: lxc/remote.go:1032 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -2045,26 +2045,26 @@ msgstr "警告を削除します"
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
 #: lxc/storage_volume.go:169 lxc/storage_volume.go:283
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:605
-#: lxc/storage_volume.go:714 lxc/storage_volume.go:801
-#: lxc/storage_volume.go:899 lxc/storage_volume.go:996
-#: lxc/storage_volume.go:1217 lxc/storage_volume.go:1348
-#: lxc/storage_volume.go:1507 lxc/storage_volume.go:1591
-#: lxc/storage_volume.go:1844 lxc/storage_volume.go:1937
-#: lxc/storage_volume.go:2064 lxc/storage_volume.go:2222
-#: lxc/storage_volume.go:2343 lxc/storage_volume.go:2405
-#: lxc/storage_volume.go:2541 lxc/storage_volume.go:2624
-#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:611
+#: lxc/storage_volume.go:720 lxc/storage_volume.go:807
+#: lxc/storage_volume.go:905 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:1223 lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1513 lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1850 lxc/storage_volume.go:1943
+#: lxc/storage_volume.go:2070 lxc/storage_volume.go:2228
+#: lxc/storage_volume.go:2349 lxc/storage_volume.go:2411
+#: lxc/storage_volume.go:2547 lxc/storage_volume.go:2630
+#: lxc/storage_volume.go:2796 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr "説明"
 
-#: lxc/storage_volume.go:1448
+#: lxc/storage_volume.go:1454
 #, c-format
 msgid "Description: %s"
 msgstr "説明: %s"
 
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:1849
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:1855
 msgid "Destination cluster member name"
 msgstr "コピー先のクラスターメンバー名"
 
@@ -2076,11 +2076,11 @@ msgstr "インスタンスからネットワークインターフェースを取
 msgid "Detach network interfaces from profiles"
 msgstr "プロファイルからネットワークインターフェースを取り外します"
 
-#: lxc/storage_volume.go:800 lxc/storage_volume.go:801
+#: lxc/storage_volume.go:806 lxc/storage_volume.go:807
 msgid "Detach storage volumes from instances"
 msgstr "インスタンスからストレージボリュームを取り外します"
 
-#: lxc/storage_volume.go:898 lxc/storage_volume.go:899
+#: lxc/storage_volume.go:904 lxc/storage_volume.go:905
 msgid "Detach storage volumes from profiles"
 msgstr "プロファイルからストレージボリュームを取り外します"
 
@@ -2318,7 +2318,7 @@ msgstr "ストレージバケットの設定をYAMLで編集します"
 msgid "Edit storage pool configurations as YAML"
 msgstr "ストレージプールの設定をYAMLで編集します"
 
-#: lxc/storage_volume.go:995 lxc/storage_volume.go:996
+#: lxc/storage_volume.go:1001 lxc/storage_volume.go:1002
 msgid "Edit storage volume configurations as YAML"
 msgstr "ストレージボリュームの設定をYAMLで編集します"
 
@@ -2326,7 +2326,7 @@ msgstr "ストレージボリュームの設定をYAMLで編集します"
 msgid "Edit trust configurations as YAML"
 msgstr "信頼済みクライアント設定をYAMLで編集します"
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1766
+#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1772
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2394,7 +2394,7 @@ msgstr "イメージの取得中: %s"
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2193
+#: lxc/storage_volume.go:2161 lxc/storage_volume.go:2199
 #, fuzzy, c-format
 msgid "Error setting properties: %v"
 msgstr "イメージの取得中: %s"
@@ -2408,8 +2408,8 @@ msgstr "イメージのプロパティを削除します"
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2149
-#: lxc/storage_volume.go:2187
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2155
+#: lxc/storage_volume.go:2193
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2462,8 +2462,8 @@ msgstr ""
 "デフォルトのモードは non-interactive です。もし標準入出力が両方ともターミナル"
 "の場合は interactive モードが選択されます (標準エラー出力は無視されます)。"
 
-#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1508
-#: lxc/storage_volume.go:1558
+#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1514
+#: lxc/storage_volume.go:1564
 msgid "Expires at"
 msgstr "失効日時"
 
@@ -2490,7 +2490,7 @@ msgstr ""
 "\n"
 "出力先はオプショナルで、デフォルトは現在のディレクトリです。"
 
-#: lxc/storage_volume.go:2623 lxc/storage_volume.go:2624
+#: lxc/storage_volume.go:2629 lxc/storage_volume.go:2630
 msgid "Export custom storage volume"
 msgstr "カスタムストレージボリュームをエクスポートします"
 
@@ -2502,12 +2502,12 @@ msgstr "インスタンスのバックアップをエクスポートします"
 msgid "Export instances as backup tarballs."
 msgstr "インスタンスを tarball 形式のバックアップとしてエクスポートします。"
 
-#: lxc/storage_volume.go:2627
+#: lxc/storage_volume.go:2633
 msgid "Export the volume without its snapshots"
 msgstr ""
 "ボリュームをエクスポートします (スナップショットはエクスポートしません)"
 
-#: lxc/export.go:152 lxc/storage_volume.go:2756
+#: lxc/export.go:152 lxc/storage_volume.go:2762
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr "バックアップのエクスポート中: %s"
@@ -2624,11 +2624,11 @@ msgstr "sshfs の起動に失敗しました: %w"
 msgid "Failed to accept incoming connection: %w"
 msgstr "受信接続の受け入れに失敗しました: %w"
 
-#: lxc/remote.go:191
+#: lxc/remote.go:203
 msgid "Failed to add remote"
 msgstr "リモートの追加に失敗しました"
 
-#: lxc/remote.go:242
+#: lxc/remote.go:254
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr "サーバー証明書ファイル %q のクローズに失敗しました: %w"
@@ -2638,7 +2638,7 @@ msgstr "サーバー証明書ファイル %q のクローズに失敗しまし�
 msgid "Failed to connect to cluster member: %w"
 msgstr "クラスタメンバへの接続に失敗しました: %w"
 
-#: lxc/remote.go:232
+#: lxc/remote.go:244
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr "%q の作成に失敗しました: %w"
@@ -2648,12 +2648,12 @@ msgstr "%q の作成に失敗しました: %w"
 msgid "Failed to create alias %s: %w"
 msgstr "エイリアス %s の作成に失敗しました: %w"
 
-#: lxc/remote.go:260
-#, c-format
-msgid "Failed to create certificate: %w"
-msgstr "証明書の作成に失敗しました: %w"
+#: lxc/remote.go:486
+#, fuzzy, c-format
+msgid "Failed to decode trust token: %w"
+msgstr "クラスタメンバへの接続に失敗しました: %w"
 
-#: lxc/remote.go:267
+#: lxc/remote.go:292
 #, c-format
 msgid "Failed to find project: %w"
 msgstr "プロジェクトが見つけられませんでした: %w"
@@ -2678,7 +2678,7 @@ msgstr "エイリアス %s の削除に失敗しました: %w"
 msgid "Failed to walk path for %s: %s"
 msgstr "パス %s にアクセスできませんでした: %s"
 
-#: lxc/remote.go:237
+#: lxc/remote.go:249
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr "サーバー証明書 %q の書き込みに失敗しました: %w"
@@ -2781,9 +2781,9 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:690 lxc/storage.go:657
+#: lxc/project.go:919 lxc/remote.go:757 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1608 lxc/warning.go:94
+#: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr "フォーマット (csv|json|table|yaml|compact)"
 
@@ -2819,7 +2819,7 @@ msgstr "クロック数: %vMhz"
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr "クロック数: %vMhz (最小: %vMhz, 最大: %vMhz)"
 
-#: lxc/remote.go:754
+#: lxc/remote.go:821
 msgid "GLOBAL"
 msgstr "GLOBAL"
 
@@ -2839,7 +2839,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr "すべてのコマンドに対する man ページを作成します"
 
-#: lxc/remote.go:160 lxc/remote.go:401
+#: lxc/remote.go:165 lxc/remote.go:443
 msgid "Generating a client certificate. This may take a minute..."
 msgstr "クライアント証明書を生成します。1分ぐらいかかります..."
 
@@ -2916,7 +2916,7 @@ msgstr "ストレージバケットに対する鍵を作成します"
 msgid "Get the key as a storage property"
 msgstr "ストレージバケットに対する鍵を作成します"
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1238
 #, fuzzy
 msgid "Get the key as a storage volume property"
 msgstr "新しいストレージボリュームをプロファイルに追加します"
@@ -2981,11 +2981,11 @@ msgstr "ストレージバケットの設定値を取得します"
 msgid "Get values for storage pool configuration keys"
 msgstr "ストレージプールの設定値を取得します"
 
-#: lxc/storage_volume.go:1216 lxc/storage_volume.go:1217
+#: lxc/storage_volume.go:1222 lxc/storage_volume.go:1223
 msgid "Get values for storage volume configuration keys"
 msgstr "ストレージボリュームの設定値を取得します"
 
-#: lxc/storage_volume.go:469
+#: lxc/storage_volume.go:475
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr "指定したコピー先 %q がコピー元のボリュームの場所 %q と一致しません"
@@ -3113,7 +3113,7 @@ msgstr ""
 "存在するスナップショット名の場合は既存のスナップショットを削除したあとに新し"
 "いスナップショットを作成します"
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2415
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2421
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 "存在するスナップショット名の場合は既存のスナップショットを削除したあとに新し"
@@ -3129,7 +3129,7 @@ msgstr "初めてこのマシンで LXD を使う場合、lxd init と実行す�
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr "設定されている自動でのインスタンスの有効期限設定を無視します"
 
-#: lxc/storage_volume.go:2414
+#: lxc/storage_volume.go:2420
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr "設定されている自動でのストレージボリュームの有効期限設定を無視します"
 
@@ -3179,7 +3179,7 @@ msgstr "イメージの更新が成功しました!"
 msgid "Immediately attach to the console"
 msgstr "起動直後にインスタンスのコンソールに接続します"
 
-#: lxc/storage_volume.go:2790
+#: lxc/storage_volume.go:2796
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 "カスタムボリュームのバックアップをスナップショットを含んだ状態でインポートし"
@@ -3190,7 +3190,7 @@ msgid "Import backups of instances including their snapshots."
 msgstr ""
 "インスタンスのバックアップをスナップショットを含んだ状態でインポートします。"
 
-#: lxc/storage_volume.go:2789
+#: lxc/storage_volume.go:2795
 msgid "Import custom storage volumes"
 msgstr "新たにカスタムストレージボリュームをインポートします"
 
@@ -3217,11 +3217,11 @@ msgstr "イメージをイメージストアにインポートします"
 msgid "Import instance backups"
 msgstr "インスタンスのバックアップをインポートします"
 
-#: lxc/storage_volume.go:2797
+#: lxc/storage_volume.go:2803
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2871
+#: lxc/storage_volume.go:2877
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr "カスタムボリュームのインポート中: %s"
@@ -3288,7 +3288,7 @@ msgstr "インスタンス名: %s"
 msgid "Instance type"
 msgstr "インスタンスタイプ"
 
-#: lxc/remote.go:353
+#: lxc/remote.go:395
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr "不正な URL スキーム \"%s\" (\"%s\" 内)"
@@ -3352,7 +3352,7 @@ msgid ""
 msgstr ""
 "'%s' は不正な名前です。空文字列は maxWidth を指定しているときのみ指定できます"
 
-#: lxc/move.go:148 lxc/storage_volume.go:2000
+#: lxc/move.go:148 lxc/storage_volume.go:2006
 msgid "Invalid new snapshot name"
 msgstr "不適切な新しいスナップショット名"
 
@@ -3362,7 +3362,7 @@ msgstr ""
 "新しいスナップショット名が不正です。親のスナップショット名はソースと同じでな"
 "ければいけません"
 
-#: lxc/storage_volume.go:1996
+#: lxc/storage_volume.go:2002
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 "新しいスナップショット名が不正です。親のボリュームはソースと同じでなければな"
@@ -3377,14 +3377,14 @@ msgstr "引数の数が不正です"
 msgid "Invalid path %s"
 msgstr "不正なパス %s"
 
-#: lxc/remote.go:342
+#: lxc/remote.go:384
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr "不正なプロトコル: %s"
 
-#: lxc/storage_volume.go:1064 lxc/storage_volume.go:1281
-#: lxc/storage_volume.go:1405 lxc/storage_volume.go:1985
-#: lxc/storage_volume.go:2132 lxc/storage_volume.go:2284
+#: lxc/storage_volume.go:1070 lxc/storage_volume.go:1287
+#: lxc/storage_volume.go:1411 lxc/storage_volume.go:1991
+#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2290
 msgid "Invalid snapshot name"
 msgstr "不正なスナップショット名"
 
@@ -3430,7 +3430,7 @@ msgstr "LISTEN ADDRESS"
 
 #: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1739 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1745 lxc/warning.go:221
 msgid "LOCATION"
 msgstr "LOCATION"
 
@@ -3846,11 +3846,11 @@ msgstr "ストレージバケットの鍵を一覧表示します"
 msgid "List storage buckets"
 msgstr "ストレージバケットを一覧表示します"
 
-#: lxc/storage_volume.go:1586
+#: lxc/storage_volume.go:1592
 msgid "List storage volumes"
 msgstr "ストレージボリュームを一覧表示します"
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1597
 #, fuzzy
 msgid ""
 "List storage volumes\n"
@@ -3885,7 +3885,7 @@ msgstr ""
 "    u - （使用中の）リファレンス数\n"
 "    U - 現在のディスク使用量"
 
-#: lxc/remote.go:685 lxc/remote.go:686
+#: lxc/remote.go:752 lxc/remote.go:753
 msgid "List the available remotes"
 msgstr "利用可能なリモートサーバを一覧表示します"
 
@@ -3942,7 +3942,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr "バックグラウンド操作の一覧表示、表示、削除を行います"
 
-#: lxc/info.go:489 lxc/storage_volume.go:1464
+#: lxc/info.go:489 lxc/storage_volume.go:1470
 #, c-format
 msgid "Location: %s"
 msgstr "ロケーション: %s"
@@ -4433,12 +4433,12 @@ msgstr "ピア名を指定する必要があります"
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:323 lxc/storage_volume.go:643
-#: lxc/storage_volume.go:750 lxc/storage_volume.go:841
-#: lxc/storage_volume.go:939 lxc/storage_volume.go:1053
-#: lxc/storage_volume.go:1270 lxc/storage_volume.go:1974
-#: lxc/storage_volume.go:2115 lxc/storage_volume.go:2273
-#: lxc/storage_volume.go:2464 lxc/storage_volume.go:2581
+#: lxc/storage_volume.go:323 lxc/storage_volume.go:649
+#: lxc/storage_volume.go:756 lxc/storage_volume.go:847
+#: lxc/storage_volume.go:945 lxc/storage_volume.go:1059
+#: lxc/storage_volume.go:1276 lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:2121 lxc/storage_volume.go:2279
+#: lxc/storage_volume.go:2470 lxc/storage_volume.go:2587
 msgid "Missing pool name"
 msgstr "ストレージプール名を指定する必要があります"
 
@@ -4457,11 +4457,11 @@ msgstr "プロジェクト名を指定する必要があります"
 msgid "Missing source profile name"
 msgstr "コピー元のプロファイル名を指定する必要があります"
 
-#: lxc/storage_volume.go:432 lxc/storage_volume.go:1884
+#: lxc/storage_volume.go:438 lxc/storage_volume.go:1890
 msgid "Missing source volume name"
 msgstr "コピー元のボリューム名を指定する必要があります"
 
-#: lxc/storage_volume.go:1394
+#: lxc/storage_volume.go:1400
 msgid "Missing storage pool name"
 msgstr "ストレージプール名を指定する必要があります"
 
@@ -4501,8 +4501,8 @@ msgstr ""
 "\n"
 "デフォルトではすべてのタイプのメッセージをモニタリングします。"
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:861
-#: lxc/storage_volume.go:958
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:867
+#: lxc/storage_volume.go:964
 msgid "More than one device matches, specify the device name"
 msgstr "複数のデバイスとマッチします。デバイス名を指定してください"
 
@@ -4552,7 +4552,7 @@ msgstr ""
 "\n"
 "すべての LXD バージョンとの互換性のため、pull 転送モードがデフォルトです。\n"
 
-#: lxc/storage_volume.go:1843 lxc/storage_volume.go:1844
+#: lxc/storage_volume.go:1849 lxc/storage_volume.go:1850
 msgid "Move storage volumes between pools"
 msgstr "プール間でストレージボリュームを移動します"
 
@@ -4560,11 +4560,11 @@ msgstr "プール間でストレージボリュームを移動します"
 msgid "Move the instance without its snapshots"
 msgstr "インスタンスを移動します。スナップショットは移動しません"
 
-#: lxc/storage_volume.go:1850
+#: lxc/storage_volume.go:1856
 msgid "Move to a project different from the source"
 msgstr "コピー／移動元とは異なるプロジェクトに移動します"
 
-#: lxc/storage_volume.go:512
+#: lxc/storage_volume.go:518
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr "ストレージボリュームの移動中: %s"
@@ -4592,8 +4592,8 @@ msgstr "インスタンス名を指定する必要があります: "
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
-#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1731
+#: lxc/remote.go:815 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
 msgstr "NAME"
 
@@ -4619,7 +4619,7 @@ msgstr "NICs:"
 
 #: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
+#: lxc/project.go:550 lxc/remote.go:775 lxc/remote.go:780 lxc/remote.go:785
 msgid "NO"
 msgstr "NO"
 
@@ -4641,8 +4641,8 @@ msgstr "NVIDIA 情報:"
 msgid "NVRM Version: %v"
 msgstr "NVRM バージョン: %v"
 
-#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1506
-#: lxc/storage_volume.go:1556
+#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1512
+#: lxc/storage_volume.go:1562
 msgid "Name"
 msgstr "名前"
 
@@ -4650,7 +4650,7 @@ msgstr "名前"
 msgid "Name of the project to use for this remote:"
 msgstr "このリモートで使うプロジェクト名:"
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1446
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1452
 #, c-format
 msgid "Name: %s"
 msgstr "名前: %s"
@@ -4797,7 +4797,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr "このネットワークに対するデバイスがありません"
 
-#: lxc/storage_volume.go:870 lxc/storage_volume.go:967
+#: lxc/storage_volume.go:876 lxc/storage_volume.go:973
 msgid "No device found for this storage volume"
 msgstr "このストレージボリュームに対するデバイスがありません"
 
@@ -4813,11 +4813,11 @@ msgstr "マッチするポートが見つかりません"
 msgid "No matching rule(s) found"
 msgstr "マッチするルールが見つかりません"
 
-#: lxc/storage_volume.go:446 lxc/storage_volume.go:1893
+#: lxc/storage_volume.go:452 lxc/storage_volume.go:1899
 msgid "No storage pool for source volume specified"
 msgstr "コピー元のボリュームに対するストレージプールが指定されていません"
 
-#: lxc/storage_volume.go:496 lxc/storage_volume.go:1904
+#: lxc/storage_volume.go:502 lxc/storage_volume.go:1910
 msgid "No storage pool for target volume specified"
 msgstr "コピー先のボリュームに対するストレージプールが指定されていません"
 
@@ -4831,7 +4831,7 @@ msgstr "%q に設定する値が指定されていません"
 msgid "Node %d:\n"
 msgstr "ノード %d:\n"
 
-#: lxc/storage_volume.go:2012
+#: lxc/storage_volume.go:2018
 msgid "Not a snapshot name"
 msgstr "スナップショット名ではありません"
 
@@ -4843,15 +4843,15 @@ msgstr "OVN:"
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr "\"カスタム\" のボリュームのみがインスタンスにアタッチできます"
 
-#: lxc/storage_volume.go:2678
+#: lxc/storage_volume.go:2684
 msgid "Only \"custom\" volumes can be exported"
 msgstr "\"カスタム\" のボリュームのみがエクスポートできます"
 
-#: lxc/storage_volume.go:2477
+#: lxc/storage_volume.go:2483
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr "\"カスタム\" のボリュームのみがスナップショットを取得できます"
 
-#: lxc/remote.go:336
+#: lxc/remote.go:378
 msgid "Only https URLs are supported for simplestreams"
 msgstr "simplestreams は https の URL のみサポートします"
 
@@ -4859,7 +4859,7 @@ msgstr "simplestreams は https の URL のみサポートします"
 msgid "Only https:// is supported for remote image import"
 msgstr "リモートイメージのインポートは https:// のみをサポートします"
 
-#: lxc/storage_volume.go:1412
+#: lxc/storage_volume.go:1418
 msgid "Only instance or custom volumes are supported"
 msgstr "インスタンスもしくはカスタムボリュームのみをサポートしています"
 
@@ -4872,7 +4872,7 @@ msgstr "管理対象のネットワークのみ変更できます"
 msgid "Operation %s deleted"
 msgstr "バックグラウンド操作 %s を削除しました"
 
-#: lxc/info.go:693 lxc/storage_volume.go:1560
+#: lxc/info.go:693 lxc/storage_volume.go:1566
 msgid "Optimized Storage"
 msgstr "最適化されたストレージ"
 
@@ -4902,7 +4902,7 @@ msgstr "PID"
 msgid "PID: %d"
 msgstr "PID: %d"
 
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1756
 msgid "POOL"
 msgstr ""
 
@@ -4918,15 +4918,15 @@ msgstr "PROCESSES"
 msgid "PROFILES"
 msgstr "PROFILES"
 
-#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:213
+#: lxc/list.go:567 lxc/storage_volume.go:1762 lxc/warning.go:213
 msgid "PROJECT"
 msgstr "PROJECT"
 
-#: lxc/remote.go:750
+#: lxc/remote.go:817
 msgid "PROTOCOL"
 msgstr "PROTOCOL"
 
-#: lxc/image.go:1136 lxc/remote.go:752
+#: lxc/image.go:1136 lxc/remote.go:819
 msgid "PUBLIC"
 msgstr "PUBLIC"
 
@@ -4955,7 +4955,7 @@ msgstr "インスタンスを一時停止します"
 msgid "Perform an incremental copy"
 msgstr "インクリメンタルコピーを実行します"
 
-#: lxc/remote.go:183
+#: lxc/remote.go:195
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr "別のサーバアドレスを指定してください（空の場合は中止）:"
 
@@ -4967,8 +4967,9 @@ msgstr "クライアント名を入力してください: "
 msgid "Please provide cluster member name: "
 msgstr "クラスターメンバー名を入力してください: "
 
-#: lxc/remote.go:466
-msgid "Please type 'y', 'n' or the fingerprint:"
+#: lxc/remote.go:536
+#, fuzzy
+msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr "'y', 'n', フィンガープリントのどれかを入力してください:"
 
 #: lxc/info.go:221
@@ -4992,8 +4993,8 @@ msgstr "終了するには ctrl+c を押してください"
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1151
-#: lxc/storage_volume.go:1183
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
+#: lxc/storage_volume.go:1189
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 "再度エディタを開くためには Enter キーを、変更を取り消すには ctrl+c を入力しま"
@@ -5112,7 +5113,7 @@ msgstr "プロパティ:"
 msgid "Property not found"
 msgstr "プロパティが見つかりません"
 
-#: lxc/storage_volume.go:1350
+#: lxc/storage_volume.go:1356
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -5126,7 +5127,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1219
+#: lxc/storage_volume.go:1225
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5142,7 +5143,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2224
+#: lxc/storage_volume.go:2230
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5163,7 +5164,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:998
+#: lxc/storage_volume.go:1004
 #, fuzzy
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
@@ -5175,7 +5176,7 @@ msgstr ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    pool.yaml の内容でストレージボリュームを更新します。"
 
-#: lxc/storage_volume.go:2069
+#: lxc/storage_volume.go:2075
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5188,7 +5189,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2345
+#: lxc/storage_volume.go:2351
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5294,33 +5295,33 @@ msgstr "インスタンスの更新中: %s"
 msgid "Refreshing the image: %s"
 msgstr "イメージの更新中: %s"
 
-#: lxc/remote.go:810
+#: lxc/remote.go:877
 #, c-format
 msgid "Remote %s already exists"
 msgstr "リモート %s は既に存在します"
 
-#: lxc/project.go:884 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
-#: lxc/remote.go:994
+#: lxc/project.go:884 lxc/remote.go:868 lxc/remote.go:949 lxc/remote.go:1013
+#: lxc/remote.go:1061
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr "リモート %s は存在しません"
 
-#: lxc/remote.go:305
+#: lxc/remote.go:345
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr "リモート %s は <%s> として存在します"
 
-#: lxc/remote.go:890
+#: lxc/remote.go:957
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr "リモート %s は global ですので削除できません"
 
-#: lxc/remote.go:805 lxc/remote.go:886 lxc/remote.go:998
+#: lxc/remote.go:872 lxc/remote.go:953 lxc/remote.go:1065
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr "リモート %s は static ですので変更できません"
 
-#: lxc/remote.go:294
+#: lxc/remote.go:319
 msgid "Remote address must not be empty"
 msgstr ""
 
@@ -5328,7 +5329,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr "リモートの管理者パスワード"
 
-#: lxc/remote.go:299
+#: lxc/remote.go:339
 msgid "Remote names may not contain colons"
 msgstr "リモート名にコロンを含めることはできません"
 
@@ -5418,7 +5419,7 @@ msgstr "ロードバランサーからポートを削除します"
 msgid "Remove profiles from instances"
 msgstr "インスタンスからプロファイルを削除します"
 
-#: lxc/remote.go:852 lxc/remote.go:853
+#: lxc/remote.go:919 lxc/remote.go:920
 msgid "Remove remotes"
 msgstr "リモートサーバを削除します"
 
@@ -5477,20 +5478,20 @@ msgstr "プロファイル名を変更します"
 msgid "Rename projects"
 msgstr "プロジェクト名を変更します"
 
-#: lxc/remote.go:771 lxc/remote.go:772
+#: lxc/remote.go:838 lxc/remote.go:839
 msgid "Rename remotes"
 msgstr "リモートサーバ名を変更します"
 
-#: lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:1943
 msgid "Rename storage volumes"
 msgstr "ストレージボリューム名を変更します"
 
-#: lxc/storage_volume.go:1936
+#: lxc/storage_volume.go:1942
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 "ストレージボリューム名とストレージボリュームのスナップショット名を変更します"
 
-#: lxc/storage_volume.go:2025 lxc/storage_volume.go:2045
+#: lxc/storage_volume.go:2031 lxc/storage_volume.go:2051
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr "ストレージボリューム名 \"%s\" を \"%s\" に変更しました"
@@ -5548,7 +5549,7 @@ msgstr ""
 "\n"
 "--stateful オプションを指定すると、インスタンスの実行状態もリストアします。"
 
-#: lxc/storage_volume.go:2540 lxc/storage_volume.go:2541
+#: lxc/storage_volume.go:2546 lxc/storage_volume.go:2547
 msgid "Restore storage volume snapshots"
 msgstr "スナップショットからストレージボリュームをリストアします"
 
@@ -5631,7 +5632,7 @@ msgstr "SSH クライアントが切断されました %q"
 msgid "STATE"
 msgstr "STATE"
 
-#: lxc/remote.go:753
+#: lxc/remote.go:820
 msgid "STATIC"
 msgstr "STATIC"
 
@@ -5673,11 +5674,11 @@ msgstr "直接リクエスト (raw query) を LXD に送ります"
 msgid "Server authentication type (tls or oidc)"
 msgstr "サーバの認証タイプ (tls もしくは candid)"
 
-#: lxc/remote.go:464
+#: lxc/remote.go:532
 msgid "Server certificate NACKed by user"
 msgstr "ユーザによりサーバ証明書が拒否されました"
 
-#: lxc/remote.go:616
+#: lxc/remote.go:285 lxc/remote.go:683
 msgid "Server doesn't trust us after authentication"
 msgstr "認証後、サーバが我々を信用していません"
 
@@ -5928,11 +5929,11 @@ msgstr ""
 "後方互換性のため、単一の設定を行うには次の形式でも設定できます:\n"
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 
-#: lxc/storage_volume.go:2063
+#: lxc/storage_volume.go:2069
 msgid "Set storage volume configuration keys"
 msgstr "ストレージボリュームの設定項目を設定します"
 
-#: lxc/storage_volume.go:2064
+#: lxc/storage_volume.go:2070
 #, fuzzy
 msgid ""
 "Set storage volume configuration keys\n"
@@ -5946,7 +5947,7 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 
-#: lxc/remote.go:964 lxc/remote.go:965
+#: lxc/remote.go:1031 lxc/remote.go:1032
 msgid "Set the URL for the remote"
 msgstr "リモートの URL を設定します"
 
@@ -6033,7 +6034,7 @@ msgstr "ストレージバケットに対する鍵を作成します"
 msgid "Set the key as a storage property"
 msgstr "ストレージバケットに対する鍵を作成します"
 
-#: lxc/storage_volume.go:2080
+#: lxc/storage_volume.go:2086
 #, fuzzy
 msgid "Set the key as a storage volume property"
 msgstr "新しいストレージボリュームをプロファイルに追加します"
@@ -6186,11 +6187,11 @@ msgstr "ストレージバケットの鍵の設定を表示する"
 msgid "Show storage pool configurations and resources"
 msgstr "ストレージプールの設定とリソースを表示します"
 
-#: lxc/storage_volume.go:2221 lxc/storage_volume.go:2222
+#: lxc/storage_volume.go:2227 lxc/storage_volume.go:2228
 msgid "Show storage volume configurations"
 msgstr "ストレージボリュームの設定を表示する"
 
-#: lxc/storage_volume.go:1347 lxc/storage_volume.go:1348
+#: lxc/storage_volume.go:1353 lxc/storage_volume.go:1354
 msgid "Show storage volume state information"
 msgstr "ストレージボリュームの状態を表示します"
 
@@ -6204,7 +6205,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:647 lxc/remote.go:648
+#: lxc/remote.go:714 lxc/remote.go:715
 msgid "Show the default remote"
 msgstr "デフォルトのリモートを表示します"
 
@@ -6258,15 +6259,15 @@ msgstr "サイズ: %.2fMB"
 msgid "Size: %s"
 msgstr "サイズ: %s"
 
-#: lxc/storage_volume.go:2404 lxc/storage_volume.go:2405
+#: lxc/storage_volume.go:2410 lxc/storage_volume.go:2411
 msgid "Snapshot storage volumes"
 msgstr "ストレージボリュームのスナップショットを取得します"
 
-#: lxc/storage_volume.go:2167
+#: lxc/storage_volume.go:2173
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr "スナップショットは読み取り専用です。設定を変更することはできません"
 
-#: lxc/info.go:607 lxc/storage_volume.go:1485
+#: lxc/info.go:607 lxc/storage_volume.go:1491
 msgid "Snapshots:"
 msgstr "スナップショット:"
 
@@ -6367,21 +6368,21 @@ msgstr "ストレージプール %s はメンバ %s 上でペンディング状�
 msgid "Storage pool name"
 msgstr "ストレージプール名"
 
-#: lxc/storage_volume.go:696
+#: lxc/storage_volume.go:702
 #, c-format
 msgid "Storage volume %s created"
 msgstr "ストレージボリューム %s を作成しました"
 
-#: lxc/storage_volume.go:784
+#: lxc/storage_volume.go:790
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr "ストレージボリューム %s を削除しました"
 
-#: lxc/storage_volume.go:509
+#: lxc/storage_volume.go:515
 msgid "Storage volume copied successfully!"
 msgstr "ストレージボリュームのコピーが成功しました!"
 
-#: lxc/storage_volume.go:513
+#: lxc/storage_volume.go:519
 msgid "Storage volume moved successfully!"
 msgstr "ストレージボリュームの移動が成功しました!"
 
@@ -6416,7 +6417,7 @@ msgstr "Swap (ピーク)"
 msgid "Switch the current project"
 msgstr "現在のプロジェクトを切り替えます"
 
-#: lxc/remote.go:916 lxc/remote.go:917
+#: lxc/remote.go:983 lxc/remote.go:984
 msgid "Switch the default remote"
 msgstr "デフォルトのリモートを切り替えます"
 
@@ -6435,11 +6436,11 @@ msgstr "TOKEN"
 #: lxc/auth.go:818 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
-#: lxc/storage_volume.go:1730 lxc/warning.go:216
+#: lxc/storage_volume.go:1736 lxc/warning.go:216
 msgid "TYPE"
 msgstr "TYPE"
 
-#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1557
+#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1563
 msgid "Taken at"
 msgstr "取得日時"
 
@@ -6450,6 +6451,12 @@ msgstr "ターゲットのパスと --listen オプションは同時に指定�
 #: lxc/file.go:1256
 msgid "Target path must be a directory"
 msgstr "ターゲットのパスはディレクトリでなければなりません"
+
+#: lxc/remote.go:161 lxc/remote.go:334
+msgid ""
+"The --accept-certificate flag is not supported when adding a remote using a "
+"trust token"
+msgstr ""
 
 #: lxc/move.go:181
 msgid "The --instance-only flag can't be used with --target"
@@ -6596,16 +6603,23 @@ msgstr "設定 %q はクラスタメンバー %q には存在しません"
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
 
-#: lxc/storage_volume.go:1323
+#: lxc/storage_volume.go:1329
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
 
-#: lxc/storage_volume.go:1300
+#: lxc/storage_volume.go:1306
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
+
+#: lxc/remote.go:527
+#, fuzzy
+msgid ""
+"The provided fingerprint does not match the server certificate fingerprint"
+msgstr ""
+"証明書のフィンガープリントが証明書トークンとサーバの間で一致しません %q"
 
 #: lxc/info.go:354
 msgid "The server doesn't implement the newer v2 resources API"
@@ -6615,8 +6629,8 @@ msgstr "サーバには新しい v2 resource API が実装されていません"
 msgid "The source LXD server is not clustered"
 msgstr "移動元の LXD サーバはクラスタに属していません"
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:875
-#: lxc/storage_volume.go:972
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:881
+#: lxc/storage_volume.go:978
 msgid "The specified device doesn't exist"
 msgstr "指定したデバイスが存在しません"
 
@@ -6712,7 +6726,7 @@ msgstr ""
 "--target オプションは、コピー先のリモートサーバがクラスタに属していなければな"
 "りません"
 
-#: lxc/storage_volume.go:1470
+#: lxc/storage_volume.go:1476
 #, c-format
 msgid "Total: %s"
 msgstr "合計: %s"
@@ -6727,7 +6741,7 @@ msgstr "合計: %v"
 msgid "Transceiver type: %s"
 msgstr "トランシーバータイプ: %s"
 
-#: lxc/storage_volume.go:1847
+#: lxc/storage_volume.go:1853
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr "転送モード。pull, push, relay のいずれか(デフォルトはpull)"
 
@@ -6761,7 +6775,16 @@ msgstr "インスタンスを転送中: %s"
 msgid "Transmit policy"
 msgstr "通信ポリシー"
 
-#: lxc/remote.go:571
+#: lxc/remote.go:329
+msgid "Trust token cannot be used for public remotes"
+msgstr ""
+
+#: lxc/remote.go:324
+#, fuzzy
+msgid "Trust token cannot be used with OIDC authentication"
+msgstr "--project は query コマンドでは使えません"
+
+#: lxc/remote.go:639
 #, fuzzy, c-format
 msgid "Trust token for %s: "
 msgstr "%s:%s のクラスターに join するためのトークンが削除されました"
@@ -6788,7 +6811,7 @@ msgstr ""
 "フィカル出力の場合は 'vga'"
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1455
+#: lxc/storage_volume.go:1461
 #, c-format
 msgid "Type: %s"
 msgstr "タイプ: %s"
@@ -6806,17 +6829,17 @@ msgstr "UNLIMITED"
 msgid "UPLOAD DATE"
 msgstr "UPLOAD DATE"
 
-#: lxc/cluster.go:193 lxc/remote.go:749
+#: lxc/cluster.go:193 lxc/remote.go:816
 msgid "URL"
 msgstr "URL"
 
-#: lxc/project.go:995 lxc/storage_volume.go:1735
+#: lxc/project.go:995 lxc/storage_volume.go:1741
 msgid "USAGE"
 msgstr "USAGE"
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1734
+#: lxc/storage.go:724 lxc/storage_volume.go:1740
 msgid "USED BY"
 msgstr "USED BY"
 
@@ -6834,7 +6857,7 @@ msgstr "UUID: %v"
 msgid "Unable to create a temporary file: %v"
 msgstr "テンポラリファイルを作成できません: %v"
 
-#: lxc/remote.go:214 lxc/remote.go:248
+#: lxc/remote.go:226 lxc/remote.go:260
 msgid "Unavailable remote server"
 msgstr "リモートサーバーが利用できません"
 
@@ -6848,7 +6871,7 @@ msgstr "未知の証明書タイプ %q"
 msgid "Unknown channel type for client %q: %s"
 msgstr "クライアント %q の未知のチャンネルタイプ: %s"
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1772
+#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1778
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6955,7 +6978,7 @@ msgstr "ストレージバケットの設定を削除します"
 msgid "Unset storage pool configuration keys"
 msgstr "ストレージプールの設定を削除します"
 
-#: lxc/storage_volume.go:2342 lxc/storage_volume.go:2343
+#: lxc/storage_volume.go:2348 lxc/storage_volume.go:2349
 msgid "Unset storage volume configuration keys"
 msgstr "ストレージボリュームの設定を削除します"
 
@@ -7015,7 +7038,7 @@ msgstr "ストレージバケットに対する鍵を作成します"
 msgid "Unset the key as a storage property"
 msgstr "ストレージバケットに対する鍵を作成します"
 
-#: lxc/storage_volume.go:2356
+#: lxc/storage_volume.go:2362
 #, fuzzy
 msgid "Unset the key as a storage volume property"
 msgstr "新しいストレージボリュームをプロファイルに追加します"
@@ -7062,12 +7085,12 @@ msgstr "アップロード日時: %s"
 msgid "Upper devices"
 msgstr "上位デバイス"
 
-#: lxc/storage_volume.go:1468
+#: lxc/storage_volume.go:1474
 #, c-format
 msgid "Usage: %s"
 msgstr "使い方: %s"
 
-#: lxc/export.go:42 lxc/storage_volume.go:2629
+#: lxc/export.go:42 lxc/storage_volume.go:2635
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -7139,7 +7162,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr "現在のプロジェクトを切り替えます"
 
-#: lxc/storage_volume.go:1559
+#: lxc/storage_volume.go:1565
 msgid "Volume Only"
 msgstr "Volume Only"
 
@@ -7176,7 +7199,7 @@ msgstr ""
 
 #: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
+#: lxc/project.go:552 lxc/remote.go:777 lxc/remote.go:782 lxc/remote.go:787
 msgid "YES"
 msgstr "YES"
 
@@ -7203,7 +7226,7 @@ msgid "You need to specify an image name or use --empty"
 msgstr ""
 "--target オプションを使うときはコピー先のインスタンス名を指定してください"
 
-#: lxc/storage_volume.go:897
+#: lxc/storage_volume.go:903
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr "[<remote:>]<pool> <volume> <profile> [<device name>]"
 
@@ -7646,7 +7669,7 @@ msgstr "[<remote>:]<operation>"
 msgid "[<remote>:]<pool>"
 msgstr "[<remote>:]<pool>"
 
-#: lxc/storage_volume.go:2788
+#: lxc/storage_volume.go:2794
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr "[<remote>:]<pool> <backup file> [<volume name>]"
 
@@ -7681,7 +7704,7 @@ msgstr "[<remote>:]<pool> <key>"
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr "[<remote>:]<pool> <key> <value>"
 
-#: lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:1941
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
@@ -7689,7 +7712,7 @@ msgstr ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 
-#: lxc/storage_volume.go:799
+#: lxc/storage_volume.go:805
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr "[<remote>:]<pool> <volume> <instance> [<device name>]"
 
@@ -7697,52 +7720,52 @@ msgstr "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 
-#: lxc/storage_volume.go:2539
+#: lxc/storage_volume.go:2545
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr "[<remote>:]<pool> <volume> <snapshot>"
 
-#: lxc/storage_volume.go:2622
+#: lxc/storage_volume.go:2628
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr "[<remote>:]<pool> <volume> [<path>]"
 
-#: lxc/storage_volume.go:2403
+#: lxc/storage_volume.go:2409
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr "[<remote>:]<pool> <volume> [<snapshot>]"
 
-#: lxc/storage_volume.go:603
+#: lxc/storage_volume.go:609
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr "[<remote>:]<pool> <volume> [key=value...]"
 
-#: lxc/storage_volume.go:711
+#: lxc/storage_volume.go:717
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr "[<remote>:]<pool> <volume>[/<snapshot>]"
 
-#: lxc/storage_volume.go:994 lxc/storage_volume.go:1346
+#: lxc/storage_volume.go:1000 lxc/storage_volume.go:1352
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr "[<remote>:]<pool> <volume>"
 
-#: lxc/storage_volume.go:2341
+#: lxc/storage_volume.go:2347
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr "[<remote>:]<pool> <volume>"
 
-#: lxc/storage_volume.go:2062
+#: lxc/storage_volume.go:2068
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr "[<remote>:]<pool> <volume> <key>=<value>..."
 
-#: lxc/storage_volume.go:2220
+#: lxc/storage_volume.go:2226
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr "[<remote>:]<pool> <volume>[/<snapshot>]"
 
-#: lxc/storage_volume.go:1215
+#: lxc/storage_volume.go:1221
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 
-#: lxc/storage_volume.go:1841
+#: lxc/storage_volume.go:1847
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 
@@ -7853,7 +7876,7 @@ msgstr "[<remote>:][<instance>] <key>"
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr "[<remote>:][<instance>] <key>=<value>..."
 
-#: lxc/storage_volume.go:1584
+#: lxc/storage_volume.go:1590
 #, fuzzy
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr "[<remote>:]<pool> [<filter>...]"
@@ -7866,7 +7889,7 @@ msgstr "[<remote>] <IP|FQDN|URL|token>"
 msgid "[[<remote>:]<member>]"
 msgstr "[[<remote>:]<member>]"
 
-#: lxc/project.go:557 lxc/remote.go:739
+#: lxc/project.go:557 lxc/remote.go:806
 msgid "current"
 msgstr "現在値"
 
@@ -8529,7 +8552,7 @@ msgstr ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    pool.yaml の内容でストレージプールを更新します。"
 
-#: lxc/storage_volume.go:607
+#: lxc/storage_volume.go:613
 #, fuzzy
 msgid ""
 "lxc storage volume create p1 v1\n"
@@ -8542,7 +8565,7 @@ msgstr ""
 "lxc init ubuntu:22.04 u1 < config.yaml\n"
 "    config.yaml の設定を使ってインスタンスを作成します"
 
-#: lxc/storage_volume.go:2792
+#: lxc/storage_volume.go:2798
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
@@ -8550,7 +8573,7 @@ msgstr ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tbackup0.tar.gz を使って新しいカスタムボリュームを作成します。"
 
-#: lxc/storage_volume.go:2407
+#: lxc/storage_volume.go:2413
 msgid ""
 "lxc storage volume snapshot create default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -8560,7 +8583,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:531
 msgid "n"
 msgstr "n"
 
@@ -8572,7 +8595,7 @@ msgstr "名前"
 msgid "no"
 msgstr "no"
 
-#: lxc/remote.go:456
+#: lxc/remote.go:510
 msgid "ok (y/n/[fingerprint])?"
 msgstr "ok (y/n/[fingerprint])?"
 
@@ -8611,7 +8634,7 @@ msgstr "サーバに接続できません"
 msgid "used by"
 msgstr "ストレージを使用中の"
 
-#: lxc/remote.go:465
+#: lxc/remote.go:519
 msgid "y"
 msgstr "y"
 
@@ -8619,6 +8642,10 @@ msgstr "y"
 #: lxc/image.go:1194
 msgid "yes"
 msgstr "yes"
+
+#, c-format
+#~ msgid "Failed to create certificate: %w"
+#~ msgstr "証明書の作成に失敗しました: %w"
 
 #, fuzzy
 #~ msgid "Asked for a container but image is of type VM"

--- a/po/ka.po
+++ b/po/ka.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-08 07:43+0100\n"
+"POT-Creation-Date: 2024-10-14 13:30+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -46,7 +46,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1024
+#: lxc/storage_volume.go:1030
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -512,15 +512,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:850 lxc/remote.go:915
+#: lxc/remote.go:917 lxc/remote.go:982
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:963
+#: lxc/remote.go:1030
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:769
+#: lxc/remote.go:836
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -553,7 +553,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:751
+#: lxc/remote.go:818
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -702,7 +702,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:581
+#: lxc/remote.go:648
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -735,11 +735,11 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1590
+#: lxc/storage_volume.go:1596
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:182
+#: lxc/remote.go:194
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -810,7 +810,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:552
+#: lxc/remote.go:621
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -846,16 +846,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2696
+#: lxc/storage_volume.go:2702
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2773
+#: lxc/export.go:192 lxc/storage_volume.go:2779
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:654 lxc/storage_volume.go:1521
+#: lxc/info.go:654 lxc/storage_volume.go:1527
 msgid "Backups:"
 msgstr ""
 
@@ -876,7 +876,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:679
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:685
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -919,7 +919,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1733
+#: lxc/storage_volume.go:1739
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -988,7 +988,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:894
+#: lxc/remote.go:961
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1004,7 +1004,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1749 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1021,12 +1021,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:486
+#: lxc/storage_volume.go:492
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:440
+#: lxc/storage_volume.go:446
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1054,11 +1054,11 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:509
 msgid "Certificate fingerprint"
 msgstr ""
 
-#: lxc/remote.go:219
+#: lxc/remote.go:231
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
@@ -1073,7 +1073,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:620
+#: lxc/remote.go:687
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1147,13 +1147,13 @@ msgstr ""
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
 #: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
-#: lxc/storage_volume.go:612 lxc/storage_volume.go:717
-#: lxc/storage_volume.go:1005 lxc/storage_volume.go:1231
-#: lxc/storage_volume.go:1360 lxc/storage_volume.go:1848
-#: lxc/storage_volume.go:1940 lxc/storage_volume.go:2079
-#: lxc/storage_volume.go:2239 lxc/storage_volume.go:2355
-#: lxc/storage_volume.go:2416 lxc/storage_volume.go:2543
-#: lxc/storage_volume.go:2631 lxc/storage_volume.go:2795
+#: lxc/storage_volume.go:618 lxc/storage_volume.go:723
+#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1237
+#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1854
+#: lxc/storage_volume.go:1946 lxc/storage_volume.go:2085
+#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2361
+#: lxc/storage_volume.go:2422 lxc/storage_volume.go:2549
+#: lxc/storage_volume.go:2637 lxc/storage_volume.go:2801
 msgid "Cluster member name"
 msgstr ""
 
@@ -1169,7 +1169,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1589
+#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1595
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1213,17 +1213,17 @@ msgstr ""
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1150
-#: lxc/storage_volume.go:1182
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
+#: lxc/storage_volume.go:1188
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:613
+#: lxc/storage_volume.go:619
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1467
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1307,7 +1307,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:508
+#: lxc/storage_volume.go:514
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1321,12 +1321,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:490
+#: lxc/remote.go:559
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:225 lxc/remote.go:474
+#: lxc/remote.go:237 lxc/remote.go:543
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1365,7 +1365,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:485
+#: lxc/remote.go:554
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1434,7 +1434,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:604 lxc/storage_volume.go:605
+#: lxc/storage_volume.go:610 lxc/storage_volume.go:611
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1486,7 +1486,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1475
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1481
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1521,7 +1521,7 @@ msgstr ""
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1732
+#: lxc/storage_volume.go:1738
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1541,7 +1541,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2630
+#: lxc/storage_volume.go:2636
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1637,7 +1637,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:713 lxc/storage_volume.go:714
+#: lxc/storage_volume.go:719 lxc/storage_volume.go:720
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1729,9 +1729,9 @@ msgstr ""
 #: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
 #: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
 #: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:648
-#: lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853 lxc/remote.go:917
-#: lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:715
+#: lxc/remote.go:753 lxc/remote.go:839 lxc/remote.go:920 lxc/remote.go:984
+#: lxc/remote.go:1032 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1743,26 +1743,26 @@ msgstr ""
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
 #: lxc/storage_volume.go:169 lxc/storage_volume.go:283
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:605
-#: lxc/storage_volume.go:714 lxc/storage_volume.go:801
-#: lxc/storage_volume.go:899 lxc/storage_volume.go:996
-#: lxc/storage_volume.go:1217 lxc/storage_volume.go:1348
-#: lxc/storage_volume.go:1507 lxc/storage_volume.go:1591
-#: lxc/storage_volume.go:1844 lxc/storage_volume.go:1937
-#: lxc/storage_volume.go:2064 lxc/storage_volume.go:2222
-#: lxc/storage_volume.go:2343 lxc/storage_volume.go:2405
-#: lxc/storage_volume.go:2541 lxc/storage_volume.go:2624
-#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:611
+#: lxc/storage_volume.go:720 lxc/storage_volume.go:807
+#: lxc/storage_volume.go:905 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:1223 lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1513 lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1850 lxc/storage_volume.go:1943
+#: lxc/storage_volume.go:2070 lxc/storage_volume.go:2228
+#: lxc/storage_volume.go:2349 lxc/storage_volume.go:2411
+#: lxc/storage_volume.go:2547 lxc/storage_volume.go:2630
+#: lxc/storage_volume.go:2796 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1448
+#: lxc/storage_volume.go:1454
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:1849
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:1855
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1774,11 +1774,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:800 lxc/storage_volume.go:801
+#: lxc/storage_volume.go:806 lxc/storage_volume.go:807
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:898 lxc/storage_volume.go:899
+#: lxc/storage_volume.go:904 lxc/storage_volume.go:905
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -2004,7 +2004,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:995 lxc/storage_volume.go:996
+#: lxc/storage_volume.go:1001 lxc/storage_volume.go:1002
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2012,7 +2012,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1766
+#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1772
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2069,7 +2069,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2193
+#: lxc/storage_volume.go:2161 lxc/storage_volume.go:2199
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2083,8 +2083,8 @@ msgstr ""
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2149
-#: lxc/storage_volume.go:2187
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2155
+#: lxc/storage_volume.go:2193
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2126,8 +2126,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1508
-#: lxc/storage_volume.go:1558
+#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1514
+#: lxc/storage_volume.go:1564
 msgid "Expires at"
 msgstr ""
 
@@ -2151,7 +2151,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2623 lxc/storage_volume.go:2624
+#: lxc/storage_volume.go:2629 lxc/storage_volume.go:2630
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2163,11 +2163,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2627
+#: lxc/storage_volume.go:2633
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2756
+#: lxc/export.go:152 lxc/storage_volume.go:2762
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2284,11 +2284,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:191
+#: lxc/remote.go:203
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:242
+#: lxc/remote.go:254
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2298,7 +2298,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:232
+#: lxc/remote.go:244
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2308,12 +2308,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:260
+#: lxc/remote.go:486
 #, c-format
-msgid "Failed to create certificate: %w"
+msgid "Failed to decode trust token: %w"
 msgstr ""
 
-#: lxc/remote.go:267
+#: lxc/remote.go:292
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2338,7 +2338,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:237
+#: lxc/remote.go:249
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2425,9 +2425,9 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:690 lxc/storage.go:657
+#: lxc/project.go:919 lxc/remote.go:757 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1608 lxc/warning.go:94
+#: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2463,7 +2463,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:754
+#: lxc/remote.go:821
 msgid "GLOBAL"
 msgstr ""
 
@@ -2483,7 +2483,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:160 lxc/remote.go:401
+#: lxc/remote.go:165 lxc/remote.go:443
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2551,7 +2551,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1238
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2615,11 +2615,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1216 lxc/storage_volume.go:1217
+#: lxc/storage_volume.go:1222 lxc/storage_volume.go:1223
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:469
+#: lxc/storage_volume.go:475
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2743,7 +2743,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2415
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2421
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2757,7 +2757,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2414
+#: lxc/storage_volume.go:2420
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2807,7 +2807,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2790
+#: lxc/storage_volume.go:2796
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2815,7 +2815,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2789
+#: lxc/storage_volume.go:2795
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2837,11 +2837,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2797
+#: lxc/storage_volume.go:2803
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2871
+#: lxc/storage_volume.go:2877
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2907,7 +2907,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:353
+#: lxc/remote.go:395
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2967,7 +2967,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2000
+#: lxc/move.go:148 lxc/storage_volume.go:2006
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2975,7 +2975,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1996
+#: lxc/storage_volume.go:2002
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2988,14 +2988,14 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:342
+#: lxc/remote.go:384
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1064 lxc/storage_volume.go:1281
-#: lxc/storage_volume.go:1405 lxc/storage_volume.go:1985
-#: lxc/storage_volume.go:2132 lxc/storage_volume.go:2284
+#: lxc/storage_volume.go:1070 lxc/storage_volume.go:1287
+#: lxc/storage_volume.go:1411 lxc/storage_volume.go:1991
+#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2290
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3041,7 +3041,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1739 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1745 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3344,11 +3344,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1586
+#: lxc/storage_volume.go:1592
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1597
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3368,7 +3368,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:685 lxc/remote.go:686
+#: lxc/remote.go:752 lxc/remote.go:753
 msgid "List the available remotes"
 msgstr ""
 
@@ -3407,7 +3407,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1464
+#: lxc/info.go:489 lxc/storage_volume.go:1470
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3871,12 +3871,12 @@ msgstr ""
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:323 lxc/storage_volume.go:643
-#: lxc/storage_volume.go:750 lxc/storage_volume.go:841
-#: lxc/storage_volume.go:939 lxc/storage_volume.go:1053
-#: lxc/storage_volume.go:1270 lxc/storage_volume.go:1974
-#: lxc/storage_volume.go:2115 lxc/storage_volume.go:2273
-#: lxc/storage_volume.go:2464 lxc/storage_volume.go:2581
+#: lxc/storage_volume.go:323 lxc/storage_volume.go:649
+#: lxc/storage_volume.go:756 lxc/storage_volume.go:847
+#: lxc/storage_volume.go:945 lxc/storage_volume.go:1059
+#: lxc/storage_volume.go:1276 lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:2121 lxc/storage_volume.go:2279
+#: lxc/storage_volume.go:2470 lxc/storage_volume.go:2587
 msgid "Missing pool name"
 msgstr ""
 
@@ -3895,11 +3895,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:432 lxc/storage_volume.go:1884
+#: lxc/storage_volume.go:438 lxc/storage_volume.go:1890
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1394
+#: lxc/storage_volume.go:1400
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -3936,8 +3936,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:861
-#: lxc/storage_volume.go:958
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:867
+#: lxc/storage_volume.go:964
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -3974,7 +3974,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1843 lxc/storage_volume.go:1844
+#: lxc/storage_volume.go:1849 lxc/storage_volume.go:1850
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -3982,11 +3982,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1850
+#: lxc/storage_volume.go:1856
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:512
+#: lxc/storage_volume.go:518
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4012,8 +4012,8 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
-#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1731
+#: lxc/remote.go:815 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
 msgstr ""
 
@@ -4039,7 +4039,7 @@ msgstr ""
 
 #: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
+#: lxc/project.go:550 lxc/remote.go:775 lxc/remote.go:780 lxc/remote.go:785
 msgid "NO"
 msgstr ""
 
@@ -4061,8 +4061,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1506
-#: lxc/storage_volume.go:1556
+#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1512
+#: lxc/storage_volume.go:1562
 msgid "Name"
 msgstr ""
 
@@ -4070,7 +4070,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1446
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1452
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4214,7 +4214,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:870 lxc/storage_volume.go:967
+#: lxc/storage_volume.go:876 lxc/storage_volume.go:973
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4230,11 +4230,11 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/storage_volume.go:446 lxc/storage_volume.go:1893
+#: lxc/storage_volume.go:452 lxc/storage_volume.go:1899
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:496 lxc/storage_volume.go:1904
+#: lxc/storage_volume.go:502 lxc/storage_volume.go:1910
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4248,7 +4248,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2012
+#: lxc/storage_volume.go:2018
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4260,15 +4260,15 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2678
+#: lxc/storage_volume.go:2684
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2477
+#: lxc/storage_volume.go:2483
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:336
+#: lxc/remote.go:378
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4276,7 +4276,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1412
+#: lxc/storage_volume.go:1418
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4289,7 +4289,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:693 lxc/storage_volume.go:1560
+#: lxc/info.go:693 lxc/storage_volume.go:1566
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4319,7 +4319,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1756
 msgid "POOL"
 msgstr ""
 
@@ -4335,15 +4335,15 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:213
+#: lxc/list.go:567 lxc/storage_volume.go:1762 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:817
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:752
+#: lxc/image.go:1136 lxc/remote.go:819
 msgid "PUBLIC"
 msgstr ""
 
@@ -4372,7 +4372,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:183
+#: lxc/remote.go:195
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4384,8 +4384,8 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:466
-msgid "Please type 'y', 'n' or the fingerprint:"
+#: lxc/remote.go:536
+msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
 #: lxc/info.go:221
@@ -4409,8 +4409,8 @@ msgstr ""
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1151
-#: lxc/storage_volume.go:1183
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
+#: lxc/storage_volume.go:1189
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4527,7 +4527,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1350
+#: lxc/storage_volume.go:1356
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4541,7 +4541,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1219
+#: lxc/storage_volume.go:1225
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4557,7 +4557,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2224
+#: lxc/storage_volume.go:2230
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4578,7 +4578,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:998
+#: lxc/storage_volume.go:1004
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4587,7 +4587,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2069
+#: lxc/storage_volume.go:2075
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4600,7 +4600,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2345
+#: lxc/storage_volume.go:2351
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4704,33 +4704,33 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:810
+#: lxc/remote.go:877
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
-#: lxc/remote.go:994
+#: lxc/project.go:884 lxc/remote.go:868 lxc/remote.go:949 lxc/remote.go:1013
+#: lxc/remote.go:1061
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:305
+#: lxc/remote.go:345
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:890
+#: lxc/remote.go:957
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:805 lxc/remote.go:886 lxc/remote.go:998
+#: lxc/remote.go:872 lxc/remote.go:953 lxc/remote.go:1065
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:294
+#: lxc/remote.go:319
 msgid "Remote address must not be empty"
 msgstr ""
 
@@ -4738,7 +4738,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:299
+#: lxc/remote.go:339
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4824,7 +4824,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:852 lxc/remote.go:853
+#: lxc/remote.go:919 lxc/remote.go:920
 msgid "Remove remotes"
 msgstr ""
 
@@ -4881,19 +4881,19 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:771 lxc/remote.go:772
+#: lxc/remote.go:838 lxc/remote.go:839
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:1943
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1936
+#: lxc/storage_volume.go:1942
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2025 lxc/storage_volume.go:2045
+#: lxc/storage_volume.go:2031 lxc/storage_volume.go:2051
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4945,7 +4945,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2540 lxc/storage_volume.go:2541
+#: lxc/storage_volume.go:2546 lxc/storage_volume.go:2547
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5026,7 +5026,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:820
 msgid "STATIC"
 msgstr ""
 
@@ -5067,11 +5067,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:464
+#: lxc/remote.go:532
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:616
+#: lxc/remote.go:285 lxc/remote.go:683
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5269,11 +5269,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2063
+#: lxc/storage_volume.go:2069
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2064
+#: lxc/storage_volume.go:2070
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5282,7 +5282,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:964 lxc/remote.go:965
+#: lxc/remote.go:1031 lxc/remote.go:1032
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5358,7 +5358,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2080
+#: lxc/storage_volume.go:2086
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5507,11 +5507,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2221 lxc/storage_volume.go:2222
+#: lxc/storage_volume.go:2227 lxc/storage_volume.go:2228
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1347 lxc/storage_volume.go:1348
+#: lxc/storage_volume.go:1353 lxc/storage_volume.go:1354
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5525,7 +5525,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:647 lxc/remote.go:648
+#: lxc/remote.go:714 lxc/remote.go:715
 msgid "Show the default remote"
 msgstr ""
 
@@ -5579,15 +5579,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2404 lxc/storage_volume.go:2405
+#: lxc/storage_volume.go:2410 lxc/storage_volume.go:2411
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2167
+#: lxc/storage_volume.go:2173
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:607 lxc/storage_volume.go:1485
+#: lxc/info.go:607 lxc/storage_volume.go:1491
 msgid "Snapshots:"
 msgstr ""
 
@@ -5688,21 +5688,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:696
+#: lxc/storage_volume.go:702
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:784
+#: lxc/storage_volume.go:790
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:509
+#: lxc/storage_volume.go:515
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:513
+#: lxc/storage_volume.go:519
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5737,7 +5737,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:916 lxc/remote.go:917
+#: lxc/remote.go:983 lxc/remote.go:984
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5756,11 +5756,11 @@ msgstr ""
 #: lxc/auth.go:818 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
-#: lxc/storage_volume.go:1730 lxc/warning.go:216
+#: lxc/storage_volume.go:1736 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1557
+#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1563
 msgid "Taken at"
 msgstr ""
 
@@ -5770,6 +5770,12 @@ msgstr ""
 
 #: lxc/file.go:1256
 msgid "Target path must be a directory"
+msgstr ""
+
+#: lxc/remote.go:161 lxc/remote.go:334
+msgid ""
+"The --accept-certificate flag is not supported when adding a remote using a "
+"trust token"
 msgstr ""
 
 #: lxc/move.go:181
@@ -5911,15 +5917,20 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1323
+#: lxc/storage_volume.go:1329
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1300
+#: lxc/storage_volume.go:1306
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
+msgstr ""
+
+#: lxc/remote.go:527
+msgid ""
+"The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
 
 #: lxc/info.go:354
@@ -5930,8 +5941,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:875
-#: lxc/storage_volume.go:972
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:881
+#: lxc/storage_volume.go:978
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6006,7 +6017,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1470
+#: lxc/storage_volume.go:1476
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6021,7 +6032,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1847
+#: lxc/storage_volume.go:1853
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6055,7 +6066,15 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:571
+#: lxc/remote.go:329
+msgid "Trust token cannot be used for public remotes"
+msgstr ""
+
+#: lxc/remote.go:324
+msgid "Trust token cannot be used with OIDC authentication"
+msgstr ""
+
+#: lxc/remote.go:639
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6080,7 +6099,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1455
+#: lxc/storage_volume.go:1461
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6098,17 +6117,17 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:193 lxc/remote.go:749
+#: lxc/cluster.go:193 lxc/remote.go:816
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1735
+#: lxc/project.go:995 lxc/storage_volume.go:1741
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1734
+#: lxc/storage.go:724 lxc/storage_volume.go:1740
 msgid "USED BY"
 msgstr ""
 
@@ -6126,7 +6145,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:214 lxc/remote.go:248
+#: lxc/remote.go:226 lxc/remote.go:260
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6140,7 +6159,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1772
+#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1778
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6246,7 +6265,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2342 lxc/storage_volume.go:2343
+#: lxc/storage_volume.go:2348 lxc/storage_volume.go:2349
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6298,7 +6317,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2356
+#: lxc/storage_volume.go:2362
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6342,12 +6361,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1468
+#: lxc/storage_volume.go:1474
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2629
+#: lxc/export.go:42 lxc/storage_volume.go:2635
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6414,7 +6433,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1559
+#: lxc/storage_volume.go:1565
 msgid "Volume Only"
 msgstr ""
 
@@ -6449,7 +6468,7 @@ msgstr ""
 
 #: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
+#: lxc/project.go:552 lxc/remote.go:777 lxc/remote.go:782 lxc/remote.go:787
 msgid "YES"
 msgstr ""
 
@@ -6473,7 +6492,7 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:897
+#: lxc/storage_volume.go:903
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
@@ -6895,7 +6914,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2788
+#: lxc/storage_volume.go:2794
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -6930,13 +6949,13 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:1941
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:799
+#: lxc/storage_volume.go:805
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
@@ -6944,47 +6963,47 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2539
+#: lxc/storage_volume.go:2545
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2622
+#: lxc/storage_volume.go:2628
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2403
+#: lxc/storage_volume.go:2409
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:603
+#: lxc/storage_volume.go:609
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:711
+#: lxc/storage_volume.go:717
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:994 lxc/storage_volume.go:1346
+#: lxc/storage_volume.go:1000 lxc/storage_volume.go:1352
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2341
+#: lxc/storage_volume.go:2347
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2062
+#: lxc/storage_volume.go:2068
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2220
+#: lxc/storage_volume.go:2226
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1215
+#: lxc/storage_volume.go:1221
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1841
+#: lxc/storage_volume.go:1847
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7094,7 +7113,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1584
+#: lxc/storage_volume.go:1590
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7106,7 +7125,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:739
+#: lxc/project.go:557 lxc/remote.go:806
 msgid "current"
 msgstr ""
 
@@ -7566,7 +7585,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:607
+#: lxc/storage_volume.go:613
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7574,13 +7593,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2792
+#: lxc/storage_volume.go:2798
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2407
+#: lxc/storage_volume.go:2413
 msgid ""
 "lxc storage volume snapshot create default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7590,7 +7609,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:531
 msgid "n"
 msgstr ""
 
@@ -7602,7 +7621,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:510
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7639,7 +7658,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:465
+#: lxc/remote.go:519
 msgid "y"
 msgstr ""
 

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-08 07:43+0100\n"
+"POT-Creation-Date: 2024-10-14 13:30+0000\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Korean <https://hosted.weblate.org/projects/linux-containers/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1024
+#: lxc/storage_volume.go:1030
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -515,15 +515,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:850 lxc/remote.go:915
+#: lxc/remote.go:917 lxc/remote.go:982
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:963
+#: lxc/remote.go:1030
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:769
+#: lxc/remote.go:836
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -556,7 +556,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:751
+#: lxc/remote.go:818
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:581
+#: lxc/remote.go:648
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -738,11 +738,11 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1590
+#: lxc/storage_volume.go:1596
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:182
+#: lxc/remote.go:194
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -813,7 +813,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:552
+#: lxc/remote.go:621
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -849,16 +849,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2696
+#: lxc/storage_volume.go:2702
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2773
+#: lxc/export.go:192 lxc/storage_volume.go:2779
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:654 lxc/storage_volume.go:1521
+#: lxc/info.go:654 lxc/storage_volume.go:1527
 msgid "Backups:"
 msgstr ""
 
@@ -879,7 +879,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:679
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:685
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -922,7 +922,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1733
+#: lxc/storage_volume.go:1739
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -991,7 +991,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:894
+#: lxc/remote.go:961
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1007,7 +1007,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1749 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1024,12 +1024,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:486
+#: lxc/storage_volume.go:492
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:440
+#: lxc/storage_volume.go:446
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1057,11 +1057,11 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:509
 msgid "Certificate fingerprint"
 msgstr ""
 
-#: lxc/remote.go:219
+#: lxc/remote.go:231
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
@@ -1076,7 +1076,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:620
+#: lxc/remote.go:687
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1150,13 +1150,13 @@ msgstr ""
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
 #: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
-#: lxc/storage_volume.go:612 lxc/storage_volume.go:717
-#: lxc/storage_volume.go:1005 lxc/storage_volume.go:1231
-#: lxc/storage_volume.go:1360 lxc/storage_volume.go:1848
-#: lxc/storage_volume.go:1940 lxc/storage_volume.go:2079
-#: lxc/storage_volume.go:2239 lxc/storage_volume.go:2355
-#: lxc/storage_volume.go:2416 lxc/storage_volume.go:2543
-#: lxc/storage_volume.go:2631 lxc/storage_volume.go:2795
+#: lxc/storage_volume.go:618 lxc/storage_volume.go:723
+#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1237
+#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1854
+#: lxc/storage_volume.go:1946 lxc/storage_volume.go:2085
+#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2361
+#: lxc/storage_volume.go:2422 lxc/storage_volume.go:2549
+#: lxc/storage_volume.go:2637 lxc/storage_volume.go:2801
 msgid "Cluster member name"
 msgstr ""
 
@@ -1172,7 +1172,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1589
+#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1595
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1216,17 +1216,17 @@ msgstr ""
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1150
-#: lxc/storage_volume.go:1182
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
+#: lxc/storage_volume.go:1188
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:613
+#: lxc/storage_volume.go:619
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1467
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1310,7 +1310,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:508
+#: lxc/storage_volume.go:514
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1324,12 +1324,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:490
+#: lxc/remote.go:559
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:225 lxc/remote.go:474
+#: lxc/remote.go:237 lxc/remote.go:543
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1368,7 +1368,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:485
+#: lxc/remote.go:554
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1437,7 +1437,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:604 lxc/storage_volume.go:605
+#: lxc/storage_volume.go:610 lxc/storage_volume.go:611
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1489,7 +1489,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1475
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1481
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1524,7 +1524,7 @@ msgstr ""
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1732
+#: lxc/storage_volume.go:1738
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1544,7 +1544,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2630
+#: lxc/storage_volume.go:2636
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1640,7 +1640,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:713 lxc/storage_volume.go:714
+#: lxc/storage_volume.go:719 lxc/storage_volume.go:720
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1732,9 +1732,9 @@ msgstr ""
 #: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
 #: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
 #: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:648
-#: lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853 lxc/remote.go:917
-#: lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:715
+#: lxc/remote.go:753 lxc/remote.go:839 lxc/remote.go:920 lxc/remote.go:984
+#: lxc/remote.go:1032 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1746,26 +1746,26 @@ msgstr ""
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
 #: lxc/storage_volume.go:169 lxc/storage_volume.go:283
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:605
-#: lxc/storage_volume.go:714 lxc/storage_volume.go:801
-#: lxc/storage_volume.go:899 lxc/storage_volume.go:996
-#: lxc/storage_volume.go:1217 lxc/storage_volume.go:1348
-#: lxc/storage_volume.go:1507 lxc/storage_volume.go:1591
-#: lxc/storage_volume.go:1844 lxc/storage_volume.go:1937
-#: lxc/storage_volume.go:2064 lxc/storage_volume.go:2222
-#: lxc/storage_volume.go:2343 lxc/storage_volume.go:2405
-#: lxc/storage_volume.go:2541 lxc/storage_volume.go:2624
-#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:611
+#: lxc/storage_volume.go:720 lxc/storage_volume.go:807
+#: lxc/storage_volume.go:905 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:1223 lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1513 lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1850 lxc/storage_volume.go:1943
+#: lxc/storage_volume.go:2070 lxc/storage_volume.go:2228
+#: lxc/storage_volume.go:2349 lxc/storage_volume.go:2411
+#: lxc/storage_volume.go:2547 lxc/storage_volume.go:2630
+#: lxc/storage_volume.go:2796 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1448
+#: lxc/storage_volume.go:1454
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:1849
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:1855
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1777,11 +1777,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:800 lxc/storage_volume.go:801
+#: lxc/storage_volume.go:806 lxc/storage_volume.go:807
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:898 lxc/storage_volume.go:899
+#: lxc/storage_volume.go:904 lxc/storage_volume.go:905
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -2007,7 +2007,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:995 lxc/storage_volume.go:996
+#: lxc/storage_volume.go:1001 lxc/storage_volume.go:1002
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2015,7 +2015,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1766
+#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1772
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2072,7 +2072,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2193
+#: lxc/storage_volume.go:2161 lxc/storage_volume.go:2199
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2086,8 +2086,8 @@ msgstr ""
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2149
-#: lxc/storage_volume.go:2187
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2155
+#: lxc/storage_volume.go:2193
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2129,8 +2129,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1508
-#: lxc/storage_volume.go:1558
+#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1514
+#: lxc/storage_volume.go:1564
 msgid "Expires at"
 msgstr ""
 
@@ -2154,7 +2154,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2623 lxc/storage_volume.go:2624
+#: lxc/storage_volume.go:2629 lxc/storage_volume.go:2630
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2166,11 +2166,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2627
+#: lxc/storage_volume.go:2633
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2756
+#: lxc/export.go:152 lxc/storage_volume.go:2762
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2287,11 +2287,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:191
+#: lxc/remote.go:203
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:242
+#: lxc/remote.go:254
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2301,7 +2301,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:232
+#: lxc/remote.go:244
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2311,12 +2311,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:260
+#: lxc/remote.go:486
 #, c-format
-msgid "Failed to create certificate: %w"
+msgid "Failed to decode trust token: %w"
 msgstr ""
 
-#: lxc/remote.go:267
+#: lxc/remote.go:292
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2341,7 +2341,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:237
+#: lxc/remote.go:249
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2428,9 +2428,9 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:690 lxc/storage.go:657
+#: lxc/project.go:919 lxc/remote.go:757 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1608 lxc/warning.go:94
+#: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2466,7 +2466,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:754
+#: lxc/remote.go:821
 msgid "GLOBAL"
 msgstr ""
 
@@ -2486,7 +2486,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:160 lxc/remote.go:401
+#: lxc/remote.go:165 lxc/remote.go:443
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2554,7 +2554,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1238
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2618,11 +2618,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1216 lxc/storage_volume.go:1217
+#: lxc/storage_volume.go:1222 lxc/storage_volume.go:1223
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:469
+#: lxc/storage_volume.go:475
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2746,7 +2746,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2415
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2421
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2760,7 +2760,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2414
+#: lxc/storage_volume.go:2420
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2810,7 +2810,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2790
+#: lxc/storage_volume.go:2796
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2818,7 +2818,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2789
+#: lxc/storage_volume.go:2795
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2840,11 +2840,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2797
+#: lxc/storage_volume.go:2803
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2871
+#: lxc/storage_volume.go:2877
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2910,7 +2910,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:353
+#: lxc/remote.go:395
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2970,7 +2970,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2000
+#: lxc/move.go:148 lxc/storage_volume.go:2006
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2978,7 +2978,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1996
+#: lxc/storage_volume.go:2002
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2991,14 +2991,14 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:342
+#: lxc/remote.go:384
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1064 lxc/storage_volume.go:1281
-#: lxc/storage_volume.go:1405 lxc/storage_volume.go:1985
-#: lxc/storage_volume.go:2132 lxc/storage_volume.go:2284
+#: lxc/storage_volume.go:1070 lxc/storage_volume.go:1287
+#: lxc/storage_volume.go:1411 lxc/storage_volume.go:1991
+#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2290
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3044,7 +3044,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1739 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1745 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3347,11 +3347,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1586
+#: lxc/storage_volume.go:1592
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1597
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3371,7 +3371,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:685 lxc/remote.go:686
+#: lxc/remote.go:752 lxc/remote.go:753
 msgid "List the available remotes"
 msgstr ""
 
@@ -3410,7 +3410,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1464
+#: lxc/info.go:489 lxc/storage_volume.go:1470
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3874,12 +3874,12 @@ msgstr ""
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:323 lxc/storage_volume.go:643
-#: lxc/storage_volume.go:750 lxc/storage_volume.go:841
-#: lxc/storage_volume.go:939 lxc/storage_volume.go:1053
-#: lxc/storage_volume.go:1270 lxc/storage_volume.go:1974
-#: lxc/storage_volume.go:2115 lxc/storage_volume.go:2273
-#: lxc/storage_volume.go:2464 lxc/storage_volume.go:2581
+#: lxc/storage_volume.go:323 lxc/storage_volume.go:649
+#: lxc/storage_volume.go:756 lxc/storage_volume.go:847
+#: lxc/storage_volume.go:945 lxc/storage_volume.go:1059
+#: lxc/storage_volume.go:1276 lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:2121 lxc/storage_volume.go:2279
+#: lxc/storage_volume.go:2470 lxc/storage_volume.go:2587
 msgid "Missing pool name"
 msgstr ""
 
@@ -3898,11 +3898,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:432 lxc/storage_volume.go:1884
+#: lxc/storage_volume.go:438 lxc/storage_volume.go:1890
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1394
+#: lxc/storage_volume.go:1400
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -3939,8 +3939,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:861
-#: lxc/storage_volume.go:958
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:867
+#: lxc/storage_volume.go:964
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -3977,7 +3977,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1843 lxc/storage_volume.go:1844
+#: lxc/storage_volume.go:1849 lxc/storage_volume.go:1850
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -3985,11 +3985,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1850
+#: lxc/storage_volume.go:1856
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:512
+#: lxc/storage_volume.go:518
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4015,8 +4015,8 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
-#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1731
+#: lxc/remote.go:815 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
 msgstr ""
 
@@ -4042,7 +4042,7 @@ msgstr ""
 
 #: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
+#: lxc/project.go:550 lxc/remote.go:775 lxc/remote.go:780 lxc/remote.go:785
 msgid "NO"
 msgstr ""
 
@@ -4064,8 +4064,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1506
-#: lxc/storage_volume.go:1556
+#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1512
+#: lxc/storage_volume.go:1562
 msgid "Name"
 msgstr ""
 
@@ -4073,7 +4073,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1446
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1452
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4217,7 +4217,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:870 lxc/storage_volume.go:967
+#: lxc/storage_volume.go:876 lxc/storage_volume.go:973
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4233,11 +4233,11 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/storage_volume.go:446 lxc/storage_volume.go:1893
+#: lxc/storage_volume.go:452 lxc/storage_volume.go:1899
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:496 lxc/storage_volume.go:1904
+#: lxc/storage_volume.go:502 lxc/storage_volume.go:1910
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4251,7 +4251,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2012
+#: lxc/storage_volume.go:2018
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4263,15 +4263,15 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2678
+#: lxc/storage_volume.go:2684
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2477
+#: lxc/storage_volume.go:2483
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:336
+#: lxc/remote.go:378
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4279,7 +4279,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1412
+#: lxc/storage_volume.go:1418
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4292,7 +4292,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:693 lxc/storage_volume.go:1560
+#: lxc/info.go:693 lxc/storage_volume.go:1566
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4322,7 +4322,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1756
 msgid "POOL"
 msgstr ""
 
@@ -4338,15 +4338,15 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:213
+#: lxc/list.go:567 lxc/storage_volume.go:1762 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:817
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:752
+#: lxc/image.go:1136 lxc/remote.go:819
 msgid "PUBLIC"
 msgstr ""
 
@@ -4375,7 +4375,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:183
+#: lxc/remote.go:195
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4387,8 +4387,8 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:466
-msgid "Please type 'y', 'n' or the fingerprint:"
+#: lxc/remote.go:536
+msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
 #: lxc/info.go:221
@@ -4412,8 +4412,8 @@ msgstr ""
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1151
-#: lxc/storage_volume.go:1183
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
+#: lxc/storage_volume.go:1189
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4530,7 +4530,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1350
+#: lxc/storage_volume.go:1356
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4544,7 +4544,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1219
+#: lxc/storage_volume.go:1225
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4560,7 +4560,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2224
+#: lxc/storage_volume.go:2230
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4581,7 +4581,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:998
+#: lxc/storage_volume.go:1004
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4590,7 +4590,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2069
+#: lxc/storage_volume.go:2075
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4603,7 +4603,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2345
+#: lxc/storage_volume.go:2351
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4707,33 +4707,33 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:810
+#: lxc/remote.go:877
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
-#: lxc/remote.go:994
+#: lxc/project.go:884 lxc/remote.go:868 lxc/remote.go:949 lxc/remote.go:1013
+#: lxc/remote.go:1061
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:305
+#: lxc/remote.go:345
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:890
+#: lxc/remote.go:957
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:805 lxc/remote.go:886 lxc/remote.go:998
+#: lxc/remote.go:872 lxc/remote.go:953 lxc/remote.go:1065
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:294
+#: lxc/remote.go:319
 msgid "Remote address must not be empty"
 msgstr ""
 
@@ -4741,7 +4741,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:299
+#: lxc/remote.go:339
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4827,7 +4827,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:852 lxc/remote.go:853
+#: lxc/remote.go:919 lxc/remote.go:920
 msgid "Remove remotes"
 msgstr ""
 
@@ -4884,19 +4884,19 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:771 lxc/remote.go:772
+#: lxc/remote.go:838 lxc/remote.go:839
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:1943
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1936
+#: lxc/storage_volume.go:1942
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2025 lxc/storage_volume.go:2045
+#: lxc/storage_volume.go:2031 lxc/storage_volume.go:2051
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4948,7 +4948,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2540 lxc/storage_volume.go:2541
+#: lxc/storage_volume.go:2546 lxc/storage_volume.go:2547
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5029,7 +5029,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:820
 msgid "STATIC"
 msgstr ""
 
@@ -5070,11 +5070,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:464
+#: lxc/remote.go:532
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:616
+#: lxc/remote.go:285 lxc/remote.go:683
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5272,11 +5272,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2063
+#: lxc/storage_volume.go:2069
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2064
+#: lxc/storage_volume.go:2070
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5285,7 +5285,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:964 lxc/remote.go:965
+#: lxc/remote.go:1031 lxc/remote.go:1032
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5361,7 +5361,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2080
+#: lxc/storage_volume.go:2086
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5510,11 +5510,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2221 lxc/storage_volume.go:2222
+#: lxc/storage_volume.go:2227 lxc/storage_volume.go:2228
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1347 lxc/storage_volume.go:1348
+#: lxc/storage_volume.go:1353 lxc/storage_volume.go:1354
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5528,7 +5528,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:647 lxc/remote.go:648
+#: lxc/remote.go:714 lxc/remote.go:715
 msgid "Show the default remote"
 msgstr ""
 
@@ -5582,15 +5582,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2404 lxc/storage_volume.go:2405
+#: lxc/storage_volume.go:2410 lxc/storage_volume.go:2411
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2167
+#: lxc/storage_volume.go:2173
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:607 lxc/storage_volume.go:1485
+#: lxc/info.go:607 lxc/storage_volume.go:1491
 msgid "Snapshots:"
 msgstr ""
 
@@ -5691,21 +5691,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:696
+#: lxc/storage_volume.go:702
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:784
+#: lxc/storage_volume.go:790
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:509
+#: lxc/storage_volume.go:515
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:513
+#: lxc/storage_volume.go:519
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5740,7 +5740,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:916 lxc/remote.go:917
+#: lxc/remote.go:983 lxc/remote.go:984
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5759,11 +5759,11 @@ msgstr ""
 #: lxc/auth.go:818 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
-#: lxc/storage_volume.go:1730 lxc/warning.go:216
+#: lxc/storage_volume.go:1736 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1557
+#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1563
 msgid "Taken at"
 msgstr ""
 
@@ -5773,6 +5773,12 @@ msgstr ""
 
 #: lxc/file.go:1256
 msgid "Target path must be a directory"
+msgstr ""
+
+#: lxc/remote.go:161 lxc/remote.go:334
+msgid ""
+"The --accept-certificate flag is not supported when adding a remote using a "
+"trust token"
 msgstr ""
 
 #: lxc/move.go:181
@@ -5914,15 +5920,20 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1323
+#: lxc/storage_volume.go:1329
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1300
+#: lxc/storage_volume.go:1306
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
+msgstr ""
+
+#: lxc/remote.go:527
+msgid ""
+"The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
 
 #: lxc/info.go:354
@@ -5933,8 +5944,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:875
-#: lxc/storage_volume.go:972
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:881
+#: lxc/storage_volume.go:978
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6009,7 +6020,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1470
+#: lxc/storage_volume.go:1476
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6024,7 +6035,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1847
+#: lxc/storage_volume.go:1853
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6058,7 +6069,15 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:571
+#: lxc/remote.go:329
+msgid "Trust token cannot be used for public remotes"
+msgstr ""
+
+#: lxc/remote.go:324
+msgid "Trust token cannot be used with OIDC authentication"
+msgstr ""
+
+#: lxc/remote.go:639
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6083,7 +6102,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1455
+#: lxc/storage_volume.go:1461
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6101,17 +6120,17 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:193 lxc/remote.go:749
+#: lxc/cluster.go:193 lxc/remote.go:816
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1735
+#: lxc/project.go:995 lxc/storage_volume.go:1741
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1734
+#: lxc/storage.go:724 lxc/storage_volume.go:1740
 msgid "USED BY"
 msgstr ""
 
@@ -6129,7 +6148,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:214 lxc/remote.go:248
+#: lxc/remote.go:226 lxc/remote.go:260
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6143,7 +6162,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1772
+#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1778
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6249,7 +6268,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2342 lxc/storage_volume.go:2343
+#: lxc/storage_volume.go:2348 lxc/storage_volume.go:2349
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6301,7 +6320,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2356
+#: lxc/storage_volume.go:2362
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6345,12 +6364,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1468
+#: lxc/storage_volume.go:1474
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2629
+#: lxc/export.go:42 lxc/storage_volume.go:2635
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6417,7 +6436,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1559
+#: lxc/storage_volume.go:1565
 msgid "Volume Only"
 msgstr ""
 
@@ -6452,7 +6471,7 @@ msgstr ""
 
 #: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
+#: lxc/project.go:552 lxc/remote.go:777 lxc/remote.go:782 lxc/remote.go:787
 msgid "YES"
 msgstr ""
 
@@ -6476,7 +6495,7 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:897
+#: lxc/storage_volume.go:903
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
@@ -6898,7 +6917,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2788
+#: lxc/storage_volume.go:2794
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -6933,13 +6952,13 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:1941
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:799
+#: lxc/storage_volume.go:805
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
@@ -6947,47 +6966,47 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2539
+#: lxc/storage_volume.go:2545
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2622
+#: lxc/storage_volume.go:2628
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2403
+#: lxc/storage_volume.go:2409
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:603
+#: lxc/storage_volume.go:609
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:711
+#: lxc/storage_volume.go:717
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:994 lxc/storage_volume.go:1346
+#: lxc/storage_volume.go:1000 lxc/storage_volume.go:1352
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2341
+#: lxc/storage_volume.go:2347
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2062
+#: lxc/storage_volume.go:2068
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2220
+#: lxc/storage_volume.go:2226
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1215
+#: lxc/storage_volume.go:1221
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1841
+#: lxc/storage_volume.go:1847
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7097,7 +7116,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1584
+#: lxc/storage_volume.go:1590
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7109,7 +7128,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:739
+#: lxc/project.go:557 lxc/remote.go:806
 msgid "current"
 msgstr ""
 
@@ -7569,7 +7588,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:607
+#: lxc/storage_volume.go:613
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7577,13 +7596,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2792
+#: lxc/storage_volume.go:2798
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2407
+#: lxc/storage_volume.go:2413
 msgid ""
 "lxc storage volume snapshot create default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7593,7 +7612,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:531
 msgid "n"
 msgstr ""
 
@@ -7605,7 +7624,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:510
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7642,7 +7661,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:465
+#: lxc/remote.go:519
 msgid "y"
 msgstr ""
 

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-        "POT-Creation-Date: 2024-10-08 07:43+0100\n"
+        "POT-Creation-Date: 2024-10-14 13:30+0000\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -44,7 +44,7 @@ msgid   "### This is a YAML representation of a storage pool.\n"
         "###   zfs.pool_name: default"
 msgstr  ""
 
-#: lxc/storage_volume.go:1024
+#: lxc/storage_volume.go:1030
 msgid   "### This is a YAML representation of a storage volume.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -482,15 +482,15 @@ msgstr  ""
 msgid   "<old alias> <new alias>"
 msgstr  ""
 
-#: lxc/remote.go:850 lxc/remote.go:915
+#: lxc/remote.go:917 lxc/remote.go:982
 msgid   "<remote>"
 msgstr  ""
 
-#: lxc/remote.go:963
+#: lxc/remote.go:1030
 msgid   "<remote> <URL>"
 msgstr  ""
 
-#: lxc/remote.go:769
+#: lxc/remote.go:836
 msgid   "<remote> <new-name>"
 msgstr  ""
 
@@ -522,7 +522,7 @@ msgstr  ""
 msgid   "ARCHITECTURE"
 msgstr  ""
 
-#: lxc/remote.go:751
+#: lxc/remote.go:818
 msgid   "AUTH TYPE"
 msgstr  ""
 
@@ -664,7 +664,7 @@ msgstr  ""
 msgid   "Admin access key: %s"
 msgstr  ""
 
-#: lxc/remote.go:581
+#: lxc/remote.go:648
 #, c-format
 msgid   "Admin password (or token) for %s:"
 msgstr  ""
@@ -697,11 +697,11 @@ msgstr  ""
 msgid   "Aliases:"
 msgstr  ""
 
-#: lxc/storage_volume.go:1590
+#: lxc/storage_volume.go:1596
 msgid   "All projects"
 msgstr  ""
 
-#: lxc/remote.go:182
+#: lxc/remote.go:194
 msgid   "All server addresses are unavailable"
 msgstr  ""
 
@@ -771,7 +771,7 @@ msgid   "Attach to instance consoles\n"
         "as well as retrieve past log entries from it."
 msgstr  ""
 
-#: lxc/remote.go:552
+#: lxc/remote.go:621
 #, c-format
 msgid   "Authentication type '%s' not supported by server"
 msgstr  ""
@@ -807,16 +807,16 @@ msgstr  ""
 msgid   "Backing up instance: %s"
 msgstr  ""
 
-#: lxc/storage_volume.go:2696
+#: lxc/storage_volume.go:2702
 #, c-format
 msgid   "Backing up storage volume: %s"
 msgstr  ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2773
+#: lxc/export.go:192 lxc/storage_volume.go:2779
 msgid   "Backup exported successfully!"
 msgstr  ""
 
-#: lxc/info.go:654 lxc/storage_volume.go:1521
+#: lxc/info.go:654 lxc/storage_volume.go:1527
 msgid   "Backups:"
 msgstr  ""
 
@@ -835,7 +835,7 @@ msgstr  ""
 msgid   "Bad key=value pair: %q"
 msgstr  ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:679
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:685
 #, c-format
 msgid   "Bad key=value pair: %s"
 msgstr  ""
@@ -878,7 +878,7 @@ msgstr  ""
 msgid   "COMMON NAME"
 msgstr  ""
 
-#: lxc/storage_volume.go:1733
+#: lxc/storage_volume.go:1739
 msgid   "CONTENT-TYPE"
 msgstr  ""
 
@@ -947,7 +947,7 @@ msgstr  ""
 msgid   "Can't read from stdin: %w"
 msgstr  ""
 
-#: lxc/remote.go:894
+#: lxc/remote.go:961
 msgid   "Can't remove the default remote"
 msgstr  ""
 
@@ -963,7 +963,7 @@ msgstr  ""
 msgid   "Can't specify a different remote for rename"
 msgstr  ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1749 lxc/warning.go:225
 msgid   "Can't specify column L when not clustered"
 msgstr  ""
 
@@ -980,11 +980,11 @@ msgstr  ""
 msgid   "Can't use an image with --empty"
 msgstr  ""
 
-#: lxc/storage_volume.go:486
+#: lxc/storage_volume.go:492
 msgid   "Cannot set --destination-target when destination server is not clustered"
 msgstr  ""
 
-#: lxc/storage_volume.go:440
+#: lxc/storage_volume.go:446
 msgid   "Cannot set --target when source server is not clustered"
 msgstr  ""
 
@@ -1012,11 +1012,11 @@ msgstr  ""
 msgid   "Certificate add token for %s deleted"
 msgstr  ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:509
 msgid   "Certificate fingerprint"
 msgstr  ""
 
-#: lxc/remote.go:219
+#: lxc/remote.go:231
 #, c-format
 msgid   "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr  ""
@@ -1030,7 +1030,7 @@ msgstr  ""
 msgid   "Client %s certificate add token:"
 msgstr  ""
 
-#: lxc/remote.go:620
+#: lxc/remote.go:687
 msgid   "Client certificate now trusted by server:"
 msgstr  ""
 
@@ -1084,7 +1084,7 @@ msgstr  ""
 msgid   "Cluster member %s removed from group %s"
 msgstr  ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776 lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65 lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877 lxc/network.go:1251 lxc/network.go:1344 lxc/network.go:1416 lxc/network_forward.go:182 lxc/network_forward.go:264 lxc/network_forward.go:497 lxc/network_forward.go:649 lxc/network_forward.go:803 lxc/network_forward.go:892 lxc/network_forward.go:974 lxc/network_load_balancer.go:184 lxc/network_load_balancer.go:266 lxc/network_load_balancer.go:484 lxc/network_load_balancer.go:619 lxc/network_load_balancer.go:774 lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938 lxc/network_load_balancer.go:1051 lxc/network_load_balancer.go:1125 lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748 lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91 lxc/storage_bucket.go:191 lxc/storage_bucket.go:254 lxc/storage_bucket.go:385 lxc/storage_bucket.go:542 lxc/storage_bucket.go:635 lxc/storage_bucket.go:701 lxc/storage_bucket.go:776 lxc/storage_bucket.go:862 lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027 lxc/storage_bucket.go:1163 lxc/storage_volume.go:394 lxc/storage_volume.go:612 lxc/storage_volume.go:717 lxc/storage_volume.go:1005 lxc/storage_volume.go:1231 lxc/storage_volume.go:1360 lxc/storage_volume.go:1848 lxc/storage_volume.go:1940 lxc/storage_volume.go:2079 lxc/storage_volume.go:2239 lxc/storage_volume.go:2355 lxc/storage_volume.go:2416 lxc/storage_volume.go:2543 lxc/storage_volume.go:2631 lxc/storage_volume.go:2795
+#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776 lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65 lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877 lxc/network.go:1251 lxc/network.go:1344 lxc/network.go:1416 lxc/network_forward.go:182 lxc/network_forward.go:264 lxc/network_forward.go:497 lxc/network_forward.go:649 lxc/network_forward.go:803 lxc/network_forward.go:892 lxc/network_forward.go:974 lxc/network_load_balancer.go:184 lxc/network_load_balancer.go:266 lxc/network_load_balancer.go:484 lxc/network_load_balancer.go:619 lxc/network_load_balancer.go:774 lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938 lxc/network_load_balancer.go:1051 lxc/network_load_balancer.go:1125 lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748 lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91 lxc/storage_bucket.go:191 lxc/storage_bucket.go:254 lxc/storage_bucket.go:385 lxc/storage_bucket.go:542 lxc/storage_bucket.go:635 lxc/storage_bucket.go:701 lxc/storage_bucket.go:776 lxc/storage_bucket.go:862 lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027 lxc/storage_bucket.go:1163 lxc/storage_volume.go:394 lxc/storage_volume.go:618 lxc/storage_volume.go:723 lxc/storage_volume.go:1011 lxc/storage_volume.go:1237 lxc/storage_volume.go:1366 lxc/storage_volume.go:1854 lxc/storage_volume.go:1946 lxc/storage_volume.go:2085 lxc/storage_volume.go:2245 lxc/storage_volume.go:2361 lxc/storage_volume.go:2422 lxc/storage_volume.go:2549 lxc/storage_volume.go:2637 lxc/storage_volume.go:2801
 msgid   "Cluster member name"
 msgstr  ""
 
@@ -1100,7 +1100,7 @@ msgstr  ""
 msgid   "Clustering enabled"
 msgstr  ""
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1589 lxc/warning.go:93
+#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1595 lxc/warning.go:93
 msgid   "Columns"
 msgstr  ""
 
@@ -1135,16 +1135,16 @@ msgstr  ""
 msgid   "Config key/value to apply to the target instance"
 msgstr  ""
 
-#: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281 lxc/config.go:356 lxc/config.go:1339 lxc/config_metadata.go:156 lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759 lxc/network_acl.go:698 lxc/network_forward.go:767 lxc/network_load_balancer.go:738 lxc/network_peer.go:698 lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595 lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349 lxc/storage_bucket.go:1126 lxc/storage_volume.go:1150 lxc/storage_volume.go:1182
+#: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281 lxc/config.go:356 lxc/config.go:1339 lxc/config_metadata.go:156 lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759 lxc/network_acl.go:698 lxc/network_forward.go:767 lxc/network_load_balancer.go:738 lxc/network_peer.go:698 lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595 lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349 lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156 lxc/storage_volume.go:1188
 #, c-format
 msgid   "Config parsing error: %s"
 msgstr  ""
 
-#: lxc/storage_volume.go:613
+#: lxc/storage_volume.go:619
 msgid   "Content type, block or filesystem"
 msgstr  ""
 
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1467
 #, c-format
 msgid   "Content type: %s"
 msgstr  ""
@@ -1221,7 +1221,7 @@ msgstr  ""
 msgid   "Copying the image: %s"
 msgstr  ""
 
-#: lxc/storage_volume.go:508
+#: lxc/storage_volume.go:514
 #, c-format
 msgid   "Copying the storage volume: %s"
 msgstr  ""
@@ -1235,12 +1235,12 @@ msgstr  ""
 msgid   "Cores:"
 msgstr  ""
 
-#: lxc/remote.go:490
+#: lxc/remote.go:559
 #, c-format
 msgid   "Could not close server cert file %q: %w"
 msgstr  ""
 
-#: lxc/remote.go:225 lxc/remote.go:474
+#: lxc/remote.go:237 lxc/remote.go:543
 msgid   "Could not create server cert dir"
 msgstr  ""
 
@@ -1279,7 +1279,7 @@ msgstr  ""
 msgid   "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr  ""
 
-#: lxc/remote.go:485
+#: lxc/remote.go:554
 #, c-format
 msgid   "Could not write server cert file %q: %w"
 msgstr  ""
@@ -1347,7 +1347,7 @@ msgstr  ""
 msgid   "Create new custom storage buckets"
 msgstr  ""
 
-#: lxc/storage_volume.go:604 lxc/storage_volume.go:605
+#: lxc/storage_volume.go:610 lxc/storage_volume.go:611
 msgid   "Create new custom storage volumes"
 msgstr  ""
 
@@ -1399,7 +1399,7 @@ msgstr  ""
 msgid   "Create the instance with no profiles applied"
 msgstr  ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1475
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1481
 #, c-format
 msgid   "Created: %s"
 msgstr  ""
@@ -1427,7 +1427,7 @@ msgstr  ""
 msgid   "DEFAULT TARGET ADDRESS"
 msgstr  ""
 
-#: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504 lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086 lxc/network_acl.go:157 lxc/network_forward.go:157 lxc/network_load_balancer.go:160 lxc/network_peer.go:149 lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173 lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723 lxc/storage_bucket.go:513 lxc/storage_bucket.go:833 lxc/storage_volume.go:1732
+#: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504 lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086 lxc/network_acl.go:157 lxc/network_forward.go:157 lxc/network_load_balancer.go:160 lxc/network_peer.go:149 lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173 lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723 lxc/storage_bucket.go:513 lxc/storage_bucket.go:833 lxc/storage_volume.go:1738
 msgid   "DESCRIPTION"
 msgstr  ""
 
@@ -1447,7 +1447,7 @@ msgstr  ""
 msgid   "Default VLAN ID"
 msgstr  ""
 
-#: lxc/storage_volume.go:2630
+#: lxc/storage_volume.go:2636
 msgid   "Define a compression algorithm: for backup or none"
 msgstr  ""
 
@@ -1543,7 +1543,7 @@ msgstr  ""
 msgid   "Delete storage pools"
 msgstr  ""
 
-#: lxc/storage_volume.go:713 lxc/storage_volume.go:714
+#: lxc/storage_volume.go:719 lxc/storage_volume.go:720
 msgid   "Delete storage volumes"
 msgstr  ""
 
@@ -1551,16 +1551,16 @@ msgstr  ""
 msgid   "Delete warning"
 msgstr  ""
 
-#: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159 lxc/alias.go:214 lxc/auth.go:31 lxc/auth.go:60 lxc/auth.go:99 lxc/auth.go:153 lxc/auth.go:202 lxc/auth.go:333 lxc/auth.go:393 lxc/auth.go:442 lxc/auth.go:494 lxc/auth.go:517 lxc/auth.go:576 lxc/auth.go:732 lxc/auth.go:769 lxc/auth.go:836 lxc/auth.go:899 lxc/auth.go:960 lxc/auth.go:1089 lxc/auth.go:1143 lxc/auth.go:1166 lxc/auth.go:1224 lxc/auth.go:1293 lxc/auth.go:1315 lxc/auth.go:1493 lxc/auth.go:1531 lxc/auth.go:1583 lxc/auth.go:1632 lxc/auth.go:1751 lxc/auth.go:1811 lxc/auth.go:1860 lxc/auth.go:1911 lxc/auth.go:1934 lxc/auth.go:1987 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677 lxc/cluster.go:770 lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087 lxc/cluster.go:1175 lxc/cluster.go:1299 lxc/cluster.go:1329 lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170 lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440 lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663 lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51 lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:955 lxc/config.go:995 lxc/config.go:1050 lxc/config.go:1141 lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:25 lxc/config_device.go:79 lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409 lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634 lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28 lxc/config_metadata.go:56 lxc/config_metadata.go:189 lxc/config_template.go:28 lxc/config_template.go:68 lxc/config_template.go:119 lxc/config_template.go:173 lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34 lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651 lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135 lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689 lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090 lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638 lxc/image.go:1701 lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1005 lxc/network.go:1106 lxc/network.go:1185 lxc/network.go:1245 lxc/network.go:1341 lxc/network.go:1413 lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731 lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:51 lxc/network_forward.go:33 lxc/network_forward.go:90 lxc/network_forward.go:179 lxc/network_forward.go:256 lxc/network_forward.go:404 lxc/network_forward.go:489 lxc/network_forward.go:599 lxc/network_forward.go:646 lxc/network_forward.go:800 lxc/network_forward.go:874 lxc/network_forward.go:889 lxc/network_forward.go:970 lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476 lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935 lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1121 lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236 lxc/network_peer.go:360 lxc/network_peer.go:445 lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:165 lxc/network_zone.go:228 lxc/network_zone.go:301 lxc/network_zone.go:396 lxc/network_zone.go:484 lxc/network_zone.go:527 lxc/network_zone.go:654 lxc/network_zone.go:710 lxc/network_zone.go:767 lxc/network_zone.go:845 lxc/network_zone.go:909 lxc/network_zone.go:985 lxc/network_zone.go:1083 lxc/network_zone.go:1172 lxc/network_zone.go:1219 lxc/network_zone.go:1349 lxc/network_zone.go:1410 lxc/network_zone.go:1425 lxc/network_zone.go:1483 lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180 lxc/profile.go:271 lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493 lxc/profile.go:629 lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860 lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31 lxc/project.go:95 lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472 lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789 lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853 lxc/remote.go:917 lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250 lxc/storage_bucket.go:383 lxc/storage_bucket.go:459 lxc/storage_bucket.go:536 lxc/storage_bucket.go:630 lxc/storage_bucket.go:699 lxc/storage_bucket.go:733 lxc/storage_bucket.go:774 lxc/storage_bucket.go:853 lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158 lxc/storage_volume.go:58 lxc/storage_volume.go:169 lxc/storage_volume.go:283 lxc/storage_volume.go:390 lxc/storage_volume.go:605 lxc/storage_volume.go:714 lxc/storage_volume.go:801 lxc/storage_volume.go:899 lxc/storage_volume.go:996 lxc/storage_volume.go:1217 lxc/storage_volume.go:1348 lxc/storage_volume.go:1507 lxc/storage_volume.go:1591 lxc/storage_volume.go:1844 lxc/storage_volume.go:1937 lxc/storage_volume.go:2064 lxc/storage_volume.go:2222 lxc/storage_volume.go:2343 lxc/storage_volume.go:2405 lxc/storage_volume.go:2541 lxc/storage_volume.go:2624 lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
+#: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159 lxc/alias.go:214 lxc/auth.go:31 lxc/auth.go:60 lxc/auth.go:99 lxc/auth.go:153 lxc/auth.go:202 lxc/auth.go:333 lxc/auth.go:393 lxc/auth.go:442 lxc/auth.go:494 lxc/auth.go:517 lxc/auth.go:576 lxc/auth.go:732 lxc/auth.go:769 lxc/auth.go:836 lxc/auth.go:899 lxc/auth.go:960 lxc/auth.go:1089 lxc/auth.go:1143 lxc/auth.go:1166 lxc/auth.go:1224 lxc/auth.go:1293 lxc/auth.go:1315 lxc/auth.go:1493 lxc/auth.go:1531 lxc/auth.go:1583 lxc/auth.go:1632 lxc/auth.go:1751 lxc/auth.go:1811 lxc/auth.go:1860 lxc/auth.go:1911 lxc/auth.go:1934 lxc/auth.go:1987 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677 lxc/cluster.go:770 lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087 lxc/cluster.go:1175 lxc/cluster.go:1299 lxc/cluster.go:1329 lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170 lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440 lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663 lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51 lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:955 lxc/config.go:995 lxc/config.go:1050 lxc/config.go:1141 lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:25 lxc/config_device.go:79 lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409 lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634 lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28 lxc/config_metadata.go:56 lxc/config_metadata.go:189 lxc/config_template.go:28 lxc/config_template.go:68 lxc/config_template.go:119 lxc/config_template.go:173 lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34 lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651 lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135 lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689 lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090 lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638 lxc/image.go:1701 lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1005 lxc/network.go:1106 lxc/network.go:1185 lxc/network.go:1245 lxc/network.go:1341 lxc/network.go:1413 lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731 lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:51 lxc/network_forward.go:33 lxc/network_forward.go:90 lxc/network_forward.go:179 lxc/network_forward.go:256 lxc/network_forward.go:404 lxc/network_forward.go:489 lxc/network_forward.go:599 lxc/network_forward.go:646 lxc/network_forward.go:800 lxc/network_forward.go:874 lxc/network_forward.go:889 lxc/network_forward.go:970 lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476 lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935 lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1121 lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236 lxc/network_peer.go:360 lxc/network_peer.go:445 lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:165 lxc/network_zone.go:228 lxc/network_zone.go:301 lxc/network_zone.go:396 lxc/network_zone.go:484 lxc/network_zone.go:527 lxc/network_zone.go:654 lxc/network_zone.go:710 lxc/network_zone.go:767 lxc/network_zone.go:845 lxc/network_zone.go:909 lxc/network_zone.go:985 lxc/network_zone.go:1083 lxc/network_zone.go:1172 lxc/network_zone.go:1219 lxc/network_zone.go:1349 lxc/network_zone.go:1410 lxc/network_zone.go:1425 lxc/network_zone.go:1483 lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180 lxc/profile.go:271 lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493 lxc/profile.go:629 lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860 lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31 lxc/project.go:95 lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472 lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789 lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:715 lxc/remote.go:753 lxc/remote.go:839 lxc/remote.go:920 lxc/remote.go:984 lxc/remote.go:1032 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250 lxc/storage_bucket.go:383 lxc/storage_bucket.go:459 lxc/storage_bucket.go:536 lxc/storage_bucket.go:630 lxc/storage_bucket.go:699 lxc/storage_bucket.go:733 lxc/storage_bucket.go:774 lxc/storage_bucket.go:853 lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158 lxc/storage_volume.go:58 lxc/storage_volume.go:169 lxc/storage_volume.go:283 lxc/storage_volume.go:390 lxc/storage_volume.go:611 lxc/storage_volume.go:720 lxc/storage_volume.go:807 lxc/storage_volume.go:905 lxc/storage_volume.go:1002 lxc/storage_volume.go:1223 lxc/storage_volume.go:1354 lxc/storage_volume.go:1513 lxc/storage_volume.go:1597 lxc/storage_volume.go:1850 lxc/storage_volume.go:1943 lxc/storage_volume.go:2070 lxc/storage_volume.go:2228 lxc/storage_volume.go:2349 lxc/storage_volume.go:2411 lxc/storage_volume.go:2547 lxc/storage_volume.go:2630 lxc/storage_volume.go:2796 lxc/version.go:22 lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid   "Description"
 msgstr  ""
 
-#: lxc/storage_volume.go:1448
+#: lxc/storage_volume.go:1454
 #, c-format
 msgid   "Description: %s"
 msgstr  ""
 
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:1849
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:1855
 msgid   "Destination cluster member name"
 msgstr  ""
 
@@ -1572,11 +1572,11 @@ msgstr  ""
 msgid   "Detach network interfaces from profiles"
 msgstr  ""
 
-#: lxc/storage_volume.go:800 lxc/storage_volume.go:801
+#: lxc/storage_volume.go:806 lxc/storage_volume.go:807
 msgid   "Detach storage volumes from instances"
 msgstr  ""
 
-#: lxc/storage_volume.go:898 lxc/storage_volume.go:899
+#: lxc/storage_volume.go:904 lxc/storage_volume.go:905
 msgid   "Detach storage volumes from profiles"
 msgstr  ""
 
@@ -1795,7 +1795,7 @@ msgstr  ""
 msgid   "Edit storage pool configurations as YAML"
 msgstr  ""
 
-#: lxc/storage_volume.go:995 lxc/storage_volume.go:996
+#: lxc/storage_volume.go:1001 lxc/storage_volume.go:1002
 msgid   "Edit storage volume configurations as YAML"
 msgstr  ""
 
@@ -1803,7 +1803,7 @@ msgstr  ""
 msgid   "Edit trust configurations as YAML"
 msgstr  ""
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1766 lxc/warning.go:236
+#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1772 lxc/warning.go:236
 #, c-format
 msgid   "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr  ""
@@ -1850,7 +1850,7 @@ msgstr  ""
 msgid   "Error retrieving aliases: %w"
 msgstr  ""
 
-#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1319 lxc/network_acl.go:524 lxc/network_forward.go:572 lxc/network_load_balancer.go:559 lxc/network_peer.go:522 lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987 lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603 lxc/storage_volume.go:2155 lxc/storage_volume.go:2193
+#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1319 lxc/network_acl.go:524 lxc/network_forward.go:572 lxc/network_load_balancer.go:559 lxc/network_peer.go:522 lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987 lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603 lxc/storage_volume.go:2161 lxc/storage_volume.go:2199
 #, c-format
 msgid   "Error setting properties: %v"
 msgstr  ""
@@ -1860,7 +1860,7 @@ msgstr  ""
 msgid   "Error unsetting properties: %v"
 msgstr  ""
 
-#: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518 lxc/network_forward.go:566 lxc/network_load_balancer.go:553 lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141 lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806 lxc/storage_bucket.go:597 lxc/storage_volume.go:2149 lxc/storage_volume.go:2187
+#: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518 lxc/network_forward.go:566 lxc/network_load_balancer.go:553 lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141 lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806 lxc/storage_bucket.go:597 lxc/storage_volume.go:2155 lxc/storage_volume.go:2193
 #, c-format
 msgid   "Error unsetting property: %v"
 msgstr  ""
@@ -1900,7 +1900,7 @@ msgid   "Execute commands in instances\n"
         "Mode defaults to non-interactive, interactive mode is selected if both stdin AND stdout are terminals (stderr is ignored)."
 msgstr  ""
 
-#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1508 lxc/storage_volume.go:1558
+#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1514 lxc/storage_volume.go:1564
 msgid   "Expires at"
 msgstr  ""
 
@@ -1923,7 +1923,7 @@ msgid   "Export and download images\n"
         "The output target is optional and defaults to the working directory."
 msgstr  ""
 
-#: lxc/storage_volume.go:2623 lxc/storage_volume.go:2624
+#: lxc/storage_volume.go:2629 lxc/storage_volume.go:2630
 msgid   "Export custom storage volume"
 msgstr  ""
 
@@ -1935,11 +1935,11 @@ msgstr  ""
 msgid   "Export instances as backup tarballs."
 msgstr  ""
 
-#: lxc/storage_volume.go:2627
+#: lxc/storage_volume.go:2633
 msgid   "Export the volume without its snapshots"
 msgstr  ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2756
+#: lxc/export.go:152 lxc/storage_volume.go:2762
 #, c-format
 msgid   "Exporting the backup: %s"
 msgstr  ""
@@ -2055,11 +2055,11 @@ msgstr  ""
 msgid   "Failed to accept incoming connection: %w"
 msgstr  ""
 
-#: lxc/remote.go:191
+#: lxc/remote.go:203
 msgid   "Failed to add remote"
 msgstr  ""
 
-#: lxc/remote.go:242
+#: lxc/remote.go:254
 #, c-format
 msgid   "Failed to close server cert file %q: %w"
 msgstr  ""
@@ -2069,7 +2069,7 @@ msgstr  ""
 msgid   "Failed to connect to cluster member: %w"
 msgstr  ""
 
-#: lxc/remote.go:232
+#: lxc/remote.go:244
 #, c-format
 msgid   "Failed to create %q: %w"
 msgstr  ""
@@ -2079,12 +2079,12 @@ msgstr  ""
 msgid   "Failed to create alias %s: %w"
 msgstr  ""
 
-#: lxc/remote.go:260
+#: lxc/remote.go:486
 #, c-format
-msgid   "Failed to create certificate: %w"
+msgid   "Failed to decode trust token: %w"
 msgstr  ""
 
-#: lxc/remote.go:267
+#: lxc/remote.go:292
 #, c-format
 msgid   "Failed to find project: %w"
 msgstr  ""
@@ -2109,7 +2109,7 @@ msgstr  ""
 msgid   "Failed to walk path for %s: %s"
 msgstr  ""
 
-#: lxc/remote.go:237
+#: lxc/remote.go:249
 #, c-format
 msgid   "Failed to write server cert file %q: %w"
 msgstr  ""
@@ -2182,7 +2182,7 @@ msgid   "Forcefully removing a server from the cluster should only be done as a 
         "Are you really sure you want to force removing %s? (yes/no): "
 msgstr  ""
 
-#: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:773 lxc/auth.go:1755 lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442 lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434 lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009 lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:57 lxc/network_forward.go:93 lxc/network_load_balancer.go:97 lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770 lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474 lxc/project.go:919 lxc/remote.go:690 lxc/storage.go:657 lxc/storage_bucket.go:460 lxc/storage_bucket.go:775 lxc/storage_volume.go:1608 lxc/warning.go:94
+#: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:773 lxc/auth.go:1755 lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442 lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434 lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009 lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:57 lxc/network_forward.go:93 lxc/network_load_balancer.go:97 lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770 lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474 lxc/project.go:919 lxc/remote.go:757 lxc/storage.go:657 lxc/storage_bucket.go:460 lxc/storage_bucket.go:775 lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid   "Format (csv|json|table|yaml|compact)"
 msgstr  ""
 
@@ -2218,7 +2218,7 @@ msgstr  ""
 msgid   "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr  ""
 
-#: lxc/remote.go:754
+#: lxc/remote.go:821
 msgid   "GLOBAL"
 msgstr  ""
 
@@ -2238,7 +2238,7 @@ msgstr  ""
 msgid   "Generate manpages for all commands"
 msgstr  ""
 
-#: lxc/remote.go:160 lxc/remote.go:401
+#: lxc/remote.go:165 lxc/remote.go:443
 msgid   "Generating a client certificate. This may take a minute..."
 msgstr  ""
 
@@ -2306,7 +2306,7 @@ msgstr  ""
 msgid   "Get the key as a storage property"
 msgstr  ""
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1238
 msgid   "Get the key as a storage volume property"
 msgstr  ""
 
@@ -2370,11 +2370,11 @@ msgstr  ""
 msgid   "Get values for storage pool configuration keys"
 msgstr  ""
 
-#: lxc/storage_volume.go:1216 lxc/storage_volume.go:1217
+#: lxc/storage_volume.go:1222 lxc/storage_volume.go:1223
 msgid   "Get values for storage volume configuration keys"
 msgstr  ""
 
-#: lxc/storage_volume.go:469
+#: lxc/storage_volume.go:475
 #, c-format
 msgid   "Given target %q does not match source volume location %q"
 msgstr  ""
@@ -2498,7 +2498,7 @@ msgstr  ""
 msgid   "If the image alias already exists, delete and create a new one"
 msgstr  ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2415
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2421
 msgid   "If the snapshot name already exists, delete and create a new one"
 msgstr  ""
 
@@ -2510,7 +2510,7 @@ msgstr  ""
 msgid   "Ignore any configured auto-expiry for the instance"
 msgstr  ""
 
-#: lxc/storage_volume.go:2414
+#: lxc/storage_volume.go:2420
 msgid   "Ignore any configured auto-expiry for the storage volume"
 msgstr  ""
 
@@ -2560,7 +2560,7 @@ msgstr  ""
 msgid   "Immediately attach to the console"
 msgstr  ""
 
-#: lxc/storage_volume.go:2790
+#: lxc/storage_volume.go:2796
 msgid   "Import backups of custom volumes including their snapshots."
 msgstr  ""
 
@@ -2568,7 +2568,7 @@ msgstr  ""
 msgid   "Import backups of instances including their snapshots."
 msgstr  ""
 
-#: lxc/storage_volume.go:2789
+#: lxc/storage_volume.go:2795
 msgid   "Import custom storage volumes"
 msgstr  ""
 
@@ -2588,11 +2588,11 @@ msgstr  ""
 msgid   "Import instance backups"
 msgstr  ""
 
-#: lxc/storage_volume.go:2797
+#: lxc/storage_volume.go:2803
 msgid   "Import type, backup or iso (default \"backup\")"
 msgstr  ""
 
-#: lxc/storage_volume.go:2871
+#: lxc/storage_volume.go:2877
 #, c-format
 msgid   "Importing custom volume: %s"
 msgstr  ""
@@ -2658,7 +2658,7 @@ msgstr  ""
 msgid   "Instance type"
 msgstr  ""
 
-#: lxc/remote.go:353
+#: lxc/remote.go:395
 #, c-format
 msgid   "Invalid URL scheme \"%s\" in \"%s\""
 msgstr  ""
@@ -2717,7 +2717,7 @@ msgstr  ""
 msgid   "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr  ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2000
+#: lxc/move.go:148 lxc/storage_volume.go:2006
 msgid   "Invalid new snapshot name"
 msgstr  ""
 
@@ -2725,7 +2725,7 @@ msgstr  ""
 msgid   "Invalid new snapshot name, parent must be the same as source"
 msgstr  ""
 
-#: lxc/storage_volume.go:1996
+#: lxc/storage_volume.go:2002
 msgid   "Invalid new snapshot name, parent volume must be the same as source"
 msgstr  ""
 
@@ -2738,12 +2738,12 @@ msgstr  ""
 msgid   "Invalid path %s"
 msgstr  ""
 
-#: lxc/remote.go:342
+#: lxc/remote.go:384
 #, c-format
 msgid   "Invalid protocol: %s"
 msgstr  ""
 
-#: lxc/storage_volume.go:1064 lxc/storage_volume.go:1281 lxc/storage_volume.go:1405 lxc/storage_volume.go:1985 lxc/storage_volume.go:2132 lxc/storage_volume.go:2284
+#: lxc/storage_volume.go:1070 lxc/storage_volume.go:1287 lxc/storage_volume.go:1411 lxc/storage_volume.go:1991 lxc/storage_volume.go:2138 lxc/storage_volume.go:2290
 msgid   "Invalid snapshot name"
 msgstr  ""
 
@@ -2787,7 +2787,7 @@ msgstr  ""
 msgid   "LISTEN ADDRESS"
 msgstr  ""
 
-#: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163 lxc/network_load_balancer.go:165 lxc/operation.go:178 lxc/storage_bucket.go:517 lxc/storage_volume.go:1739 lxc/warning.go:221
+#: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163 lxc/network_load_balancer.go:165 lxc/operation.go:178 lxc/storage_bucket.go:517 lxc/storage_volume.go:1745 lxc/warning.go:221
 msgid   "LOCATION"
 msgstr  ""
 
@@ -3079,11 +3079,11 @@ msgstr  ""
 msgid   "List storage buckets"
 msgstr  ""
 
-#: lxc/storage_volume.go:1586
+#: lxc/storage_volume.go:1592
 msgid   "List storage volumes"
 msgstr  ""
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1597
 msgid   "List storage volumes\n"
         "\n"
         "The -c option takes a (optionally comma-separated) list of arguments\n"
@@ -3102,7 +3102,7 @@ msgid   "List storage volumes\n"
         "    U - Current disk usage"
 msgstr  ""
 
-#: lxc/remote.go:685 lxc/remote.go:686
+#: lxc/remote.go:752 lxc/remote.go:753
 msgid   "List the available remotes"
 msgstr  ""
 
@@ -3140,7 +3140,7 @@ msgstr  ""
 msgid   "List, show and delete background operations"
 msgstr  ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1464
+#: lxc/info.go:489 lxc/storage_volume.go:1470
 #, c-format
 msgid   "Location: %s"
 msgstr  ""
@@ -3545,7 +3545,7 @@ msgstr  ""
 msgid   "Missing peer name"
 msgstr  ""
 
-#: lxc/storage.go:235 lxc/storage.go:313 lxc/storage.go:431 lxc/storage.go:509 lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:113 lxc/storage_bucket.go:213 lxc/storage_bucket.go:289 lxc/storage_bucket.go:408 lxc/storage_bucket.go:483 lxc/storage_bucket.go:565 lxc/storage_bucket.go:657 lxc/storage_bucket.go:799 lxc/storage_bucket.go:886 lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062 lxc/storage_bucket.go:1185 lxc/storage_volume.go:209 lxc/storage_volume.go:323 lxc/storage_volume.go:643 lxc/storage_volume.go:750 lxc/storage_volume.go:841 lxc/storage_volume.go:939 lxc/storage_volume.go:1053 lxc/storage_volume.go:1270 lxc/storage_volume.go:1974 lxc/storage_volume.go:2115 lxc/storage_volume.go:2273 lxc/storage_volume.go:2464 lxc/storage_volume.go:2581
+#: lxc/storage.go:235 lxc/storage.go:313 lxc/storage.go:431 lxc/storage.go:509 lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:113 lxc/storage_bucket.go:213 lxc/storage_bucket.go:289 lxc/storage_bucket.go:408 lxc/storage_bucket.go:483 lxc/storage_bucket.go:565 lxc/storage_bucket.go:657 lxc/storage_bucket.go:799 lxc/storage_bucket.go:886 lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062 lxc/storage_bucket.go:1185 lxc/storage_volume.go:209 lxc/storage_volume.go:323 lxc/storage_volume.go:649 lxc/storage_volume.go:756 lxc/storage_volume.go:847 lxc/storage_volume.go:945 lxc/storage_volume.go:1059 lxc/storage_volume.go:1276 lxc/storage_volume.go:1980 lxc/storage_volume.go:2121 lxc/storage_volume.go:2279 lxc/storage_volume.go:2470 lxc/storage_volume.go:2587
 msgid   "Missing pool name"
 msgstr  ""
 
@@ -3561,11 +3561,11 @@ msgstr  ""
 msgid   "Missing source profile name"
 msgstr  ""
 
-#: lxc/storage_volume.go:432 lxc/storage_volume.go:1884
+#: lxc/storage_volume.go:438 lxc/storage_volume.go:1890
 msgid   "Missing source volume name"
 msgstr  ""
 
-#: lxc/storage_volume.go:1394
+#: lxc/storage_volume.go:1400
 msgid   "Missing storage pool name"
 msgstr  ""
 
@@ -3601,7 +3601,7 @@ msgid   "Monitor a local or remote LXD server\n"
         "By default the monitor will listen to all message types."
 msgstr  ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:861 lxc/storage_volume.go:958
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:867 lxc/storage_volume.go:964
 msgid   "More than one device matches, specify the device name"
 msgstr  ""
 
@@ -3633,7 +3633,7 @@ msgid   "Move instances within or in between LXD servers\n"
         "The pull transfer mode is the default as it is compatible with all LXD versions.\n"
 msgstr  ""
 
-#: lxc/storage_volume.go:1843 lxc/storage_volume.go:1844
+#: lxc/storage_volume.go:1849 lxc/storage_volume.go:1850
 msgid   "Move storage volumes between pools"
 msgstr  ""
 
@@ -3641,11 +3641,11 @@ msgstr  ""
 msgid   "Move the instance without its snapshots"
 msgstr  ""
 
-#: lxc/storage_volume.go:1850
+#: lxc/storage_volume.go:1856
 msgid   "Move to a project different from the source"
 msgstr  ""
 
-#: lxc/storage_volume.go:512
+#: lxc/storage_volume.go:518
 #, c-format
 msgid   "Moving the storage volume: %s"
 msgstr  ""
@@ -3666,7 +3666,7 @@ msgstr  ""
 msgid   "Must supply instance name for: "
 msgstr  ""
 
-#: lxc/auth.go:376 lxc/auth.go:819 lxc/auth.go:1794 lxc/cluster.go:192 lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081 lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147 lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567 lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:512 lxc/storage_bucket.go:832 lxc/storage_volume.go:1731
+#: lxc/auth.go:376 lxc/auth.go:819 lxc/auth.go:1794 lxc/cluster.go:192 lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081 lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147 lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567 lxc/remote.go:815 lxc/storage.go:715 lxc/storage_bucket.go:512 lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid   "NAME"
 msgstr  ""
 
@@ -3690,7 +3690,7 @@ msgstr  ""
 msgid   "NICs:"
 msgstr  ""
 
-#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525 lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545 lxc/project.go:550 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
+#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525 lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545 lxc/project.go:550 lxc/remote.go:775 lxc/remote.go:780 lxc/remote.go:785
 msgid   "NO"
 msgstr  ""
 
@@ -3712,7 +3712,7 @@ msgstr  ""
 msgid   "NVRM Version: %v"
 msgstr  ""
 
-#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1506 lxc/storage_volume.go:1556
+#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1512 lxc/storage_volume.go:1562
 msgid   "Name"
 msgstr  ""
 
@@ -3720,7 +3720,7 @@ msgstr  ""
 msgid   "Name of the project to use for this remote:"
 msgstr  ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1446
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1452
 #, c-format
 msgid   "Name: %s"
 msgstr  ""
@@ -3863,7 +3863,7 @@ msgstr  ""
 msgid   "No device found for this network"
 msgstr  ""
 
-#: lxc/storage_volume.go:870 lxc/storage_volume.go:967
+#: lxc/storage_volume.go:876 lxc/storage_volume.go:973
 msgid   "No device found for this storage volume"
 msgstr  ""
 
@@ -3879,11 +3879,11 @@ msgstr  ""
 msgid   "No matching rule(s) found"
 msgstr  ""
 
-#: lxc/storage_volume.go:446 lxc/storage_volume.go:1893
+#: lxc/storage_volume.go:452 lxc/storage_volume.go:1899
 msgid   "No storage pool for source volume specified"
 msgstr  ""
 
-#: lxc/storage_volume.go:496 lxc/storage_volume.go:1904
+#: lxc/storage_volume.go:502 lxc/storage_volume.go:1910
 msgid   "No storage pool for target volume specified"
 msgstr  ""
 
@@ -3897,7 +3897,7 @@ msgstr  ""
 msgid   "Node %d:\n"
 msgstr  ""
 
-#: lxc/storage_volume.go:2012
+#: lxc/storage_volume.go:2018
 msgid   "Not a snapshot name"
 msgstr  ""
 
@@ -3909,15 +3909,15 @@ msgstr  ""
 msgid   "Only \"custom\" volumes can be attached to instances"
 msgstr  ""
 
-#: lxc/storage_volume.go:2678
+#: lxc/storage_volume.go:2684
 msgid   "Only \"custom\" volumes can be exported"
 msgstr  ""
 
-#: lxc/storage_volume.go:2477
+#: lxc/storage_volume.go:2483
 msgid   "Only \"custom\" volumes can be snapshotted"
 msgstr  ""
 
-#: lxc/remote.go:336
+#: lxc/remote.go:378
 msgid   "Only https URLs are supported for simplestreams"
 msgstr  ""
 
@@ -3925,7 +3925,7 @@ msgstr  ""
 msgid   "Only https:// is supported for remote image import"
 msgstr  ""
 
-#: lxc/storage_volume.go:1412
+#: lxc/storage_volume.go:1418
 msgid   "Only instance or custom volumes are supported"
 msgstr  ""
 
@@ -3938,7 +3938,7 @@ msgstr  ""
 msgid   "Operation %s deleted"
 msgstr  ""
 
-#: lxc/info.go:693 lxc/storage_volume.go:1560
+#: lxc/info.go:693 lxc/storage_volume.go:1566
 msgid   "Optimized Storage"
 msgstr  ""
 
@@ -3968,7 +3968,7 @@ msgstr  ""
 msgid   "PID: %d"
 msgstr  ""
 
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1756
 msgid   "POOL"
 msgstr  ""
 
@@ -3984,15 +3984,15 @@ msgstr  ""
 msgid   "PROFILES"
 msgstr  ""
 
-#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:213
+#: lxc/list.go:567 lxc/storage_volume.go:1762 lxc/warning.go:213
 msgid   "PROJECT"
 msgstr  ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:817
 msgid   "PROTOCOL"
 msgstr  ""
 
-#: lxc/image.go:1136 lxc/remote.go:752
+#: lxc/image.go:1136 lxc/remote.go:819
 msgid   "PUBLIC"
 msgstr  ""
 
@@ -4021,7 +4021,7 @@ msgstr  ""
 msgid   "Perform an incremental copy"
 msgstr  ""
 
-#: lxc/remote.go:183
+#: lxc/remote.go:195
 msgid   "Please provide an alternate server address (empty to abort):"
 msgstr  ""
 
@@ -4033,8 +4033,8 @@ msgstr  ""
 msgid   "Please provide cluster member name: "
 msgstr  ""
 
-#: lxc/remote.go:466
-msgid   "Please type 'y', 'n' or the fingerprint:"
+#: lxc/remote.go:536
+msgid   "Please type 'y', 'n' or the fingerprint: "
 msgstr  ""
 
 #: lxc/info.go:221
@@ -4050,7 +4050,7 @@ msgstr  ""
 msgid   "Press ctrl+c to finish"
 msgstr  ""
 
-#: lxc/auth.go:302 lxc/auth.go:1059 lxc/auth.go:1720 lxc/cluster.go:860 lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357 lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239 lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760 lxc/network_acl.go:699 lxc/network_forward.go:768 lxc/network_load_balancer.go:739 lxc/network_peer.go:699 lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596 lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350 lxc/storage_bucket.go:1127 lxc/storage_volume.go:1151 lxc/storage_volume.go:1183
+#: lxc/auth.go:302 lxc/auth.go:1059 lxc/auth.go:1720 lxc/cluster.go:860 lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357 lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239 lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760 lxc/network_acl.go:699 lxc/network_forward.go:768 lxc/network_load_balancer.go:739 lxc/network_peer.go:699 lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596 lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350 lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157 lxc/storage_volume.go:1189
 msgid   "Press enter to open the editor again or ctrl+c to abort change"
 msgstr  ""
 
@@ -4167,7 +4167,7 @@ msgstr  ""
 msgid   "Property not found"
 msgstr  ""
 
-#: lxc/storage_volume.go:1350
+#: lxc/storage_volume.go:1356
 msgid   "Provide the type of the storage volume if it is not custom.\n"
         "Supported types are custom, container and virtual-machine.\n"
         "\n"
@@ -4178,7 +4178,7 @@ msgid   "Provide the type of the storage volume if it is not custom.\n"
         "    Returns state information for a virtual machine \"data\" in pool \"default\"."
 msgstr  ""
 
-#: lxc/storage_volume.go:1219
+#: lxc/storage_volume.go:1225
 msgid   "Provide the type of the storage volume if it is not custom.\n"
         "Supported types are custom, image, container and virtual-machine.\n"
         "\n"
@@ -4191,7 +4191,7 @@ msgid   "Provide the type of the storage volume if it is not custom.\n"
         "    Returns the snapshot expiration period for a virtual machine \"data\" in pool \"default\"."
 msgstr  ""
 
-#: lxc/storage_volume.go:2224
+#: lxc/storage_volume.go:2230
 msgid   "Provide the type of the storage volume if it is not custom.\n"
         "Supported types are custom, image, container and virtual-machine.\n"
         "\n"
@@ -4207,7 +4207,7 @@ msgid   "Provide the type of the storage volume if it is not custom.\n"
         "    Will show the properties of snapshot \"snap0\" for a virtual machine called \"data\" in the \"default\" pool."
 msgstr  ""
 
-#: lxc/storage_volume.go:998
+#: lxc/storage_volume.go:1004
 msgid   "Provide the type of the storage volume if it is not custom.\n"
         "Supported types are custom, image, container and virtual-machine.\n"
         "\n"
@@ -4215,7 +4215,7 @@ msgid   "Provide the type of the storage volume if it is not custom.\n"
         "    Update a storage volume using the content of pool.yaml."
 msgstr  ""
 
-#: lxc/storage_volume.go:2069
+#: lxc/storage_volume.go:2075
 msgid   "Provide the type of the storage volume if it is not custom.\n"
         "Supported types are custom, image, container and virtual-machine.\n"
         "\n"
@@ -4226,7 +4226,7 @@ msgid   "Provide the type of the storage volume if it is not custom.\n"
         "    Sets the snapshot expiration period for a virtual machine \"data\" in pool \"default\" to seven days."
 msgstr  ""
 
-#: lxc/storage_volume.go:2345
+#: lxc/storage_volume.go:2351
 msgid   "Provide the type of the storage volume if it is not custom.\n"
         "Supported types are custom, image, container and virtual-machine.\n"
         "\n"
@@ -4328,32 +4328,32 @@ msgstr  ""
 msgid   "Refreshing the image: %s"
 msgstr  ""
 
-#: lxc/remote.go:810
+#: lxc/remote.go:877
 #, c-format
 msgid   "Remote %s already exists"
 msgstr  ""
 
-#: lxc/project.go:884 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946 lxc/remote.go:994
+#: lxc/project.go:884 lxc/remote.go:868 lxc/remote.go:949 lxc/remote.go:1013 lxc/remote.go:1061
 #, c-format
 msgid   "Remote %s doesn't exist"
 msgstr  ""
 
-#: lxc/remote.go:305
+#: lxc/remote.go:345
 #, c-format
 msgid   "Remote %s exists as <%s>"
 msgstr  ""
 
-#: lxc/remote.go:890
+#: lxc/remote.go:957
 #, c-format
 msgid   "Remote %s is global and cannot be removed"
 msgstr  ""
 
-#: lxc/remote.go:805 lxc/remote.go:886 lxc/remote.go:998
+#: lxc/remote.go:872 lxc/remote.go:953 lxc/remote.go:1065
 #, c-format
 msgid   "Remote %s is static and cannot be modified"
 msgstr  ""
 
-#: lxc/remote.go:294
+#: lxc/remote.go:319
 msgid   "Remote address must not be empty"
 msgstr  ""
 
@@ -4361,7 +4361,7 @@ msgstr  ""
 msgid   "Remote admin password"
 msgstr  ""
 
-#: lxc/remote.go:299
+#: lxc/remote.go:339
 msgid   "Remote names may not contain colons"
 msgstr  ""
 
@@ -4447,7 +4447,7 @@ msgstr  ""
 msgid   "Remove profiles from instances"
 msgstr  ""
 
-#: lxc/remote.go:852 lxc/remote.go:853
+#: lxc/remote.go:919 lxc/remote.go:920
 msgid   "Remove remotes"
 msgstr  ""
 
@@ -4503,19 +4503,19 @@ msgstr  ""
 msgid   "Rename projects"
 msgstr  ""
 
-#: lxc/remote.go:771 lxc/remote.go:772
+#: lxc/remote.go:838 lxc/remote.go:839
 msgid   "Rename remotes"
 msgstr  ""
 
-#: lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:1943
 msgid   "Rename storage volumes"
 msgstr  ""
 
-#: lxc/storage_volume.go:1936
+#: lxc/storage_volume.go:1942
 msgid   "Rename storage volumes and storage volume snapshots"
 msgstr  ""
 
-#: lxc/storage_volume.go:2025 lxc/storage_volume.go:2045
+#: lxc/storage_volume.go:2031 lxc/storage_volume.go:2051
 #, c-format
 msgid   "Renamed storage volume from \"%s\" to \"%s\""
 msgstr  ""
@@ -4565,7 +4565,7 @@ msgid   "Restore instances from snapshots\n"
         "If --stateful is passed, then the running state will be restored too."
 msgstr  ""
 
-#: lxc/storage_volume.go:2540 lxc/storage_volume.go:2541
+#: lxc/storage_volume.go:2546 lxc/storage_volume.go:2547
 msgid   "Restore storage volume snapshots"
 msgstr  ""
 
@@ -4645,7 +4645,7 @@ msgstr  ""
 msgid   "STATE"
 msgstr  ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:820
 msgid   "STATIC"
 msgstr  ""
 
@@ -4686,11 +4686,11 @@ msgstr  ""
 msgid   "Server authentication type (tls or oidc)"
 msgstr  ""
 
-#: lxc/remote.go:464
+#: lxc/remote.go:532
 msgid   "Server certificate NACKed by user"
 msgstr  ""
 
-#: lxc/remote.go:616
+#: lxc/remote.go:285 lxc/remote.go:683
 msgid   "Server doesn't trust us after authentication"
 msgstr  ""
 
@@ -4862,18 +4862,18 @@ msgid   "Set storage pool configuration keys\n"
         "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr  ""
 
-#: lxc/storage_volume.go:2063
+#: lxc/storage_volume.go:2069
 msgid   "Set storage volume configuration keys"
 msgstr  ""
 
-#: lxc/storage_volume.go:2064
+#: lxc/storage_volume.go:2070
 msgid   "Set storage volume configuration keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
         "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr  ""
 
-#: lxc/remote.go:964 lxc/remote.go:965
+#: lxc/remote.go:1031 lxc/remote.go:1032
 msgid   "Set the URL for the remote"
 msgstr  ""
 
@@ -4949,7 +4949,7 @@ msgstr  ""
 msgid   "Set the key as a storage property"
 msgstr  ""
 
-#: lxc/storage_volume.go:2080
+#: lxc/storage_volume.go:2086
 msgid   "Set the key as a storage volume property"
 msgstr  ""
 
@@ -5094,11 +5094,11 @@ msgstr  ""
 msgid   "Show storage pool configurations and resources"
 msgstr  ""
 
-#: lxc/storage_volume.go:2221 lxc/storage_volume.go:2222
+#: lxc/storage_volume.go:2227 lxc/storage_volume.go:2228
 msgid   "Show storage volume configurations"
 msgstr  ""
 
-#: lxc/storage_volume.go:1347 lxc/storage_volume.go:1348
+#: lxc/storage_volume.go:1353 lxc/storage_volume.go:1354
 msgid   "Show storage volume state information"
 msgstr  ""
 
@@ -5110,7 +5110,7 @@ msgid   "Show the current identity\n"
         "that are granted via identity provider group mappings. \n"
 msgstr  ""
 
-#: lxc/remote.go:647 lxc/remote.go:648
+#: lxc/remote.go:714 lxc/remote.go:715
 msgid   "Show the default remote"
 msgstr  ""
 
@@ -5164,15 +5164,15 @@ msgstr  ""
 msgid   "Size: %s"
 msgstr  ""
 
-#: lxc/storage_volume.go:2404 lxc/storage_volume.go:2405
+#: lxc/storage_volume.go:2410 lxc/storage_volume.go:2411
 msgid   "Snapshot storage volumes"
 msgstr  ""
 
-#: lxc/storage_volume.go:2167
+#: lxc/storage_volume.go:2173
 msgid   "Snapshots are read-only and can't have their configuration changed"
 msgstr  ""
 
-#: lxc/info.go:607 lxc/storage_volume.go:1485
+#: lxc/info.go:607 lxc/storage_volume.go:1491
 msgid   "Snapshots:"
 msgstr  ""
 
@@ -5273,21 +5273,21 @@ msgstr  ""
 msgid   "Storage pool name"
 msgstr  ""
 
-#: lxc/storage_volume.go:696
+#: lxc/storage_volume.go:702
 #, c-format
 msgid   "Storage volume %s created"
 msgstr  ""
 
-#: lxc/storage_volume.go:784
+#: lxc/storage_volume.go:790
 #, c-format
 msgid   "Storage volume %s deleted"
 msgstr  ""
 
-#: lxc/storage_volume.go:509
+#: lxc/storage_volume.go:515
 msgid   "Storage volume copied successfully!"
 msgstr  ""
 
-#: lxc/storage_volume.go:513
+#: lxc/storage_volume.go:519
 msgid   "Storage volume moved successfully!"
 msgstr  ""
 
@@ -5322,7 +5322,7 @@ msgstr  ""
 msgid   "Switch the current project"
 msgstr  ""
 
-#: lxc/remote.go:916 lxc/remote.go:917
+#: lxc/remote.go:983 lxc/remote.go:984
 msgid   "Switch the default remote"
 msgstr  ""
 
@@ -5338,11 +5338,11 @@ msgstr  ""
 msgid   "TOKEN"
 msgstr  ""
 
-#: lxc/auth.go:818 lxc/config_trust.go:408 lxc/image.go:1141 lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082 lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172 lxc/storage_volume.go:1730 lxc/warning.go:216
+#: lxc/auth.go:818 lxc/config_trust.go:408 lxc/image.go:1141 lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082 lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172 lxc/storage_volume.go:1736 lxc/warning.go:216
 msgid   "TYPE"
 msgstr  ""
 
-#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1557
+#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1563
 msgid   "Taken at"
 msgstr  ""
 
@@ -5352,6 +5352,10 @@ msgstr  ""
 
 #: lxc/file.go:1256
 msgid   "Target path must be a directory"
+msgstr  ""
+
+#: lxc/remote.go:161 lxc/remote.go:334
+msgid   "The --accept-certificate flag is not supported when adding a remote using a trust token"
 msgstr  ""
 
 #: lxc/move.go:181
@@ -5491,14 +5495,18 @@ msgstr  ""
 msgid   "The property %q does not exist on the storage pool %q: %v"
 msgstr  ""
 
-#: lxc/storage_volume.go:1323
+#: lxc/storage_volume.go:1329
 #, c-format
 msgid   "The property %q does not exist on the storage pool volume %q: %v"
 msgstr  ""
 
-#: lxc/storage_volume.go:1300
+#: lxc/storage_volume.go:1306
 #, c-format
 msgid   "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
+msgstr  ""
+
+#: lxc/remote.go:527
+msgid   "The provided fingerprint does not match the server certificate fingerprint"
 msgstr  ""
 
 #: lxc/info.go:354
@@ -5509,7 +5517,7 @@ msgstr  ""
 msgid   "The source LXD server is not clustered"
 msgstr  ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:875 lxc/storage_volume.go:972
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:881 lxc/storage_volume.go:978
 msgid   "The specified device doesn't exist"
 msgstr  ""
 
@@ -5578,7 +5586,7 @@ msgstr  ""
 msgid   "To use --target, the destination remote must be a cluster"
 msgstr  ""
 
-#: lxc/storage_volume.go:1470
+#: lxc/storage_volume.go:1476
 #, c-format
 msgid   "Total: %s"
 msgstr  ""
@@ -5593,7 +5601,7 @@ msgstr  ""
 msgid   "Transceiver type: %s"
 msgstr  ""
 
-#: lxc/storage_volume.go:1847
+#: lxc/storage_volume.go:1853
 msgid   "Transfer mode, one of pull (default), push or relay"
 msgstr  ""
 
@@ -5627,7 +5635,15 @@ msgstr  ""
 msgid   "Transmit policy"
 msgstr  ""
 
-#: lxc/remote.go:571
+#: lxc/remote.go:329
+msgid   "Trust token cannot be used for public remotes"
+msgstr  ""
+
+#: lxc/remote.go:324
+msgid   "Trust token cannot be used with OIDC authentication"
+msgstr  ""
+
+#: lxc/remote.go:639
 #, c-format
 msgid   "Trust token for %s: "
 msgstr  ""
@@ -5649,7 +5665,7 @@ msgstr  ""
 msgid   "Type of connection to establish: 'console' for serial console, 'vga' for SPICE graphical output"
 msgstr  ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930 lxc/storage_volume.go:1455
+#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930 lxc/storage_volume.go:1461
 #, c-format
 msgid   "Type: %s"
 msgstr  ""
@@ -5667,15 +5683,15 @@ msgstr  ""
 msgid   "UPLOAD DATE"
 msgstr  ""
 
-#: lxc/cluster.go:193 lxc/remote.go:749
+#: lxc/cluster.go:193 lxc/remote.go:816
 msgid   "URL"
 msgstr  ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1735
+#: lxc/project.go:995 lxc/storage_volume.go:1741
 msgid   "USAGE"
 msgstr  ""
 
-#: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24 lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575 lxc/storage.go:724 lxc/storage_volume.go:1734
+#: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24 lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575 lxc/storage.go:724 lxc/storage_volume.go:1740
 msgid   "USED BY"
 msgstr  ""
 
@@ -5693,7 +5709,7 @@ msgstr  ""
 msgid   "Unable to create a temporary file: %v"
 msgstr  ""
 
-#: lxc/remote.go:214 lxc/remote.go:248
+#: lxc/remote.go:226 lxc/remote.go:260
 msgid   "Unavailable remote server"
 msgstr  ""
 
@@ -5707,7 +5723,7 @@ msgstr  ""
 msgid   "Unknown channel type for client %q: %s"
 msgstr  ""
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1772 lxc/warning.go:242
+#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1778 lxc/warning.go:242
 #, c-format
 msgid   "Unknown column shorthand char '%c' in '%s'"
 msgstr  ""
@@ -5812,7 +5828,7 @@ msgstr  ""
 msgid   "Unset storage pool configuration keys"
 msgstr  ""
 
-#: lxc/storage_volume.go:2342 lxc/storage_volume.go:2343
+#: lxc/storage_volume.go:2348 lxc/storage_volume.go:2349
 msgid   "Unset storage volume configuration keys"
 msgstr  ""
 
@@ -5864,7 +5880,7 @@ msgstr  ""
 msgid   "Unset the key as a storage property"
 msgstr  ""
 
-#: lxc/storage_volume.go:2356
+#: lxc/storage_volume.go:2362
 msgid   "Unset the key as a storage volume property"
 msgstr  ""
 
@@ -5906,12 +5922,12 @@ msgstr  ""
 msgid   "Upper devices"
 msgstr  ""
 
-#: lxc/storage_volume.go:1468
+#: lxc/storage_volume.go:1474
 #, c-format
 msgid   "Usage: %s"
 msgstr  ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2629
+#: lxc/export.go:42 lxc/storage_volume.go:2635
 msgid   "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr  ""
 
@@ -5976,7 +5992,7 @@ msgstr  ""
 msgid   "View the current identity"
 msgstr  ""
 
-#: lxc/storage_volume.go:1559
+#: lxc/storage_volume.go:1565
 msgid   "Volume Only"
 msgstr  ""
 
@@ -6005,7 +6021,7 @@ msgstr  ""
 msgid   "Wipe the instance root disk and re-initialize. The original image is used to re-initialize the instance if a different image or --empty is not specified."
 msgstr  ""
 
-#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527 lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547 lxc/project.go:552 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
+#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527 lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547 lxc/project.go:552 lxc/remote.go:777 lxc/remote.go:782 lxc/remote.go:787
 msgid   "YES"
 msgstr  ""
 
@@ -6029,7 +6045,7 @@ msgstr  ""
 msgid   "You need to specify an image name or use --empty"
 msgstr  ""
 
-#: lxc/storage_volume.go:897
+#: lxc/storage_volume.go:903
 msgid   "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr  ""
 
@@ -6421,7 +6437,7 @@ msgstr  ""
 msgid   "[<remote>:]<pool>"
 msgstr  ""
 
-#: lxc/storage_volume.go:2788
+#: lxc/storage_volume.go:2794
 msgid   "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr  ""
 
@@ -6453,11 +6469,11 @@ msgstr  ""
 msgid   "[<remote>:]<pool> <key> <value>"
 msgstr  ""
 
-#: lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:1941
 msgid   "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot name>]"
 msgstr  ""
 
-#: lxc/storage_volume.go:799
+#: lxc/storage_volume.go:805
 msgid   "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr  ""
 
@@ -6465,47 +6481,47 @@ msgstr  ""
 msgid   "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr  ""
 
-#: lxc/storage_volume.go:2539
+#: lxc/storage_volume.go:2545
 msgid   "[<remote>:]<pool> <volume> <snapshot>"
 msgstr  ""
 
-#: lxc/storage_volume.go:2622
+#: lxc/storage_volume.go:2628
 msgid   "[<remote>:]<pool> <volume> [<path>]"
 msgstr  ""
 
-#: lxc/storage_volume.go:2403
+#: lxc/storage_volume.go:2409
 msgid   "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr  ""
 
-#: lxc/storage_volume.go:603
+#: lxc/storage_volume.go:609
 msgid   "[<remote>:]<pool> <volume> [key=value...]"
 msgstr  ""
 
-#: lxc/storage_volume.go:711
+#: lxc/storage_volume.go:717
 msgid   "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr  ""
 
-#: lxc/storage_volume.go:994 lxc/storage_volume.go:1346
+#: lxc/storage_volume.go:1000 lxc/storage_volume.go:1352
 msgid   "[<remote>:]<pool> [<type>/]<volume>"
 msgstr  ""
 
-#: lxc/storage_volume.go:2341
+#: lxc/storage_volume.go:2347
 msgid   "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr  ""
 
-#: lxc/storage_volume.go:2062
+#: lxc/storage_volume.go:2068
 msgid   "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr  ""
 
-#: lxc/storage_volume.go:2220
+#: lxc/storage_volume.go:2226
 msgid   "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr  ""
 
-#: lxc/storage_volume.go:1215
+#: lxc/storage_volume.go:1221
 msgid   "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr  ""
 
-#: lxc/storage_volume.go:1841
+#: lxc/storage_volume.go:1847
 msgid   "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr  ""
 
@@ -6613,7 +6629,7 @@ msgstr  ""
 msgid   "[<remote>:][<instance>] <key>=<value>..."
 msgstr  ""
 
-#: lxc/storage_volume.go:1584
+#: lxc/storage_volume.go:1590
 msgid   "[<remote>:][<pool>] [<filter>...]"
 msgstr  ""
 
@@ -6625,7 +6641,7 @@ msgstr  ""
 msgid   "[[<remote>:]<member>]"
 msgstr  ""
 
-#: lxc/project.go:557 lxc/remote.go:739
+#: lxc/project.go:557 lxc/remote.go:806
 msgid   "current"
 msgstr  ""
 
@@ -7007,19 +7023,19 @@ msgid   "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
         "    Update a storage pool using the content of pool.yaml."
 msgstr  ""
 
-#: lxc/storage_volume.go:607
+#: lxc/storage_volume.go:613
 msgid   "lxc storage volume create p1 v1\n"
         "\n"
         "lxc storage volume create p1 v1 < config.yaml\n"
         "	Create storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr  ""
 
-#: lxc/storage_volume.go:2792
+#: lxc/storage_volume.go:2798
 msgid   "lxc storage volume import default backup0.tar.gz\n"
         "		Create a new custom volume using backup0.tar.gz as the source."
 msgstr  ""
 
-#: lxc/storage_volume.go:2407
+#: lxc/storage_volume.go:2413
 msgid   "lxc storage volume snapshot create default v1 snap0\n"
         "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
         "\n"
@@ -7027,7 +7043,7 @@ msgid   "lxc storage volume snapshot create default v1 snap0\n"
         "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\" with the configuration from \"config.yaml\"."
 msgstr  ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:531
 msgid   "n"
 msgstr  ""
 
@@ -7039,7 +7055,7 @@ msgstr  ""
 msgid   "no"
 msgstr  ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:510
 msgid   "ok (y/n/[fingerprint])?"
 msgstr  ""
 
@@ -7076,7 +7092,7 @@ msgstr  ""
 msgid   "used by"
 msgstr  ""
 
-#: lxc/remote.go:465
+#: lxc/remote.go:519
 msgid   "y"
 msgstr  ""
 

--- a/po/mr.po
+++ b/po/mr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-08 07:43+0100\n"
+"POT-Creation-Date: 2024-10-14 13:30+0000\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Marathi <https://hosted.weblate.org/projects/linux-containers/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1024
+#: lxc/storage_volume.go:1030
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -515,15 +515,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:850 lxc/remote.go:915
+#: lxc/remote.go:917 lxc/remote.go:982
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:963
+#: lxc/remote.go:1030
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:769
+#: lxc/remote.go:836
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -556,7 +556,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:751
+#: lxc/remote.go:818
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:581
+#: lxc/remote.go:648
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -738,11 +738,11 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1590
+#: lxc/storage_volume.go:1596
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:182
+#: lxc/remote.go:194
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -813,7 +813,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:552
+#: lxc/remote.go:621
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -849,16 +849,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2696
+#: lxc/storage_volume.go:2702
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2773
+#: lxc/export.go:192 lxc/storage_volume.go:2779
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:654 lxc/storage_volume.go:1521
+#: lxc/info.go:654 lxc/storage_volume.go:1527
 msgid "Backups:"
 msgstr ""
 
@@ -879,7 +879,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:679
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:685
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -922,7 +922,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1733
+#: lxc/storage_volume.go:1739
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -991,7 +991,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:894
+#: lxc/remote.go:961
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1007,7 +1007,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1749 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1024,12 +1024,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:486
+#: lxc/storage_volume.go:492
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:440
+#: lxc/storage_volume.go:446
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1057,11 +1057,11 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:509
 msgid "Certificate fingerprint"
 msgstr ""
 
-#: lxc/remote.go:219
+#: lxc/remote.go:231
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
@@ -1076,7 +1076,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:620
+#: lxc/remote.go:687
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1150,13 +1150,13 @@ msgstr ""
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
 #: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
-#: lxc/storage_volume.go:612 lxc/storage_volume.go:717
-#: lxc/storage_volume.go:1005 lxc/storage_volume.go:1231
-#: lxc/storage_volume.go:1360 lxc/storage_volume.go:1848
-#: lxc/storage_volume.go:1940 lxc/storage_volume.go:2079
-#: lxc/storage_volume.go:2239 lxc/storage_volume.go:2355
-#: lxc/storage_volume.go:2416 lxc/storage_volume.go:2543
-#: lxc/storage_volume.go:2631 lxc/storage_volume.go:2795
+#: lxc/storage_volume.go:618 lxc/storage_volume.go:723
+#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1237
+#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1854
+#: lxc/storage_volume.go:1946 lxc/storage_volume.go:2085
+#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2361
+#: lxc/storage_volume.go:2422 lxc/storage_volume.go:2549
+#: lxc/storage_volume.go:2637 lxc/storage_volume.go:2801
 msgid "Cluster member name"
 msgstr ""
 
@@ -1172,7 +1172,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1589
+#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1595
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1216,17 +1216,17 @@ msgstr ""
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1150
-#: lxc/storage_volume.go:1182
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
+#: lxc/storage_volume.go:1188
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:613
+#: lxc/storage_volume.go:619
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1467
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1310,7 +1310,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:508
+#: lxc/storage_volume.go:514
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1324,12 +1324,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:490
+#: lxc/remote.go:559
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:225 lxc/remote.go:474
+#: lxc/remote.go:237 lxc/remote.go:543
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1368,7 +1368,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:485
+#: lxc/remote.go:554
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1437,7 +1437,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:604 lxc/storage_volume.go:605
+#: lxc/storage_volume.go:610 lxc/storage_volume.go:611
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1489,7 +1489,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1475
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1481
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1524,7 +1524,7 @@ msgstr ""
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1732
+#: lxc/storage_volume.go:1738
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1544,7 +1544,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2630
+#: lxc/storage_volume.go:2636
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1640,7 +1640,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:713 lxc/storage_volume.go:714
+#: lxc/storage_volume.go:719 lxc/storage_volume.go:720
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1732,9 +1732,9 @@ msgstr ""
 #: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
 #: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
 #: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:648
-#: lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853 lxc/remote.go:917
-#: lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:715
+#: lxc/remote.go:753 lxc/remote.go:839 lxc/remote.go:920 lxc/remote.go:984
+#: lxc/remote.go:1032 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1746,26 +1746,26 @@ msgstr ""
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
 #: lxc/storage_volume.go:169 lxc/storage_volume.go:283
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:605
-#: lxc/storage_volume.go:714 lxc/storage_volume.go:801
-#: lxc/storage_volume.go:899 lxc/storage_volume.go:996
-#: lxc/storage_volume.go:1217 lxc/storage_volume.go:1348
-#: lxc/storage_volume.go:1507 lxc/storage_volume.go:1591
-#: lxc/storage_volume.go:1844 lxc/storage_volume.go:1937
-#: lxc/storage_volume.go:2064 lxc/storage_volume.go:2222
-#: lxc/storage_volume.go:2343 lxc/storage_volume.go:2405
-#: lxc/storage_volume.go:2541 lxc/storage_volume.go:2624
-#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:611
+#: lxc/storage_volume.go:720 lxc/storage_volume.go:807
+#: lxc/storage_volume.go:905 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:1223 lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1513 lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1850 lxc/storage_volume.go:1943
+#: lxc/storage_volume.go:2070 lxc/storage_volume.go:2228
+#: lxc/storage_volume.go:2349 lxc/storage_volume.go:2411
+#: lxc/storage_volume.go:2547 lxc/storage_volume.go:2630
+#: lxc/storage_volume.go:2796 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1448
+#: lxc/storage_volume.go:1454
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:1849
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:1855
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1777,11 +1777,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:800 lxc/storage_volume.go:801
+#: lxc/storage_volume.go:806 lxc/storage_volume.go:807
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:898 lxc/storage_volume.go:899
+#: lxc/storage_volume.go:904 lxc/storage_volume.go:905
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -2007,7 +2007,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:995 lxc/storage_volume.go:996
+#: lxc/storage_volume.go:1001 lxc/storage_volume.go:1002
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2015,7 +2015,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1766
+#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1772
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2072,7 +2072,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2193
+#: lxc/storage_volume.go:2161 lxc/storage_volume.go:2199
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2086,8 +2086,8 @@ msgstr ""
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2149
-#: lxc/storage_volume.go:2187
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2155
+#: lxc/storage_volume.go:2193
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2129,8 +2129,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1508
-#: lxc/storage_volume.go:1558
+#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1514
+#: lxc/storage_volume.go:1564
 msgid "Expires at"
 msgstr ""
 
@@ -2154,7 +2154,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2623 lxc/storage_volume.go:2624
+#: lxc/storage_volume.go:2629 lxc/storage_volume.go:2630
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2166,11 +2166,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2627
+#: lxc/storage_volume.go:2633
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2756
+#: lxc/export.go:152 lxc/storage_volume.go:2762
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2287,11 +2287,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:191
+#: lxc/remote.go:203
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:242
+#: lxc/remote.go:254
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2301,7 +2301,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:232
+#: lxc/remote.go:244
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2311,12 +2311,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:260
+#: lxc/remote.go:486
 #, c-format
-msgid "Failed to create certificate: %w"
+msgid "Failed to decode trust token: %w"
 msgstr ""
 
-#: lxc/remote.go:267
+#: lxc/remote.go:292
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2341,7 +2341,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:237
+#: lxc/remote.go:249
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2428,9 +2428,9 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:690 lxc/storage.go:657
+#: lxc/project.go:919 lxc/remote.go:757 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1608 lxc/warning.go:94
+#: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2466,7 +2466,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:754
+#: lxc/remote.go:821
 msgid "GLOBAL"
 msgstr ""
 
@@ -2486,7 +2486,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:160 lxc/remote.go:401
+#: lxc/remote.go:165 lxc/remote.go:443
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2554,7 +2554,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1238
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2618,11 +2618,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1216 lxc/storage_volume.go:1217
+#: lxc/storage_volume.go:1222 lxc/storage_volume.go:1223
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:469
+#: lxc/storage_volume.go:475
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2746,7 +2746,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2415
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2421
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2760,7 +2760,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2414
+#: lxc/storage_volume.go:2420
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2810,7 +2810,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2790
+#: lxc/storage_volume.go:2796
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2818,7 +2818,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2789
+#: lxc/storage_volume.go:2795
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2840,11 +2840,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2797
+#: lxc/storage_volume.go:2803
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2871
+#: lxc/storage_volume.go:2877
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2910,7 +2910,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:353
+#: lxc/remote.go:395
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2970,7 +2970,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2000
+#: lxc/move.go:148 lxc/storage_volume.go:2006
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2978,7 +2978,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1996
+#: lxc/storage_volume.go:2002
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2991,14 +2991,14 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:342
+#: lxc/remote.go:384
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1064 lxc/storage_volume.go:1281
-#: lxc/storage_volume.go:1405 lxc/storage_volume.go:1985
-#: lxc/storage_volume.go:2132 lxc/storage_volume.go:2284
+#: lxc/storage_volume.go:1070 lxc/storage_volume.go:1287
+#: lxc/storage_volume.go:1411 lxc/storage_volume.go:1991
+#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2290
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3044,7 +3044,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1739 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1745 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3347,11 +3347,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1586
+#: lxc/storage_volume.go:1592
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1597
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3371,7 +3371,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:685 lxc/remote.go:686
+#: lxc/remote.go:752 lxc/remote.go:753
 msgid "List the available remotes"
 msgstr ""
 
@@ -3410,7 +3410,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1464
+#: lxc/info.go:489 lxc/storage_volume.go:1470
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3874,12 +3874,12 @@ msgstr ""
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:323 lxc/storage_volume.go:643
-#: lxc/storage_volume.go:750 lxc/storage_volume.go:841
-#: lxc/storage_volume.go:939 lxc/storage_volume.go:1053
-#: lxc/storage_volume.go:1270 lxc/storage_volume.go:1974
-#: lxc/storage_volume.go:2115 lxc/storage_volume.go:2273
-#: lxc/storage_volume.go:2464 lxc/storage_volume.go:2581
+#: lxc/storage_volume.go:323 lxc/storage_volume.go:649
+#: lxc/storage_volume.go:756 lxc/storage_volume.go:847
+#: lxc/storage_volume.go:945 lxc/storage_volume.go:1059
+#: lxc/storage_volume.go:1276 lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:2121 lxc/storage_volume.go:2279
+#: lxc/storage_volume.go:2470 lxc/storage_volume.go:2587
 msgid "Missing pool name"
 msgstr ""
 
@@ -3898,11 +3898,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:432 lxc/storage_volume.go:1884
+#: lxc/storage_volume.go:438 lxc/storage_volume.go:1890
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1394
+#: lxc/storage_volume.go:1400
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -3939,8 +3939,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:861
-#: lxc/storage_volume.go:958
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:867
+#: lxc/storage_volume.go:964
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -3977,7 +3977,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1843 lxc/storage_volume.go:1844
+#: lxc/storage_volume.go:1849 lxc/storage_volume.go:1850
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -3985,11 +3985,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1850
+#: lxc/storage_volume.go:1856
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:512
+#: lxc/storage_volume.go:518
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4015,8 +4015,8 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
-#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1731
+#: lxc/remote.go:815 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
 msgstr ""
 
@@ -4042,7 +4042,7 @@ msgstr ""
 
 #: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
+#: lxc/project.go:550 lxc/remote.go:775 lxc/remote.go:780 lxc/remote.go:785
 msgid "NO"
 msgstr ""
 
@@ -4064,8 +4064,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1506
-#: lxc/storage_volume.go:1556
+#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1512
+#: lxc/storage_volume.go:1562
 msgid "Name"
 msgstr ""
 
@@ -4073,7 +4073,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1446
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1452
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4217,7 +4217,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:870 lxc/storage_volume.go:967
+#: lxc/storage_volume.go:876 lxc/storage_volume.go:973
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4233,11 +4233,11 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/storage_volume.go:446 lxc/storage_volume.go:1893
+#: lxc/storage_volume.go:452 lxc/storage_volume.go:1899
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:496 lxc/storage_volume.go:1904
+#: lxc/storage_volume.go:502 lxc/storage_volume.go:1910
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4251,7 +4251,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2012
+#: lxc/storage_volume.go:2018
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4263,15 +4263,15 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2678
+#: lxc/storage_volume.go:2684
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2477
+#: lxc/storage_volume.go:2483
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:336
+#: lxc/remote.go:378
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4279,7 +4279,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1412
+#: lxc/storage_volume.go:1418
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4292,7 +4292,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:693 lxc/storage_volume.go:1560
+#: lxc/info.go:693 lxc/storage_volume.go:1566
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4322,7 +4322,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1756
 msgid "POOL"
 msgstr ""
 
@@ -4338,15 +4338,15 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:213
+#: lxc/list.go:567 lxc/storage_volume.go:1762 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:817
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:752
+#: lxc/image.go:1136 lxc/remote.go:819
 msgid "PUBLIC"
 msgstr ""
 
@@ -4375,7 +4375,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:183
+#: lxc/remote.go:195
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4387,8 +4387,8 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:466
-msgid "Please type 'y', 'n' or the fingerprint:"
+#: lxc/remote.go:536
+msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
 #: lxc/info.go:221
@@ -4412,8 +4412,8 @@ msgstr ""
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1151
-#: lxc/storage_volume.go:1183
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
+#: lxc/storage_volume.go:1189
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4530,7 +4530,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1350
+#: lxc/storage_volume.go:1356
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4544,7 +4544,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1219
+#: lxc/storage_volume.go:1225
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4560,7 +4560,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2224
+#: lxc/storage_volume.go:2230
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4581,7 +4581,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:998
+#: lxc/storage_volume.go:1004
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4590,7 +4590,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2069
+#: lxc/storage_volume.go:2075
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4603,7 +4603,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2345
+#: lxc/storage_volume.go:2351
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4707,33 +4707,33 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:810
+#: lxc/remote.go:877
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
-#: lxc/remote.go:994
+#: lxc/project.go:884 lxc/remote.go:868 lxc/remote.go:949 lxc/remote.go:1013
+#: lxc/remote.go:1061
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:305
+#: lxc/remote.go:345
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:890
+#: lxc/remote.go:957
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:805 lxc/remote.go:886 lxc/remote.go:998
+#: lxc/remote.go:872 lxc/remote.go:953 lxc/remote.go:1065
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:294
+#: lxc/remote.go:319
 msgid "Remote address must not be empty"
 msgstr ""
 
@@ -4741,7 +4741,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:299
+#: lxc/remote.go:339
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4827,7 +4827,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:852 lxc/remote.go:853
+#: lxc/remote.go:919 lxc/remote.go:920
 msgid "Remove remotes"
 msgstr ""
 
@@ -4884,19 +4884,19 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:771 lxc/remote.go:772
+#: lxc/remote.go:838 lxc/remote.go:839
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:1943
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1936
+#: lxc/storage_volume.go:1942
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2025 lxc/storage_volume.go:2045
+#: lxc/storage_volume.go:2031 lxc/storage_volume.go:2051
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4948,7 +4948,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2540 lxc/storage_volume.go:2541
+#: lxc/storage_volume.go:2546 lxc/storage_volume.go:2547
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5029,7 +5029,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:820
 msgid "STATIC"
 msgstr ""
 
@@ -5070,11 +5070,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:464
+#: lxc/remote.go:532
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:616
+#: lxc/remote.go:285 lxc/remote.go:683
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5272,11 +5272,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2063
+#: lxc/storage_volume.go:2069
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2064
+#: lxc/storage_volume.go:2070
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5285,7 +5285,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:964 lxc/remote.go:965
+#: lxc/remote.go:1031 lxc/remote.go:1032
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5361,7 +5361,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2080
+#: lxc/storage_volume.go:2086
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5510,11 +5510,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2221 lxc/storage_volume.go:2222
+#: lxc/storage_volume.go:2227 lxc/storage_volume.go:2228
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1347 lxc/storage_volume.go:1348
+#: lxc/storage_volume.go:1353 lxc/storage_volume.go:1354
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5528,7 +5528,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:647 lxc/remote.go:648
+#: lxc/remote.go:714 lxc/remote.go:715
 msgid "Show the default remote"
 msgstr ""
 
@@ -5582,15 +5582,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2404 lxc/storage_volume.go:2405
+#: lxc/storage_volume.go:2410 lxc/storage_volume.go:2411
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2167
+#: lxc/storage_volume.go:2173
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:607 lxc/storage_volume.go:1485
+#: lxc/info.go:607 lxc/storage_volume.go:1491
 msgid "Snapshots:"
 msgstr ""
 
@@ -5691,21 +5691,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:696
+#: lxc/storage_volume.go:702
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:784
+#: lxc/storage_volume.go:790
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:509
+#: lxc/storage_volume.go:515
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:513
+#: lxc/storage_volume.go:519
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5740,7 +5740,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:916 lxc/remote.go:917
+#: lxc/remote.go:983 lxc/remote.go:984
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5759,11 +5759,11 @@ msgstr ""
 #: lxc/auth.go:818 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
-#: lxc/storage_volume.go:1730 lxc/warning.go:216
+#: lxc/storage_volume.go:1736 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1557
+#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1563
 msgid "Taken at"
 msgstr ""
 
@@ -5773,6 +5773,12 @@ msgstr ""
 
 #: lxc/file.go:1256
 msgid "Target path must be a directory"
+msgstr ""
+
+#: lxc/remote.go:161 lxc/remote.go:334
+msgid ""
+"The --accept-certificate flag is not supported when adding a remote using a "
+"trust token"
 msgstr ""
 
 #: lxc/move.go:181
@@ -5914,15 +5920,20 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1323
+#: lxc/storage_volume.go:1329
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1300
+#: lxc/storage_volume.go:1306
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
+msgstr ""
+
+#: lxc/remote.go:527
+msgid ""
+"The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
 
 #: lxc/info.go:354
@@ -5933,8 +5944,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:875
-#: lxc/storage_volume.go:972
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:881
+#: lxc/storage_volume.go:978
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6009,7 +6020,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1470
+#: lxc/storage_volume.go:1476
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6024,7 +6035,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1847
+#: lxc/storage_volume.go:1853
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6058,7 +6069,15 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:571
+#: lxc/remote.go:329
+msgid "Trust token cannot be used for public remotes"
+msgstr ""
+
+#: lxc/remote.go:324
+msgid "Trust token cannot be used with OIDC authentication"
+msgstr ""
+
+#: lxc/remote.go:639
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6083,7 +6102,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1455
+#: lxc/storage_volume.go:1461
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6101,17 +6120,17 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:193 lxc/remote.go:749
+#: lxc/cluster.go:193 lxc/remote.go:816
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1735
+#: lxc/project.go:995 lxc/storage_volume.go:1741
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1734
+#: lxc/storage.go:724 lxc/storage_volume.go:1740
 msgid "USED BY"
 msgstr ""
 
@@ -6129,7 +6148,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:214 lxc/remote.go:248
+#: lxc/remote.go:226 lxc/remote.go:260
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6143,7 +6162,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1772
+#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1778
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6249,7 +6268,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2342 lxc/storage_volume.go:2343
+#: lxc/storage_volume.go:2348 lxc/storage_volume.go:2349
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6301,7 +6320,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2356
+#: lxc/storage_volume.go:2362
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6345,12 +6364,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1468
+#: lxc/storage_volume.go:1474
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2629
+#: lxc/export.go:42 lxc/storage_volume.go:2635
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6417,7 +6436,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1559
+#: lxc/storage_volume.go:1565
 msgid "Volume Only"
 msgstr ""
 
@@ -6452,7 +6471,7 @@ msgstr ""
 
 #: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
+#: lxc/project.go:552 lxc/remote.go:777 lxc/remote.go:782 lxc/remote.go:787
 msgid "YES"
 msgstr ""
 
@@ -6476,7 +6495,7 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:897
+#: lxc/storage_volume.go:903
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
@@ -6898,7 +6917,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2788
+#: lxc/storage_volume.go:2794
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -6933,13 +6952,13 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:1941
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:799
+#: lxc/storage_volume.go:805
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
@@ -6947,47 +6966,47 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2539
+#: lxc/storage_volume.go:2545
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2622
+#: lxc/storage_volume.go:2628
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2403
+#: lxc/storage_volume.go:2409
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:603
+#: lxc/storage_volume.go:609
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:711
+#: lxc/storage_volume.go:717
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:994 lxc/storage_volume.go:1346
+#: lxc/storage_volume.go:1000 lxc/storage_volume.go:1352
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2341
+#: lxc/storage_volume.go:2347
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2062
+#: lxc/storage_volume.go:2068
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2220
+#: lxc/storage_volume.go:2226
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1215
+#: lxc/storage_volume.go:1221
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1841
+#: lxc/storage_volume.go:1847
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7097,7 +7116,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1584
+#: lxc/storage_volume.go:1590
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7109,7 +7128,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:739
+#: lxc/project.go:557 lxc/remote.go:806
 msgid "current"
 msgstr ""
 
@@ -7569,7 +7588,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:607
+#: lxc/storage_volume.go:613
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7577,13 +7596,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2792
+#: lxc/storage_volume.go:2798
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2407
+#: lxc/storage_volume.go:2413
 msgid ""
 "lxc storage volume snapshot create default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7593,7 +7612,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:531
 msgid "n"
 msgstr ""
 
@@ -7605,7 +7624,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:510
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7642,7 +7661,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:465
+#: lxc/remote.go:519
 msgid "y"
 msgstr ""
 

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-08 07:43+0100\n"
+"POT-Creation-Date: 2024-10-14 13:30+0000\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Norwegian Bokmål <https://hosted.weblate.org/projects/linux-"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1024
+#: lxc/storage_volume.go:1030
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -515,15 +515,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:850 lxc/remote.go:915
+#: lxc/remote.go:917 lxc/remote.go:982
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:963
+#: lxc/remote.go:1030
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:769
+#: lxc/remote.go:836
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -556,7 +556,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:751
+#: lxc/remote.go:818
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:581
+#: lxc/remote.go:648
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -738,11 +738,11 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1590
+#: lxc/storage_volume.go:1596
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:182
+#: lxc/remote.go:194
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -813,7 +813,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:552
+#: lxc/remote.go:621
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -849,16 +849,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2696
+#: lxc/storage_volume.go:2702
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2773
+#: lxc/export.go:192 lxc/storage_volume.go:2779
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:654 lxc/storage_volume.go:1521
+#: lxc/info.go:654 lxc/storage_volume.go:1527
 msgid "Backups:"
 msgstr ""
 
@@ -879,7 +879,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:679
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:685
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -922,7 +922,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1733
+#: lxc/storage_volume.go:1739
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -991,7 +991,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:894
+#: lxc/remote.go:961
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1007,7 +1007,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1749 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1024,12 +1024,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:486
+#: lxc/storage_volume.go:492
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:440
+#: lxc/storage_volume.go:446
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1057,11 +1057,11 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:509
 msgid "Certificate fingerprint"
 msgstr ""
 
-#: lxc/remote.go:219
+#: lxc/remote.go:231
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
@@ -1076,7 +1076,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:620
+#: lxc/remote.go:687
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1150,13 +1150,13 @@ msgstr ""
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
 #: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
-#: lxc/storage_volume.go:612 lxc/storage_volume.go:717
-#: lxc/storage_volume.go:1005 lxc/storage_volume.go:1231
-#: lxc/storage_volume.go:1360 lxc/storage_volume.go:1848
-#: lxc/storage_volume.go:1940 lxc/storage_volume.go:2079
-#: lxc/storage_volume.go:2239 lxc/storage_volume.go:2355
-#: lxc/storage_volume.go:2416 lxc/storage_volume.go:2543
-#: lxc/storage_volume.go:2631 lxc/storage_volume.go:2795
+#: lxc/storage_volume.go:618 lxc/storage_volume.go:723
+#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1237
+#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1854
+#: lxc/storage_volume.go:1946 lxc/storage_volume.go:2085
+#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2361
+#: lxc/storage_volume.go:2422 lxc/storage_volume.go:2549
+#: lxc/storage_volume.go:2637 lxc/storage_volume.go:2801
 msgid "Cluster member name"
 msgstr ""
 
@@ -1172,7 +1172,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1589
+#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1595
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1216,17 +1216,17 @@ msgstr ""
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1150
-#: lxc/storage_volume.go:1182
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
+#: lxc/storage_volume.go:1188
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:613
+#: lxc/storage_volume.go:619
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1467
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1310,7 +1310,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:508
+#: lxc/storage_volume.go:514
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1324,12 +1324,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:490
+#: lxc/remote.go:559
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:225 lxc/remote.go:474
+#: lxc/remote.go:237 lxc/remote.go:543
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1368,7 +1368,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:485
+#: lxc/remote.go:554
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1437,7 +1437,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:604 lxc/storage_volume.go:605
+#: lxc/storage_volume.go:610 lxc/storage_volume.go:611
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1489,7 +1489,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1475
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1481
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1524,7 +1524,7 @@ msgstr ""
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1732
+#: lxc/storage_volume.go:1738
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1544,7 +1544,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2630
+#: lxc/storage_volume.go:2636
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1640,7 +1640,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:713 lxc/storage_volume.go:714
+#: lxc/storage_volume.go:719 lxc/storage_volume.go:720
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1732,9 +1732,9 @@ msgstr ""
 #: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
 #: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
 #: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:648
-#: lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853 lxc/remote.go:917
-#: lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:715
+#: lxc/remote.go:753 lxc/remote.go:839 lxc/remote.go:920 lxc/remote.go:984
+#: lxc/remote.go:1032 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1746,26 +1746,26 @@ msgstr ""
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
 #: lxc/storage_volume.go:169 lxc/storage_volume.go:283
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:605
-#: lxc/storage_volume.go:714 lxc/storage_volume.go:801
-#: lxc/storage_volume.go:899 lxc/storage_volume.go:996
-#: lxc/storage_volume.go:1217 lxc/storage_volume.go:1348
-#: lxc/storage_volume.go:1507 lxc/storage_volume.go:1591
-#: lxc/storage_volume.go:1844 lxc/storage_volume.go:1937
-#: lxc/storage_volume.go:2064 lxc/storage_volume.go:2222
-#: lxc/storage_volume.go:2343 lxc/storage_volume.go:2405
-#: lxc/storage_volume.go:2541 lxc/storage_volume.go:2624
-#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:611
+#: lxc/storage_volume.go:720 lxc/storage_volume.go:807
+#: lxc/storage_volume.go:905 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:1223 lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1513 lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1850 lxc/storage_volume.go:1943
+#: lxc/storage_volume.go:2070 lxc/storage_volume.go:2228
+#: lxc/storage_volume.go:2349 lxc/storage_volume.go:2411
+#: lxc/storage_volume.go:2547 lxc/storage_volume.go:2630
+#: lxc/storage_volume.go:2796 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1448
+#: lxc/storage_volume.go:1454
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:1849
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:1855
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1777,11 +1777,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:800 lxc/storage_volume.go:801
+#: lxc/storage_volume.go:806 lxc/storage_volume.go:807
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:898 lxc/storage_volume.go:899
+#: lxc/storage_volume.go:904 lxc/storage_volume.go:905
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -2007,7 +2007,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:995 lxc/storage_volume.go:996
+#: lxc/storage_volume.go:1001 lxc/storage_volume.go:1002
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2015,7 +2015,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1766
+#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1772
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2072,7 +2072,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2193
+#: lxc/storage_volume.go:2161 lxc/storage_volume.go:2199
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2086,8 +2086,8 @@ msgstr ""
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2149
-#: lxc/storage_volume.go:2187
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2155
+#: lxc/storage_volume.go:2193
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2129,8 +2129,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1508
-#: lxc/storage_volume.go:1558
+#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1514
+#: lxc/storage_volume.go:1564
 msgid "Expires at"
 msgstr ""
 
@@ -2154,7 +2154,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2623 lxc/storage_volume.go:2624
+#: lxc/storage_volume.go:2629 lxc/storage_volume.go:2630
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2166,11 +2166,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2627
+#: lxc/storage_volume.go:2633
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2756
+#: lxc/export.go:152 lxc/storage_volume.go:2762
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2287,11 +2287,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:191
+#: lxc/remote.go:203
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:242
+#: lxc/remote.go:254
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2301,7 +2301,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:232
+#: lxc/remote.go:244
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2311,12 +2311,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:260
+#: lxc/remote.go:486
 #, c-format
-msgid "Failed to create certificate: %w"
+msgid "Failed to decode trust token: %w"
 msgstr ""
 
-#: lxc/remote.go:267
+#: lxc/remote.go:292
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2341,7 +2341,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:237
+#: lxc/remote.go:249
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2428,9 +2428,9 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:690 lxc/storage.go:657
+#: lxc/project.go:919 lxc/remote.go:757 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1608 lxc/warning.go:94
+#: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2466,7 +2466,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:754
+#: lxc/remote.go:821
 msgid "GLOBAL"
 msgstr ""
 
@@ -2486,7 +2486,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:160 lxc/remote.go:401
+#: lxc/remote.go:165 lxc/remote.go:443
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2554,7 +2554,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1238
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2618,11 +2618,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1216 lxc/storage_volume.go:1217
+#: lxc/storage_volume.go:1222 lxc/storage_volume.go:1223
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:469
+#: lxc/storage_volume.go:475
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2746,7 +2746,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2415
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2421
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2760,7 +2760,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2414
+#: lxc/storage_volume.go:2420
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2810,7 +2810,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2790
+#: lxc/storage_volume.go:2796
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2818,7 +2818,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2789
+#: lxc/storage_volume.go:2795
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2840,11 +2840,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2797
+#: lxc/storage_volume.go:2803
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2871
+#: lxc/storage_volume.go:2877
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2910,7 +2910,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:353
+#: lxc/remote.go:395
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2970,7 +2970,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2000
+#: lxc/move.go:148 lxc/storage_volume.go:2006
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2978,7 +2978,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1996
+#: lxc/storage_volume.go:2002
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2991,14 +2991,14 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:342
+#: lxc/remote.go:384
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1064 lxc/storage_volume.go:1281
-#: lxc/storage_volume.go:1405 lxc/storage_volume.go:1985
-#: lxc/storage_volume.go:2132 lxc/storage_volume.go:2284
+#: lxc/storage_volume.go:1070 lxc/storage_volume.go:1287
+#: lxc/storage_volume.go:1411 lxc/storage_volume.go:1991
+#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2290
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3044,7 +3044,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1739 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1745 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3347,11 +3347,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1586
+#: lxc/storage_volume.go:1592
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1597
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3371,7 +3371,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:685 lxc/remote.go:686
+#: lxc/remote.go:752 lxc/remote.go:753
 msgid "List the available remotes"
 msgstr ""
 
@@ -3410,7 +3410,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1464
+#: lxc/info.go:489 lxc/storage_volume.go:1470
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3874,12 +3874,12 @@ msgstr ""
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:323 lxc/storage_volume.go:643
-#: lxc/storage_volume.go:750 lxc/storage_volume.go:841
-#: lxc/storage_volume.go:939 lxc/storage_volume.go:1053
-#: lxc/storage_volume.go:1270 lxc/storage_volume.go:1974
-#: lxc/storage_volume.go:2115 lxc/storage_volume.go:2273
-#: lxc/storage_volume.go:2464 lxc/storage_volume.go:2581
+#: lxc/storage_volume.go:323 lxc/storage_volume.go:649
+#: lxc/storage_volume.go:756 lxc/storage_volume.go:847
+#: lxc/storage_volume.go:945 lxc/storage_volume.go:1059
+#: lxc/storage_volume.go:1276 lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:2121 lxc/storage_volume.go:2279
+#: lxc/storage_volume.go:2470 lxc/storage_volume.go:2587
 msgid "Missing pool name"
 msgstr ""
 
@@ -3898,11 +3898,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:432 lxc/storage_volume.go:1884
+#: lxc/storage_volume.go:438 lxc/storage_volume.go:1890
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1394
+#: lxc/storage_volume.go:1400
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -3939,8 +3939,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:861
-#: lxc/storage_volume.go:958
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:867
+#: lxc/storage_volume.go:964
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -3977,7 +3977,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1843 lxc/storage_volume.go:1844
+#: lxc/storage_volume.go:1849 lxc/storage_volume.go:1850
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -3985,11 +3985,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1850
+#: lxc/storage_volume.go:1856
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:512
+#: lxc/storage_volume.go:518
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4015,8 +4015,8 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
-#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1731
+#: lxc/remote.go:815 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
 msgstr ""
 
@@ -4042,7 +4042,7 @@ msgstr ""
 
 #: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
+#: lxc/project.go:550 lxc/remote.go:775 lxc/remote.go:780 lxc/remote.go:785
 msgid "NO"
 msgstr ""
 
@@ -4064,8 +4064,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1506
-#: lxc/storage_volume.go:1556
+#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1512
+#: lxc/storage_volume.go:1562
 msgid "Name"
 msgstr ""
 
@@ -4073,7 +4073,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1446
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1452
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4217,7 +4217,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:870 lxc/storage_volume.go:967
+#: lxc/storage_volume.go:876 lxc/storage_volume.go:973
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4233,11 +4233,11 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/storage_volume.go:446 lxc/storage_volume.go:1893
+#: lxc/storage_volume.go:452 lxc/storage_volume.go:1899
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:496 lxc/storage_volume.go:1904
+#: lxc/storage_volume.go:502 lxc/storage_volume.go:1910
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4251,7 +4251,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2012
+#: lxc/storage_volume.go:2018
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4263,15 +4263,15 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2678
+#: lxc/storage_volume.go:2684
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2477
+#: lxc/storage_volume.go:2483
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:336
+#: lxc/remote.go:378
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4279,7 +4279,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1412
+#: lxc/storage_volume.go:1418
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4292,7 +4292,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:693 lxc/storage_volume.go:1560
+#: lxc/info.go:693 lxc/storage_volume.go:1566
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4322,7 +4322,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1756
 msgid "POOL"
 msgstr ""
 
@@ -4338,15 +4338,15 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:213
+#: lxc/list.go:567 lxc/storage_volume.go:1762 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:817
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:752
+#: lxc/image.go:1136 lxc/remote.go:819
 msgid "PUBLIC"
 msgstr ""
 
@@ -4375,7 +4375,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:183
+#: lxc/remote.go:195
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4387,8 +4387,8 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:466
-msgid "Please type 'y', 'n' or the fingerprint:"
+#: lxc/remote.go:536
+msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
 #: lxc/info.go:221
@@ -4412,8 +4412,8 @@ msgstr ""
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1151
-#: lxc/storage_volume.go:1183
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
+#: lxc/storage_volume.go:1189
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4530,7 +4530,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1350
+#: lxc/storage_volume.go:1356
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4544,7 +4544,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1219
+#: lxc/storage_volume.go:1225
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4560,7 +4560,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2224
+#: lxc/storage_volume.go:2230
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4581,7 +4581,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:998
+#: lxc/storage_volume.go:1004
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4590,7 +4590,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2069
+#: lxc/storage_volume.go:2075
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4603,7 +4603,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2345
+#: lxc/storage_volume.go:2351
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4707,33 +4707,33 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:810
+#: lxc/remote.go:877
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
-#: lxc/remote.go:994
+#: lxc/project.go:884 lxc/remote.go:868 lxc/remote.go:949 lxc/remote.go:1013
+#: lxc/remote.go:1061
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:305
+#: lxc/remote.go:345
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:890
+#: lxc/remote.go:957
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:805 lxc/remote.go:886 lxc/remote.go:998
+#: lxc/remote.go:872 lxc/remote.go:953 lxc/remote.go:1065
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:294
+#: lxc/remote.go:319
 msgid "Remote address must not be empty"
 msgstr ""
 
@@ -4741,7 +4741,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:299
+#: lxc/remote.go:339
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4827,7 +4827,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:852 lxc/remote.go:853
+#: lxc/remote.go:919 lxc/remote.go:920
 msgid "Remove remotes"
 msgstr ""
 
@@ -4884,19 +4884,19 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:771 lxc/remote.go:772
+#: lxc/remote.go:838 lxc/remote.go:839
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:1943
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1936
+#: lxc/storage_volume.go:1942
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2025 lxc/storage_volume.go:2045
+#: lxc/storage_volume.go:2031 lxc/storage_volume.go:2051
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4948,7 +4948,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2540 lxc/storage_volume.go:2541
+#: lxc/storage_volume.go:2546 lxc/storage_volume.go:2547
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5029,7 +5029,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:820
 msgid "STATIC"
 msgstr ""
 
@@ -5070,11 +5070,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:464
+#: lxc/remote.go:532
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:616
+#: lxc/remote.go:285 lxc/remote.go:683
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5272,11 +5272,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2063
+#: lxc/storage_volume.go:2069
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2064
+#: lxc/storage_volume.go:2070
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5285,7 +5285,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:964 lxc/remote.go:965
+#: lxc/remote.go:1031 lxc/remote.go:1032
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5361,7 +5361,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2080
+#: lxc/storage_volume.go:2086
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5510,11 +5510,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2221 lxc/storage_volume.go:2222
+#: lxc/storage_volume.go:2227 lxc/storage_volume.go:2228
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1347 lxc/storage_volume.go:1348
+#: lxc/storage_volume.go:1353 lxc/storage_volume.go:1354
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5528,7 +5528,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:647 lxc/remote.go:648
+#: lxc/remote.go:714 lxc/remote.go:715
 msgid "Show the default remote"
 msgstr ""
 
@@ -5582,15 +5582,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2404 lxc/storage_volume.go:2405
+#: lxc/storage_volume.go:2410 lxc/storage_volume.go:2411
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2167
+#: lxc/storage_volume.go:2173
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:607 lxc/storage_volume.go:1485
+#: lxc/info.go:607 lxc/storage_volume.go:1491
 msgid "Snapshots:"
 msgstr ""
 
@@ -5691,21 +5691,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:696
+#: lxc/storage_volume.go:702
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:784
+#: lxc/storage_volume.go:790
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:509
+#: lxc/storage_volume.go:515
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:513
+#: lxc/storage_volume.go:519
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5740,7 +5740,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:916 lxc/remote.go:917
+#: lxc/remote.go:983 lxc/remote.go:984
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5759,11 +5759,11 @@ msgstr ""
 #: lxc/auth.go:818 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
-#: lxc/storage_volume.go:1730 lxc/warning.go:216
+#: lxc/storage_volume.go:1736 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1557
+#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1563
 msgid "Taken at"
 msgstr ""
 
@@ -5773,6 +5773,12 @@ msgstr ""
 
 #: lxc/file.go:1256
 msgid "Target path must be a directory"
+msgstr ""
+
+#: lxc/remote.go:161 lxc/remote.go:334
+msgid ""
+"The --accept-certificate flag is not supported when adding a remote using a "
+"trust token"
 msgstr ""
 
 #: lxc/move.go:181
@@ -5914,15 +5920,20 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1323
+#: lxc/storage_volume.go:1329
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1300
+#: lxc/storage_volume.go:1306
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
+msgstr ""
+
+#: lxc/remote.go:527
+msgid ""
+"The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
 
 #: lxc/info.go:354
@@ -5933,8 +5944,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:875
-#: lxc/storage_volume.go:972
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:881
+#: lxc/storage_volume.go:978
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6009,7 +6020,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1470
+#: lxc/storage_volume.go:1476
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6024,7 +6035,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1847
+#: lxc/storage_volume.go:1853
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6058,7 +6069,15 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:571
+#: lxc/remote.go:329
+msgid "Trust token cannot be used for public remotes"
+msgstr ""
+
+#: lxc/remote.go:324
+msgid "Trust token cannot be used with OIDC authentication"
+msgstr ""
+
+#: lxc/remote.go:639
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6083,7 +6102,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1455
+#: lxc/storage_volume.go:1461
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6101,17 +6120,17 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:193 lxc/remote.go:749
+#: lxc/cluster.go:193 lxc/remote.go:816
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1735
+#: lxc/project.go:995 lxc/storage_volume.go:1741
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1734
+#: lxc/storage.go:724 lxc/storage_volume.go:1740
 msgid "USED BY"
 msgstr ""
 
@@ -6129,7 +6148,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:214 lxc/remote.go:248
+#: lxc/remote.go:226 lxc/remote.go:260
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6143,7 +6162,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1772
+#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1778
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6249,7 +6268,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2342 lxc/storage_volume.go:2343
+#: lxc/storage_volume.go:2348 lxc/storage_volume.go:2349
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6301,7 +6320,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2356
+#: lxc/storage_volume.go:2362
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6345,12 +6364,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1468
+#: lxc/storage_volume.go:1474
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2629
+#: lxc/export.go:42 lxc/storage_volume.go:2635
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6417,7 +6436,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1559
+#: lxc/storage_volume.go:1565
 msgid "Volume Only"
 msgstr ""
 
@@ -6452,7 +6471,7 @@ msgstr ""
 
 #: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
+#: lxc/project.go:552 lxc/remote.go:777 lxc/remote.go:782 lxc/remote.go:787
 msgid "YES"
 msgstr ""
 
@@ -6476,7 +6495,7 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:897
+#: lxc/storage_volume.go:903
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
@@ -6898,7 +6917,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2788
+#: lxc/storage_volume.go:2794
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -6933,13 +6952,13 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:1941
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:799
+#: lxc/storage_volume.go:805
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
@@ -6947,47 +6966,47 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2539
+#: lxc/storage_volume.go:2545
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2622
+#: lxc/storage_volume.go:2628
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2403
+#: lxc/storage_volume.go:2409
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:603
+#: lxc/storage_volume.go:609
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:711
+#: lxc/storage_volume.go:717
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:994 lxc/storage_volume.go:1346
+#: lxc/storage_volume.go:1000 lxc/storage_volume.go:1352
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2341
+#: lxc/storage_volume.go:2347
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2062
+#: lxc/storage_volume.go:2068
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2220
+#: lxc/storage_volume.go:2226
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1215
+#: lxc/storage_volume.go:1221
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1841
+#: lxc/storage_volume.go:1847
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7097,7 +7116,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1584
+#: lxc/storage_volume.go:1590
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7109,7 +7128,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:739
+#: lxc/project.go:557 lxc/remote.go:806
 msgid "current"
 msgstr ""
 
@@ -7569,7 +7588,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:607
+#: lxc/storage_volume.go:613
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7577,13 +7596,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2792
+#: lxc/storage_volume.go:2798
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2407
+#: lxc/storage_volume.go:2413
 msgid ""
 "lxc storage volume snapshot create default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7593,7 +7612,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:531
 msgid "n"
 msgstr ""
 
@@ -7605,7 +7624,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:510
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7642,7 +7661,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:465
+#: lxc/remote.go:519
 msgid "y"
 msgstr ""
 

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-08 07:43+0100\n"
+"POT-Creation-Date: 2024-10-14 13:30+0000\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Heimen Stoffels <vistausss@fastmail.com>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/linux-containers/"
@@ -74,7 +74,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/storage_volume.go:1024
+#: lxc/storage_volume.go:1030
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
@@ -739,15 +739,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:850 lxc/remote.go:915
+#: lxc/remote.go:917 lxc/remote.go:982
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:963
+#: lxc/remote.go:1030
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:769
+#: lxc/remote.go:836
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -780,7 +780,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr "ARCHITECTUUR"
 
-#: lxc/remote.go:751
+#: lxc/remote.go:818
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -929,7 +929,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:581
+#: lxc/remote.go:648
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -962,11 +962,11 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1590
+#: lxc/storage_volume.go:1596
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:182
+#: lxc/remote.go:194
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -1037,7 +1037,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:552
+#: lxc/remote.go:621
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -1073,16 +1073,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2696
+#: lxc/storage_volume.go:2702
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2773
+#: lxc/export.go:192 lxc/storage_volume.go:2779
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:654 lxc/storage_volume.go:1521
+#: lxc/info.go:654 lxc/storage_volume.go:1527
 msgid "Backups:"
 msgstr ""
 
@@ -1103,7 +1103,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:679
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:685
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -1146,7 +1146,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1733
+#: lxc/storage_volume.go:1739
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1215,7 +1215,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:894
+#: lxc/remote.go:961
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1231,7 +1231,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1749 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1248,12 +1248,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:486
+#: lxc/storage_volume.go:492
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:440
+#: lxc/storage_volume.go:446
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1281,11 +1281,11 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:509
 msgid "Certificate fingerprint"
 msgstr ""
 
-#: lxc/remote.go:219
+#: lxc/remote.go:231
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
@@ -1300,7 +1300,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:620
+#: lxc/remote.go:687
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1374,13 +1374,13 @@ msgstr ""
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
 #: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
-#: lxc/storage_volume.go:612 lxc/storage_volume.go:717
-#: lxc/storage_volume.go:1005 lxc/storage_volume.go:1231
-#: lxc/storage_volume.go:1360 lxc/storage_volume.go:1848
-#: lxc/storage_volume.go:1940 lxc/storage_volume.go:2079
-#: lxc/storage_volume.go:2239 lxc/storage_volume.go:2355
-#: lxc/storage_volume.go:2416 lxc/storage_volume.go:2543
-#: lxc/storage_volume.go:2631 lxc/storage_volume.go:2795
+#: lxc/storage_volume.go:618 lxc/storage_volume.go:723
+#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1237
+#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1854
+#: lxc/storage_volume.go:1946 lxc/storage_volume.go:2085
+#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2361
+#: lxc/storage_volume.go:2422 lxc/storage_volume.go:2549
+#: lxc/storage_volume.go:2637 lxc/storage_volume.go:2801
 msgid "Cluster member name"
 msgstr ""
 
@@ -1396,7 +1396,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1589
+#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1595
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1440,17 +1440,17 @@ msgstr ""
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1150
-#: lxc/storage_volume.go:1182
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
+#: lxc/storage_volume.go:1188
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:613
+#: lxc/storage_volume.go:619
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1467
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1534,7 +1534,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:508
+#: lxc/storage_volume.go:514
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1548,12 +1548,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:490
+#: lxc/remote.go:559
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:225 lxc/remote.go:474
+#: lxc/remote.go:237 lxc/remote.go:543
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1592,7 +1592,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:485
+#: lxc/remote.go:554
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1661,7 +1661,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:604 lxc/storage_volume.go:605
+#: lxc/storage_volume.go:610 lxc/storage_volume.go:611
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1713,7 +1713,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1475
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1481
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1748,7 +1748,7 @@ msgstr ""
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1732
+#: lxc/storage_volume.go:1738
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1768,7 +1768,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2630
+#: lxc/storage_volume.go:2636
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1864,7 +1864,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:713 lxc/storage_volume.go:714
+#: lxc/storage_volume.go:719 lxc/storage_volume.go:720
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1956,9 +1956,9 @@ msgstr ""
 #: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
 #: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
 #: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:648
-#: lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853 lxc/remote.go:917
-#: lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:715
+#: lxc/remote.go:753 lxc/remote.go:839 lxc/remote.go:920 lxc/remote.go:984
+#: lxc/remote.go:1032 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1970,26 +1970,26 @@ msgstr ""
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
 #: lxc/storage_volume.go:169 lxc/storage_volume.go:283
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:605
-#: lxc/storage_volume.go:714 lxc/storage_volume.go:801
-#: lxc/storage_volume.go:899 lxc/storage_volume.go:996
-#: lxc/storage_volume.go:1217 lxc/storage_volume.go:1348
-#: lxc/storage_volume.go:1507 lxc/storage_volume.go:1591
-#: lxc/storage_volume.go:1844 lxc/storage_volume.go:1937
-#: lxc/storage_volume.go:2064 lxc/storage_volume.go:2222
-#: lxc/storage_volume.go:2343 lxc/storage_volume.go:2405
-#: lxc/storage_volume.go:2541 lxc/storage_volume.go:2624
-#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:611
+#: lxc/storage_volume.go:720 lxc/storage_volume.go:807
+#: lxc/storage_volume.go:905 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:1223 lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1513 lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1850 lxc/storage_volume.go:1943
+#: lxc/storage_volume.go:2070 lxc/storage_volume.go:2228
+#: lxc/storage_volume.go:2349 lxc/storage_volume.go:2411
+#: lxc/storage_volume.go:2547 lxc/storage_volume.go:2630
+#: lxc/storage_volume.go:2796 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1448
+#: lxc/storage_volume.go:1454
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:1849
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:1855
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -2001,11 +2001,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:800 lxc/storage_volume.go:801
+#: lxc/storage_volume.go:806 lxc/storage_volume.go:807
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:898 lxc/storage_volume.go:899
+#: lxc/storage_volume.go:904 lxc/storage_volume.go:905
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -2231,7 +2231,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:995 lxc/storage_volume.go:996
+#: lxc/storage_volume.go:1001 lxc/storage_volume.go:1002
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2239,7 +2239,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1766
+#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1772
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2296,7 +2296,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2193
+#: lxc/storage_volume.go:2161 lxc/storage_volume.go:2199
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2310,8 +2310,8 @@ msgstr ""
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2149
-#: lxc/storage_volume.go:2187
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2155
+#: lxc/storage_volume.go:2193
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2353,8 +2353,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1508
-#: lxc/storage_volume.go:1558
+#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1514
+#: lxc/storage_volume.go:1564
 msgid "Expires at"
 msgstr ""
 
@@ -2378,7 +2378,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2623 lxc/storage_volume.go:2624
+#: lxc/storage_volume.go:2629 lxc/storage_volume.go:2630
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2390,11 +2390,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2627
+#: lxc/storage_volume.go:2633
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2756
+#: lxc/export.go:152 lxc/storage_volume.go:2762
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2511,11 +2511,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:191
+#: lxc/remote.go:203
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:242
+#: lxc/remote.go:254
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2525,7 +2525,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:232
+#: lxc/remote.go:244
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2535,12 +2535,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:260
+#: lxc/remote.go:486
 #, c-format
-msgid "Failed to create certificate: %w"
+msgid "Failed to decode trust token: %w"
 msgstr ""
 
-#: lxc/remote.go:267
+#: lxc/remote.go:292
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2565,7 +2565,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:237
+#: lxc/remote.go:249
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2652,9 +2652,9 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:690 lxc/storage.go:657
+#: lxc/project.go:919 lxc/remote.go:757 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1608 lxc/warning.go:94
+#: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2690,7 +2690,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:754
+#: lxc/remote.go:821
 msgid "GLOBAL"
 msgstr ""
 
@@ -2710,7 +2710,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:160 lxc/remote.go:401
+#: lxc/remote.go:165 lxc/remote.go:443
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2778,7 +2778,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1238
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2842,11 +2842,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1216 lxc/storage_volume.go:1217
+#: lxc/storage_volume.go:1222 lxc/storage_volume.go:1223
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:469
+#: lxc/storage_volume.go:475
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2970,7 +2970,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2415
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2421
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2984,7 +2984,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2414
+#: lxc/storage_volume.go:2420
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -3034,7 +3034,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2790
+#: lxc/storage_volume.go:2796
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -3042,7 +3042,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2789
+#: lxc/storage_volume.go:2795
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -3064,11 +3064,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2797
+#: lxc/storage_volume.go:2803
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2871
+#: lxc/storage_volume.go:2877
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3134,7 +3134,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:353
+#: lxc/remote.go:395
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3194,7 +3194,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2000
+#: lxc/move.go:148 lxc/storage_volume.go:2006
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -3202,7 +3202,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1996
+#: lxc/storage_volume.go:2002
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3215,14 +3215,14 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:342
+#: lxc/remote.go:384
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1064 lxc/storage_volume.go:1281
-#: lxc/storage_volume.go:1405 lxc/storage_volume.go:1985
-#: lxc/storage_volume.go:2132 lxc/storage_volume.go:2284
+#: lxc/storage_volume.go:1070 lxc/storage_volume.go:1287
+#: lxc/storage_volume.go:1411 lxc/storage_volume.go:1991
+#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2290
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3268,7 +3268,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1739 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1745 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3571,11 +3571,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1586
+#: lxc/storage_volume.go:1592
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1597
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3595,7 +3595,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:685 lxc/remote.go:686
+#: lxc/remote.go:752 lxc/remote.go:753
 msgid "List the available remotes"
 msgstr ""
 
@@ -3634,7 +3634,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1464
+#: lxc/info.go:489 lxc/storage_volume.go:1470
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -4098,12 +4098,12 @@ msgstr ""
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:323 lxc/storage_volume.go:643
-#: lxc/storage_volume.go:750 lxc/storage_volume.go:841
-#: lxc/storage_volume.go:939 lxc/storage_volume.go:1053
-#: lxc/storage_volume.go:1270 lxc/storage_volume.go:1974
-#: lxc/storage_volume.go:2115 lxc/storage_volume.go:2273
-#: lxc/storage_volume.go:2464 lxc/storage_volume.go:2581
+#: lxc/storage_volume.go:323 lxc/storage_volume.go:649
+#: lxc/storage_volume.go:756 lxc/storage_volume.go:847
+#: lxc/storage_volume.go:945 lxc/storage_volume.go:1059
+#: lxc/storage_volume.go:1276 lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:2121 lxc/storage_volume.go:2279
+#: lxc/storage_volume.go:2470 lxc/storage_volume.go:2587
 msgid "Missing pool name"
 msgstr ""
 
@@ -4122,11 +4122,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:432 lxc/storage_volume.go:1884
+#: lxc/storage_volume.go:438 lxc/storage_volume.go:1890
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1394
+#: lxc/storage_volume.go:1400
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -4163,8 +4163,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:861
-#: lxc/storage_volume.go:958
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:867
+#: lxc/storage_volume.go:964
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4201,7 +4201,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1843 lxc/storage_volume.go:1844
+#: lxc/storage_volume.go:1849 lxc/storage_volume.go:1850
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4209,11 +4209,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1850
+#: lxc/storage_volume.go:1856
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:512
+#: lxc/storage_volume.go:518
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4239,8 +4239,8 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
-#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1731
+#: lxc/remote.go:815 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
 msgstr ""
 
@@ -4266,7 +4266,7 @@ msgstr ""
 
 #: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
+#: lxc/project.go:550 lxc/remote.go:775 lxc/remote.go:780 lxc/remote.go:785
 msgid "NO"
 msgstr ""
 
@@ -4288,8 +4288,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1506
-#: lxc/storage_volume.go:1556
+#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1512
+#: lxc/storage_volume.go:1562
 msgid "Name"
 msgstr ""
 
@@ -4297,7 +4297,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1446
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1452
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4441,7 +4441,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:870 lxc/storage_volume.go:967
+#: lxc/storage_volume.go:876 lxc/storage_volume.go:973
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4457,11 +4457,11 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/storage_volume.go:446 lxc/storage_volume.go:1893
+#: lxc/storage_volume.go:452 lxc/storage_volume.go:1899
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:496 lxc/storage_volume.go:1904
+#: lxc/storage_volume.go:502 lxc/storage_volume.go:1910
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4475,7 +4475,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2012
+#: lxc/storage_volume.go:2018
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4487,15 +4487,15 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2678
+#: lxc/storage_volume.go:2684
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2477
+#: lxc/storage_volume.go:2483
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:336
+#: lxc/remote.go:378
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4503,7 +4503,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1412
+#: lxc/storage_volume.go:1418
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4516,7 +4516,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:693 lxc/storage_volume.go:1560
+#: lxc/info.go:693 lxc/storage_volume.go:1566
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4546,7 +4546,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1756
 msgid "POOL"
 msgstr ""
 
@@ -4562,15 +4562,15 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:213
+#: lxc/list.go:567 lxc/storage_volume.go:1762 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:817
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:752
+#: lxc/image.go:1136 lxc/remote.go:819
 msgid "PUBLIC"
 msgstr ""
 
@@ -4599,7 +4599,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:183
+#: lxc/remote.go:195
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4611,8 +4611,8 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:466
-msgid "Please type 'y', 'n' or the fingerprint:"
+#: lxc/remote.go:536
+msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
 #: lxc/info.go:221
@@ -4636,8 +4636,8 @@ msgstr ""
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1151
-#: lxc/storage_volume.go:1183
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
+#: lxc/storage_volume.go:1189
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4754,7 +4754,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1350
+#: lxc/storage_volume.go:1356
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4768,7 +4768,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1219
+#: lxc/storage_volume.go:1225
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4784,7 +4784,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2224
+#: lxc/storage_volume.go:2230
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4805,7 +4805,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:998
+#: lxc/storage_volume.go:1004
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4814,7 +4814,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2069
+#: lxc/storage_volume.go:2075
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4827,7 +4827,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2345
+#: lxc/storage_volume.go:2351
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4931,33 +4931,33 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:810
+#: lxc/remote.go:877
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
-#: lxc/remote.go:994
+#: lxc/project.go:884 lxc/remote.go:868 lxc/remote.go:949 lxc/remote.go:1013
+#: lxc/remote.go:1061
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:305
+#: lxc/remote.go:345
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:890
+#: lxc/remote.go:957
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:805 lxc/remote.go:886 lxc/remote.go:998
+#: lxc/remote.go:872 lxc/remote.go:953 lxc/remote.go:1065
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:294
+#: lxc/remote.go:319
 msgid "Remote address must not be empty"
 msgstr ""
 
@@ -4965,7 +4965,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:299
+#: lxc/remote.go:339
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -5051,7 +5051,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:852 lxc/remote.go:853
+#: lxc/remote.go:919 lxc/remote.go:920
 msgid "Remove remotes"
 msgstr ""
 
@@ -5108,19 +5108,19 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:771 lxc/remote.go:772
+#: lxc/remote.go:838 lxc/remote.go:839
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:1943
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1936
+#: lxc/storage_volume.go:1942
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2025 lxc/storage_volume.go:2045
+#: lxc/storage_volume.go:2031 lxc/storage_volume.go:2051
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5172,7 +5172,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2540 lxc/storage_volume.go:2541
+#: lxc/storage_volume.go:2546 lxc/storage_volume.go:2547
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5253,7 +5253,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:820
 msgid "STATIC"
 msgstr ""
 
@@ -5294,11 +5294,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:464
+#: lxc/remote.go:532
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:616
+#: lxc/remote.go:285 lxc/remote.go:683
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5496,11 +5496,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2063
+#: lxc/storage_volume.go:2069
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2064
+#: lxc/storage_volume.go:2070
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5509,7 +5509,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:964 lxc/remote.go:965
+#: lxc/remote.go:1031 lxc/remote.go:1032
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5585,7 +5585,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2080
+#: lxc/storage_volume.go:2086
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5734,11 +5734,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2221 lxc/storage_volume.go:2222
+#: lxc/storage_volume.go:2227 lxc/storage_volume.go:2228
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1347 lxc/storage_volume.go:1348
+#: lxc/storage_volume.go:1353 lxc/storage_volume.go:1354
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5752,7 +5752,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:647 lxc/remote.go:648
+#: lxc/remote.go:714 lxc/remote.go:715
 msgid "Show the default remote"
 msgstr ""
 
@@ -5806,15 +5806,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2404 lxc/storage_volume.go:2405
+#: lxc/storage_volume.go:2410 lxc/storage_volume.go:2411
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2167
+#: lxc/storage_volume.go:2173
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:607 lxc/storage_volume.go:1485
+#: lxc/info.go:607 lxc/storage_volume.go:1491
 msgid "Snapshots:"
 msgstr ""
 
@@ -5915,21 +5915,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:696
+#: lxc/storage_volume.go:702
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:784
+#: lxc/storage_volume.go:790
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:509
+#: lxc/storage_volume.go:515
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:513
+#: lxc/storage_volume.go:519
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5964,7 +5964,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:916 lxc/remote.go:917
+#: lxc/remote.go:983 lxc/remote.go:984
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5983,11 +5983,11 @@ msgstr ""
 #: lxc/auth.go:818 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
-#: lxc/storage_volume.go:1730 lxc/warning.go:216
+#: lxc/storage_volume.go:1736 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1557
+#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1563
 msgid "Taken at"
 msgstr ""
 
@@ -5997,6 +5997,12 @@ msgstr ""
 
 #: lxc/file.go:1256
 msgid "Target path must be a directory"
+msgstr ""
+
+#: lxc/remote.go:161 lxc/remote.go:334
+msgid ""
+"The --accept-certificate flag is not supported when adding a remote using a "
+"trust token"
 msgstr ""
 
 #: lxc/move.go:181
@@ -6138,15 +6144,20 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1323
+#: lxc/storage_volume.go:1329
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1300
+#: lxc/storage_volume.go:1306
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
+msgstr ""
+
+#: lxc/remote.go:527
+msgid ""
+"The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
 
 #: lxc/info.go:354
@@ -6157,8 +6168,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:875
-#: lxc/storage_volume.go:972
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:881
+#: lxc/storage_volume.go:978
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6233,7 +6244,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1470
+#: lxc/storage_volume.go:1476
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6248,7 +6259,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1847
+#: lxc/storage_volume.go:1853
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6282,7 +6293,15 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:571
+#: lxc/remote.go:329
+msgid "Trust token cannot be used for public remotes"
+msgstr ""
+
+#: lxc/remote.go:324
+msgid "Trust token cannot be used with OIDC authentication"
+msgstr ""
+
+#: lxc/remote.go:639
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6307,7 +6326,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1455
+#: lxc/storage_volume.go:1461
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6325,17 +6344,17 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:193 lxc/remote.go:749
+#: lxc/cluster.go:193 lxc/remote.go:816
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1735
+#: lxc/project.go:995 lxc/storage_volume.go:1741
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1734
+#: lxc/storage.go:724 lxc/storage_volume.go:1740
 msgid "USED BY"
 msgstr ""
 
@@ -6353,7 +6372,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:214 lxc/remote.go:248
+#: lxc/remote.go:226 lxc/remote.go:260
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6367,7 +6386,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1772
+#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1778
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6473,7 +6492,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2342 lxc/storage_volume.go:2343
+#: lxc/storage_volume.go:2348 lxc/storage_volume.go:2349
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6525,7 +6544,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2356
+#: lxc/storage_volume.go:2362
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6569,12 +6588,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1468
+#: lxc/storage_volume.go:1474
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2629
+#: lxc/export.go:42 lxc/storage_volume.go:2635
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6641,7 +6660,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1559
+#: lxc/storage_volume.go:1565
 msgid "Volume Only"
 msgstr ""
 
@@ -6676,7 +6695,7 @@ msgstr ""
 
 #: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
+#: lxc/project.go:552 lxc/remote.go:777 lxc/remote.go:782 lxc/remote.go:787
 msgid "YES"
 msgstr ""
 
@@ -6700,7 +6719,7 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:897
+#: lxc/storage_volume.go:903
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
@@ -7122,7 +7141,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2788
+#: lxc/storage_volume.go:2794
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7157,13 +7176,13 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:1941
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:799
+#: lxc/storage_volume.go:805
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
@@ -7171,47 +7190,47 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2539
+#: lxc/storage_volume.go:2545
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2622
+#: lxc/storage_volume.go:2628
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2403
+#: lxc/storage_volume.go:2409
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:603
+#: lxc/storage_volume.go:609
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:711
+#: lxc/storage_volume.go:717
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:994 lxc/storage_volume.go:1346
+#: lxc/storage_volume.go:1000 lxc/storage_volume.go:1352
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2341
+#: lxc/storage_volume.go:2347
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2062
+#: lxc/storage_volume.go:2068
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2220
+#: lxc/storage_volume.go:2226
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1215
+#: lxc/storage_volume.go:1221
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1841
+#: lxc/storage_volume.go:1847
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7321,7 +7340,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1584
+#: lxc/storage_volume.go:1590
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7333,7 +7352,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:739
+#: lxc/project.go:557 lxc/remote.go:806
 msgid "current"
 msgstr ""
 
@@ -7793,7 +7812,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:607
+#: lxc/storage_volume.go:613
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7801,13 +7820,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2792
+#: lxc/storage_volume.go:2798
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2407
+#: lxc/storage_volume.go:2413
 msgid ""
 "lxc storage volume snapshot create default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7817,7 +7836,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:531
 msgid "n"
 msgstr ""
 
@@ -7829,7 +7848,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:510
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7866,7 +7885,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:465
+#: lxc/remote.go:519
 msgid "y"
 msgstr ""
 

--- a/po/pa.po
+++ b/po/pa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-08 07:43+0100\n"
+"POT-Creation-Date: 2024-10-14 13:30+0000\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Punjabi <https://hosted.weblate.org/projects/linux-containers/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1024
+#: lxc/storage_volume.go:1030
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -515,15 +515,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:850 lxc/remote.go:915
+#: lxc/remote.go:917 lxc/remote.go:982
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:963
+#: lxc/remote.go:1030
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:769
+#: lxc/remote.go:836
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -556,7 +556,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:751
+#: lxc/remote.go:818
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:581
+#: lxc/remote.go:648
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -738,11 +738,11 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1590
+#: lxc/storage_volume.go:1596
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:182
+#: lxc/remote.go:194
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -813,7 +813,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:552
+#: lxc/remote.go:621
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -849,16 +849,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2696
+#: lxc/storage_volume.go:2702
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2773
+#: lxc/export.go:192 lxc/storage_volume.go:2779
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:654 lxc/storage_volume.go:1521
+#: lxc/info.go:654 lxc/storage_volume.go:1527
 msgid "Backups:"
 msgstr ""
 
@@ -879,7 +879,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:679
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:685
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -922,7 +922,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1733
+#: lxc/storage_volume.go:1739
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -991,7 +991,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:894
+#: lxc/remote.go:961
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1007,7 +1007,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1749 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1024,12 +1024,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:486
+#: lxc/storage_volume.go:492
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:440
+#: lxc/storage_volume.go:446
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1057,11 +1057,11 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:509
 msgid "Certificate fingerprint"
 msgstr ""
 
-#: lxc/remote.go:219
+#: lxc/remote.go:231
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
@@ -1076,7 +1076,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:620
+#: lxc/remote.go:687
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1150,13 +1150,13 @@ msgstr ""
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
 #: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
-#: lxc/storage_volume.go:612 lxc/storage_volume.go:717
-#: lxc/storage_volume.go:1005 lxc/storage_volume.go:1231
-#: lxc/storage_volume.go:1360 lxc/storage_volume.go:1848
-#: lxc/storage_volume.go:1940 lxc/storage_volume.go:2079
-#: lxc/storage_volume.go:2239 lxc/storage_volume.go:2355
-#: lxc/storage_volume.go:2416 lxc/storage_volume.go:2543
-#: lxc/storage_volume.go:2631 lxc/storage_volume.go:2795
+#: lxc/storage_volume.go:618 lxc/storage_volume.go:723
+#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1237
+#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1854
+#: lxc/storage_volume.go:1946 lxc/storage_volume.go:2085
+#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2361
+#: lxc/storage_volume.go:2422 lxc/storage_volume.go:2549
+#: lxc/storage_volume.go:2637 lxc/storage_volume.go:2801
 msgid "Cluster member name"
 msgstr ""
 
@@ -1172,7 +1172,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1589
+#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1595
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1216,17 +1216,17 @@ msgstr ""
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1150
-#: lxc/storage_volume.go:1182
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
+#: lxc/storage_volume.go:1188
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:613
+#: lxc/storage_volume.go:619
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1467
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1310,7 +1310,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:508
+#: lxc/storage_volume.go:514
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1324,12 +1324,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:490
+#: lxc/remote.go:559
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:225 lxc/remote.go:474
+#: lxc/remote.go:237 lxc/remote.go:543
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1368,7 +1368,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:485
+#: lxc/remote.go:554
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1437,7 +1437,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:604 lxc/storage_volume.go:605
+#: lxc/storage_volume.go:610 lxc/storage_volume.go:611
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1489,7 +1489,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1475
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1481
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1524,7 +1524,7 @@ msgstr ""
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1732
+#: lxc/storage_volume.go:1738
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1544,7 +1544,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2630
+#: lxc/storage_volume.go:2636
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1640,7 +1640,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:713 lxc/storage_volume.go:714
+#: lxc/storage_volume.go:719 lxc/storage_volume.go:720
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1732,9 +1732,9 @@ msgstr ""
 #: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
 #: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
 #: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:648
-#: lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853 lxc/remote.go:917
-#: lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:715
+#: lxc/remote.go:753 lxc/remote.go:839 lxc/remote.go:920 lxc/remote.go:984
+#: lxc/remote.go:1032 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1746,26 +1746,26 @@ msgstr ""
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
 #: lxc/storage_volume.go:169 lxc/storage_volume.go:283
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:605
-#: lxc/storage_volume.go:714 lxc/storage_volume.go:801
-#: lxc/storage_volume.go:899 lxc/storage_volume.go:996
-#: lxc/storage_volume.go:1217 lxc/storage_volume.go:1348
-#: lxc/storage_volume.go:1507 lxc/storage_volume.go:1591
-#: lxc/storage_volume.go:1844 lxc/storage_volume.go:1937
-#: lxc/storage_volume.go:2064 lxc/storage_volume.go:2222
-#: lxc/storage_volume.go:2343 lxc/storage_volume.go:2405
-#: lxc/storage_volume.go:2541 lxc/storage_volume.go:2624
-#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:611
+#: lxc/storage_volume.go:720 lxc/storage_volume.go:807
+#: lxc/storage_volume.go:905 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:1223 lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1513 lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1850 lxc/storage_volume.go:1943
+#: lxc/storage_volume.go:2070 lxc/storage_volume.go:2228
+#: lxc/storage_volume.go:2349 lxc/storage_volume.go:2411
+#: lxc/storage_volume.go:2547 lxc/storage_volume.go:2630
+#: lxc/storage_volume.go:2796 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1448
+#: lxc/storage_volume.go:1454
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:1849
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:1855
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1777,11 +1777,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:800 lxc/storage_volume.go:801
+#: lxc/storage_volume.go:806 lxc/storage_volume.go:807
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:898 lxc/storage_volume.go:899
+#: lxc/storage_volume.go:904 lxc/storage_volume.go:905
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -2007,7 +2007,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:995 lxc/storage_volume.go:996
+#: lxc/storage_volume.go:1001 lxc/storage_volume.go:1002
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2015,7 +2015,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1766
+#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1772
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2072,7 +2072,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2193
+#: lxc/storage_volume.go:2161 lxc/storage_volume.go:2199
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2086,8 +2086,8 @@ msgstr ""
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2149
-#: lxc/storage_volume.go:2187
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2155
+#: lxc/storage_volume.go:2193
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2129,8 +2129,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1508
-#: lxc/storage_volume.go:1558
+#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1514
+#: lxc/storage_volume.go:1564
 msgid "Expires at"
 msgstr ""
 
@@ -2154,7 +2154,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2623 lxc/storage_volume.go:2624
+#: lxc/storage_volume.go:2629 lxc/storage_volume.go:2630
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2166,11 +2166,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2627
+#: lxc/storage_volume.go:2633
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2756
+#: lxc/export.go:152 lxc/storage_volume.go:2762
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2287,11 +2287,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:191
+#: lxc/remote.go:203
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:242
+#: lxc/remote.go:254
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2301,7 +2301,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:232
+#: lxc/remote.go:244
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2311,12 +2311,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:260
+#: lxc/remote.go:486
 #, c-format
-msgid "Failed to create certificate: %w"
+msgid "Failed to decode trust token: %w"
 msgstr ""
 
-#: lxc/remote.go:267
+#: lxc/remote.go:292
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2341,7 +2341,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:237
+#: lxc/remote.go:249
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2428,9 +2428,9 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:690 lxc/storage.go:657
+#: lxc/project.go:919 lxc/remote.go:757 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1608 lxc/warning.go:94
+#: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2466,7 +2466,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:754
+#: lxc/remote.go:821
 msgid "GLOBAL"
 msgstr ""
 
@@ -2486,7 +2486,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:160 lxc/remote.go:401
+#: lxc/remote.go:165 lxc/remote.go:443
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2554,7 +2554,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1238
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2618,11 +2618,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1216 lxc/storage_volume.go:1217
+#: lxc/storage_volume.go:1222 lxc/storage_volume.go:1223
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:469
+#: lxc/storage_volume.go:475
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2746,7 +2746,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2415
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2421
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2760,7 +2760,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2414
+#: lxc/storage_volume.go:2420
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2810,7 +2810,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2790
+#: lxc/storage_volume.go:2796
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2818,7 +2818,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2789
+#: lxc/storage_volume.go:2795
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2840,11 +2840,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2797
+#: lxc/storage_volume.go:2803
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2871
+#: lxc/storage_volume.go:2877
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2910,7 +2910,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:353
+#: lxc/remote.go:395
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2970,7 +2970,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2000
+#: lxc/move.go:148 lxc/storage_volume.go:2006
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2978,7 +2978,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1996
+#: lxc/storage_volume.go:2002
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2991,14 +2991,14 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:342
+#: lxc/remote.go:384
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1064 lxc/storage_volume.go:1281
-#: lxc/storage_volume.go:1405 lxc/storage_volume.go:1985
-#: lxc/storage_volume.go:2132 lxc/storage_volume.go:2284
+#: lxc/storage_volume.go:1070 lxc/storage_volume.go:1287
+#: lxc/storage_volume.go:1411 lxc/storage_volume.go:1991
+#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2290
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3044,7 +3044,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1739 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1745 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3347,11 +3347,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1586
+#: lxc/storage_volume.go:1592
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1597
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3371,7 +3371,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:685 lxc/remote.go:686
+#: lxc/remote.go:752 lxc/remote.go:753
 msgid "List the available remotes"
 msgstr ""
 
@@ -3410,7 +3410,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1464
+#: lxc/info.go:489 lxc/storage_volume.go:1470
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3874,12 +3874,12 @@ msgstr ""
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:323 lxc/storage_volume.go:643
-#: lxc/storage_volume.go:750 lxc/storage_volume.go:841
-#: lxc/storage_volume.go:939 lxc/storage_volume.go:1053
-#: lxc/storage_volume.go:1270 lxc/storage_volume.go:1974
-#: lxc/storage_volume.go:2115 lxc/storage_volume.go:2273
-#: lxc/storage_volume.go:2464 lxc/storage_volume.go:2581
+#: lxc/storage_volume.go:323 lxc/storage_volume.go:649
+#: lxc/storage_volume.go:756 lxc/storage_volume.go:847
+#: lxc/storage_volume.go:945 lxc/storage_volume.go:1059
+#: lxc/storage_volume.go:1276 lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:2121 lxc/storage_volume.go:2279
+#: lxc/storage_volume.go:2470 lxc/storage_volume.go:2587
 msgid "Missing pool name"
 msgstr ""
 
@@ -3898,11 +3898,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:432 lxc/storage_volume.go:1884
+#: lxc/storage_volume.go:438 lxc/storage_volume.go:1890
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1394
+#: lxc/storage_volume.go:1400
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -3939,8 +3939,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:861
-#: lxc/storage_volume.go:958
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:867
+#: lxc/storage_volume.go:964
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -3977,7 +3977,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1843 lxc/storage_volume.go:1844
+#: lxc/storage_volume.go:1849 lxc/storage_volume.go:1850
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -3985,11 +3985,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1850
+#: lxc/storage_volume.go:1856
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:512
+#: lxc/storage_volume.go:518
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4015,8 +4015,8 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
-#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1731
+#: lxc/remote.go:815 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
 msgstr ""
 
@@ -4042,7 +4042,7 @@ msgstr ""
 
 #: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
+#: lxc/project.go:550 lxc/remote.go:775 lxc/remote.go:780 lxc/remote.go:785
 msgid "NO"
 msgstr ""
 
@@ -4064,8 +4064,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1506
-#: lxc/storage_volume.go:1556
+#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1512
+#: lxc/storage_volume.go:1562
 msgid "Name"
 msgstr ""
 
@@ -4073,7 +4073,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1446
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1452
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4217,7 +4217,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:870 lxc/storage_volume.go:967
+#: lxc/storage_volume.go:876 lxc/storage_volume.go:973
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4233,11 +4233,11 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/storage_volume.go:446 lxc/storage_volume.go:1893
+#: lxc/storage_volume.go:452 lxc/storage_volume.go:1899
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:496 lxc/storage_volume.go:1904
+#: lxc/storage_volume.go:502 lxc/storage_volume.go:1910
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4251,7 +4251,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2012
+#: lxc/storage_volume.go:2018
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4263,15 +4263,15 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2678
+#: lxc/storage_volume.go:2684
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2477
+#: lxc/storage_volume.go:2483
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:336
+#: lxc/remote.go:378
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4279,7 +4279,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1412
+#: lxc/storage_volume.go:1418
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4292,7 +4292,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:693 lxc/storage_volume.go:1560
+#: lxc/info.go:693 lxc/storage_volume.go:1566
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4322,7 +4322,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1756
 msgid "POOL"
 msgstr ""
 
@@ -4338,15 +4338,15 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:213
+#: lxc/list.go:567 lxc/storage_volume.go:1762 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:817
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:752
+#: lxc/image.go:1136 lxc/remote.go:819
 msgid "PUBLIC"
 msgstr ""
 
@@ -4375,7 +4375,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:183
+#: lxc/remote.go:195
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4387,8 +4387,8 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:466
-msgid "Please type 'y', 'n' or the fingerprint:"
+#: lxc/remote.go:536
+msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
 #: lxc/info.go:221
@@ -4412,8 +4412,8 @@ msgstr ""
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1151
-#: lxc/storage_volume.go:1183
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
+#: lxc/storage_volume.go:1189
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4530,7 +4530,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1350
+#: lxc/storage_volume.go:1356
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4544,7 +4544,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1219
+#: lxc/storage_volume.go:1225
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4560,7 +4560,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2224
+#: lxc/storage_volume.go:2230
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4581,7 +4581,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:998
+#: lxc/storage_volume.go:1004
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4590,7 +4590,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2069
+#: lxc/storage_volume.go:2075
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4603,7 +4603,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2345
+#: lxc/storage_volume.go:2351
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4707,33 +4707,33 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:810
+#: lxc/remote.go:877
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
-#: lxc/remote.go:994
+#: lxc/project.go:884 lxc/remote.go:868 lxc/remote.go:949 lxc/remote.go:1013
+#: lxc/remote.go:1061
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:305
+#: lxc/remote.go:345
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:890
+#: lxc/remote.go:957
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:805 lxc/remote.go:886 lxc/remote.go:998
+#: lxc/remote.go:872 lxc/remote.go:953 lxc/remote.go:1065
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:294
+#: lxc/remote.go:319
 msgid "Remote address must not be empty"
 msgstr ""
 
@@ -4741,7 +4741,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:299
+#: lxc/remote.go:339
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4827,7 +4827,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:852 lxc/remote.go:853
+#: lxc/remote.go:919 lxc/remote.go:920
 msgid "Remove remotes"
 msgstr ""
 
@@ -4884,19 +4884,19 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:771 lxc/remote.go:772
+#: lxc/remote.go:838 lxc/remote.go:839
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:1943
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1936
+#: lxc/storage_volume.go:1942
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2025 lxc/storage_volume.go:2045
+#: lxc/storage_volume.go:2031 lxc/storage_volume.go:2051
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4948,7 +4948,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2540 lxc/storage_volume.go:2541
+#: lxc/storage_volume.go:2546 lxc/storage_volume.go:2547
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5029,7 +5029,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:820
 msgid "STATIC"
 msgstr ""
 
@@ -5070,11 +5070,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:464
+#: lxc/remote.go:532
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:616
+#: lxc/remote.go:285 lxc/remote.go:683
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5272,11 +5272,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2063
+#: lxc/storage_volume.go:2069
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2064
+#: lxc/storage_volume.go:2070
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5285,7 +5285,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:964 lxc/remote.go:965
+#: lxc/remote.go:1031 lxc/remote.go:1032
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5361,7 +5361,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2080
+#: lxc/storage_volume.go:2086
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5510,11 +5510,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2221 lxc/storage_volume.go:2222
+#: lxc/storage_volume.go:2227 lxc/storage_volume.go:2228
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1347 lxc/storage_volume.go:1348
+#: lxc/storage_volume.go:1353 lxc/storage_volume.go:1354
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5528,7 +5528,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:647 lxc/remote.go:648
+#: lxc/remote.go:714 lxc/remote.go:715
 msgid "Show the default remote"
 msgstr ""
 
@@ -5582,15 +5582,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2404 lxc/storage_volume.go:2405
+#: lxc/storage_volume.go:2410 lxc/storage_volume.go:2411
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2167
+#: lxc/storage_volume.go:2173
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:607 lxc/storage_volume.go:1485
+#: lxc/info.go:607 lxc/storage_volume.go:1491
 msgid "Snapshots:"
 msgstr ""
 
@@ -5691,21 +5691,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:696
+#: lxc/storage_volume.go:702
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:784
+#: lxc/storage_volume.go:790
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:509
+#: lxc/storage_volume.go:515
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:513
+#: lxc/storage_volume.go:519
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5740,7 +5740,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:916 lxc/remote.go:917
+#: lxc/remote.go:983 lxc/remote.go:984
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5759,11 +5759,11 @@ msgstr ""
 #: lxc/auth.go:818 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
-#: lxc/storage_volume.go:1730 lxc/warning.go:216
+#: lxc/storage_volume.go:1736 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1557
+#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1563
 msgid "Taken at"
 msgstr ""
 
@@ -5773,6 +5773,12 @@ msgstr ""
 
 #: lxc/file.go:1256
 msgid "Target path must be a directory"
+msgstr ""
+
+#: lxc/remote.go:161 lxc/remote.go:334
+msgid ""
+"The --accept-certificate flag is not supported when adding a remote using a "
+"trust token"
 msgstr ""
 
 #: lxc/move.go:181
@@ -5914,15 +5920,20 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1323
+#: lxc/storage_volume.go:1329
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1300
+#: lxc/storage_volume.go:1306
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
+msgstr ""
+
+#: lxc/remote.go:527
+msgid ""
+"The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
 
 #: lxc/info.go:354
@@ -5933,8 +5944,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:875
-#: lxc/storage_volume.go:972
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:881
+#: lxc/storage_volume.go:978
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6009,7 +6020,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1470
+#: lxc/storage_volume.go:1476
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6024,7 +6035,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1847
+#: lxc/storage_volume.go:1853
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6058,7 +6069,15 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:571
+#: lxc/remote.go:329
+msgid "Trust token cannot be used for public remotes"
+msgstr ""
+
+#: lxc/remote.go:324
+msgid "Trust token cannot be used with OIDC authentication"
+msgstr ""
+
+#: lxc/remote.go:639
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6083,7 +6102,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1455
+#: lxc/storage_volume.go:1461
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6101,17 +6120,17 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:193 lxc/remote.go:749
+#: lxc/cluster.go:193 lxc/remote.go:816
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1735
+#: lxc/project.go:995 lxc/storage_volume.go:1741
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1734
+#: lxc/storage.go:724 lxc/storage_volume.go:1740
 msgid "USED BY"
 msgstr ""
 
@@ -6129,7 +6148,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:214 lxc/remote.go:248
+#: lxc/remote.go:226 lxc/remote.go:260
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6143,7 +6162,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1772
+#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1778
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6249,7 +6268,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2342 lxc/storage_volume.go:2343
+#: lxc/storage_volume.go:2348 lxc/storage_volume.go:2349
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6301,7 +6320,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2356
+#: lxc/storage_volume.go:2362
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6345,12 +6364,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1468
+#: lxc/storage_volume.go:1474
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2629
+#: lxc/export.go:42 lxc/storage_volume.go:2635
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6417,7 +6436,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1559
+#: lxc/storage_volume.go:1565
 msgid "Volume Only"
 msgstr ""
 
@@ -6452,7 +6471,7 @@ msgstr ""
 
 #: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
+#: lxc/project.go:552 lxc/remote.go:777 lxc/remote.go:782 lxc/remote.go:787
 msgid "YES"
 msgstr ""
 
@@ -6476,7 +6495,7 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:897
+#: lxc/storage_volume.go:903
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
@@ -6898,7 +6917,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2788
+#: lxc/storage_volume.go:2794
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -6933,13 +6952,13 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:1941
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:799
+#: lxc/storage_volume.go:805
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
@@ -6947,47 +6966,47 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2539
+#: lxc/storage_volume.go:2545
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2622
+#: lxc/storage_volume.go:2628
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2403
+#: lxc/storage_volume.go:2409
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:603
+#: lxc/storage_volume.go:609
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:711
+#: lxc/storage_volume.go:717
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:994 lxc/storage_volume.go:1346
+#: lxc/storage_volume.go:1000 lxc/storage_volume.go:1352
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2341
+#: lxc/storage_volume.go:2347
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2062
+#: lxc/storage_volume.go:2068
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2220
+#: lxc/storage_volume.go:2226
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1215
+#: lxc/storage_volume.go:1221
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1841
+#: lxc/storage_volume.go:1847
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7097,7 +7116,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1584
+#: lxc/storage_volume.go:1590
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7109,7 +7128,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:739
+#: lxc/project.go:557 lxc/remote.go:806
 msgid "current"
 msgstr ""
 
@@ -7569,7 +7588,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:607
+#: lxc/storage_volume.go:613
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7577,13 +7596,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2792
+#: lxc/storage_volume.go:2798
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2407
+#: lxc/storage_volume.go:2413
 msgid ""
 "lxc storage volume snapshot create default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7593,7 +7612,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:531
 msgid "n"
 msgstr ""
 
@@ -7605,7 +7624,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:510
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7642,7 +7661,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:465
+#: lxc/remote.go:519
 msgid "y"
 msgstr ""
 

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-08 07:43+0100\n"
+"POT-Creation-Date: 2024-10-14 13:30+0000\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/linux-containers/"
@@ -72,7 +72,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/storage_volume.go:1024
+#: lxc/storage_volume.go:1030
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
@@ -777,15 +777,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:850 lxc/remote.go:915
+#: lxc/remote.go:917 lxc/remote.go:982
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:963
+#: lxc/remote.go:1030
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:769
+#: lxc/remote.go:836
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -818,7 +818,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:751
+#: lxc/remote.go:818
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -967,7 +967,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:581
+#: lxc/remote.go:648
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -1000,11 +1000,11 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1590
+#: lxc/storage_volume.go:1596
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:182
+#: lxc/remote.go:194
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -1075,7 +1075,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:552
+#: lxc/remote.go:621
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -1111,16 +1111,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2696
+#: lxc/storage_volume.go:2702
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2773
+#: lxc/export.go:192 lxc/storage_volume.go:2779
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:654 lxc/storage_volume.go:1521
+#: lxc/info.go:654 lxc/storage_volume.go:1527
 msgid "Backups:"
 msgstr ""
 
@@ -1141,7 +1141,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:679
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:685
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -1184,7 +1184,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1733
+#: lxc/storage_volume.go:1739
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1253,7 +1253,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:894
+#: lxc/remote.go:961
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1269,7 +1269,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1749 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1286,12 +1286,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:486
+#: lxc/storage_volume.go:492
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:440
+#: lxc/storage_volume.go:446
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1319,11 +1319,11 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:509
 msgid "Certificate fingerprint"
 msgstr ""
 
-#: lxc/remote.go:219
+#: lxc/remote.go:231
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
@@ -1338,7 +1338,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:620
+#: lxc/remote.go:687
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1412,13 +1412,13 @@ msgstr ""
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
 #: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
-#: lxc/storage_volume.go:612 lxc/storage_volume.go:717
-#: lxc/storage_volume.go:1005 lxc/storage_volume.go:1231
-#: lxc/storage_volume.go:1360 lxc/storage_volume.go:1848
-#: lxc/storage_volume.go:1940 lxc/storage_volume.go:2079
-#: lxc/storage_volume.go:2239 lxc/storage_volume.go:2355
-#: lxc/storage_volume.go:2416 lxc/storage_volume.go:2543
-#: lxc/storage_volume.go:2631 lxc/storage_volume.go:2795
+#: lxc/storage_volume.go:618 lxc/storage_volume.go:723
+#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1237
+#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1854
+#: lxc/storage_volume.go:1946 lxc/storage_volume.go:2085
+#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2361
+#: lxc/storage_volume.go:2422 lxc/storage_volume.go:2549
+#: lxc/storage_volume.go:2637 lxc/storage_volume.go:2801
 msgid "Cluster member name"
 msgstr ""
 
@@ -1434,7 +1434,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1589
+#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1595
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1478,17 +1478,17 @@ msgstr ""
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1150
-#: lxc/storage_volume.go:1182
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
+#: lxc/storage_volume.go:1188
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:613
+#: lxc/storage_volume.go:619
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1467
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1572,7 +1572,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:508
+#: lxc/storage_volume.go:514
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1586,12 +1586,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:490
+#: lxc/remote.go:559
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:225 lxc/remote.go:474
+#: lxc/remote.go:237 lxc/remote.go:543
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1630,7 +1630,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:485
+#: lxc/remote.go:554
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1699,7 +1699,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:604 lxc/storage_volume.go:605
+#: lxc/storage_volume.go:610 lxc/storage_volume.go:611
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1751,7 +1751,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1475
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1481
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1786,7 +1786,7 @@ msgstr ""
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1732
+#: lxc/storage_volume.go:1738
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1806,7 +1806,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2630
+#: lxc/storage_volume.go:2636
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1902,7 +1902,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:713 lxc/storage_volume.go:714
+#: lxc/storage_volume.go:719 lxc/storage_volume.go:720
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1994,9 +1994,9 @@ msgstr ""
 #: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
 #: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
 #: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:648
-#: lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853 lxc/remote.go:917
-#: lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:715
+#: lxc/remote.go:753 lxc/remote.go:839 lxc/remote.go:920 lxc/remote.go:984
+#: lxc/remote.go:1032 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -2008,26 +2008,26 @@ msgstr ""
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
 #: lxc/storage_volume.go:169 lxc/storage_volume.go:283
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:605
-#: lxc/storage_volume.go:714 lxc/storage_volume.go:801
-#: lxc/storage_volume.go:899 lxc/storage_volume.go:996
-#: lxc/storage_volume.go:1217 lxc/storage_volume.go:1348
-#: lxc/storage_volume.go:1507 lxc/storage_volume.go:1591
-#: lxc/storage_volume.go:1844 lxc/storage_volume.go:1937
-#: lxc/storage_volume.go:2064 lxc/storage_volume.go:2222
-#: lxc/storage_volume.go:2343 lxc/storage_volume.go:2405
-#: lxc/storage_volume.go:2541 lxc/storage_volume.go:2624
-#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:611
+#: lxc/storage_volume.go:720 lxc/storage_volume.go:807
+#: lxc/storage_volume.go:905 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:1223 lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1513 lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1850 lxc/storage_volume.go:1943
+#: lxc/storage_volume.go:2070 lxc/storage_volume.go:2228
+#: lxc/storage_volume.go:2349 lxc/storage_volume.go:2411
+#: lxc/storage_volume.go:2547 lxc/storage_volume.go:2630
+#: lxc/storage_volume.go:2796 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1448
+#: lxc/storage_volume.go:1454
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:1849
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:1855
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -2039,11 +2039,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:800 lxc/storage_volume.go:801
+#: lxc/storage_volume.go:806 lxc/storage_volume.go:807
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:898 lxc/storage_volume.go:899
+#: lxc/storage_volume.go:904 lxc/storage_volume.go:905
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -2269,7 +2269,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:995 lxc/storage_volume.go:996
+#: lxc/storage_volume.go:1001 lxc/storage_volume.go:1002
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2277,7 +2277,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1766
+#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1772
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2334,7 +2334,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2193
+#: lxc/storage_volume.go:2161 lxc/storage_volume.go:2199
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2348,8 +2348,8 @@ msgstr ""
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2149
-#: lxc/storage_volume.go:2187
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2155
+#: lxc/storage_volume.go:2193
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2391,8 +2391,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1508
-#: lxc/storage_volume.go:1558
+#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1514
+#: lxc/storage_volume.go:1564
 msgid "Expires at"
 msgstr ""
 
@@ -2416,7 +2416,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2623 lxc/storage_volume.go:2624
+#: lxc/storage_volume.go:2629 lxc/storage_volume.go:2630
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2428,11 +2428,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2627
+#: lxc/storage_volume.go:2633
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2756
+#: lxc/export.go:152 lxc/storage_volume.go:2762
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2549,11 +2549,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:191
+#: lxc/remote.go:203
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:242
+#: lxc/remote.go:254
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2563,7 +2563,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:232
+#: lxc/remote.go:244
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2573,12 +2573,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:260
+#: lxc/remote.go:486
 #, c-format
-msgid "Failed to create certificate: %w"
+msgid "Failed to decode trust token: %w"
 msgstr ""
 
-#: lxc/remote.go:267
+#: lxc/remote.go:292
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2603,7 +2603,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:237
+#: lxc/remote.go:249
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2690,9 +2690,9 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:690 lxc/storage.go:657
+#: lxc/project.go:919 lxc/remote.go:757 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1608 lxc/warning.go:94
+#: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2728,7 +2728,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:754
+#: lxc/remote.go:821
 msgid "GLOBAL"
 msgstr ""
 
@@ -2748,7 +2748,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:160 lxc/remote.go:401
+#: lxc/remote.go:165 lxc/remote.go:443
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2816,7 +2816,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1238
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2880,11 +2880,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1216 lxc/storage_volume.go:1217
+#: lxc/storage_volume.go:1222 lxc/storage_volume.go:1223
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:469
+#: lxc/storage_volume.go:475
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -3008,7 +3008,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2415
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2421
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -3022,7 +3022,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2414
+#: lxc/storage_volume.go:2420
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -3072,7 +3072,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2790
+#: lxc/storage_volume.go:2796
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -3080,7 +3080,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2789
+#: lxc/storage_volume.go:2795
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -3102,11 +3102,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2797
+#: lxc/storage_volume.go:2803
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2871
+#: lxc/storage_volume.go:2877
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3172,7 +3172,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:353
+#: lxc/remote.go:395
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3232,7 +3232,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2000
+#: lxc/move.go:148 lxc/storage_volume.go:2006
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -3240,7 +3240,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1996
+#: lxc/storage_volume.go:2002
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3253,14 +3253,14 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:342
+#: lxc/remote.go:384
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1064 lxc/storage_volume.go:1281
-#: lxc/storage_volume.go:1405 lxc/storage_volume.go:1985
-#: lxc/storage_volume.go:2132 lxc/storage_volume.go:2284
+#: lxc/storage_volume.go:1070 lxc/storage_volume.go:1287
+#: lxc/storage_volume.go:1411 lxc/storage_volume.go:1991
+#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2290
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3306,7 +3306,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1739 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1745 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3609,11 +3609,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1586
+#: lxc/storage_volume.go:1592
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1597
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3633,7 +3633,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:685 lxc/remote.go:686
+#: lxc/remote.go:752 lxc/remote.go:753
 msgid "List the available remotes"
 msgstr ""
 
@@ -3672,7 +3672,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1464
+#: lxc/info.go:489 lxc/storage_volume.go:1470
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -4136,12 +4136,12 @@ msgstr ""
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:323 lxc/storage_volume.go:643
-#: lxc/storage_volume.go:750 lxc/storage_volume.go:841
-#: lxc/storage_volume.go:939 lxc/storage_volume.go:1053
-#: lxc/storage_volume.go:1270 lxc/storage_volume.go:1974
-#: lxc/storage_volume.go:2115 lxc/storage_volume.go:2273
-#: lxc/storage_volume.go:2464 lxc/storage_volume.go:2581
+#: lxc/storage_volume.go:323 lxc/storage_volume.go:649
+#: lxc/storage_volume.go:756 lxc/storage_volume.go:847
+#: lxc/storage_volume.go:945 lxc/storage_volume.go:1059
+#: lxc/storage_volume.go:1276 lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:2121 lxc/storage_volume.go:2279
+#: lxc/storage_volume.go:2470 lxc/storage_volume.go:2587
 msgid "Missing pool name"
 msgstr ""
 
@@ -4160,11 +4160,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:432 lxc/storage_volume.go:1884
+#: lxc/storage_volume.go:438 lxc/storage_volume.go:1890
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1394
+#: lxc/storage_volume.go:1400
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -4201,8 +4201,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:861
-#: lxc/storage_volume.go:958
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:867
+#: lxc/storage_volume.go:964
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4239,7 +4239,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1843 lxc/storage_volume.go:1844
+#: lxc/storage_volume.go:1849 lxc/storage_volume.go:1850
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4247,11 +4247,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1850
+#: lxc/storage_volume.go:1856
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:512
+#: lxc/storage_volume.go:518
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4277,8 +4277,8 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
-#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1731
+#: lxc/remote.go:815 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
 msgstr ""
 
@@ -4304,7 +4304,7 @@ msgstr ""
 
 #: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
+#: lxc/project.go:550 lxc/remote.go:775 lxc/remote.go:780 lxc/remote.go:785
 msgid "NO"
 msgstr ""
 
@@ -4326,8 +4326,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1506
-#: lxc/storage_volume.go:1556
+#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1512
+#: lxc/storage_volume.go:1562
 msgid "Name"
 msgstr ""
 
@@ -4335,7 +4335,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1446
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1452
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4479,7 +4479,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:870 lxc/storage_volume.go:967
+#: lxc/storage_volume.go:876 lxc/storage_volume.go:973
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4495,11 +4495,11 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/storage_volume.go:446 lxc/storage_volume.go:1893
+#: lxc/storage_volume.go:452 lxc/storage_volume.go:1899
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:496 lxc/storage_volume.go:1904
+#: lxc/storage_volume.go:502 lxc/storage_volume.go:1910
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4513,7 +4513,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2012
+#: lxc/storage_volume.go:2018
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4525,15 +4525,15 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2678
+#: lxc/storage_volume.go:2684
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2477
+#: lxc/storage_volume.go:2483
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:336
+#: lxc/remote.go:378
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4541,7 +4541,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1412
+#: lxc/storage_volume.go:1418
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4554,7 +4554,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:693 lxc/storage_volume.go:1560
+#: lxc/info.go:693 lxc/storage_volume.go:1566
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4584,7 +4584,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1756
 msgid "POOL"
 msgstr ""
 
@@ -4600,15 +4600,15 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:213
+#: lxc/list.go:567 lxc/storage_volume.go:1762 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:817
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:752
+#: lxc/image.go:1136 lxc/remote.go:819
 msgid "PUBLIC"
 msgstr ""
 
@@ -4637,7 +4637,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:183
+#: lxc/remote.go:195
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4649,8 +4649,8 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:466
-msgid "Please type 'y', 'n' or the fingerprint:"
+#: lxc/remote.go:536
+msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
 #: lxc/info.go:221
@@ -4674,8 +4674,8 @@ msgstr ""
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1151
-#: lxc/storage_volume.go:1183
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
+#: lxc/storage_volume.go:1189
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4792,7 +4792,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1350
+#: lxc/storage_volume.go:1356
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4806,7 +4806,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1219
+#: lxc/storage_volume.go:1225
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4822,7 +4822,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2224
+#: lxc/storage_volume.go:2230
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4843,7 +4843,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:998
+#: lxc/storage_volume.go:1004
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4852,7 +4852,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2069
+#: lxc/storage_volume.go:2075
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4865,7 +4865,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2345
+#: lxc/storage_volume.go:2351
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4969,33 +4969,33 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:810
+#: lxc/remote.go:877
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
-#: lxc/remote.go:994
+#: lxc/project.go:884 lxc/remote.go:868 lxc/remote.go:949 lxc/remote.go:1013
+#: lxc/remote.go:1061
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:305
+#: lxc/remote.go:345
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:890
+#: lxc/remote.go:957
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:805 lxc/remote.go:886 lxc/remote.go:998
+#: lxc/remote.go:872 lxc/remote.go:953 lxc/remote.go:1065
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:294
+#: lxc/remote.go:319
 msgid "Remote address must not be empty"
 msgstr ""
 
@@ -5003,7 +5003,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:299
+#: lxc/remote.go:339
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -5089,7 +5089,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:852 lxc/remote.go:853
+#: lxc/remote.go:919 lxc/remote.go:920
 msgid "Remove remotes"
 msgstr ""
 
@@ -5146,19 +5146,19 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:771 lxc/remote.go:772
+#: lxc/remote.go:838 lxc/remote.go:839
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:1943
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1936
+#: lxc/storage_volume.go:1942
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2025 lxc/storage_volume.go:2045
+#: lxc/storage_volume.go:2031 lxc/storage_volume.go:2051
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5210,7 +5210,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2540 lxc/storage_volume.go:2541
+#: lxc/storage_volume.go:2546 lxc/storage_volume.go:2547
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5291,7 +5291,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:820
 msgid "STATIC"
 msgstr ""
 
@@ -5332,11 +5332,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:464
+#: lxc/remote.go:532
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:616
+#: lxc/remote.go:285 lxc/remote.go:683
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5534,11 +5534,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2063
+#: lxc/storage_volume.go:2069
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2064
+#: lxc/storage_volume.go:2070
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5547,7 +5547,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:964 lxc/remote.go:965
+#: lxc/remote.go:1031 lxc/remote.go:1032
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5623,7 +5623,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2080
+#: lxc/storage_volume.go:2086
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5772,11 +5772,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2221 lxc/storage_volume.go:2222
+#: lxc/storage_volume.go:2227 lxc/storage_volume.go:2228
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1347 lxc/storage_volume.go:1348
+#: lxc/storage_volume.go:1353 lxc/storage_volume.go:1354
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5790,7 +5790,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:647 lxc/remote.go:648
+#: lxc/remote.go:714 lxc/remote.go:715
 msgid "Show the default remote"
 msgstr ""
 
@@ -5844,15 +5844,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2404 lxc/storage_volume.go:2405
+#: lxc/storage_volume.go:2410 lxc/storage_volume.go:2411
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2167
+#: lxc/storage_volume.go:2173
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:607 lxc/storage_volume.go:1485
+#: lxc/info.go:607 lxc/storage_volume.go:1491
 msgid "Snapshots:"
 msgstr ""
 
@@ -5953,21 +5953,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:696
+#: lxc/storage_volume.go:702
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:784
+#: lxc/storage_volume.go:790
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:509
+#: lxc/storage_volume.go:515
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:513
+#: lxc/storage_volume.go:519
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -6002,7 +6002,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:916 lxc/remote.go:917
+#: lxc/remote.go:983 lxc/remote.go:984
 msgid "Switch the default remote"
 msgstr ""
 
@@ -6021,11 +6021,11 @@ msgstr ""
 #: lxc/auth.go:818 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
-#: lxc/storage_volume.go:1730 lxc/warning.go:216
+#: lxc/storage_volume.go:1736 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1557
+#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1563
 msgid "Taken at"
 msgstr ""
 
@@ -6035,6 +6035,12 @@ msgstr ""
 
 #: lxc/file.go:1256
 msgid "Target path must be a directory"
+msgstr ""
+
+#: lxc/remote.go:161 lxc/remote.go:334
+msgid ""
+"The --accept-certificate flag is not supported when adding a remote using a "
+"trust token"
 msgstr ""
 
 #: lxc/move.go:181
@@ -6176,15 +6182,20 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1323
+#: lxc/storage_volume.go:1329
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1300
+#: lxc/storage_volume.go:1306
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
+msgstr ""
+
+#: lxc/remote.go:527
+msgid ""
+"The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
 
 #: lxc/info.go:354
@@ -6195,8 +6206,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:875
-#: lxc/storage_volume.go:972
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:881
+#: lxc/storage_volume.go:978
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6271,7 +6282,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1470
+#: lxc/storage_volume.go:1476
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6286,7 +6297,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1847
+#: lxc/storage_volume.go:1853
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6320,7 +6331,15 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:571
+#: lxc/remote.go:329
+msgid "Trust token cannot be used for public remotes"
+msgstr ""
+
+#: lxc/remote.go:324
+msgid "Trust token cannot be used with OIDC authentication"
+msgstr ""
+
+#: lxc/remote.go:639
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6345,7 +6364,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1455
+#: lxc/storage_volume.go:1461
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6363,17 +6382,17 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:193 lxc/remote.go:749
+#: lxc/cluster.go:193 lxc/remote.go:816
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1735
+#: lxc/project.go:995 lxc/storage_volume.go:1741
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1734
+#: lxc/storage.go:724 lxc/storage_volume.go:1740
 msgid "USED BY"
 msgstr ""
 
@@ -6391,7 +6410,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:214 lxc/remote.go:248
+#: lxc/remote.go:226 lxc/remote.go:260
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6405,7 +6424,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1772
+#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1778
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6511,7 +6530,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2342 lxc/storage_volume.go:2343
+#: lxc/storage_volume.go:2348 lxc/storage_volume.go:2349
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6563,7 +6582,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2356
+#: lxc/storage_volume.go:2362
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6607,12 +6626,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1468
+#: lxc/storage_volume.go:1474
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2629
+#: lxc/export.go:42 lxc/storage_volume.go:2635
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6679,7 +6698,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1559
+#: lxc/storage_volume.go:1565
 msgid "Volume Only"
 msgstr ""
 
@@ -6714,7 +6733,7 @@ msgstr ""
 
 #: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
+#: lxc/project.go:552 lxc/remote.go:777 lxc/remote.go:782 lxc/remote.go:787
 msgid "YES"
 msgstr ""
 
@@ -6738,7 +6757,7 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:897
+#: lxc/storage_volume.go:903
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
@@ -7160,7 +7179,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2788
+#: lxc/storage_volume.go:2794
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7195,13 +7214,13 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:1941
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:799
+#: lxc/storage_volume.go:805
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
@@ -7209,47 +7228,47 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2539
+#: lxc/storage_volume.go:2545
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2622
+#: lxc/storage_volume.go:2628
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2403
+#: lxc/storage_volume.go:2409
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:603
+#: lxc/storage_volume.go:609
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:711
+#: lxc/storage_volume.go:717
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:994 lxc/storage_volume.go:1346
+#: lxc/storage_volume.go:1000 lxc/storage_volume.go:1352
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2341
+#: lxc/storage_volume.go:2347
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2062
+#: lxc/storage_volume.go:2068
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2220
+#: lxc/storage_volume.go:2226
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1215
+#: lxc/storage_volume.go:1221
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1841
+#: lxc/storage_volume.go:1847
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7359,7 +7378,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1584
+#: lxc/storage_volume.go:1590
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7371,7 +7390,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:739
+#: lxc/project.go:557 lxc/remote.go:806
 msgid "current"
 msgstr ""
 
@@ -7831,7 +7850,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:607
+#: lxc/storage_volume.go:613
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7839,13 +7858,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2792
+#: lxc/storage_volume.go:2798
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2407
+#: lxc/storage_volume.go:2413
 msgid ""
 "lxc storage volume snapshot create default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7855,7 +7874,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:531
 msgid "n"
 msgstr ""
 
@@ -7867,7 +7886,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:510
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7904,7 +7923,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:465
+#: lxc/remote.go:519
 msgid "y"
 msgstr ""
 

--- a/po/pt.po
+++ b/po/pt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-08 07:43+0100\n"
+"POT-Creation-Date: 2024-10-14 13:30+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -46,7 +46,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1024
+#: lxc/storage_volume.go:1030
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -512,15 +512,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:850 lxc/remote.go:915
+#: lxc/remote.go:917 lxc/remote.go:982
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:963
+#: lxc/remote.go:1030
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:769
+#: lxc/remote.go:836
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -553,7 +553,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:751
+#: lxc/remote.go:818
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -702,7 +702,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:581
+#: lxc/remote.go:648
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -735,11 +735,11 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1590
+#: lxc/storage_volume.go:1596
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:182
+#: lxc/remote.go:194
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -810,7 +810,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:552
+#: lxc/remote.go:621
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -846,16 +846,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2696
+#: lxc/storage_volume.go:2702
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2773
+#: lxc/export.go:192 lxc/storage_volume.go:2779
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:654 lxc/storage_volume.go:1521
+#: lxc/info.go:654 lxc/storage_volume.go:1527
 msgid "Backups:"
 msgstr ""
 
@@ -876,7 +876,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:679
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:685
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -919,7 +919,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1733
+#: lxc/storage_volume.go:1739
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -988,7 +988,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:894
+#: lxc/remote.go:961
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1004,7 +1004,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1749 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1021,12 +1021,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:486
+#: lxc/storage_volume.go:492
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:440
+#: lxc/storage_volume.go:446
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1054,11 +1054,11 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:509
 msgid "Certificate fingerprint"
 msgstr ""
 
-#: lxc/remote.go:219
+#: lxc/remote.go:231
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
@@ -1073,7 +1073,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:620
+#: lxc/remote.go:687
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1147,13 +1147,13 @@ msgstr ""
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
 #: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
-#: lxc/storage_volume.go:612 lxc/storage_volume.go:717
-#: lxc/storage_volume.go:1005 lxc/storage_volume.go:1231
-#: lxc/storage_volume.go:1360 lxc/storage_volume.go:1848
-#: lxc/storage_volume.go:1940 lxc/storage_volume.go:2079
-#: lxc/storage_volume.go:2239 lxc/storage_volume.go:2355
-#: lxc/storage_volume.go:2416 lxc/storage_volume.go:2543
-#: lxc/storage_volume.go:2631 lxc/storage_volume.go:2795
+#: lxc/storage_volume.go:618 lxc/storage_volume.go:723
+#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1237
+#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1854
+#: lxc/storage_volume.go:1946 lxc/storage_volume.go:2085
+#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2361
+#: lxc/storage_volume.go:2422 lxc/storage_volume.go:2549
+#: lxc/storage_volume.go:2637 lxc/storage_volume.go:2801
 msgid "Cluster member name"
 msgstr ""
 
@@ -1169,7 +1169,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1589
+#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1595
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1213,17 +1213,17 @@ msgstr ""
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1150
-#: lxc/storage_volume.go:1182
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
+#: lxc/storage_volume.go:1188
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:613
+#: lxc/storage_volume.go:619
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1467
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1307,7 +1307,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:508
+#: lxc/storage_volume.go:514
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1321,12 +1321,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:490
+#: lxc/remote.go:559
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:225 lxc/remote.go:474
+#: lxc/remote.go:237 lxc/remote.go:543
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1365,7 +1365,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:485
+#: lxc/remote.go:554
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1434,7 +1434,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:604 lxc/storage_volume.go:605
+#: lxc/storage_volume.go:610 lxc/storage_volume.go:611
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1486,7 +1486,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1475
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1481
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1521,7 +1521,7 @@ msgstr ""
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1732
+#: lxc/storage_volume.go:1738
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1541,7 +1541,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2630
+#: lxc/storage_volume.go:2636
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1637,7 +1637,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:713 lxc/storage_volume.go:714
+#: lxc/storage_volume.go:719 lxc/storage_volume.go:720
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1729,9 +1729,9 @@ msgstr ""
 #: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
 #: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
 #: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:648
-#: lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853 lxc/remote.go:917
-#: lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:715
+#: lxc/remote.go:753 lxc/remote.go:839 lxc/remote.go:920 lxc/remote.go:984
+#: lxc/remote.go:1032 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1743,26 +1743,26 @@ msgstr ""
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
 #: lxc/storage_volume.go:169 lxc/storage_volume.go:283
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:605
-#: lxc/storage_volume.go:714 lxc/storage_volume.go:801
-#: lxc/storage_volume.go:899 lxc/storage_volume.go:996
-#: lxc/storage_volume.go:1217 lxc/storage_volume.go:1348
-#: lxc/storage_volume.go:1507 lxc/storage_volume.go:1591
-#: lxc/storage_volume.go:1844 lxc/storage_volume.go:1937
-#: lxc/storage_volume.go:2064 lxc/storage_volume.go:2222
-#: lxc/storage_volume.go:2343 lxc/storage_volume.go:2405
-#: lxc/storage_volume.go:2541 lxc/storage_volume.go:2624
-#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:611
+#: lxc/storage_volume.go:720 lxc/storage_volume.go:807
+#: lxc/storage_volume.go:905 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:1223 lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1513 lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1850 lxc/storage_volume.go:1943
+#: lxc/storage_volume.go:2070 lxc/storage_volume.go:2228
+#: lxc/storage_volume.go:2349 lxc/storage_volume.go:2411
+#: lxc/storage_volume.go:2547 lxc/storage_volume.go:2630
+#: lxc/storage_volume.go:2796 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1448
+#: lxc/storage_volume.go:1454
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:1849
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:1855
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1774,11 +1774,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:800 lxc/storage_volume.go:801
+#: lxc/storage_volume.go:806 lxc/storage_volume.go:807
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:898 lxc/storage_volume.go:899
+#: lxc/storage_volume.go:904 lxc/storage_volume.go:905
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -2004,7 +2004,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:995 lxc/storage_volume.go:996
+#: lxc/storage_volume.go:1001 lxc/storage_volume.go:1002
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2012,7 +2012,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1766
+#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1772
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2069,7 +2069,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2193
+#: lxc/storage_volume.go:2161 lxc/storage_volume.go:2199
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2083,8 +2083,8 @@ msgstr ""
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2149
-#: lxc/storage_volume.go:2187
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2155
+#: lxc/storage_volume.go:2193
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2126,8 +2126,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1508
-#: lxc/storage_volume.go:1558
+#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1514
+#: lxc/storage_volume.go:1564
 msgid "Expires at"
 msgstr ""
 
@@ -2151,7 +2151,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2623 lxc/storage_volume.go:2624
+#: lxc/storage_volume.go:2629 lxc/storage_volume.go:2630
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2163,11 +2163,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2627
+#: lxc/storage_volume.go:2633
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2756
+#: lxc/export.go:152 lxc/storage_volume.go:2762
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2284,11 +2284,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:191
+#: lxc/remote.go:203
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:242
+#: lxc/remote.go:254
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2298,7 +2298,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:232
+#: lxc/remote.go:244
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2308,12 +2308,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:260
+#: lxc/remote.go:486
 #, c-format
-msgid "Failed to create certificate: %w"
+msgid "Failed to decode trust token: %w"
 msgstr ""
 
-#: lxc/remote.go:267
+#: lxc/remote.go:292
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2338,7 +2338,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:237
+#: lxc/remote.go:249
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2425,9 +2425,9 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:690 lxc/storage.go:657
+#: lxc/project.go:919 lxc/remote.go:757 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1608 lxc/warning.go:94
+#: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2463,7 +2463,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:754
+#: lxc/remote.go:821
 msgid "GLOBAL"
 msgstr ""
 
@@ -2483,7 +2483,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:160 lxc/remote.go:401
+#: lxc/remote.go:165 lxc/remote.go:443
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2551,7 +2551,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1238
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2615,11 +2615,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1216 lxc/storage_volume.go:1217
+#: lxc/storage_volume.go:1222 lxc/storage_volume.go:1223
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:469
+#: lxc/storage_volume.go:475
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2743,7 +2743,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2415
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2421
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2757,7 +2757,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2414
+#: lxc/storage_volume.go:2420
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2807,7 +2807,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2790
+#: lxc/storage_volume.go:2796
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2815,7 +2815,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2789
+#: lxc/storage_volume.go:2795
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2837,11 +2837,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2797
+#: lxc/storage_volume.go:2803
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2871
+#: lxc/storage_volume.go:2877
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2907,7 +2907,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:353
+#: lxc/remote.go:395
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2967,7 +2967,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2000
+#: lxc/move.go:148 lxc/storage_volume.go:2006
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2975,7 +2975,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1996
+#: lxc/storage_volume.go:2002
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2988,14 +2988,14 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:342
+#: lxc/remote.go:384
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1064 lxc/storage_volume.go:1281
-#: lxc/storage_volume.go:1405 lxc/storage_volume.go:1985
-#: lxc/storage_volume.go:2132 lxc/storage_volume.go:2284
+#: lxc/storage_volume.go:1070 lxc/storage_volume.go:1287
+#: lxc/storage_volume.go:1411 lxc/storage_volume.go:1991
+#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2290
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3041,7 +3041,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1739 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1745 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3344,11 +3344,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1586
+#: lxc/storage_volume.go:1592
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1597
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3368,7 +3368,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:685 lxc/remote.go:686
+#: lxc/remote.go:752 lxc/remote.go:753
 msgid "List the available remotes"
 msgstr ""
 
@@ -3407,7 +3407,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1464
+#: lxc/info.go:489 lxc/storage_volume.go:1470
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3871,12 +3871,12 @@ msgstr ""
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:323 lxc/storage_volume.go:643
-#: lxc/storage_volume.go:750 lxc/storage_volume.go:841
-#: lxc/storage_volume.go:939 lxc/storage_volume.go:1053
-#: lxc/storage_volume.go:1270 lxc/storage_volume.go:1974
-#: lxc/storage_volume.go:2115 lxc/storage_volume.go:2273
-#: lxc/storage_volume.go:2464 lxc/storage_volume.go:2581
+#: lxc/storage_volume.go:323 lxc/storage_volume.go:649
+#: lxc/storage_volume.go:756 lxc/storage_volume.go:847
+#: lxc/storage_volume.go:945 lxc/storage_volume.go:1059
+#: lxc/storage_volume.go:1276 lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:2121 lxc/storage_volume.go:2279
+#: lxc/storage_volume.go:2470 lxc/storage_volume.go:2587
 msgid "Missing pool name"
 msgstr ""
 
@@ -3895,11 +3895,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:432 lxc/storage_volume.go:1884
+#: lxc/storage_volume.go:438 lxc/storage_volume.go:1890
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1394
+#: lxc/storage_volume.go:1400
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -3936,8 +3936,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:861
-#: lxc/storage_volume.go:958
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:867
+#: lxc/storage_volume.go:964
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -3974,7 +3974,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1843 lxc/storage_volume.go:1844
+#: lxc/storage_volume.go:1849 lxc/storage_volume.go:1850
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -3982,11 +3982,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1850
+#: lxc/storage_volume.go:1856
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:512
+#: lxc/storage_volume.go:518
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4012,8 +4012,8 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
-#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1731
+#: lxc/remote.go:815 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
 msgstr ""
 
@@ -4039,7 +4039,7 @@ msgstr ""
 
 #: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
+#: lxc/project.go:550 lxc/remote.go:775 lxc/remote.go:780 lxc/remote.go:785
 msgid "NO"
 msgstr ""
 
@@ -4061,8 +4061,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1506
-#: lxc/storage_volume.go:1556
+#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1512
+#: lxc/storage_volume.go:1562
 msgid "Name"
 msgstr ""
 
@@ -4070,7 +4070,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1446
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1452
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4214,7 +4214,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:870 lxc/storage_volume.go:967
+#: lxc/storage_volume.go:876 lxc/storage_volume.go:973
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4230,11 +4230,11 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/storage_volume.go:446 lxc/storage_volume.go:1893
+#: lxc/storage_volume.go:452 lxc/storage_volume.go:1899
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:496 lxc/storage_volume.go:1904
+#: lxc/storage_volume.go:502 lxc/storage_volume.go:1910
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4248,7 +4248,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2012
+#: lxc/storage_volume.go:2018
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4260,15 +4260,15 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2678
+#: lxc/storage_volume.go:2684
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2477
+#: lxc/storage_volume.go:2483
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:336
+#: lxc/remote.go:378
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4276,7 +4276,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1412
+#: lxc/storage_volume.go:1418
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4289,7 +4289,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:693 lxc/storage_volume.go:1560
+#: lxc/info.go:693 lxc/storage_volume.go:1566
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4319,7 +4319,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1756
 msgid "POOL"
 msgstr ""
 
@@ -4335,15 +4335,15 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:213
+#: lxc/list.go:567 lxc/storage_volume.go:1762 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:817
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:752
+#: lxc/image.go:1136 lxc/remote.go:819
 msgid "PUBLIC"
 msgstr ""
 
@@ -4372,7 +4372,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:183
+#: lxc/remote.go:195
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4384,8 +4384,8 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:466
-msgid "Please type 'y', 'n' or the fingerprint:"
+#: lxc/remote.go:536
+msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
 #: lxc/info.go:221
@@ -4409,8 +4409,8 @@ msgstr ""
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1151
-#: lxc/storage_volume.go:1183
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
+#: lxc/storage_volume.go:1189
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4527,7 +4527,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1350
+#: lxc/storage_volume.go:1356
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4541,7 +4541,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1219
+#: lxc/storage_volume.go:1225
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4557,7 +4557,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2224
+#: lxc/storage_volume.go:2230
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4578,7 +4578,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:998
+#: lxc/storage_volume.go:1004
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4587,7 +4587,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2069
+#: lxc/storage_volume.go:2075
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4600,7 +4600,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2345
+#: lxc/storage_volume.go:2351
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4704,33 +4704,33 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:810
+#: lxc/remote.go:877
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
-#: lxc/remote.go:994
+#: lxc/project.go:884 lxc/remote.go:868 lxc/remote.go:949 lxc/remote.go:1013
+#: lxc/remote.go:1061
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:305
+#: lxc/remote.go:345
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:890
+#: lxc/remote.go:957
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:805 lxc/remote.go:886 lxc/remote.go:998
+#: lxc/remote.go:872 lxc/remote.go:953 lxc/remote.go:1065
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:294
+#: lxc/remote.go:319
 msgid "Remote address must not be empty"
 msgstr ""
 
@@ -4738,7 +4738,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:299
+#: lxc/remote.go:339
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4824,7 +4824,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:852 lxc/remote.go:853
+#: lxc/remote.go:919 lxc/remote.go:920
 msgid "Remove remotes"
 msgstr ""
 
@@ -4881,19 +4881,19 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:771 lxc/remote.go:772
+#: lxc/remote.go:838 lxc/remote.go:839
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:1943
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1936
+#: lxc/storage_volume.go:1942
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2025 lxc/storage_volume.go:2045
+#: lxc/storage_volume.go:2031 lxc/storage_volume.go:2051
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4945,7 +4945,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2540 lxc/storage_volume.go:2541
+#: lxc/storage_volume.go:2546 lxc/storage_volume.go:2547
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5026,7 +5026,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:820
 msgid "STATIC"
 msgstr ""
 
@@ -5067,11 +5067,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:464
+#: lxc/remote.go:532
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:616
+#: lxc/remote.go:285 lxc/remote.go:683
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5269,11 +5269,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2063
+#: lxc/storage_volume.go:2069
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2064
+#: lxc/storage_volume.go:2070
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5282,7 +5282,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:964 lxc/remote.go:965
+#: lxc/remote.go:1031 lxc/remote.go:1032
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5358,7 +5358,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2080
+#: lxc/storage_volume.go:2086
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5507,11 +5507,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2221 lxc/storage_volume.go:2222
+#: lxc/storage_volume.go:2227 lxc/storage_volume.go:2228
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1347 lxc/storage_volume.go:1348
+#: lxc/storage_volume.go:1353 lxc/storage_volume.go:1354
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5525,7 +5525,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:647 lxc/remote.go:648
+#: lxc/remote.go:714 lxc/remote.go:715
 msgid "Show the default remote"
 msgstr ""
 
@@ -5579,15 +5579,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2404 lxc/storage_volume.go:2405
+#: lxc/storage_volume.go:2410 lxc/storage_volume.go:2411
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2167
+#: lxc/storage_volume.go:2173
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:607 lxc/storage_volume.go:1485
+#: lxc/info.go:607 lxc/storage_volume.go:1491
 msgid "Snapshots:"
 msgstr ""
 
@@ -5688,21 +5688,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:696
+#: lxc/storage_volume.go:702
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:784
+#: lxc/storage_volume.go:790
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:509
+#: lxc/storage_volume.go:515
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:513
+#: lxc/storage_volume.go:519
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5737,7 +5737,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:916 lxc/remote.go:917
+#: lxc/remote.go:983 lxc/remote.go:984
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5756,11 +5756,11 @@ msgstr ""
 #: lxc/auth.go:818 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
-#: lxc/storage_volume.go:1730 lxc/warning.go:216
+#: lxc/storage_volume.go:1736 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1557
+#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1563
 msgid "Taken at"
 msgstr ""
 
@@ -5770,6 +5770,12 @@ msgstr ""
 
 #: lxc/file.go:1256
 msgid "Target path must be a directory"
+msgstr ""
+
+#: lxc/remote.go:161 lxc/remote.go:334
+msgid ""
+"The --accept-certificate flag is not supported when adding a remote using a "
+"trust token"
 msgstr ""
 
 #: lxc/move.go:181
@@ -5911,15 +5917,20 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1323
+#: lxc/storage_volume.go:1329
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1300
+#: lxc/storage_volume.go:1306
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
+msgstr ""
+
+#: lxc/remote.go:527
+msgid ""
+"The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
 
 #: lxc/info.go:354
@@ -5930,8 +5941,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:875
-#: lxc/storage_volume.go:972
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:881
+#: lxc/storage_volume.go:978
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6006,7 +6017,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1470
+#: lxc/storage_volume.go:1476
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6021,7 +6032,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1847
+#: lxc/storage_volume.go:1853
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6055,7 +6066,15 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:571
+#: lxc/remote.go:329
+msgid "Trust token cannot be used for public remotes"
+msgstr ""
+
+#: lxc/remote.go:324
+msgid "Trust token cannot be used with OIDC authentication"
+msgstr ""
+
+#: lxc/remote.go:639
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6080,7 +6099,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1455
+#: lxc/storage_volume.go:1461
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6098,17 +6117,17 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:193 lxc/remote.go:749
+#: lxc/cluster.go:193 lxc/remote.go:816
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1735
+#: lxc/project.go:995 lxc/storage_volume.go:1741
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1734
+#: lxc/storage.go:724 lxc/storage_volume.go:1740
 msgid "USED BY"
 msgstr ""
 
@@ -6126,7 +6145,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:214 lxc/remote.go:248
+#: lxc/remote.go:226 lxc/remote.go:260
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6140,7 +6159,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1772
+#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1778
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6246,7 +6265,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2342 lxc/storage_volume.go:2343
+#: lxc/storage_volume.go:2348 lxc/storage_volume.go:2349
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6298,7 +6317,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2356
+#: lxc/storage_volume.go:2362
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6342,12 +6361,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1468
+#: lxc/storage_volume.go:1474
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2629
+#: lxc/export.go:42 lxc/storage_volume.go:2635
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6414,7 +6433,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1559
+#: lxc/storage_volume.go:1565
 msgid "Volume Only"
 msgstr ""
 
@@ -6449,7 +6468,7 @@ msgstr ""
 
 #: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
+#: lxc/project.go:552 lxc/remote.go:777 lxc/remote.go:782 lxc/remote.go:787
 msgid "YES"
 msgstr ""
 
@@ -6473,7 +6492,7 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:897
+#: lxc/storage_volume.go:903
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
@@ -6895,7 +6914,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2788
+#: lxc/storage_volume.go:2794
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -6930,13 +6949,13 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:1941
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:799
+#: lxc/storage_volume.go:805
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
@@ -6944,47 +6963,47 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2539
+#: lxc/storage_volume.go:2545
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2622
+#: lxc/storage_volume.go:2628
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2403
+#: lxc/storage_volume.go:2409
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:603
+#: lxc/storage_volume.go:609
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:711
+#: lxc/storage_volume.go:717
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:994 lxc/storage_volume.go:1346
+#: lxc/storage_volume.go:1000 lxc/storage_volume.go:1352
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2341
+#: lxc/storage_volume.go:2347
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2062
+#: lxc/storage_volume.go:2068
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2220
+#: lxc/storage_volume.go:2226
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1215
+#: lxc/storage_volume.go:1221
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1841
+#: lxc/storage_volume.go:1847
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7094,7 +7113,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1584
+#: lxc/storage_volume.go:1590
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7106,7 +7125,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:739
+#: lxc/project.go:557 lxc/remote.go:806
 msgid "current"
 msgstr ""
 
@@ -7566,7 +7585,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:607
+#: lxc/storage_volume.go:613
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7574,13 +7593,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2792
+#: lxc/storage_volume.go:2798
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2407
+#: lxc/storage_volume.go:2413
 msgid ""
 "lxc storage volume snapshot create default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7590,7 +7609,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:531
 msgid "n"
 msgstr ""
 
@@ -7602,7 +7621,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:510
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7639,7 +7658,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:465
+#: lxc/remote.go:519
 msgid "y"
 msgstr ""
 

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-08 07:43+0100\n"
+"POT-Creation-Date: 2024-10-14 13:30+0000\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Renato dos Santos <renato.santos@wplex.com.br>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -76,7 +76,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/storage_volume.go:1024
+#: lxc/storage_volume.go:1030
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
@@ -773,15 +773,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:850 lxc/remote.go:915
+#: lxc/remote.go:917 lxc/remote.go:982
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:963
+#: lxc/remote.go:1030
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:769
+#: lxc/remote.go:836
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -815,7 +815,7 @@ msgstr "ALIASES"
 msgid "ARCHITECTURE"
 msgstr "ARQUITETURA"
 
-#: lxc/remote.go:751
+#: lxc/remote.go:818
 msgid "AUTH TYPE"
 msgstr "TIPO DE AUTENTICAÇÃO"
 
@@ -972,7 +972,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr "Senha de administrador para %s: "
 
-#: lxc/remote.go:581
+#: lxc/remote.go:648
 #, fuzzy, c-format
 msgid "Admin password (or token) for %s:"
 msgstr "Senha de administrador para %s: "
@@ -1005,12 +1005,12 @@ msgstr "Alias %s já existe"
 msgid "Aliases:"
 msgstr "Aliases:"
 
-#: lxc/storage_volume.go:1590
+#: lxc/storage_volume.go:1596
 #, fuzzy
 msgid "All projects"
 msgstr "Criar projetos"
 
-#: lxc/remote.go:182
+#: lxc/remote.go:194
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -1088,7 +1088,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:552
+#: lxc/remote.go:621
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr "Tipo de autenticação '%s' não suportada pelo servidor"
@@ -1125,16 +1125,16 @@ msgstr "IMAGEM BASE"
 msgid "Backing up instance: %s"
 msgstr "Editar arquivos no container"
 
-#: lxc/storage_volume.go:2696
+#: lxc/storage_volume.go:2702
 #, fuzzy, c-format
 msgid "Backing up storage volume: %s"
 msgstr "Editar arquivos no container"
 
-#: lxc/export.go:192 lxc/storage_volume.go:2773
+#: lxc/export.go:192 lxc/storage_volume.go:2779
 msgid "Backup exported successfully!"
 msgstr "Backup exportado com sucesso!"
 
-#: lxc/info.go:654 lxc/storage_volume.go:1521
+#: lxc/info.go:654 lxc/storage_volume.go:1527
 msgid "Backups:"
 msgstr ""
 
@@ -1155,7 +1155,7 @@ msgstr "par de chave/valor inválido %s"
 msgid "Bad key=value pair: %q"
 msgstr "par de chave=valor inválido %s"
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:679
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:685
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr "par de chave=valor inválido %s"
@@ -1198,7 +1198,7 @@ msgstr "CANCELÁVEL"
 msgid "COMMON NAME"
 msgstr "NOME COMUM"
 
-#: lxc/storage_volume.go:1733
+#: lxc/storage_volume.go:1739
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1268,7 +1268,7 @@ msgstr "Não pode pegar um diretório sem --recursive"
 msgid "Can't read from stdin: %w"
 msgstr "Não é possível ler stdin: %s"
 
-#: lxc/remote.go:894
+#: lxc/remote.go:961
 msgid "Can't remove the default remote"
 msgstr "Não é possível remover o default remoto"
 
@@ -1285,7 +1285,7 @@ msgstr "Não é possível especificar --fast com --columns"
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1749 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr "Não pode especificar a coluna L, quando não em cluster"
 
@@ -1302,12 +1302,12 @@ msgstr "Não é possível remover chave '%s', não está atualmente definido"
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:486
+#: lxc/storage_volume.go:492
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:440
+#: lxc/storage_volume.go:446
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1335,12 +1335,12 @@ msgstr "Em cache: %s"
 msgid "Certificate add token for %s deleted"
 msgstr "Clustering ativado"
 
-#: lxc/remote.go:455
+#: lxc/remote.go:509
 #, fuzzy
 msgid "Certificate fingerprint"
 msgstr "Certificado fingerprint: %s"
 
-#: lxc/remote.go:219
+#: lxc/remote.go:231
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
@@ -1355,7 +1355,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr "Nome de membro do cluster"
 
-#: lxc/remote.go:620
+#: lxc/remote.go:687
 #, fuzzy
 msgid "Client certificate now trusted by server:"
 msgstr "Certificado do cliente armazenado no servidor: "
@@ -1430,13 +1430,13 @@ msgstr "Dispositivo %s removido de %s"
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
 #: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
-#: lxc/storage_volume.go:612 lxc/storage_volume.go:717
-#: lxc/storage_volume.go:1005 lxc/storage_volume.go:1231
-#: lxc/storage_volume.go:1360 lxc/storage_volume.go:1848
-#: lxc/storage_volume.go:1940 lxc/storage_volume.go:2079
-#: lxc/storage_volume.go:2239 lxc/storage_volume.go:2355
-#: lxc/storage_volume.go:2416 lxc/storage_volume.go:2543
-#: lxc/storage_volume.go:2631 lxc/storage_volume.go:2795
+#: lxc/storage_volume.go:618 lxc/storage_volume.go:723
+#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1237
+#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1854
+#: lxc/storage_volume.go:1946 lxc/storage_volume.go:2085
+#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2361
+#: lxc/storage_volume.go:2422 lxc/storage_volume.go:2549
+#: lxc/storage_volume.go:2637 lxc/storage_volume.go:2801
 msgid "Cluster member name"
 msgstr "Nome de membro do cluster"
 
@@ -1452,7 +1452,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr "Clustering ativado"
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1589
+#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1595
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr "Colunas"
@@ -1505,17 +1505,17 @@ msgstr "Configuração chave/valor para aplicar ao novo contêiner"
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1150
-#: lxc/storage_volume.go:1182
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
+#: lxc/storage_volume.go:1188
 #, c-format
 msgid "Config parsing error: %s"
 msgstr "Erro de análise de configuração: %s"
 
-#: lxc/storage_volume.go:613
+#: lxc/storage_volume.go:619
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1467
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1601,7 +1601,7 @@ msgstr "Copiar a imagem: %s"
 msgid "Copying the image: %s"
 msgstr "Copiar a imagem: %s"
 
-#: lxc/storage_volume.go:508
+#: lxc/storage_volume.go:514
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1615,12 +1615,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:490
+#: lxc/remote.go:559
 #, fuzzy, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "Impossível criar diretório para certificado do servidor"
 
-#: lxc/remote.go:225 lxc/remote.go:474
+#: lxc/remote.go:237 lxc/remote.go:543
 msgid "Could not create server cert dir"
 msgstr "Impossível criar diretório para certificado do servidor"
 
@@ -1659,7 +1659,7 @@ msgstr "Certificado fingerprint: %s"
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:485
+#: lxc/remote.go:554
 #, fuzzy, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "Impossível criar diretório para certificado do servidor"
@@ -1738,7 +1738,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr "Criar novas redes"
 
-#: lxc/storage_volume.go:604 lxc/storage_volume.go:605
+#: lxc/storage_volume.go:610 lxc/storage_volume.go:611
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1797,7 +1797,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1475
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1481
 #, c-format
 msgid "Created: %s"
 msgstr "Criado: %s"
@@ -1833,7 +1833,7 @@ msgstr ""
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1732
+#: lxc/storage_volume.go:1738
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1853,7 +1853,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2630
+#: lxc/storage_volume.go:2636
 #, fuzzy
 msgid "Define a compression algorithm: for backup or none"
 msgstr "Definir um algoritmo de compressão: para imagem ou nenhum"
@@ -1963,7 +1963,7 @@ msgstr "Apagar projetos"
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:713 lxc/storage_volume.go:714
+#: lxc/storage_volume.go:719 lxc/storage_volume.go:720
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -2055,9 +2055,9 @@ msgstr ""
 #: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
 #: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
 #: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:648
-#: lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853 lxc/remote.go:917
-#: lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:715
+#: lxc/remote.go:753 lxc/remote.go:839 lxc/remote.go:920 lxc/remote.go:984
+#: lxc/remote.go:1032 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -2069,26 +2069,26 @@ msgstr ""
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
 #: lxc/storage_volume.go:169 lxc/storage_volume.go:283
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:605
-#: lxc/storage_volume.go:714 lxc/storage_volume.go:801
-#: lxc/storage_volume.go:899 lxc/storage_volume.go:996
-#: lxc/storage_volume.go:1217 lxc/storage_volume.go:1348
-#: lxc/storage_volume.go:1507 lxc/storage_volume.go:1591
-#: lxc/storage_volume.go:1844 lxc/storage_volume.go:1937
-#: lxc/storage_volume.go:2064 lxc/storage_volume.go:2222
-#: lxc/storage_volume.go:2343 lxc/storage_volume.go:2405
-#: lxc/storage_volume.go:2541 lxc/storage_volume.go:2624
-#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:611
+#: lxc/storage_volume.go:720 lxc/storage_volume.go:807
+#: lxc/storage_volume.go:905 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:1223 lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1513 lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1850 lxc/storage_volume.go:1943
+#: lxc/storage_volume.go:2070 lxc/storage_volume.go:2228
+#: lxc/storage_volume.go:2349 lxc/storage_volume.go:2411
+#: lxc/storage_volume.go:2547 lxc/storage_volume.go:2630
+#: lxc/storage_volume.go:2796 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr "Descrição"
 
-#: lxc/storage_volume.go:1448
+#: lxc/storage_volume.go:1454
 #, fuzzy, c-format
 msgid "Description: %s"
 msgstr "Descrição"
 
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:1849
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:1855
 #, fuzzy
 msgid "Destination cluster member name"
 msgstr "Nome de membro do cluster"
@@ -2102,12 +2102,12 @@ msgstr "Desconectar interfaces de rede dos containers"
 msgid "Detach network interfaces from profiles"
 msgstr "Desconectar interfaces de rede dos perfis"
 
-#: lxc/storage_volume.go:800 lxc/storage_volume.go:801
+#: lxc/storage_volume.go:806 lxc/storage_volume.go:807
 #, fuzzy
 msgid "Detach storage volumes from instances"
 msgstr "Desconectar volumes de armazenamento dos containers"
 
-#: lxc/storage_volume.go:898 lxc/storage_volume.go:899
+#: lxc/storage_volume.go:904 lxc/storage_volume.go:905
 msgid "Detach storage volumes from profiles"
 msgstr "Desconectar volumes de armazenamento dos perfis"
 
@@ -2354,7 +2354,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:995 lxc/storage_volume.go:996
+#: lxc/storage_volume.go:1001 lxc/storage_volume.go:1002
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2363,7 +2363,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1766
+#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1772
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2420,7 +2420,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2193
+#: lxc/storage_volume.go:2161 lxc/storage_volume.go:2199
 #, fuzzy, c-format
 msgid "Error setting properties: %v"
 msgstr "Editar propriedades da imagem"
@@ -2434,8 +2434,8 @@ msgstr "Editar propriedades da imagem"
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2149
-#: lxc/storage_volume.go:2187
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2155
+#: lxc/storage_volume.go:2193
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2478,8 +2478,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1508
-#: lxc/storage_volume.go:1558
+#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1514
+#: lxc/storage_volume.go:1564
 msgid "Expires at"
 msgstr ""
 
@@ -2503,7 +2503,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2623 lxc/storage_volume.go:2624
+#: lxc/storage_volume.go:2629 lxc/storage_volume.go:2630
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2515,11 +2515,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2627
+#: lxc/storage_volume.go:2633
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2756
+#: lxc/export.go:152 lxc/storage_volume.go:2762
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2636,11 +2636,11 @@ msgstr "Aceitar certificado"
 msgid "Failed to accept incoming connection: %w"
 msgstr "Aceitar certificado"
 
-#: lxc/remote.go:191
+#: lxc/remote.go:203
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:242
+#: lxc/remote.go:254
 #, fuzzy, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr "Aceitar certificado"
@@ -2650,7 +2650,7 @@ msgstr "Aceitar certificado"
 msgid "Failed to connect to cluster member: %w"
 msgstr "Nome de membro do cluster"
 
-#: lxc/remote.go:232
+#: lxc/remote.go:244
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2660,12 +2660,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr "Aceitar certificado"
 
-#: lxc/remote.go:260
+#: lxc/remote.go:486
 #, fuzzy, c-format
-msgid "Failed to create certificate: %w"
-msgstr "Aceitar certificado"
+msgid "Failed to decode trust token: %w"
+msgstr "Nome de membro do cluster"
 
-#: lxc/remote.go:267
+#: lxc/remote.go:292
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2690,7 +2690,7 @@ msgstr "Aceitar certificado"
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:237
+#: lxc/remote.go:249
 #, fuzzy, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr "Aceitar certificado"
@@ -2778,9 +2778,9 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:690 lxc/storage.go:657
+#: lxc/project.go:919 lxc/remote.go:757 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1608 lxc/warning.go:94
+#: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2816,7 +2816,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:754
+#: lxc/remote.go:821
 msgid "GLOBAL"
 msgstr ""
 
@@ -2836,7 +2836,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:160 lxc/remote.go:401
+#: lxc/remote.go:165 lxc/remote.go:443
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2912,7 +2912,7 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1238
 #, fuzzy
 msgid "Get the key as a storage volume property"
 msgstr "Desconectar volumes de armazenamento dos perfis"
@@ -2988,11 +2988,11 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1216 lxc/storage_volume.go:1217
+#: lxc/storage_volume.go:1222 lxc/storage_volume.go:1223
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:469
+#: lxc/storage_volume.go:475
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -3116,7 +3116,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2415
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2421
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -3130,7 +3130,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2414
+#: lxc/storage_volume.go:2420
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -3182,7 +3182,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr "Anexar interfaces de rede aos perfis"
 
-#: lxc/storage_volume.go:2790
+#: lxc/storage_volume.go:2796
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -3190,7 +3190,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2789
+#: lxc/storage_volume.go:2795
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -3212,11 +3212,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2797
+#: lxc/storage_volume.go:2803
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2871
+#: lxc/storage_volume.go:2877
 #, fuzzy, c-format
 msgid "Importing custom volume: %s"
 msgstr "Editar arquivos no container"
@@ -3282,7 +3282,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:353
+#: lxc/remote.go:395
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3342,7 +3342,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2000
+#: lxc/move.go:148 lxc/storage_volume.go:2006
 #, fuzzy
 msgid "Invalid new snapshot name"
 msgstr "Editar arquivos no container"
@@ -3351,7 +3351,7 @@ msgstr "Editar arquivos no container"
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1996
+#: lxc/storage_volume.go:2002
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3364,14 +3364,14 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:342
+#: lxc/remote.go:384
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1064 lxc/storage_volume.go:1281
-#: lxc/storage_volume.go:1405 lxc/storage_volume.go:1985
-#: lxc/storage_volume.go:2132 lxc/storage_volume.go:2284
+#: lxc/storage_volume.go:1070 lxc/storage_volume.go:1287
+#: lxc/storage_volume.go:1411 lxc/storage_volume.go:1991
+#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2290
 #, fuzzy
 msgid "Invalid snapshot name"
 msgstr "Editar arquivos no container"
@@ -3418,7 +3418,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1739 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1745 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3730,11 +3730,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1586
+#: lxc/storage_volume.go:1592
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1597
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3754,7 +3754,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:685 lxc/remote.go:686
+#: lxc/remote.go:752 lxc/remote.go:753
 msgid "List the available remotes"
 msgstr ""
 
@@ -3793,7 +3793,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1464
+#: lxc/info.go:489 lxc/storage_volume.go:1470
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -4299,12 +4299,12 @@ msgstr "Nome de membro do cluster"
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:323 lxc/storage_volume.go:643
-#: lxc/storage_volume.go:750 lxc/storage_volume.go:841
-#: lxc/storage_volume.go:939 lxc/storage_volume.go:1053
-#: lxc/storage_volume.go:1270 lxc/storage_volume.go:1974
-#: lxc/storage_volume.go:2115 lxc/storage_volume.go:2273
-#: lxc/storage_volume.go:2464 lxc/storage_volume.go:2581
+#: lxc/storage_volume.go:323 lxc/storage_volume.go:649
+#: lxc/storage_volume.go:756 lxc/storage_volume.go:847
+#: lxc/storage_volume.go:945 lxc/storage_volume.go:1059
+#: lxc/storage_volume.go:1276 lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:2121 lxc/storage_volume.go:2279
+#: lxc/storage_volume.go:2470 lxc/storage_volume.go:2587
 msgid "Missing pool name"
 msgstr ""
 
@@ -4323,11 +4323,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:432 lxc/storage_volume.go:1884
+#: lxc/storage_volume.go:438 lxc/storage_volume.go:1890
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1394
+#: lxc/storage_volume.go:1400
 #, fuzzy
 msgid "Missing storage pool name"
 msgstr "Nome de membro do cluster"
@@ -4366,8 +4366,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:861
-#: lxc/storage_volume.go:958
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:867
+#: lxc/storage_volume.go:964
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4405,7 +4405,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1843 lxc/storage_volume.go:1844
+#: lxc/storage_volume.go:1849 lxc/storage_volume.go:1850
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4413,11 +4413,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1850
+#: lxc/storage_volume.go:1856
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:512
+#: lxc/storage_volume.go:518
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4443,8 +4443,8 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
-#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1731
+#: lxc/remote.go:815 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
 msgstr ""
 
@@ -4470,7 +4470,7 @@ msgstr ""
 
 #: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
+#: lxc/project.go:550 lxc/remote.go:775 lxc/remote.go:780 lxc/remote.go:785
 msgid "NO"
 msgstr ""
 
@@ -4492,8 +4492,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1506
-#: lxc/storage_volume.go:1556
+#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1512
+#: lxc/storage_volume.go:1562
 msgid "Name"
 msgstr ""
 
@@ -4501,7 +4501,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1446
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1452
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4645,7 +4645,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:870 lxc/storage_volume.go:967
+#: lxc/storage_volume.go:876 lxc/storage_volume.go:973
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4661,11 +4661,11 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/storage_volume.go:446 lxc/storage_volume.go:1893
+#: lxc/storage_volume.go:452 lxc/storage_volume.go:1899
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:496 lxc/storage_volume.go:1904
+#: lxc/storage_volume.go:502 lxc/storage_volume.go:1910
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4679,7 +4679,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2012
+#: lxc/storage_volume.go:2018
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4691,15 +4691,15 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2678
+#: lxc/storage_volume.go:2684
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2477
+#: lxc/storage_volume.go:2483
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:336
+#: lxc/remote.go:378
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4707,7 +4707,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1412
+#: lxc/storage_volume.go:1418
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4720,7 +4720,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:693 lxc/storage_volume.go:1560
+#: lxc/info.go:693 lxc/storage_volume.go:1566
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4750,7 +4750,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1756
 msgid "POOL"
 msgstr ""
 
@@ -4766,15 +4766,15 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:213
+#: lxc/list.go:567 lxc/storage_volume.go:1762 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:817
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:752
+#: lxc/image.go:1136 lxc/remote.go:819
 msgid "PUBLIC"
 msgstr ""
 
@@ -4803,7 +4803,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:183
+#: lxc/remote.go:195
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4816,8 +4816,8 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr "Nome de membro do cluster"
 
-#: lxc/remote.go:466
-msgid "Please type 'y', 'n' or the fingerprint:"
+#: lxc/remote.go:536
+msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
 #: lxc/info.go:221
@@ -4841,8 +4841,8 @@ msgstr ""
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1151
-#: lxc/storage_volume.go:1183
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
+#: lxc/storage_volume.go:1189
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4964,7 +4964,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1350
+#: lxc/storage_volume.go:1356
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4978,7 +4978,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1219
+#: lxc/storage_volume.go:1225
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4994,7 +4994,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2224
+#: lxc/storage_volume.go:2230
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5015,7 +5015,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:998
+#: lxc/storage_volume.go:1004
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5024,7 +5024,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2069
+#: lxc/storage_volume.go:2075
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5037,7 +5037,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2345
+#: lxc/storage_volume.go:2351
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5144,33 +5144,33 @@ msgstr "Editar arquivos no container"
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:810
+#: lxc/remote.go:877
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
-#: lxc/remote.go:994
+#: lxc/project.go:884 lxc/remote.go:868 lxc/remote.go:949 lxc/remote.go:1013
+#: lxc/remote.go:1061
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:305
+#: lxc/remote.go:345
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:890
+#: lxc/remote.go:957
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:805 lxc/remote.go:886 lxc/remote.go:998
+#: lxc/remote.go:872 lxc/remote.go:953 lxc/remote.go:1065
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:294
+#: lxc/remote.go:319
 msgid "Remote address must not be empty"
 msgstr ""
 
@@ -5179,7 +5179,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr "Senha de administrador para %s: "
 
-#: lxc/remote.go:299
+#: lxc/remote.go:339
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -5277,7 +5277,7 @@ msgstr "Adicionar perfis aos containers"
 msgid "Remove profiles from instances"
 msgstr "Adicionar perfis aos containers"
 
-#: lxc/remote.go:852 lxc/remote.go:853
+#: lxc/remote.go:919 lxc/remote.go:920
 msgid "Remove remotes"
 msgstr ""
 
@@ -5338,19 +5338,19 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:771 lxc/remote.go:772
+#: lxc/remote.go:838 lxc/remote.go:839
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:1943
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1936
+#: lxc/storage_volume.go:1942
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2025 lxc/storage_volume.go:2045
+#: lxc/storage_volume.go:2031 lxc/storage_volume.go:2051
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5409,7 +5409,7 @@ msgstr ""
 "Quando --stateful é usado, o LXD tenta criar um checkpoint do estado atual \n"
 "do container, incluindo estado de memória dos processos, conexões TCP, ..."
 
-#: lxc/storage_volume.go:2540 lxc/storage_volume.go:2541
+#: lxc/storage_volume.go:2546 lxc/storage_volume.go:2547
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5493,7 +5493,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:820
 msgid "STATIC"
 msgstr ""
 
@@ -5534,11 +5534,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:464
+#: lxc/remote.go:532
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:616
+#: lxc/remote.go:285 lxc/remote.go:683
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5749,11 +5749,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2063
+#: lxc/storage_volume.go:2069
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2064
+#: lxc/storage_volume.go:2070
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5762,7 +5762,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:964 lxc/remote.go:965
+#: lxc/remote.go:1031 lxc/remote.go:1032
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5844,7 +5844,7 @@ msgstr "Criar novas redes"
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2080
+#: lxc/storage_volume.go:2086
 #, fuzzy
 msgid "Set the key as a storage volume property"
 msgstr "Desconectar volumes de armazenamento dos perfis"
@@ -6012,11 +6012,11 @@ msgstr "Editar configurações do container ou do servidor como YAML"
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2221 lxc/storage_volume.go:2222
+#: lxc/storage_volume.go:2227 lxc/storage_volume.go:2228
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1347 lxc/storage_volume.go:1348
+#: lxc/storage_volume.go:1353 lxc/storage_volume.go:1354
 #, fuzzy
 msgid "Show storage volume state information"
 msgstr "Editar configurações do container ou do servidor como YAML"
@@ -6031,7 +6031,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:647 lxc/remote.go:648
+#: lxc/remote.go:714 lxc/remote.go:715
 msgid "Show the default remote"
 msgstr ""
 
@@ -6087,15 +6087,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2404 lxc/storage_volume.go:2405
+#: lxc/storage_volume.go:2410 lxc/storage_volume.go:2411
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2167
+#: lxc/storage_volume.go:2173
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:607 lxc/storage_volume.go:1485
+#: lxc/info.go:607 lxc/storage_volume.go:1491
 msgid "Snapshots:"
 msgstr ""
 
@@ -6196,21 +6196,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:696
+#: lxc/storage_volume.go:702
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:784
+#: lxc/storage_volume.go:790
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:509
+#: lxc/storage_volume.go:515
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:513
+#: lxc/storage_volume.go:519
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -6246,7 +6246,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:916 lxc/remote.go:917
+#: lxc/remote.go:983 lxc/remote.go:984
 msgid "Switch the default remote"
 msgstr ""
 
@@ -6265,11 +6265,11 @@ msgstr ""
 #: lxc/auth.go:818 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
-#: lxc/storage_volume.go:1730 lxc/warning.go:216
+#: lxc/storage_volume.go:1736 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1557
+#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1563
 msgid "Taken at"
 msgstr ""
 
@@ -6280,6 +6280,12 @@ msgstr "--refresh só pode ser usado com containers"
 
 #: lxc/file.go:1256
 msgid "Target path must be a directory"
+msgstr ""
+
+#: lxc/remote.go:161 lxc/remote.go:334
+msgid ""
+"The --accept-certificate flag is not supported when adding a remote using a "
+"trust token"
 msgstr ""
 
 #: lxc/move.go:181
@@ -6424,15 +6430,20 @@ msgstr "Nome de membro do cluster"
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr "Nome de membro do cluster"
 
-#: lxc/storage_volume.go:1323
+#: lxc/storage_volume.go:1329
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr "Nome de membro do cluster"
 
-#: lxc/storage_volume.go:1300
+#: lxc/storage_volume.go:1306
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
+msgstr ""
+
+#: lxc/remote.go:527
+msgid ""
+"The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
 
 #: lxc/info.go:354
@@ -6443,8 +6454,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:875
-#: lxc/storage_volume.go:972
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:881
+#: lxc/storage_volume.go:978
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6521,7 +6532,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1470
+#: lxc/storage_volume.go:1476
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6536,7 +6547,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1847
+#: lxc/storage_volume.go:1853
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6570,7 +6581,16 @@ msgstr "Editar arquivos no container"
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:571
+#: lxc/remote.go:329
+msgid "Trust token cannot be used for public remotes"
+msgstr ""
+
+#: lxc/remote.go:324
+#, fuzzy
+msgid "Trust token cannot be used with OIDC authentication"
+msgstr "--refresh só pode ser usado com containers"
+
+#: lxc/remote.go:639
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6596,7 +6616,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1455
+#: lxc/storage_volume.go:1461
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6614,17 +6634,17 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:193 lxc/remote.go:749
+#: lxc/cluster.go:193 lxc/remote.go:816
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1735
+#: lxc/project.go:995 lxc/storage_volume.go:1741
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1734
+#: lxc/storage.go:724 lxc/storage_volume.go:1740
 msgid "USED BY"
 msgstr ""
 
@@ -6642,7 +6662,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:214 lxc/remote.go:248
+#: lxc/remote.go:226 lxc/remote.go:260
 #, fuzzy
 msgid "Unavailable remote server"
 msgstr "Adicionar novos servidores remoto"
@@ -6657,7 +6677,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1772
+#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1778
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6780,7 +6800,7 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2342 lxc/storage_volume.go:2343
+#: lxc/storage_volume.go:2348 lxc/storage_volume.go:2349
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6839,7 +6859,7 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2356
+#: lxc/storage_volume.go:2362
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6885,12 +6905,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr "Editar arquivos no container"
 
-#: lxc/storage_volume.go:1468
+#: lxc/storage_volume.go:1474
 #, fuzzy, c-format
 msgid "Usage: %s"
 msgstr "Criado: %s"
 
-#: lxc/export.go:42 lxc/storage_volume.go:2629
+#: lxc/export.go:42 lxc/storage_volume.go:2635
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6957,7 +6977,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1559
+#: lxc/storage_volume.go:1565
 msgid "Volume Only"
 msgstr ""
 
@@ -6992,7 +7012,7 @@ msgstr ""
 
 #: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
+#: lxc/project.go:552 lxc/remote.go:777 lxc/remote.go:782 lxc/remote.go:787
 msgid "YES"
 msgstr ""
 
@@ -7016,7 +7036,7 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:897
+#: lxc/storage_volume.go:903
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
@@ -7485,7 +7505,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2788
+#: lxc/storage_volume.go:2794
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr "Criar perfis"
@@ -7525,13 +7545,13 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:1941
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:799
+#: lxc/storage_volume.go:805
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
@@ -7540,53 +7560,53 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr "Criar perfis"
 
-#: lxc/storage_volume.go:2539
+#: lxc/storage_volume.go:2545
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2622
+#: lxc/storage_volume.go:2628
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr "Criar perfis"
 
-#: lxc/storage_volume.go:2403
+#: lxc/storage_volume.go:2409
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:603
+#: lxc/storage_volume.go:609
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:711
+#: lxc/storage_volume.go:717
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:994 lxc/storage_volume.go:1346
+#: lxc/storage_volume.go:1000 lxc/storage_volume.go:1352
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr "Criar perfis"
 
-#: lxc/storage_volume.go:2341
+#: lxc/storage_volume.go:2347
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr "Criar perfis"
 
-#: lxc/storage_volume.go:2062
+#: lxc/storage_volume.go:2068
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr "Criar perfis"
 
-#: lxc/storage_volume.go:2220
+#: lxc/storage_volume.go:2226
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr "Criar perfis"
 
-#: lxc/storage_volume.go:1215
+#: lxc/storage_volume.go:1221
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr "Criar perfis"
 
-#: lxc/storage_volume.go:1841
+#: lxc/storage_volume.go:1847
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr "Criar perfis"
@@ -7708,7 +7728,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1584
+#: lxc/storage_volume.go:1590
 #, fuzzy
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr "Criar perfis"
@@ -7723,7 +7743,7 @@ msgstr "Criar perfis"
 msgid "[[<remote>:]<member>]"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/project.go:557 lxc/remote.go:739
+#: lxc/project.go:557 lxc/remote.go:806
 msgid "current"
 msgstr ""
 
@@ -8183,7 +8203,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:607
+#: lxc/storage_volume.go:613
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -8191,13 +8211,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2792
+#: lxc/storage_volume.go:2798
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2407
+#: lxc/storage_volume.go:2413
 msgid ""
 "lxc storage volume snapshot create default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -8207,7 +8227,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:531
 msgid "n"
 msgstr ""
 
@@ -8219,7 +8239,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:510
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -8256,7 +8276,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:465
+#: lxc/remote.go:519
 msgid "y"
 msgstr ""
 
@@ -8264,6 +8284,10 @@ msgstr ""
 #: lxc/image.go:1194
 msgid "yes"
 msgstr "sim"
+
+#, fuzzy, c-format
+#~ msgid "Failed to create certificate: %w"
+#~ msgstr "Aceitar certificado"
 
 #~ msgid "Console log:"
 #~ msgstr "Log de Console:"

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-08 07:43+0100\n"
+"POT-Creation-Date: 2024-10-14 13:30+0000\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Александр Киль <shorrey@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -78,7 +78,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/storage_volume.go:1024
+#: lxc/storage_volume.go:1030
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
@@ -773,15 +773,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:850 lxc/remote.go:915
+#: lxc/remote.go:917 lxc/remote.go:982
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:963
+#: lxc/remote.go:1030
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:769
+#: lxc/remote.go:836
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -819,7 +819,7 @@ msgstr "ПСЕВДОНИМ"
 msgid "ARCHITECTURE"
 msgstr "АРХИТЕКТУРА"
 
-#: lxc/remote.go:751
+#: lxc/remote.go:818
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -973,7 +973,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr "Пароль администратора для %s: "
 
-#: lxc/remote.go:581
+#: lxc/remote.go:648
 #, fuzzy, c-format
 msgid "Admin password (or token) for %s:"
 msgstr "Пароль администратора для %s: "
@@ -1006,12 +1006,12 @@ msgstr ""
 msgid "Aliases:"
 msgstr "Псевдонимы:"
 
-#: lxc/storage_volume.go:1590
+#: lxc/storage_volume.go:1596
 #, fuzzy
 msgid "All projects"
 msgstr "Доступные команды:"
 
-#: lxc/remote.go:182
+#: lxc/remote.go:194
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -1085,7 +1085,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:552
+#: lxc/remote.go:621
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -1122,16 +1122,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/storage_volume.go:2696
+#: lxc/storage_volume.go:2702
 #, fuzzy, c-format
 msgid "Backing up storage volume: %s"
 msgstr "Копирование образа: %s"
 
-#: lxc/export.go:192 lxc/storage_volume.go:2773
+#: lxc/export.go:192 lxc/storage_volume.go:2779
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:654 lxc/storage_volume.go:1521
+#: lxc/info.go:654 lxc/storage_volume.go:1527
 msgid "Backups:"
 msgstr ""
 
@@ -1152,7 +1152,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr "Имя контейнера: %s"
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:679
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:685
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -1195,7 +1195,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr "ОБЩЕЕ ИМЯ"
 
-#: lxc/storage_volume.go:1733
+#: lxc/storage_volume.go:1739
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1266,7 +1266,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr "Невозможно прочитать из стандартного ввода: %s"
 
-#: lxc/remote.go:894
+#: lxc/remote.go:961
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1282,7 +1282,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1749 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1299,12 +1299,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:486
+#: lxc/storage_volume.go:492
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:440
+#: lxc/storage_volume.go:446
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1332,7 +1332,7 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr " Использование сети:"
 
-#: lxc/remote.go:455
+#: lxc/remote.go:509
 #, fuzzy
 msgid "Certificate fingerprint"
 msgstr ""
@@ -1340,7 +1340,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/remote.go:219
+#: lxc/remote.go:231
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
@@ -1355,7 +1355,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr "Копирование образа: %s"
 
-#: lxc/remote.go:620
+#: lxc/remote.go:687
 #, fuzzy
 msgid "Client certificate now trusted by server:"
 msgstr "Сертификат клиента хранится на сервере: "
@@ -1430,13 +1430,13 @@ msgstr ""
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
 #: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
-#: lxc/storage_volume.go:612 lxc/storage_volume.go:717
-#: lxc/storage_volume.go:1005 lxc/storage_volume.go:1231
-#: lxc/storage_volume.go:1360 lxc/storage_volume.go:1848
-#: lxc/storage_volume.go:1940 lxc/storage_volume.go:2079
-#: lxc/storage_volume.go:2239 lxc/storage_volume.go:2355
-#: lxc/storage_volume.go:2416 lxc/storage_volume.go:2543
-#: lxc/storage_volume.go:2631 lxc/storage_volume.go:2795
+#: lxc/storage_volume.go:618 lxc/storage_volume.go:723
+#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1237
+#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1854
+#: lxc/storage_volume.go:1946 lxc/storage_volume.go:2085
+#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2361
+#: lxc/storage_volume.go:2422 lxc/storage_volume.go:2549
+#: lxc/storage_volume.go:2637 lxc/storage_volume.go:2801
 msgid "Cluster member name"
 msgstr ""
 
@@ -1452,7 +1452,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1589
+#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1595
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr "Столбцы"
@@ -1496,17 +1496,17 @@ msgstr ""
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1150
-#: lxc/storage_volume.go:1182
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
+#: lxc/storage_volume.go:1188
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:613
+#: lxc/storage_volume.go:619
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1467
 #, fuzzy, c-format
 msgid "Content type: %s"
 msgstr "Авто-обновление: %s"
@@ -1592,7 +1592,7 @@ msgstr "Копирование образа: %s"
 msgid "Copying the image: %s"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:508
+#: lxc/storage_volume.go:514
 #, fuzzy, c-format
 msgid "Copying the storage volume: %s"
 msgstr "Копирование образа: %s"
@@ -1606,12 +1606,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:490
+#: lxc/remote.go:559
 #, fuzzy, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "Не удалось создать каталог сертификата сервера"
 
-#: lxc/remote.go:225 lxc/remote.go:474
+#: lxc/remote.go:237 lxc/remote.go:543
 msgid "Could not create server cert dir"
 msgstr "Не удалось создать каталог сертификата сервера"
 
@@ -1650,7 +1650,7 @@ msgstr "Не удалось очистить путь %s"
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:485
+#: lxc/remote.go:554
 #, fuzzy, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "Не удалось создать каталог сертификата сервера"
@@ -1728,7 +1728,7 @@ msgstr "Копирование образа: %s"
 msgid "Create new custom storage buckets"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:604 lxc/storage_volume.go:605
+#: lxc/storage_volume.go:610 lxc/storage_volume.go:611
 #, fuzzy
 msgid "Create new custom storage volumes"
 msgstr "Копирование образа: %s"
@@ -1789,7 +1789,7 @@ msgstr "Копирование образа: %s"
 msgid "Create the instance with no profiles applied"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1475
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1481
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1825,7 +1825,7 @@ msgstr ""
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1732
+#: lxc/storage_volume.go:1738
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1845,7 +1845,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2630
+#: lxc/storage_volume.go:2636
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1950,7 +1950,7 @@ msgstr "Копирование образа: %s"
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:713 lxc/storage_volume.go:714
+#: lxc/storage_volume.go:719 lxc/storage_volume.go:720
 #, fuzzy
 msgid "Delete storage volumes"
 msgstr "Копирование образа: %s"
@@ -2043,9 +2043,9 @@ msgstr ""
 #: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
 #: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
 #: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:648
-#: lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853 lxc/remote.go:917
-#: lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:715
+#: lxc/remote.go:753 lxc/remote.go:839 lxc/remote.go:920 lxc/remote.go:984
+#: lxc/remote.go:1032 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -2057,26 +2057,26 @@ msgstr ""
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
 #: lxc/storage_volume.go:169 lxc/storage_volume.go:283
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:605
-#: lxc/storage_volume.go:714 lxc/storage_volume.go:801
-#: lxc/storage_volume.go:899 lxc/storage_volume.go:996
-#: lxc/storage_volume.go:1217 lxc/storage_volume.go:1348
-#: lxc/storage_volume.go:1507 lxc/storage_volume.go:1591
-#: lxc/storage_volume.go:1844 lxc/storage_volume.go:1937
-#: lxc/storage_volume.go:2064 lxc/storage_volume.go:2222
-#: lxc/storage_volume.go:2343 lxc/storage_volume.go:2405
-#: lxc/storage_volume.go:2541 lxc/storage_volume.go:2624
-#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:611
+#: lxc/storage_volume.go:720 lxc/storage_volume.go:807
+#: lxc/storage_volume.go:905 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:1223 lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1513 lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1850 lxc/storage_volume.go:1943
+#: lxc/storage_volume.go:2070 lxc/storage_volume.go:2228
+#: lxc/storage_volume.go:2349 lxc/storage_volume.go:2411
+#: lxc/storage_volume.go:2547 lxc/storage_volume.go:2630
+#: lxc/storage_volume.go:2796 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1448
+#: lxc/storage_volume.go:1454
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:1849
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:1855
 #, fuzzy
 msgid "Destination cluster member name"
 msgstr "Копирование образа: %s"
@@ -2089,12 +2089,12 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:800 lxc/storage_volume.go:801
+#: lxc/storage_volume.go:806 lxc/storage_volume.go:807
 #, fuzzy
 msgid "Detach storage volumes from instances"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:898 lxc/storage_volume.go:899
+#: lxc/storage_volume.go:904 lxc/storage_volume.go:905
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -2333,7 +2333,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:995 lxc/storage_volume.go:996
+#: lxc/storage_volume.go:1001 lxc/storage_volume.go:1002
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2341,7 +2341,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1766
+#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1772
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2398,7 +2398,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2193
+#: lxc/storage_volume.go:2161 lxc/storage_volume.go:2199
 #, fuzzy, c-format
 msgid "Error setting properties: %v"
 msgstr "Копирование образа: %s"
@@ -2412,8 +2412,8 @@ msgstr "Копирование образа: %s"
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2149
-#: lxc/storage_volume.go:2187
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2155
+#: lxc/storage_volume.go:2193
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2459,8 +2459,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1508
-#: lxc/storage_volume.go:1558
+#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1514
+#: lxc/storage_volume.go:1564
 msgid "Expires at"
 msgstr ""
 
@@ -2485,7 +2485,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2623 lxc/storage_volume.go:2624
+#: lxc/storage_volume.go:2629 lxc/storage_volume.go:2630
 #, fuzzy
 msgid "Export custom storage volume"
 msgstr "Копирование образа: %s"
@@ -2500,12 +2500,12 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Export instances as backup tarballs."
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/storage_volume.go:2627
+#: lxc/storage_volume.go:2633
 #, fuzzy
 msgid "Export the volume without its snapshots"
 msgstr "Копирование образа: %s"
 
-#: lxc/export.go:152 lxc/storage_volume.go:2756
+#: lxc/export.go:152 lxc/storage_volume.go:2762
 #, fuzzy, c-format
 msgid "Exporting the backup: %s"
 msgstr "Копирование образа: %s"
@@ -2622,11 +2622,11 @@ msgstr "Принять сертификат"
 msgid "Failed to accept incoming connection: %w"
 msgstr "Принять сертификат"
 
-#: lxc/remote.go:191
+#: lxc/remote.go:203
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:242
+#: lxc/remote.go:254
 #, fuzzy, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr "Принять сертификат"
@@ -2636,7 +2636,7 @@ msgstr "Принять сертификат"
 msgid "Failed to connect to cluster member: %w"
 msgstr "Копирование образа: %s"
 
-#: lxc/remote.go:232
+#: lxc/remote.go:244
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2646,12 +2646,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr "Принять сертификат"
 
-#: lxc/remote.go:260
+#: lxc/remote.go:486
 #, fuzzy, c-format
-msgid "Failed to create certificate: %w"
-msgstr "Принять сертификат"
+msgid "Failed to decode trust token: %w"
+msgstr "Копирование образа: %s"
 
-#: lxc/remote.go:267
+#: lxc/remote.go:292
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2676,7 +2676,7 @@ msgstr "Принять сертификат"
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:237
+#: lxc/remote.go:249
 #, fuzzy, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr "Принять сертификат"
@@ -2764,9 +2764,9 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:690 lxc/storage.go:657
+#: lxc/project.go:919 lxc/remote.go:757 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1608 lxc/warning.go:94
+#: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2802,7 +2802,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:754
+#: lxc/remote.go:821
 msgid "GLOBAL"
 msgstr ""
 
@@ -2822,7 +2822,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:160 lxc/remote.go:401
+#: lxc/remote.go:165 lxc/remote.go:443
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2898,7 +2898,7 @@ msgstr "Копирование образа: %s"
 msgid "Get the key as a storage property"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1238
 #, fuzzy
 msgid "Get the key as a storage volume property"
 msgstr "Копирование образа: %s"
@@ -2970,11 +2970,11 @@ msgstr "Копирование образа: %s"
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1216 lxc/storage_volume.go:1217
+#: lxc/storage_volume.go:1222 lxc/storage_volume.go:1223
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:469
+#: lxc/storage_volume.go:475
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -3099,7 +3099,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2415
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2421
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -3113,7 +3113,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2414
+#: lxc/storage_volume.go:2420
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -3164,7 +3164,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2790
+#: lxc/storage_volume.go:2796
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -3172,7 +3172,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2789
+#: lxc/storage_volume.go:2795
 #, fuzzy
 msgid "Import custom storage volumes"
 msgstr "Копирование образа: %s"
@@ -3197,11 +3197,11 @@ msgstr "Копирование образа: %s"
 msgid "Import instance backups"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/storage_volume.go:2797
+#: lxc/storage_volume.go:2803
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2871
+#: lxc/storage_volume.go:2877
 #, fuzzy, c-format
 msgid "Importing custom volume: %s"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -3270,7 +3270,7 @@ msgstr "Имя контейнера: %s"
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:353
+#: lxc/remote.go:395
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3330,7 +3330,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2000
+#: lxc/move.go:148 lxc/storage_volume.go:2006
 #, fuzzy
 msgid "Invalid new snapshot name"
 msgstr "Нельзя использовать '/' в имени снимка"
@@ -3339,7 +3339,7 @@ msgstr "Нельзя использовать '/' в имени снимка"
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1996
+#: lxc/storage_volume.go:2002
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3352,14 +3352,14 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:342
+#: lxc/remote.go:384
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1064 lxc/storage_volume.go:1281
-#: lxc/storage_volume.go:1405 lxc/storage_volume.go:1985
-#: lxc/storage_volume.go:2132 lxc/storage_volume.go:2284
+#: lxc/storage_volume.go:1070 lxc/storage_volume.go:1287
+#: lxc/storage_volume.go:1411 lxc/storage_volume.go:1991
+#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2290
 #, fuzzy
 msgid "Invalid snapshot name"
 msgstr "Имя контейнера: %s"
@@ -3406,7 +3406,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1739 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1745 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3725,12 +3725,12 @@ msgstr "Копирование образа: %s"
 msgid "List storage buckets"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:1586
+#: lxc/storage_volume.go:1592
 #, fuzzy
 msgid "List storage volumes"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1597
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3750,7 +3750,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:685 lxc/remote.go:686
+#: lxc/remote.go:752 lxc/remote.go:753
 msgid "List the available remotes"
 msgstr ""
 
@@ -3790,7 +3790,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1464
+#: lxc/info.go:489 lxc/storage_volume.go:1470
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -4299,12 +4299,12 @@ msgstr "Имя контейнера: %s"
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:323 lxc/storage_volume.go:643
-#: lxc/storage_volume.go:750 lxc/storage_volume.go:841
-#: lxc/storage_volume.go:939 lxc/storage_volume.go:1053
-#: lxc/storage_volume.go:1270 lxc/storage_volume.go:1974
-#: lxc/storage_volume.go:2115 lxc/storage_volume.go:2273
-#: lxc/storage_volume.go:2464 lxc/storage_volume.go:2581
+#: lxc/storage_volume.go:323 lxc/storage_volume.go:649
+#: lxc/storage_volume.go:756 lxc/storage_volume.go:847
+#: lxc/storage_volume.go:945 lxc/storage_volume.go:1059
+#: lxc/storage_volume.go:1276 lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:2121 lxc/storage_volume.go:2279
+#: lxc/storage_volume.go:2470 lxc/storage_volume.go:2587
 msgid "Missing pool name"
 msgstr ""
 
@@ -4324,12 +4324,12 @@ msgstr "Имя контейнера: %s"
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:432 lxc/storage_volume.go:1884
+#: lxc/storage_volume.go:438 lxc/storage_volume.go:1890
 #, fuzzy
 msgid "Missing source volume name"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:1394
+#: lxc/storage_volume.go:1400
 #, fuzzy
 msgid "Missing storage pool name"
 msgstr "Копирование образа: %s"
@@ -4368,8 +4368,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:861
-#: lxc/storage_volume.go:958
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:867
+#: lxc/storage_volume.go:964
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4407,7 +4407,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1843 lxc/storage_volume.go:1844
+#: lxc/storage_volume.go:1849 lxc/storage_volume.go:1850
 #, fuzzy
 msgid "Move storage volumes between pools"
 msgstr "Копирование образа: %s"
@@ -4416,11 +4416,11 @@ msgstr "Копирование образа: %s"
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1850
+#: lxc/storage_volume.go:1856
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:512
+#: lxc/storage_volume.go:518
 #, fuzzy, c-format
 msgid "Moving the storage volume: %s"
 msgstr "Копирование образа: %s"
@@ -4446,8 +4446,8 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
-#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1731
+#: lxc/remote.go:815 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
 msgstr ""
 
@@ -4473,7 +4473,7 @@ msgstr ""
 
 #: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
+#: lxc/project.go:550 lxc/remote.go:775 lxc/remote.go:780 lxc/remote.go:785
 msgid "NO"
 msgstr ""
 
@@ -4495,8 +4495,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1506
-#: lxc/storage_volume.go:1556
+#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1512
+#: lxc/storage_volume.go:1562
 msgid "Name"
 msgstr ""
 
@@ -4504,7 +4504,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1446
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1452
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4650,7 +4650,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:870 lxc/storage_volume.go:967
+#: lxc/storage_volume.go:876 lxc/storage_volume.go:973
 #, fuzzy
 msgid "No device found for this storage volume"
 msgstr "Копирование образа: %s"
@@ -4667,11 +4667,11 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/storage_volume.go:446 lxc/storage_volume.go:1893
+#: lxc/storage_volume.go:452 lxc/storage_volume.go:1899
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:496 lxc/storage_volume.go:1904
+#: lxc/storage_volume.go:502 lxc/storage_volume.go:1910
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4685,7 +4685,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2012
+#: lxc/storage_volume.go:2018
 #, fuzzy
 msgid "Not a snapshot name"
 msgstr "Нельзя использовать '/' в имени снимка"
@@ -4698,15 +4698,15 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2678
+#: lxc/storage_volume.go:2684
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2477
+#: lxc/storage_volume.go:2483
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:336
+#: lxc/remote.go:378
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4714,7 +4714,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1412
+#: lxc/storage_volume.go:1418
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4727,7 +4727,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:693 lxc/storage_volume.go:1560
+#: lxc/info.go:693 lxc/storage_volume.go:1566
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4757,7 +4757,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1756
 msgid "POOL"
 msgstr ""
 
@@ -4773,15 +4773,15 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:213
+#: lxc/list.go:567 lxc/storage_volume.go:1762 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:817
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:752
+#: lxc/image.go:1136 lxc/remote.go:819
 msgid "PUBLIC"
 msgstr ""
 
@@ -4810,7 +4810,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:183
+#: lxc/remote.go:195
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4823,8 +4823,8 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr "Копирование образа: %s"
 
-#: lxc/remote.go:466
-msgid "Please type 'y', 'n' or the fingerprint:"
+#: lxc/remote.go:536
+msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
 #: lxc/info.go:221
@@ -4848,8 +4848,8 @@ msgstr ""
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1151
-#: lxc/storage_volume.go:1183
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
+#: lxc/storage_volume.go:1189
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4966,7 +4966,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1350
+#: lxc/storage_volume.go:1356
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4980,7 +4980,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1219
+#: lxc/storage_volume.go:1225
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4996,7 +4996,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2224
+#: lxc/storage_volume.go:2230
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5017,7 +5017,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:998
+#: lxc/storage_volume.go:1004
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5026,7 +5026,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2069
+#: lxc/storage_volume.go:2075
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5039,7 +5039,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2345
+#: lxc/storage_volume.go:2351
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5147,33 +5147,33 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Refreshing the image: %s"
 msgstr "Копирование образа: %s"
 
-#: lxc/remote.go:810
+#: lxc/remote.go:877
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
-#: lxc/remote.go:994
+#: lxc/project.go:884 lxc/remote.go:868 lxc/remote.go:949 lxc/remote.go:1013
+#: lxc/remote.go:1061
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:305
+#: lxc/remote.go:345
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:890
+#: lxc/remote.go:957
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:805 lxc/remote.go:886 lxc/remote.go:998
+#: lxc/remote.go:872 lxc/remote.go:953 lxc/remote.go:1065
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:294
+#: lxc/remote.go:319
 msgid "Remote address must not be empty"
 msgstr ""
 
@@ -5182,7 +5182,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr "Пароль администратора для %s: "
 
-#: lxc/remote.go:299
+#: lxc/remote.go:339
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -5274,7 +5274,7 @@ msgstr "Копирование образа: %s"
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:852 lxc/remote.go:853
+#: lxc/remote.go:919 lxc/remote.go:920
 msgid "Remove remotes"
 msgstr ""
 
@@ -5335,21 +5335,21 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:771 lxc/remote.go:772
+#: lxc/remote.go:838 lxc/remote.go:839
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:1943
 #, fuzzy
 msgid "Rename storage volumes"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:1936
+#: lxc/storage_volume.go:1942
 #, fuzzy
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:2025 lxc/storage_volume.go:2045
+#: lxc/storage_volume.go:2031 lxc/storage_volume.go:2051
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5404,7 +5404,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2540 lxc/storage_volume.go:2541
+#: lxc/storage_volume.go:2546 lxc/storage_volume.go:2547
 #, fuzzy
 msgid "Restore storage volume snapshots"
 msgstr "Копирование образа: %s"
@@ -5489,7 +5489,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:820
 msgid "STATIC"
 msgstr ""
 
@@ -5530,11 +5530,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:464
+#: lxc/remote.go:532
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:616
+#: lxc/remote.go:285 lxc/remote.go:683
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5740,11 +5740,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2063
+#: lxc/storage_volume.go:2069
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2064
+#: lxc/storage_volume.go:2070
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5753,7 +5753,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:964 lxc/remote.go:965
+#: lxc/remote.go:1031 lxc/remote.go:1032
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5836,7 +5836,7 @@ msgstr "Копирование образа: %s"
 msgid "Set the key as a storage property"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:2080
+#: lxc/storage_volume.go:2086
 #, fuzzy
 msgid "Set the key as a storage volume property"
 msgstr "Копирование образа: %s"
@@ -6000,11 +6000,11 @@ msgstr "Копирование образа: %s"
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2221 lxc/storage_volume.go:2222
+#: lxc/storage_volume.go:2227 lxc/storage_volume.go:2228
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1347 lxc/storage_volume.go:1348
+#: lxc/storage_volume.go:1353 lxc/storage_volume.go:1354
 #, fuzzy
 msgid "Show storage volume state information"
 msgstr "Копирование образа: %s"
@@ -6019,7 +6019,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:647 lxc/remote.go:648
+#: lxc/remote.go:714 lxc/remote.go:715
 msgid "Show the default remote"
 msgstr ""
 
@@ -6075,16 +6075,16 @@ msgstr "Авто-обновление: %s"
 msgid "Size: %s"
 msgstr "Авто-обновление: %s"
 
-#: lxc/storage_volume.go:2404 lxc/storage_volume.go:2405
+#: lxc/storage_volume.go:2410 lxc/storage_volume.go:2411
 #, fuzzy
 msgid "Snapshot storage volumes"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:2167
+#: lxc/storage_volume.go:2173
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:607 lxc/storage_volume.go:1485
+#: lxc/info.go:607 lxc/storage_volume.go:1491
 msgid "Snapshots:"
 msgstr ""
 
@@ -6188,21 +6188,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:696
+#: lxc/storage_volume.go:702
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:784
+#: lxc/storage_volume.go:790
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:509
+#: lxc/storage_volume.go:515
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:513
+#: lxc/storage_volume.go:519
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -6238,7 +6238,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:916 lxc/remote.go:917
+#: lxc/remote.go:983 lxc/remote.go:984
 msgid "Switch the default remote"
 msgstr ""
 
@@ -6257,11 +6257,11 @@ msgstr ""
 #: lxc/auth.go:818 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
-#: lxc/storage_volume.go:1730 lxc/warning.go:216
+#: lxc/storage_volume.go:1736 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1557
+#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1563
 msgid "Taken at"
 msgstr ""
 
@@ -6271,6 +6271,12 @@ msgstr ""
 
 #: lxc/file.go:1256
 msgid "Target path must be a directory"
+msgstr ""
+
+#: lxc/remote.go:161 lxc/remote.go:334
+msgid ""
+"The --accept-certificate flag is not supported when adding a remote using a "
+"trust token"
 msgstr ""
 
 #: lxc/move.go:181
@@ -6412,15 +6418,20 @@ msgstr "Копирование образа: %s"
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:1323
+#: lxc/storage_volume.go:1329
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:1300
+#: lxc/storage_volume.go:1306
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
+msgstr ""
+
+#: lxc/remote.go:527
+msgid ""
+"The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
 
 #: lxc/info.go:354
@@ -6431,8 +6442,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:875
-#: lxc/storage_volume.go:972
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:881
+#: lxc/storage_volume.go:978
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6508,7 +6519,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1470
+#: lxc/storage_volume.go:1476
 #, fuzzy, c-format
 msgid "Total: %s"
 msgstr "Авто-обновление: %s"
@@ -6523,7 +6534,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1847
+#: lxc/storage_volume.go:1853
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6557,7 +6568,15 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:571
+#: lxc/remote.go:329
+msgid "Trust token cannot be used for public remotes"
+msgstr ""
+
+#: lxc/remote.go:324
+msgid "Trust token cannot be used with OIDC authentication"
+msgstr ""
+
+#: lxc/remote.go:639
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6583,7 +6602,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1455
+#: lxc/storage_volume.go:1461
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6601,17 +6620,17 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:193 lxc/remote.go:749
+#: lxc/cluster.go:193 lxc/remote.go:816
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1735
+#: lxc/project.go:995 lxc/storage_volume.go:1741
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1734
+#: lxc/storage.go:724 lxc/storage_volume.go:1740
 msgid "USED BY"
 msgstr ""
 
@@ -6629,7 +6648,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:214 lxc/remote.go:248
+#: lxc/remote.go:226 lxc/remote.go:260
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6643,7 +6662,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1772
+#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1778
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6760,7 +6779,7 @@ msgstr "Копирование образа: %s"
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2342 lxc/storage_volume.go:2343
+#: lxc/storage_volume.go:2348 lxc/storage_volume.go:2349
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6820,7 +6839,7 @@ msgstr "Копирование образа: %s"
 msgid "Unset the key as a storage property"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:2356
+#: lxc/storage_volume.go:2362
 #, fuzzy
 msgid "Unset the key as a storage volume property"
 msgstr "Копирование образа: %s"
@@ -6867,12 +6886,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:1468
+#: lxc/storage_volume.go:1474
 #, fuzzy, c-format
 msgid "Usage: %s"
 msgstr "Авто-обновление: %s"
 
-#: lxc/export.go:42 lxc/storage_volume.go:2629
+#: lxc/export.go:42 lxc/storage_volume.go:2635
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6939,7 +6958,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1559
+#: lxc/storage_volume.go:1565
 msgid "Volume Only"
 msgstr ""
 
@@ -6974,7 +6993,7 @@ msgstr ""
 
 #: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
+#: lxc/project.go:552 lxc/remote.go:777 lxc/remote.go:782 lxc/remote.go:787
 msgid "YES"
 msgstr ""
 
@@ -6998,7 +7017,7 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:897
+#: lxc/storage_volume.go:903
 #, fuzzy
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
@@ -7796,7 +7815,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:2788
+#: lxc/storage_volume.go:2794
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
@@ -7863,7 +7882,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:1941
 #, fuzzy
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
@@ -7873,7 +7892,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:799
+#: lxc/storage_volume.go:805
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
@@ -7889,7 +7908,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:2539
+#: lxc/storage_volume.go:2545
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
@@ -7897,7 +7916,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:2622
+#: lxc/storage_volume.go:2628
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
@@ -7905,7 +7924,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:2403
+#: lxc/storage_volume.go:2409
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
@@ -7913,7 +7932,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:603
+#: lxc/storage_volume.go:609
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
@@ -7921,7 +7940,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:711
+#: lxc/storage_volume.go:717
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
@@ -7929,7 +7948,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:994 lxc/storage_volume.go:1346
+#: lxc/storage_volume.go:1000 lxc/storage_volume.go:1352
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
@@ -7937,7 +7956,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:2341
+#: lxc/storage_volume.go:2347
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
@@ -7945,7 +7964,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:2062
+#: lxc/storage_volume.go:2068
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
@@ -7953,7 +7972,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:2220
+#: lxc/storage_volume.go:2226
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
@@ -7961,7 +7980,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:1215
+#: lxc/storage_volume.go:1221
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
@@ -7969,7 +7988,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:1841
+#: lxc/storage_volume.go:1847
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
@@ -8187,7 +8206,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:1584
+#: lxc/storage_volume.go:1590
 #, fuzzy
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
@@ -8211,7 +8230,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/project.go:557 lxc/remote.go:739
+#: lxc/project.go:557 lxc/remote.go:806
 msgid "current"
 msgstr ""
 
@@ -8671,7 +8690,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:607
+#: lxc/storage_volume.go:613
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -8679,13 +8698,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2792
+#: lxc/storage_volume.go:2798
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2407
+#: lxc/storage_volume.go:2413
 msgid ""
 "lxc storage volume snapshot create default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -8695,7 +8714,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:531
 msgid "n"
 msgstr ""
 
@@ -8707,7 +8726,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:510
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -8744,7 +8763,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:465
+#: lxc/remote.go:519
 msgid "y"
 msgstr ""
 
@@ -8752,6 +8771,10 @@ msgstr ""
 #: lxc/image.go:1194
 msgid "yes"
 msgstr "да"
+
+#, fuzzy, c-format
+#~ msgid "Failed to create certificate: %w"
+#~ msgstr "Принять сертификат"
 
 #, fuzzy
 #~ msgid "[<remote>:]<cluster member>"

--- a/po/si.po
+++ b/po/si.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-08 07:43+0100\n"
+"POT-Creation-Date: 2024-10-14 13:30+0000\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Sinhala <https://hosted.weblate.org/projects/linux-containers/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1024
+#: lxc/storage_volume.go:1030
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -515,15 +515,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:850 lxc/remote.go:915
+#: lxc/remote.go:917 lxc/remote.go:982
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:963
+#: lxc/remote.go:1030
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:769
+#: lxc/remote.go:836
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -556,7 +556,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:751
+#: lxc/remote.go:818
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:581
+#: lxc/remote.go:648
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -738,11 +738,11 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1590
+#: lxc/storage_volume.go:1596
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:182
+#: lxc/remote.go:194
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -813,7 +813,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:552
+#: lxc/remote.go:621
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -849,16 +849,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2696
+#: lxc/storage_volume.go:2702
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2773
+#: lxc/export.go:192 lxc/storage_volume.go:2779
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:654 lxc/storage_volume.go:1521
+#: lxc/info.go:654 lxc/storage_volume.go:1527
 msgid "Backups:"
 msgstr ""
 
@@ -879,7 +879,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:679
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:685
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -922,7 +922,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1733
+#: lxc/storage_volume.go:1739
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -991,7 +991,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:894
+#: lxc/remote.go:961
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1007,7 +1007,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1749 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1024,12 +1024,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:486
+#: lxc/storage_volume.go:492
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:440
+#: lxc/storage_volume.go:446
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1057,11 +1057,11 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:509
 msgid "Certificate fingerprint"
 msgstr ""
 
-#: lxc/remote.go:219
+#: lxc/remote.go:231
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
@@ -1076,7 +1076,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:620
+#: lxc/remote.go:687
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1150,13 +1150,13 @@ msgstr ""
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
 #: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
-#: lxc/storage_volume.go:612 lxc/storage_volume.go:717
-#: lxc/storage_volume.go:1005 lxc/storage_volume.go:1231
-#: lxc/storage_volume.go:1360 lxc/storage_volume.go:1848
-#: lxc/storage_volume.go:1940 lxc/storage_volume.go:2079
-#: lxc/storage_volume.go:2239 lxc/storage_volume.go:2355
-#: lxc/storage_volume.go:2416 lxc/storage_volume.go:2543
-#: lxc/storage_volume.go:2631 lxc/storage_volume.go:2795
+#: lxc/storage_volume.go:618 lxc/storage_volume.go:723
+#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1237
+#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1854
+#: lxc/storage_volume.go:1946 lxc/storage_volume.go:2085
+#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2361
+#: lxc/storage_volume.go:2422 lxc/storage_volume.go:2549
+#: lxc/storage_volume.go:2637 lxc/storage_volume.go:2801
 msgid "Cluster member name"
 msgstr ""
 
@@ -1172,7 +1172,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1589
+#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1595
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1216,17 +1216,17 @@ msgstr ""
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1150
-#: lxc/storage_volume.go:1182
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
+#: lxc/storage_volume.go:1188
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:613
+#: lxc/storage_volume.go:619
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1467
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1310,7 +1310,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:508
+#: lxc/storage_volume.go:514
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1324,12 +1324,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:490
+#: lxc/remote.go:559
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:225 lxc/remote.go:474
+#: lxc/remote.go:237 lxc/remote.go:543
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1368,7 +1368,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:485
+#: lxc/remote.go:554
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1437,7 +1437,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:604 lxc/storage_volume.go:605
+#: lxc/storage_volume.go:610 lxc/storage_volume.go:611
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1489,7 +1489,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1475
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1481
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1524,7 +1524,7 @@ msgstr ""
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1732
+#: lxc/storage_volume.go:1738
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1544,7 +1544,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2630
+#: lxc/storage_volume.go:2636
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1640,7 +1640,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:713 lxc/storage_volume.go:714
+#: lxc/storage_volume.go:719 lxc/storage_volume.go:720
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1732,9 +1732,9 @@ msgstr ""
 #: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
 #: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
 #: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:648
-#: lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853 lxc/remote.go:917
-#: lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:715
+#: lxc/remote.go:753 lxc/remote.go:839 lxc/remote.go:920 lxc/remote.go:984
+#: lxc/remote.go:1032 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1746,26 +1746,26 @@ msgstr ""
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
 #: lxc/storage_volume.go:169 lxc/storage_volume.go:283
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:605
-#: lxc/storage_volume.go:714 lxc/storage_volume.go:801
-#: lxc/storage_volume.go:899 lxc/storage_volume.go:996
-#: lxc/storage_volume.go:1217 lxc/storage_volume.go:1348
-#: lxc/storage_volume.go:1507 lxc/storage_volume.go:1591
-#: lxc/storage_volume.go:1844 lxc/storage_volume.go:1937
-#: lxc/storage_volume.go:2064 lxc/storage_volume.go:2222
-#: lxc/storage_volume.go:2343 lxc/storage_volume.go:2405
-#: lxc/storage_volume.go:2541 lxc/storage_volume.go:2624
-#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:611
+#: lxc/storage_volume.go:720 lxc/storage_volume.go:807
+#: lxc/storage_volume.go:905 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:1223 lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1513 lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1850 lxc/storage_volume.go:1943
+#: lxc/storage_volume.go:2070 lxc/storage_volume.go:2228
+#: lxc/storage_volume.go:2349 lxc/storage_volume.go:2411
+#: lxc/storage_volume.go:2547 lxc/storage_volume.go:2630
+#: lxc/storage_volume.go:2796 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1448
+#: lxc/storage_volume.go:1454
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:1849
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:1855
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1777,11 +1777,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:800 lxc/storage_volume.go:801
+#: lxc/storage_volume.go:806 lxc/storage_volume.go:807
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:898 lxc/storage_volume.go:899
+#: lxc/storage_volume.go:904 lxc/storage_volume.go:905
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -2007,7 +2007,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:995 lxc/storage_volume.go:996
+#: lxc/storage_volume.go:1001 lxc/storage_volume.go:1002
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2015,7 +2015,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1766
+#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1772
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2072,7 +2072,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2193
+#: lxc/storage_volume.go:2161 lxc/storage_volume.go:2199
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2086,8 +2086,8 @@ msgstr ""
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2149
-#: lxc/storage_volume.go:2187
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2155
+#: lxc/storage_volume.go:2193
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2129,8 +2129,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1508
-#: lxc/storage_volume.go:1558
+#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1514
+#: lxc/storage_volume.go:1564
 msgid "Expires at"
 msgstr ""
 
@@ -2154,7 +2154,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2623 lxc/storage_volume.go:2624
+#: lxc/storage_volume.go:2629 lxc/storage_volume.go:2630
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2166,11 +2166,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2627
+#: lxc/storage_volume.go:2633
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2756
+#: lxc/export.go:152 lxc/storage_volume.go:2762
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2287,11 +2287,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:191
+#: lxc/remote.go:203
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:242
+#: lxc/remote.go:254
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2301,7 +2301,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:232
+#: lxc/remote.go:244
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2311,12 +2311,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:260
+#: lxc/remote.go:486
 #, c-format
-msgid "Failed to create certificate: %w"
+msgid "Failed to decode trust token: %w"
 msgstr ""
 
-#: lxc/remote.go:267
+#: lxc/remote.go:292
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2341,7 +2341,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:237
+#: lxc/remote.go:249
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2428,9 +2428,9 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:690 lxc/storage.go:657
+#: lxc/project.go:919 lxc/remote.go:757 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1608 lxc/warning.go:94
+#: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2466,7 +2466,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:754
+#: lxc/remote.go:821
 msgid "GLOBAL"
 msgstr ""
 
@@ -2486,7 +2486,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:160 lxc/remote.go:401
+#: lxc/remote.go:165 lxc/remote.go:443
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2554,7 +2554,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1238
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2618,11 +2618,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1216 lxc/storage_volume.go:1217
+#: lxc/storage_volume.go:1222 lxc/storage_volume.go:1223
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:469
+#: lxc/storage_volume.go:475
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2746,7 +2746,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2415
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2421
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2760,7 +2760,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2414
+#: lxc/storage_volume.go:2420
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2810,7 +2810,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2790
+#: lxc/storage_volume.go:2796
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2818,7 +2818,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2789
+#: lxc/storage_volume.go:2795
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2840,11 +2840,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2797
+#: lxc/storage_volume.go:2803
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2871
+#: lxc/storage_volume.go:2877
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2910,7 +2910,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:353
+#: lxc/remote.go:395
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2970,7 +2970,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2000
+#: lxc/move.go:148 lxc/storage_volume.go:2006
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2978,7 +2978,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1996
+#: lxc/storage_volume.go:2002
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2991,14 +2991,14 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:342
+#: lxc/remote.go:384
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1064 lxc/storage_volume.go:1281
-#: lxc/storage_volume.go:1405 lxc/storage_volume.go:1985
-#: lxc/storage_volume.go:2132 lxc/storage_volume.go:2284
+#: lxc/storage_volume.go:1070 lxc/storage_volume.go:1287
+#: lxc/storage_volume.go:1411 lxc/storage_volume.go:1991
+#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2290
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3044,7 +3044,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1739 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1745 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3347,11 +3347,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1586
+#: lxc/storage_volume.go:1592
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1597
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3371,7 +3371,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:685 lxc/remote.go:686
+#: lxc/remote.go:752 lxc/remote.go:753
 msgid "List the available remotes"
 msgstr ""
 
@@ -3410,7 +3410,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1464
+#: lxc/info.go:489 lxc/storage_volume.go:1470
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3874,12 +3874,12 @@ msgstr ""
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:323 lxc/storage_volume.go:643
-#: lxc/storage_volume.go:750 lxc/storage_volume.go:841
-#: lxc/storage_volume.go:939 lxc/storage_volume.go:1053
-#: lxc/storage_volume.go:1270 lxc/storage_volume.go:1974
-#: lxc/storage_volume.go:2115 lxc/storage_volume.go:2273
-#: lxc/storage_volume.go:2464 lxc/storage_volume.go:2581
+#: lxc/storage_volume.go:323 lxc/storage_volume.go:649
+#: lxc/storage_volume.go:756 lxc/storage_volume.go:847
+#: lxc/storage_volume.go:945 lxc/storage_volume.go:1059
+#: lxc/storage_volume.go:1276 lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:2121 lxc/storage_volume.go:2279
+#: lxc/storage_volume.go:2470 lxc/storage_volume.go:2587
 msgid "Missing pool name"
 msgstr ""
 
@@ -3898,11 +3898,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:432 lxc/storage_volume.go:1884
+#: lxc/storage_volume.go:438 lxc/storage_volume.go:1890
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1394
+#: lxc/storage_volume.go:1400
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -3939,8 +3939,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:861
-#: lxc/storage_volume.go:958
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:867
+#: lxc/storage_volume.go:964
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -3977,7 +3977,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1843 lxc/storage_volume.go:1844
+#: lxc/storage_volume.go:1849 lxc/storage_volume.go:1850
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -3985,11 +3985,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1850
+#: lxc/storage_volume.go:1856
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:512
+#: lxc/storage_volume.go:518
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4015,8 +4015,8 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
-#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1731
+#: lxc/remote.go:815 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
 msgstr ""
 
@@ -4042,7 +4042,7 @@ msgstr ""
 
 #: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
+#: lxc/project.go:550 lxc/remote.go:775 lxc/remote.go:780 lxc/remote.go:785
 msgid "NO"
 msgstr ""
 
@@ -4064,8 +4064,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1506
-#: lxc/storage_volume.go:1556
+#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1512
+#: lxc/storage_volume.go:1562
 msgid "Name"
 msgstr ""
 
@@ -4073,7 +4073,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1446
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1452
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4217,7 +4217,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:870 lxc/storage_volume.go:967
+#: lxc/storage_volume.go:876 lxc/storage_volume.go:973
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4233,11 +4233,11 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/storage_volume.go:446 lxc/storage_volume.go:1893
+#: lxc/storage_volume.go:452 lxc/storage_volume.go:1899
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:496 lxc/storage_volume.go:1904
+#: lxc/storage_volume.go:502 lxc/storage_volume.go:1910
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4251,7 +4251,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2012
+#: lxc/storage_volume.go:2018
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4263,15 +4263,15 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2678
+#: lxc/storage_volume.go:2684
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2477
+#: lxc/storage_volume.go:2483
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:336
+#: lxc/remote.go:378
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4279,7 +4279,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1412
+#: lxc/storage_volume.go:1418
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4292,7 +4292,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:693 lxc/storage_volume.go:1560
+#: lxc/info.go:693 lxc/storage_volume.go:1566
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4322,7 +4322,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1756
 msgid "POOL"
 msgstr ""
 
@@ -4338,15 +4338,15 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:213
+#: lxc/list.go:567 lxc/storage_volume.go:1762 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:817
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:752
+#: lxc/image.go:1136 lxc/remote.go:819
 msgid "PUBLIC"
 msgstr ""
 
@@ -4375,7 +4375,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:183
+#: lxc/remote.go:195
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4387,8 +4387,8 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:466
-msgid "Please type 'y', 'n' or the fingerprint:"
+#: lxc/remote.go:536
+msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
 #: lxc/info.go:221
@@ -4412,8 +4412,8 @@ msgstr ""
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1151
-#: lxc/storage_volume.go:1183
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
+#: lxc/storage_volume.go:1189
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4530,7 +4530,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1350
+#: lxc/storage_volume.go:1356
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4544,7 +4544,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1219
+#: lxc/storage_volume.go:1225
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4560,7 +4560,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2224
+#: lxc/storage_volume.go:2230
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4581,7 +4581,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:998
+#: lxc/storage_volume.go:1004
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4590,7 +4590,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2069
+#: lxc/storage_volume.go:2075
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4603,7 +4603,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2345
+#: lxc/storage_volume.go:2351
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4707,33 +4707,33 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:810
+#: lxc/remote.go:877
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
-#: lxc/remote.go:994
+#: lxc/project.go:884 lxc/remote.go:868 lxc/remote.go:949 lxc/remote.go:1013
+#: lxc/remote.go:1061
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:305
+#: lxc/remote.go:345
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:890
+#: lxc/remote.go:957
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:805 lxc/remote.go:886 lxc/remote.go:998
+#: lxc/remote.go:872 lxc/remote.go:953 lxc/remote.go:1065
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:294
+#: lxc/remote.go:319
 msgid "Remote address must not be empty"
 msgstr ""
 
@@ -4741,7 +4741,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:299
+#: lxc/remote.go:339
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4827,7 +4827,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:852 lxc/remote.go:853
+#: lxc/remote.go:919 lxc/remote.go:920
 msgid "Remove remotes"
 msgstr ""
 
@@ -4884,19 +4884,19 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:771 lxc/remote.go:772
+#: lxc/remote.go:838 lxc/remote.go:839
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:1943
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1936
+#: lxc/storage_volume.go:1942
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2025 lxc/storage_volume.go:2045
+#: lxc/storage_volume.go:2031 lxc/storage_volume.go:2051
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4948,7 +4948,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2540 lxc/storage_volume.go:2541
+#: lxc/storage_volume.go:2546 lxc/storage_volume.go:2547
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5029,7 +5029,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:820
 msgid "STATIC"
 msgstr ""
 
@@ -5070,11 +5070,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:464
+#: lxc/remote.go:532
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:616
+#: lxc/remote.go:285 lxc/remote.go:683
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5272,11 +5272,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2063
+#: lxc/storage_volume.go:2069
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2064
+#: lxc/storage_volume.go:2070
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5285,7 +5285,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:964 lxc/remote.go:965
+#: lxc/remote.go:1031 lxc/remote.go:1032
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5361,7 +5361,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2080
+#: lxc/storage_volume.go:2086
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5510,11 +5510,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2221 lxc/storage_volume.go:2222
+#: lxc/storage_volume.go:2227 lxc/storage_volume.go:2228
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1347 lxc/storage_volume.go:1348
+#: lxc/storage_volume.go:1353 lxc/storage_volume.go:1354
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5528,7 +5528,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:647 lxc/remote.go:648
+#: lxc/remote.go:714 lxc/remote.go:715
 msgid "Show the default remote"
 msgstr ""
 
@@ -5582,15 +5582,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2404 lxc/storage_volume.go:2405
+#: lxc/storage_volume.go:2410 lxc/storage_volume.go:2411
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2167
+#: lxc/storage_volume.go:2173
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:607 lxc/storage_volume.go:1485
+#: lxc/info.go:607 lxc/storage_volume.go:1491
 msgid "Snapshots:"
 msgstr ""
 
@@ -5691,21 +5691,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:696
+#: lxc/storage_volume.go:702
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:784
+#: lxc/storage_volume.go:790
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:509
+#: lxc/storage_volume.go:515
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:513
+#: lxc/storage_volume.go:519
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5740,7 +5740,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:916 lxc/remote.go:917
+#: lxc/remote.go:983 lxc/remote.go:984
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5759,11 +5759,11 @@ msgstr ""
 #: lxc/auth.go:818 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
-#: lxc/storage_volume.go:1730 lxc/warning.go:216
+#: lxc/storage_volume.go:1736 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1557
+#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1563
 msgid "Taken at"
 msgstr ""
 
@@ -5773,6 +5773,12 @@ msgstr ""
 
 #: lxc/file.go:1256
 msgid "Target path must be a directory"
+msgstr ""
+
+#: lxc/remote.go:161 lxc/remote.go:334
+msgid ""
+"The --accept-certificate flag is not supported when adding a remote using a "
+"trust token"
 msgstr ""
 
 #: lxc/move.go:181
@@ -5914,15 +5920,20 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1323
+#: lxc/storage_volume.go:1329
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1300
+#: lxc/storage_volume.go:1306
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
+msgstr ""
+
+#: lxc/remote.go:527
+msgid ""
+"The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
 
 #: lxc/info.go:354
@@ -5933,8 +5944,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:875
-#: lxc/storage_volume.go:972
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:881
+#: lxc/storage_volume.go:978
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6009,7 +6020,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1470
+#: lxc/storage_volume.go:1476
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6024,7 +6035,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1847
+#: lxc/storage_volume.go:1853
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6058,7 +6069,15 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:571
+#: lxc/remote.go:329
+msgid "Trust token cannot be used for public remotes"
+msgstr ""
+
+#: lxc/remote.go:324
+msgid "Trust token cannot be used with OIDC authentication"
+msgstr ""
+
+#: lxc/remote.go:639
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6083,7 +6102,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1455
+#: lxc/storage_volume.go:1461
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6101,17 +6120,17 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:193 lxc/remote.go:749
+#: lxc/cluster.go:193 lxc/remote.go:816
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1735
+#: lxc/project.go:995 lxc/storage_volume.go:1741
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1734
+#: lxc/storage.go:724 lxc/storage_volume.go:1740
 msgid "USED BY"
 msgstr ""
 
@@ -6129,7 +6148,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:214 lxc/remote.go:248
+#: lxc/remote.go:226 lxc/remote.go:260
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6143,7 +6162,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1772
+#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1778
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6249,7 +6268,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2342 lxc/storage_volume.go:2343
+#: lxc/storage_volume.go:2348 lxc/storage_volume.go:2349
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6301,7 +6320,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2356
+#: lxc/storage_volume.go:2362
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6345,12 +6364,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1468
+#: lxc/storage_volume.go:1474
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2629
+#: lxc/export.go:42 lxc/storage_volume.go:2635
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6417,7 +6436,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1559
+#: lxc/storage_volume.go:1565
 msgid "Volume Only"
 msgstr ""
 
@@ -6452,7 +6471,7 @@ msgstr ""
 
 #: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
+#: lxc/project.go:552 lxc/remote.go:777 lxc/remote.go:782 lxc/remote.go:787
 msgid "YES"
 msgstr ""
 
@@ -6476,7 +6495,7 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:897
+#: lxc/storage_volume.go:903
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
@@ -6898,7 +6917,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2788
+#: lxc/storage_volume.go:2794
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -6933,13 +6952,13 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:1941
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:799
+#: lxc/storage_volume.go:805
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
@@ -6947,47 +6966,47 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2539
+#: lxc/storage_volume.go:2545
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2622
+#: lxc/storage_volume.go:2628
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2403
+#: lxc/storage_volume.go:2409
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:603
+#: lxc/storage_volume.go:609
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:711
+#: lxc/storage_volume.go:717
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:994 lxc/storage_volume.go:1346
+#: lxc/storage_volume.go:1000 lxc/storage_volume.go:1352
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2341
+#: lxc/storage_volume.go:2347
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2062
+#: lxc/storage_volume.go:2068
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2220
+#: lxc/storage_volume.go:2226
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1215
+#: lxc/storage_volume.go:1221
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1841
+#: lxc/storage_volume.go:1847
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7097,7 +7116,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1584
+#: lxc/storage_volume.go:1590
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7109,7 +7128,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:739
+#: lxc/project.go:557 lxc/remote.go:806
 msgid "current"
 msgstr ""
 
@@ -7569,7 +7588,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:607
+#: lxc/storage_volume.go:613
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7577,13 +7596,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2792
+#: lxc/storage_volume.go:2798
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2407
+#: lxc/storage_volume.go:2413
 msgid ""
 "lxc storage volume snapshot create default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7593,7 +7612,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:531
 msgid "n"
 msgstr ""
 
@@ -7605,7 +7624,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:510
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7642,7 +7661,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:465
+#: lxc/remote.go:519
 msgid "y"
 msgstr ""
 

--- a/po/sl.po
+++ b/po/sl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-08 07:43+0100\n"
+"POT-Creation-Date: 2024-10-14 13:30+0000\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Slovenian <https://hosted.weblate.org/projects/linux-"
@@ -50,7 +50,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1024
+#: lxc/storage_volume.go:1030
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -516,15 +516,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:850 lxc/remote.go:915
+#: lxc/remote.go:917 lxc/remote.go:982
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:963
+#: lxc/remote.go:1030
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:769
+#: lxc/remote.go:836
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -557,7 +557,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:751
+#: lxc/remote.go:818
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -706,7 +706,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:581
+#: lxc/remote.go:648
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -739,11 +739,11 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1590
+#: lxc/storage_volume.go:1596
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:182
+#: lxc/remote.go:194
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -814,7 +814,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:552
+#: lxc/remote.go:621
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -850,16 +850,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2696
+#: lxc/storage_volume.go:2702
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2773
+#: lxc/export.go:192 lxc/storage_volume.go:2779
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:654 lxc/storage_volume.go:1521
+#: lxc/info.go:654 lxc/storage_volume.go:1527
 msgid "Backups:"
 msgstr ""
 
@@ -880,7 +880,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:679
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:685
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -923,7 +923,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1733
+#: lxc/storage_volume.go:1739
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -992,7 +992,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:894
+#: lxc/remote.go:961
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1008,7 +1008,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1749 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1025,12 +1025,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:486
+#: lxc/storage_volume.go:492
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:440
+#: lxc/storage_volume.go:446
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1058,11 +1058,11 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:509
 msgid "Certificate fingerprint"
 msgstr ""
 
-#: lxc/remote.go:219
+#: lxc/remote.go:231
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:620
+#: lxc/remote.go:687
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1151,13 +1151,13 @@ msgstr ""
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
 #: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
-#: lxc/storage_volume.go:612 lxc/storage_volume.go:717
-#: lxc/storage_volume.go:1005 lxc/storage_volume.go:1231
-#: lxc/storage_volume.go:1360 lxc/storage_volume.go:1848
-#: lxc/storage_volume.go:1940 lxc/storage_volume.go:2079
-#: lxc/storage_volume.go:2239 lxc/storage_volume.go:2355
-#: lxc/storage_volume.go:2416 lxc/storage_volume.go:2543
-#: lxc/storage_volume.go:2631 lxc/storage_volume.go:2795
+#: lxc/storage_volume.go:618 lxc/storage_volume.go:723
+#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1237
+#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1854
+#: lxc/storage_volume.go:1946 lxc/storage_volume.go:2085
+#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2361
+#: lxc/storage_volume.go:2422 lxc/storage_volume.go:2549
+#: lxc/storage_volume.go:2637 lxc/storage_volume.go:2801
 msgid "Cluster member name"
 msgstr ""
 
@@ -1173,7 +1173,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1589
+#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1595
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1217,17 +1217,17 @@ msgstr ""
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1150
-#: lxc/storage_volume.go:1182
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
+#: lxc/storage_volume.go:1188
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:613
+#: lxc/storage_volume.go:619
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1467
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1311,7 +1311,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:508
+#: lxc/storage_volume.go:514
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1325,12 +1325,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:490
+#: lxc/remote.go:559
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:225 lxc/remote.go:474
+#: lxc/remote.go:237 lxc/remote.go:543
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1369,7 +1369,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:485
+#: lxc/remote.go:554
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1438,7 +1438,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:604 lxc/storage_volume.go:605
+#: lxc/storage_volume.go:610 lxc/storage_volume.go:611
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1490,7 +1490,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1475
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1481
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1525,7 +1525,7 @@ msgstr ""
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1732
+#: lxc/storage_volume.go:1738
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1545,7 +1545,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2630
+#: lxc/storage_volume.go:2636
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1641,7 +1641,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:713 lxc/storage_volume.go:714
+#: lxc/storage_volume.go:719 lxc/storage_volume.go:720
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1733,9 +1733,9 @@ msgstr ""
 #: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
 #: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
 #: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:648
-#: lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853 lxc/remote.go:917
-#: lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:715
+#: lxc/remote.go:753 lxc/remote.go:839 lxc/remote.go:920 lxc/remote.go:984
+#: lxc/remote.go:1032 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1747,26 +1747,26 @@ msgstr ""
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
 #: lxc/storage_volume.go:169 lxc/storage_volume.go:283
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:605
-#: lxc/storage_volume.go:714 lxc/storage_volume.go:801
-#: lxc/storage_volume.go:899 lxc/storage_volume.go:996
-#: lxc/storage_volume.go:1217 lxc/storage_volume.go:1348
-#: lxc/storage_volume.go:1507 lxc/storage_volume.go:1591
-#: lxc/storage_volume.go:1844 lxc/storage_volume.go:1937
-#: lxc/storage_volume.go:2064 lxc/storage_volume.go:2222
-#: lxc/storage_volume.go:2343 lxc/storage_volume.go:2405
-#: lxc/storage_volume.go:2541 lxc/storage_volume.go:2624
-#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:611
+#: lxc/storage_volume.go:720 lxc/storage_volume.go:807
+#: lxc/storage_volume.go:905 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:1223 lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1513 lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1850 lxc/storage_volume.go:1943
+#: lxc/storage_volume.go:2070 lxc/storage_volume.go:2228
+#: lxc/storage_volume.go:2349 lxc/storage_volume.go:2411
+#: lxc/storage_volume.go:2547 lxc/storage_volume.go:2630
+#: lxc/storage_volume.go:2796 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1448
+#: lxc/storage_volume.go:1454
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:1849
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:1855
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1778,11 +1778,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:800 lxc/storage_volume.go:801
+#: lxc/storage_volume.go:806 lxc/storage_volume.go:807
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:898 lxc/storage_volume.go:899
+#: lxc/storage_volume.go:904 lxc/storage_volume.go:905
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -2008,7 +2008,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:995 lxc/storage_volume.go:996
+#: lxc/storage_volume.go:1001 lxc/storage_volume.go:1002
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2016,7 +2016,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1766
+#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1772
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2073,7 +2073,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2193
+#: lxc/storage_volume.go:2161 lxc/storage_volume.go:2199
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2087,8 +2087,8 @@ msgstr ""
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2149
-#: lxc/storage_volume.go:2187
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2155
+#: lxc/storage_volume.go:2193
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2130,8 +2130,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1508
-#: lxc/storage_volume.go:1558
+#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1514
+#: lxc/storage_volume.go:1564
 msgid "Expires at"
 msgstr ""
 
@@ -2155,7 +2155,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2623 lxc/storage_volume.go:2624
+#: lxc/storage_volume.go:2629 lxc/storage_volume.go:2630
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2167,11 +2167,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2627
+#: lxc/storage_volume.go:2633
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2756
+#: lxc/export.go:152 lxc/storage_volume.go:2762
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2288,11 +2288,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:191
+#: lxc/remote.go:203
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:242
+#: lxc/remote.go:254
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2302,7 +2302,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:232
+#: lxc/remote.go:244
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2312,12 +2312,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:260
+#: lxc/remote.go:486
 #, c-format
-msgid "Failed to create certificate: %w"
+msgid "Failed to decode trust token: %w"
 msgstr ""
 
-#: lxc/remote.go:267
+#: lxc/remote.go:292
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2342,7 +2342,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:237
+#: lxc/remote.go:249
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2429,9 +2429,9 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:690 lxc/storage.go:657
+#: lxc/project.go:919 lxc/remote.go:757 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1608 lxc/warning.go:94
+#: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2467,7 +2467,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:754
+#: lxc/remote.go:821
 msgid "GLOBAL"
 msgstr ""
 
@@ -2487,7 +2487,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:160 lxc/remote.go:401
+#: lxc/remote.go:165 lxc/remote.go:443
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2555,7 +2555,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1238
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2619,11 +2619,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1216 lxc/storage_volume.go:1217
+#: lxc/storage_volume.go:1222 lxc/storage_volume.go:1223
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:469
+#: lxc/storage_volume.go:475
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2747,7 +2747,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2415
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2421
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2761,7 +2761,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2414
+#: lxc/storage_volume.go:2420
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2811,7 +2811,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2790
+#: lxc/storage_volume.go:2796
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2819,7 +2819,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2789
+#: lxc/storage_volume.go:2795
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2841,11 +2841,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2797
+#: lxc/storage_volume.go:2803
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2871
+#: lxc/storage_volume.go:2877
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2911,7 +2911,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:353
+#: lxc/remote.go:395
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2971,7 +2971,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2000
+#: lxc/move.go:148 lxc/storage_volume.go:2006
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2979,7 +2979,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1996
+#: lxc/storage_volume.go:2002
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2992,14 +2992,14 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:342
+#: lxc/remote.go:384
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1064 lxc/storage_volume.go:1281
-#: lxc/storage_volume.go:1405 lxc/storage_volume.go:1985
-#: lxc/storage_volume.go:2132 lxc/storage_volume.go:2284
+#: lxc/storage_volume.go:1070 lxc/storage_volume.go:1287
+#: lxc/storage_volume.go:1411 lxc/storage_volume.go:1991
+#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2290
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3045,7 +3045,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1739 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1745 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3348,11 +3348,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1586
+#: lxc/storage_volume.go:1592
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1597
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3372,7 +3372,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:685 lxc/remote.go:686
+#: lxc/remote.go:752 lxc/remote.go:753
 msgid "List the available remotes"
 msgstr ""
 
@@ -3411,7 +3411,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1464
+#: lxc/info.go:489 lxc/storage_volume.go:1470
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3875,12 +3875,12 @@ msgstr ""
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:323 lxc/storage_volume.go:643
-#: lxc/storage_volume.go:750 lxc/storage_volume.go:841
-#: lxc/storage_volume.go:939 lxc/storage_volume.go:1053
-#: lxc/storage_volume.go:1270 lxc/storage_volume.go:1974
-#: lxc/storage_volume.go:2115 lxc/storage_volume.go:2273
-#: lxc/storage_volume.go:2464 lxc/storage_volume.go:2581
+#: lxc/storage_volume.go:323 lxc/storage_volume.go:649
+#: lxc/storage_volume.go:756 lxc/storage_volume.go:847
+#: lxc/storage_volume.go:945 lxc/storage_volume.go:1059
+#: lxc/storage_volume.go:1276 lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:2121 lxc/storage_volume.go:2279
+#: lxc/storage_volume.go:2470 lxc/storage_volume.go:2587
 msgid "Missing pool name"
 msgstr ""
 
@@ -3899,11 +3899,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:432 lxc/storage_volume.go:1884
+#: lxc/storage_volume.go:438 lxc/storage_volume.go:1890
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1394
+#: lxc/storage_volume.go:1400
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -3940,8 +3940,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:861
-#: lxc/storage_volume.go:958
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:867
+#: lxc/storage_volume.go:964
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -3978,7 +3978,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1843 lxc/storage_volume.go:1844
+#: lxc/storage_volume.go:1849 lxc/storage_volume.go:1850
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -3986,11 +3986,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1850
+#: lxc/storage_volume.go:1856
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:512
+#: lxc/storage_volume.go:518
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4016,8 +4016,8 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
-#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1731
+#: lxc/remote.go:815 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
 msgstr ""
 
@@ -4043,7 +4043,7 @@ msgstr ""
 
 #: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
+#: lxc/project.go:550 lxc/remote.go:775 lxc/remote.go:780 lxc/remote.go:785
 msgid "NO"
 msgstr ""
 
@@ -4065,8 +4065,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1506
-#: lxc/storage_volume.go:1556
+#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1512
+#: lxc/storage_volume.go:1562
 msgid "Name"
 msgstr ""
 
@@ -4074,7 +4074,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1446
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1452
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4218,7 +4218,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:870 lxc/storage_volume.go:967
+#: lxc/storage_volume.go:876 lxc/storage_volume.go:973
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4234,11 +4234,11 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/storage_volume.go:446 lxc/storage_volume.go:1893
+#: lxc/storage_volume.go:452 lxc/storage_volume.go:1899
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:496 lxc/storage_volume.go:1904
+#: lxc/storage_volume.go:502 lxc/storage_volume.go:1910
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4252,7 +4252,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2012
+#: lxc/storage_volume.go:2018
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4264,15 +4264,15 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2678
+#: lxc/storage_volume.go:2684
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2477
+#: lxc/storage_volume.go:2483
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:336
+#: lxc/remote.go:378
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4280,7 +4280,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1412
+#: lxc/storage_volume.go:1418
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4293,7 +4293,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:693 lxc/storage_volume.go:1560
+#: lxc/info.go:693 lxc/storage_volume.go:1566
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4323,7 +4323,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1756
 msgid "POOL"
 msgstr ""
 
@@ -4339,15 +4339,15 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:213
+#: lxc/list.go:567 lxc/storage_volume.go:1762 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:817
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:752
+#: lxc/image.go:1136 lxc/remote.go:819
 msgid "PUBLIC"
 msgstr ""
 
@@ -4376,7 +4376,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:183
+#: lxc/remote.go:195
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4388,8 +4388,8 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:466
-msgid "Please type 'y', 'n' or the fingerprint:"
+#: lxc/remote.go:536
+msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
 #: lxc/info.go:221
@@ -4413,8 +4413,8 @@ msgstr ""
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1151
-#: lxc/storage_volume.go:1183
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
+#: lxc/storage_volume.go:1189
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4531,7 +4531,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1350
+#: lxc/storage_volume.go:1356
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4545,7 +4545,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1219
+#: lxc/storage_volume.go:1225
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4561,7 +4561,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2224
+#: lxc/storage_volume.go:2230
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4582,7 +4582,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:998
+#: lxc/storage_volume.go:1004
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4591,7 +4591,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2069
+#: lxc/storage_volume.go:2075
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4604,7 +4604,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2345
+#: lxc/storage_volume.go:2351
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4708,33 +4708,33 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:810
+#: lxc/remote.go:877
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
-#: lxc/remote.go:994
+#: lxc/project.go:884 lxc/remote.go:868 lxc/remote.go:949 lxc/remote.go:1013
+#: lxc/remote.go:1061
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:305
+#: lxc/remote.go:345
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:890
+#: lxc/remote.go:957
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:805 lxc/remote.go:886 lxc/remote.go:998
+#: lxc/remote.go:872 lxc/remote.go:953 lxc/remote.go:1065
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:294
+#: lxc/remote.go:319
 msgid "Remote address must not be empty"
 msgstr ""
 
@@ -4742,7 +4742,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:299
+#: lxc/remote.go:339
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4828,7 +4828,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:852 lxc/remote.go:853
+#: lxc/remote.go:919 lxc/remote.go:920
 msgid "Remove remotes"
 msgstr ""
 
@@ -4885,19 +4885,19 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:771 lxc/remote.go:772
+#: lxc/remote.go:838 lxc/remote.go:839
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:1943
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1936
+#: lxc/storage_volume.go:1942
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2025 lxc/storage_volume.go:2045
+#: lxc/storage_volume.go:2031 lxc/storage_volume.go:2051
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4949,7 +4949,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2540 lxc/storage_volume.go:2541
+#: lxc/storage_volume.go:2546 lxc/storage_volume.go:2547
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5030,7 +5030,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:820
 msgid "STATIC"
 msgstr ""
 
@@ -5071,11 +5071,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:464
+#: lxc/remote.go:532
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:616
+#: lxc/remote.go:285 lxc/remote.go:683
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5273,11 +5273,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2063
+#: lxc/storage_volume.go:2069
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2064
+#: lxc/storage_volume.go:2070
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5286,7 +5286,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:964 lxc/remote.go:965
+#: lxc/remote.go:1031 lxc/remote.go:1032
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5362,7 +5362,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2080
+#: lxc/storage_volume.go:2086
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5511,11 +5511,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2221 lxc/storage_volume.go:2222
+#: lxc/storage_volume.go:2227 lxc/storage_volume.go:2228
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1347 lxc/storage_volume.go:1348
+#: lxc/storage_volume.go:1353 lxc/storage_volume.go:1354
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5529,7 +5529,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:647 lxc/remote.go:648
+#: lxc/remote.go:714 lxc/remote.go:715
 msgid "Show the default remote"
 msgstr ""
 
@@ -5583,15 +5583,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2404 lxc/storage_volume.go:2405
+#: lxc/storage_volume.go:2410 lxc/storage_volume.go:2411
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2167
+#: lxc/storage_volume.go:2173
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:607 lxc/storage_volume.go:1485
+#: lxc/info.go:607 lxc/storage_volume.go:1491
 msgid "Snapshots:"
 msgstr ""
 
@@ -5692,21 +5692,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:696
+#: lxc/storage_volume.go:702
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:784
+#: lxc/storage_volume.go:790
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:509
+#: lxc/storage_volume.go:515
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:513
+#: lxc/storage_volume.go:519
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5741,7 +5741,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:916 lxc/remote.go:917
+#: lxc/remote.go:983 lxc/remote.go:984
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5760,11 +5760,11 @@ msgstr ""
 #: lxc/auth.go:818 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
-#: lxc/storage_volume.go:1730 lxc/warning.go:216
+#: lxc/storage_volume.go:1736 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1557
+#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1563
 msgid "Taken at"
 msgstr ""
 
@@ -5774,6 +5774,12 @@ msgstr ""
 
 #: lxc/file.go:1256
 msgid "Target path must be a directory"
+msgstr ""
+
+#: lxc/remote.go:161 lxc/remote.go:334
+msgid ""
+"The --accept-certificate flag is not supported when adding a remote using a "
+"trust token"
 msgstr ""
 
 #: lxc/move.go:181
@@ -5915,15 +5921,20 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1323
+#: lxc/storage_volume.go:1329
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1300
+#: lxc/storage_volume.go:1306
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
+msgstr ""
+
+#: lxc/remote.go:527
+msgid ""
+"The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
 
 #: lxc/info.go:354
@@ -5934,8 +5945,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:875
-#: lxc/storage_volume.go:972
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:881
+#: lxc/storage_volume.go:978
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6010,7 +6021,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1470
+#: lxc/storage_volume.go:1476
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6025,7 +6036,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1847
+#: lxc/storage_volume.go:1853
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6059,7 +6070,15 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:571
+#: lxc/remote.go:329
+msgid "Trust token cannot be used for public remotes"
+msgstr ""
+
+#: lxc/remote.go:324
+msgid "Trust token cannot be used with OIDC authentication"
+msgstr ""
+
+#: lxc/remote.go:639
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6084,7 +6103,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1455
+#: lxc/storage_volume.go:1461
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6102,17 +6121,17 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:193 lxc/remote.go:749
+#: lxc/cluster.go:193 lxc/remote.go:816
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1735
+#: lxc/project.go:995 lxc/storage_volume.go:1741
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1734
+#: lxc/storage.go:724 lxc/storage_volume.go:1740
 msgid "USED BY"
 msgstr ""
 
@@ -6130,7 +6149,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:214 lxc/remote.go:248
+#: lxc/remote.go:226 lxc/remote.go:260
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6144,7 +6163,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1772
+#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1778
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6250,7 +6269,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2342 lxc/storage_volume.go:2343
+#: lxc/storage_volume.go:2348 lxc/storage_volume.go:2349
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6302,7 +6321,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2356
+#: lxc/storage_volume.go:2362
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6346,12 +6365,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1468
+#: lxc/storage_volume.go:1474
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2629
+#: lxc/export.go:42 lxc/storage_volume.go:2635
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6418,7 +6437,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1559
+#: lxc/storage_volume.go:1565
 msgid "Volume Only"
 msgstr ""
 
@@ -6453,7 +6472,7 @@ msgstr ""
 
 #: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
+#: lxc/project.go:552 lxc/remote.go:777 lxc/remote.go:782 lxc/remote.go:787
 msgid "YES"
 msgstr ""
 
@@ -6477,7 +6496,7 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:897
+#: lxc/storage_volume.go:903
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
@@ -6899,7 +6918,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2788
+#: lxc/storage_volume.go:2794
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -6934,13 +6953,13 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:1941
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:799
+#: lxc/storage_volume.go:805
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
@@ -6948,47 +6967,47 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2539
+#: lxc/storage_volume.go:2545
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2622
+#: lxc/storage_volume.go:2628
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2403
+#: lxc/storage_volume.go:2409
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:603
+#: lxc/storage_volume.go:609
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:711
+#: lxc/storage_volume.go:717
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:994 lxc/storage_volume.go:1346
+#: lxc/storage_volume.go:1000 lxc/storage_volume.go:1352
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2341
+#: lxc/storage_volume.go:2347
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2062
+#: lxc/storage_volume.go:2068
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2220
+#: lxc/storage_volume.go:2226
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1215
+#: lxc/storage_volume.go:1221
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1841
+#: lxc/storage_volume.go:1847
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7098,7 +7117,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1584
+#: lxc/storage_volume.go:1590
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7110,7 +7129,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:739
+#: lxc/project.go:557 lxc/remote.go:806
 msgid "current"
 msgstr ""
 
@@ -7570,7 +7589,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:607
+#: lxc/storage_volume.go:613
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7578,13 +7597,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2792
+#: lxc/storage_volume.go:2798
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2407
+#: lxc/storage_volume.go:2413
 msgid ""
 "lxc storage volume snapshot create default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7594,7 +7613,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:531
 msgid "n"
 msgstr ""
 
@@ -7606,7 +7625,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:510
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7643,7 +7662,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:465
+#: lxc/remote.go:519
 msgid "y"
 msgstr ""
 

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-08 07:43+0100\n"
+"POT-Creation-Date: 2024-10-14 13:30+0000\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Serbian <https://hosted.weblate.org/projects/linux-containers/"
@@ -50,7 +50,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1024
+#: lxc/storage_volume.go:1030
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -516,15 +516,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:850 lxc/remote.go:915
+#: lxc/remote.go:917 lxc/remote.go:982
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:963
+#: lxc/remote.go:1030
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:769
+#: lxc/remote.go:836
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -557,7 +557,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:751
+#: lxc/remote.go:818
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -706,7 +706,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:581
+#: lxc/remote.go:648
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -739,11 +739,11 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1590
+#: lxc/storage_volume.go:1596
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:182
+#: lxc/remote.go:194
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -814,7 +814,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:552
+#: lxc/remote.go:621
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -850,16 +850,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2696
+#: lxc/storage_volume.go:2702
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2773
+#: lxc/export.go:192 lxc/storage_volume.go:2779
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:654 lxc/storage_volume.go:1521
+#: lxc/info.go:654 lxc/storage_volume.go:1527
 msgid "Backups:"
 msgstr ""
 
@@ -880,7 +880,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:679
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:685
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -923,7 +923,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1733
+#: lxc/storage_volume.go:1739
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -992,7 +992,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:894
+#: lxc/remote.go:961
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1008,7 +1008,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1749 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1025,12 +1025,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:486
+#: lxc/storage_volume.go:492
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:440
+#: lxc/storage_volume.go:446
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1058,11 +1058,11 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:509
 msgid "Certificate fingerprint"
 msgstr ""
 
-#: lxc/remote.go:219
+#: lxc/remote.go:231
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:620
+#: lxc/remote.go:687
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1151,13 +1151,13 @@ msgstr ""
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
 #: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
-#: lxc/storage_volume.go:612 lxc/storage_volume.go:717
-#: lxc/storage_volume.go:1005 lxc/storage_volume.go:1231
-#: lxc/storage_volume.go:1360 lxc/storage_volume.go:1848
-#: lxc/storage_volume.go:1940 lxc/storage_volume.go:2079
-#: lxc/storage_volume.go:2239 lxc/storage_volume.go:2355
-#: lxc/storage_volume.go:2416 lxc/storage_volume.go:2543
-#: lxc/storage_volume.go:2631 lxc/storage_volume.go:2795
+#: lxc/storage_volume.go:618 lxc/storage_volume.go:723
+#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1237
+#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1854
+#: lxc/storage_volume.go:1946 lxc/storage_volume.go:2085
+#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2361
+#: lxc/storage_volume.go:2422 lxc/storage_volume.go:2549
+#: lxc/storage_volume.go:2637 lxc/storage_volume.go:2801
 msgid "Cluster member name"
 msgstr ""
 
@@ -1173,7 +1173,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1589
+#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1595
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1217,17 +1217,17 @@ msgstr ""
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1150
-#: lxc/storage_volume.go:1182
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
+#: lxc/storage_volume.go:1188
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:613
+#: lxc/storage_volume.go:619
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1467
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1311,7 +1311,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:508
+#: lxc/storage_volume.go:514
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1325,12 +1325,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:490
+#: lxc/remote.go:559
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:225 lxc/remote.go:474
+#: lxc/remote.go:237 lxc/remote.go:543
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1369,7 +1369,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:485
+#: lxc/remote.go:554
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1438,7 +1438,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:604 lxc/storage_volume.go:605
+#: lxc/storage_volume.go:610 lxc/storage_volume.go:611
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1490,7 +1490,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1475
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1481
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1525,7 +1525,7 @@ msgstr ""
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1732
+#: lxc/storage_volume.go:1738
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1545,7 +1545,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2630
+#: lxc/storage_volume.go:2636
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1641,7 +1641,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:713 lxc/storage_volume.go:714
+#: lxc/storage_volume.go:719 lxc/storage_volume.go:720
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1733,9 +1733,9 @@ msgstr ""
 #: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
 #: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
 #: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:648
-#: lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853 lxc/remote.go:917
-#: lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:715
+#: lxc/remote.go:753 lxc/remote.go:839 lxc/remote.go:920 lxc/remote.go:984
+#: lxc/remote.go:1032 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1747,26 +1747,26 @@ msgstr ""
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
 #: lxc/storage_volume.go:169 lxc/storage_volume.go:283
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:605
-#: lxc/storage_volume.go:714 lxc/storage_volume.go:801
-#: lxc/storage_volume.go:899 lxc/storage_volume.go:996
-#: lxc/storage_volume.go:1217 lxc/storage_volume.go:1348
-#: lxc/storage_volume.go:1507 lxc/storage_volume.go:1591
-#: lxc/storage_volume.go:1844 lxc/storage_volume.go:1937
-#: lxc/storage_volume.go:2064 lxc/storage_volume.go:2222
-#: lxc/storage_volume.go:2343 lxc/storage_volume.go:2405
-#: lxc/storage_volume.go:2541 lxc/storage_volume.go:2624
-#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:611
+#: lxc/storage_volume.go:720 lxc/storage_volume.go:807
+#: lxc/storage_volume.go:905 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:1223 lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1513 lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1850 lxc/storage_volume.go:1943
+#: lxc/storage_volume.go:2070 lxc/storage_volume.go:2228
+#: lxc/storage_volume.go:2349 lxc/storage_volume.go:2411
+#: lxc/storage_volume.go:2547 lxc/storage_volume.go:2630
+#: lxc/storage_volume.go:2796 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1448
+#: lxc/storage_volume.go:1454
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:1849
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:1855
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1778,11 +1778,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:800 lxc/storage_volume.go:801
+#: lxc/storage_volume.go:806 lxc/storage_volume.go:807
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:898 lxc/storage_volume.go:899
+#: lxc/storage_volume.go:904 lxc/storage_volume.go:905
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -2008,7 +2008,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:995 lxc/storage_volume.go:996
+#: lxc/storage_volume.go:1001 lxc/storage_volume.go:1002
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2016,7 +2016,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1766
+#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1772
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2073,7 +2073,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2193
+#: lxc/storage_volume.go:2161 lxc/storage_volume.go:2199
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2087,8 +2087,8 @@ msgstr ""
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2149
-#: lxc/storage_volume.go:2187
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2155
+#: lxc/storage_volume.go:2193
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2130,8 +2130,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1508
-#: lxc/storage_volume.go:1558
+#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1514
+#: lxc/storage_volume.go:1564
 msgid "Expires at"
 msgstr ""
 
@@ -2155,7 +2155,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2623 lxc/storage_volume.go:2624
+#: lxc/storage_volume.go:2629 lxc/storage_volume.go:2630
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2167,11 +2167,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2627
+#: lxc/storage_volume.go:2633
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2756
+#: lxc/export.go:152 lxc/storage_volume.go:2762
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2288,11 +2288,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:191
+#: lxc/remote.go:203
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:242
+#: lxc/remote.go:254
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2302,7 +2302,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:232
+#: lxc/remote.go:244
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2312,12 +2312,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:260
+#: lxc/remote.go:486
 #, c-format
-msgid "Failed to create certificate: %w"
+msgid "Failed to decode trust token: %w"
 msgstr ""
 
-#: lxc/remote.go:267
+#: lxc/remote.go:292
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2342,7 +2342,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:237
+#: lxc/remote.go:249
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2429,9 +2429,9 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:690 lxc/storage.go:657
+#: lxc/project.go:919 lxc/remote.go:757 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1608 lxc/warning.go:94
+#: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2467,7 +2467,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:754
+#: lxc/remote.go:821
 msgid "GLOBAL"
 msgstr ""
 
@@ -2487,7 +2487,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:160 lxc/remote.go:401
+#: lxc/remote.go:165 lxc/remote.go:443
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2555,7 +2555,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1238
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2619,11 +2619,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1216 lxc/storage_volume.go:1217
+#: lxc/storage_volume.go:1222 lxc/storage_volume.go:1223
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:469
+#: lxc/storage_volume.go:475
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2747,7 +2747,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2415
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2421
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2761,7 +2761,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2414
+#: lxc/storage_volume.go:2420
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2811,7 +2811,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2790
+#: lxc/storage_volume.go:2796
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2819,7 +2819,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2789
+#: lxc/storage_volume.go:2795
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2841,11 +2841,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2797
+#: lxc/storage_volume.go:2803
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2871
+#: lxc/storage_volume.go:2877
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2911,7 +2911,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:353
+#: lxc/remote.go:395
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2971,7 +2971,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2000
+#: lxc/move.go:148 lxc/storage_volume.go:2006
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2979,7 +2979,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1996
+#: lxc/storage_volume.go:2002
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2992,14 +2992,14 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:342
+#: lxc/remote.go:384
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1064 lxc/storage_volume.go:1281
-#: lxc/storage_volume.go:1405 lxc/storage_volume.go:1985
-#: lxc/storage_volume.go:2132 lxc/storage_volume.go:2284
+#: lxc/storage_volume.go:1070 lxc/storage_volume.go:1287
+#: lxc/storage_volume.go:1411 lxc/storage_volume.go:1991
+#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2290
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3045,7 +3045,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1739 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1745 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3348,11 +3348,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1586
+#: lxc/storage_volume.go:1592
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1597
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3372,7 +3372,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:685 lxc/remote.go:686
+#: lxc/remote.go:752 lxc/remote.go:753
 msgid "List the available remotes"
 msgstr ""
 
@@ -3411,7 +3411,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1464
+#: lxc/info.go:489 lxc/storage_volume.go:1470
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3875,12 +3875,12 @@ msgstr ""
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:323 lxc/storage_volume.go:643
-#: lxc/storage_volume.go:750 lxc/storage_volume.go:841
-#: lxc/storage_volume.go:939 lxc/storage_volume.go:1053
-#: lxc/storage_volume.go:1270 lxc/storage_volume.go:1974
-#: lxc/storage_volume.go:2115 lxc/storage_volume.go:2273
-#: lxc/storage_volume.go:2464 lxc/storage_volume.go:2581
+#: lxc/storage_volume.go:323 lxc/storage_volume.go:649
+#: lxc/storage_volume.go:756 lxc/storage_volume.go:847
+#: lxc/storage_volume.go:945 lxc/storage_volume.go:1059
+#: lxc/storage_volume.go:1276 lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:2121 lxc/storage_volume.go:2279
+#: lxc/storage_volume.go:2470 lxc/storage_volume.go:2587
 msgid "Missing pool name"
 msgstr ""
 
@@ -3899,11 +3899,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:432 lxc/storage_volume.go:1884
+#: lxc/storage_volume.go:438 lxc/storage_volume.go:1890
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1394
+#: lxc/storage_volume.go:1400
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -3940,8 +3940,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:861
-#: lxc/storage_volume.go:958
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:867
+#: lxc/storage_volume.go:964
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -3978,7 +3978,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1843 lxc/storage_volume.go:1844
+#: lxc/storage_volume.go:1849 lxc/storage_volume.go:1850
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -3986,11 +3986,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1850
+#: lxc/storage_volume.go:1856
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:512
+#: lxc/storage_volume.go:518
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4016,8 +4016,8 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
-#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1731
+#: lxc/remote.go:815 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
 msgstr ""
 
@@ -4043,7 +4043,7 @@ msgstr ""
 
 #: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
+#: lxc/project.go:550 lxc/remote.go:775 lxc/remote.go:780 lxc/remote.go:785
 msgid "NO"
 msgstr ""
 
@@ -4065,8 +4065,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1506
-#: lxc/storage_volume.go:1556
+#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1512
+#: lxc/storage_volume.go:1562
 msgid "Name"
 msgstr ""
 
@@ -4074,7 +4074,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1446
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1452
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4218,7 +4218,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:870 lxc/storage_volume.go:967
+#: lxc/storage_volume.go:876 lxc/storage_volume.go:973
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4234,11 +4234,11 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/storage_volume.go:446 lxc/storage_volume.go:1893
+#: lxc/storage_volume.go:452 lxc/storage_volume.go:1899
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:496 lxc/storage_volume.go:1904
+#: lxc/storage_volume.go:502 lxc/storage_volume.go:1910
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4252,7 +4252,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2012
+#: lxc/storage_volume.go:2018
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4264,15 +4264,15 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2678
+#: lxc/storage_volume.go:2684
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2477
+#: lxc/storage_volume.go:2483
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:336
+#: lxc/remote.go:378
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4280,7 +4280,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1412
+#: lxc/storage_volume.go:1418
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4293,7 +4293,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:693 lxc/storage_volume.go:1560
+#: lxc/info.go:693 lxc/storage_volume.go:1566
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4323,7 +4323,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1756
 msgid "POOL"
 msgstr ""
 
@@ -4339,15 +4339,15 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:213
+#: lxc/list.go:567 lxc/storage_volume.go:1762 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:817
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:752
+#: lxc/image.go:1136 lxc/remote.go:819
 msgid "PUBLIC"
 msgstr ""
 
@@ -4376,7 +4376,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:183
+#: lxc/remote.go:195
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4388,8 +4388,8 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:466
-msgid "Please type 'y', 'n' or the fingerprint:"
+#: lxc/remote.go:536
+msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
 #: lxc/info.go:221
@@ -4413,8 +4413,8 @@ msgstr ""
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1151
-#: lxc/storage_volume.go:1183
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
+#: lxc/storage_volume.go:1189
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4531,7 +4531,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1350
+#: lxc/storage_volume.go:1356
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4545,7 +4545,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1219
+#: lxc/storage_volume.go:1225
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4561,7 +4561,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2224
+#: lxc/storage_volume.go:2230
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4582,7 +4582,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:998
+#: lxc/storage_volume.go:1004
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4591,7 +4591,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2069
+#: lxc/storage_volume.go:2075
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4604,7 +4604,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2345
+#: lxc/storage_volume.go:2351
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4708,33 +4708,33 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:810
+#: lxc/remote.go:877
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
-#: lxc/remote.go:994
+#: lxc/project.go:884 lxc/remote.go:868 lxc/remote.go:949 lxc/remote.go:1013
+#: lxc/remote.go:1061
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:305
+#: lxc/remote.go:345
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:890
+#: lxc/remote.go:957
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:805 lxc/remote.go:886 lxc/remote.go:998
+#: lxc/remote.go:872 lxc/remote.go:953 lxc/remote.go:1065
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:294
+#: lxc/remote.go:319
 msgid "Remote address must not be empty"
 msgstr ""
 
@@ -4742,7 +4742,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:299
+#: lxc/remote.go:339
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4828,7 +4828,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:852 lxc/remote.go:853
+#: lxc/remote.go:919 lxc/remote.go:920
 msgid "Remove remotes"
 msgstr ""
 
@@ -4885,19 +4885,19 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:771 lxc/remote.go:772
+#: lxc/remote.go:838 lxc/remote.go:839
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:1943
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1936
+#: lxc/storage_volume.go:1942
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2025 lxc/storage_volume.go:2045
+#: lxc/storage_volume.go:2031 lxc/storage_volume.go:2051
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4949,7 +4949,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2540 lxc/storage_volume.go:2541
+#: lxc/storage_volume.go:2546 lxc/storage_volume.go:2547
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5030,7 +5030,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:820
 msgid "STATIC"
 msgstr ""
 
@@ -5071,11 +5071,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:464
+#: lxc/remote.go:532
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:616
+#: lxc/remote.go:285 lxc/remote.go:683
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5273,11 +5273,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2063
+#: lxc/storage_volume.go:2069
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2064
+#: lxc/storage_volume.go:2070
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5286,7 +5286,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:964 lxc/remote.go:965
+#: lxc/remote.go:1031 lxc/remote.go:1032
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5362,7 +5362,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2080
+#: lxc/storage_volume.go:2086
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5511,11 +5511,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2221 lxc/storage_volume.go:2222
+#: lxc/storage_volume.go:2227 lxc/storage_volume.go:2228
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1347 lxc/storage_volume.go:1348
+#: lxc/storage_volume.go:1353 lxc/storage_volume.go:1354
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5529,7 +5529,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:647 lxc/remote.go:648
+#: lxc/remote.go:714 lxc/remote.go:715
 msgid "Show the default remote"
 msgstr ""
 
@@ -5583,15 +5583,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2404 lxc/storage_volume.go:2405
+#: lxc/storage_volume.go:2410 lxc/storage_volume.go:2411
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2167
+#: lxc/storage_volume.go:2173
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:607 lxc/storage_volume.go:1485
+#: lxc/info.go:607 lxc/storage_volume.go:1491
 msgid "Snapshots:"
 msgstr ""
 
@@ -5692,21 +5692,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:696
+#: lxc/storage_volume.go:702
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:784
+#: lxc/storage_volume.go:790
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:509
+#: lxc/storage_volume.go:515
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:513
+#: lxc/storage_volume.go:519
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5741,7 +5741,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:916 lxc/remote.go:917
+#: lxc/remote.go:983 lxc/remote.go:984
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5760,11 +5760,11 @@ msgstr ""
 #: lxc/auth.go:818 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
-#: lxc/storage_volume.go:1730 lxc/warning.go:216
+#: lxc/storage_volume.go:1736 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1557
+#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1563
 msgid "Taken at"
 msgstr ""
 
@@ -5774,6 +5774,12 @@ msgstr ""
 
 #: lxc/file.go:1256
 msgid "Target path must be a directory"
+msgstr ""
+
+#: lxc/remote.go:161 lxc/remote.go:334
+msgid ""
+"The --accept-certificate flag is not supported when adding a remote using a "
+"trust token"
 msgstr ""
 
 #: lxc/move.go:181
@@ -5915,15 +5921,20 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1323
+#: lxc/storage_volume.go:1329
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1300
+#: lxc/storage_volume.go:1306
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
+msgstr ""
+
+#: lxc/remote.go:527
+msgid ""
+"The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
 
 #: lxc/info.go:354
@@ -5934,8 +5945,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:875
-#: lxc/storage_volume.go:972
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:881
+#: lxc/storage_volume.go:978
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6010,7 +6021,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1470
+#: lxc/storage_volume.go:1476
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6025,7 +6036,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1847
+#: lxc/storage_volume.go:1853
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6059,7 +6070,15 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:571
+#: lxc/remote.go:329
+msgid "Trust token cannot be used for public remotes"
+msgstr ""
+
+#: lxc/remote.go:324
+msgid "Trust token cannot be used with OIDC authentication"
+msgstr ""
+
+#: lxc/remote.go:639
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6084,7 +6103,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1455
+#: lxc/storage_volume.go:1461
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6102,17 +6121,17 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:193 lxc/remote.go:749
+#: lxc/cluster.go:193 lxc/remote.go:816
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1735
+#: lxc/project.go:995 lxc/storage_volume.go:1741
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1734
+#: lxc/storage.go:724 lxc/storage_volume.go:1740
 msgid "USED BY"
 msgstr ""
 
@@ -6130,7 +6149,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:214 lxc/remote.go:248
+#: lxc/remote.go:226 lxc/remote.go:260
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6144,7 +6163,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1772
+#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1778
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6250,7 +6269,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2342 lxc/storage_volume.go:2343
+#: lxc/storage_volume.go:2348 lxc/storage_volume.go:2349
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6302,7 +6321,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2356
+#: lxc/storage_volume.go:2362
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6346,12 +6365,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1468
+#: lxc/storage_volume.go:1474
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2629
+#: lxc/export.go:42 lxc/storage_volume.go:2635
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6418,7 +6437,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1559
+#: lxc/storage_volume.go:1565
 msgid "Volume Only"
 msgstr ""
 
@@ -6453,7 +6472,7 @@ msgstr ""
 
 #: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
+#: lxc/project.go:552 lxc/remote.go:777 lxc/remote.go:782 lxc/remote.go:787
 msgid "YES"
 msgstr ""
 
@@ -6477,7 +6496,7 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:897
+#: lxc/storage_volume.go:903
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
@@ -6899,7 +6918,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2788
+#: lxc/storage_volume.go:2794
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -6934,13 +6953,13 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:1941
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:799
+#: lxc/storage_volume.go:805
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
@@ -6948,47 +6967,47 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2539
+#: lxc/storage_volume.go:2545
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2622
+#: lxc/storage_volume.go:2628
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2403
+#: lxc/storage_volume.go:2409
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:603
+#: lxc/storage_volume.go:609
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:711
+#: lxc/storage_volume.go:717
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:994 lxc/storage_volume.go:1346
+#: lxc/storage_volume.go:1000 lxc/storage_volume.go:1352
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2341
+#: lxc/storage_volume.go:2347
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2062
+#: lxc/storage_volume.go:2068
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2220
+#: lxc/storage_volume.go:2226
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1215
+#: lxc/storage_volume.go:1221
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1841
+#: lxc/storage_volume.go:1847
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7098,7 +7117,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1584
+#: lxc/storage_volume.go:1590
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7110,7 +7129,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:739
+#: lxc/project.go:557 lxc/remote.go:806
 msgid "current"
 msgstr ""
 
@@ -7570,7 +7589,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:607
+#: lxc/storage_volume.go:613
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7578,13 +7597,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2792
+#: lxc/storage_volume.go:2798
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2407
+#: lxc/storage_volume.go:2413
 msgid ""
 "lxc storage volume snapshot create default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7594,7 +7613,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:531
 msgid "n"
 msgstr ""
 
@@ -7606,7 +7625,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:510
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7643,7 +7662,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:465
+#: lxc/remote.go:519
 msgid "y"
 msgstr ""
 

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-08 07:43+0100\n"
+"POT-Creation-Date: 2024-10-14 13:30+0000\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Swedish <https://hosted.weblate.org/projects/linux-containers/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1024
+#: lxc/storage_volume.go:1030
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -515,15 +515,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:850 lxc/remote.go:915
+#: lxc/remote.go:917 lxc/remote.go:982
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:963
+#: lxc/remote.go:1030
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:769
+#: lxc/remote.go:836
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -556,7 +556,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:751
+#: lxc/remote.go:818
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:581
+#: lxc/remote.go:648
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -738,11 +738,11 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1590
+#: lxc/storage_volume.go:1596
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:182
+#: lxc/remote.go:194
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -813,7 +813,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:552
+#: lxc/remote.go:621
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -849,16 +849,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2696
+#: lxc/storage_volume.go:2702
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2773
+#: lxc/export.go:192 lxc/storage_volume.go:2779
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:654 lxc/storage_volume.go:1521
+#: lxc/info.go:654 lxc/storage_volume.go:1527
 msgid "Backups:"
 msgstr ""
 
@@ -879,7 +879,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:679
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:685
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -922,7 +922,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1733
+#: lxc/storage_volume.go:1739
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -991,7 +991,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:894
+#: lxc/remote.go:961
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1007,7 +1007,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1749 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1024,12 +1024,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:486
+#: lxc/storage_volume.go:492
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:440
+#: lxc/storage_volume.go:446
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1057,11 +1057,11 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:509
 msgid "Certificate fingerprint"
 msgstr ""
 
-#: lxc/remote.go:219
+#: lxc/remote.go:231
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
@@ -1076,7 +1076,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:620
+#: lxc/remote.go:687
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1150,13 +1150,13 @@ msgstr ""
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
 #: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
-#: lxc/storage_volume.go:612 lxc/storage_volume.go:717
-#: lxc/storage_volume.go:1005 lxc/storage_volume.go:1231
-#: lxc/storage_volume.go:1360 lxc/storage_volume.go:1848
-#: lxc/storage_volume.go:1940 lxc/storage_volume.go:2079
-#: lxc/storage_volume.go:2239 lxc/storage_volume.go:2355
-#: lxc/storage_volume.go:2416 lxc/storage_volume.go:2543
-#: lxc/storage_volume.go:2631 lxc/storage_volume.go:2795
+#: lxc/storage_volume.go:618 lxc/storage_volume.go:723
+#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1237
+#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1854
+#: lxc/storage_volume.go:1946 lxc/storage_volume.go:2085
+#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2361
+#: lxc/storage_volume.go:2422 lxc/storage_volume.go:2549
+#: lxc/storage_volume.go:2637 lxc/storage_volume.go:2801
 msgid "Cluster member name"
 msgstr ""
 
@@ -1172,7 +1172,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1589
+#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1595
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1216,17 +1216,17 @@ msgstr ""
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1150
-#: lxc/storage_volume.go:1182
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
+#: lxc/storage_volume.go:1188
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:613
+#: lxc/storage_volume.go:619
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1467
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1310,7 +1310,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:508
+#: lxc/storage_volume.go:514
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1324,12 +1324,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:490
+#: lxc/remote.go:559
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:225 lxc/remote.go:474
+#: lxc/remote.go:237 lxc/remote.go:543
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1368,7 +1368,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:485
+#: lxc/remote.go:554
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1437,7 +1437,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:604 lxc/storage_volume.go:605
+#: lxc/storage_volume.go:610 lxc/storage_volume.go:611
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1489,7 +1489,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1475
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1481
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1524,7 +1524,7 @@ msgstr ""
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1732
+#: lxc/storage_volume.go:1738
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1544,7 +1544,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2630
+#: lxc/storage_volume.go:2636
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1640,7 +1640,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:713 lxc/storage_volume.go:714
+#: lxc/storage_volume.go:719 lxc/storage_volume.go:720
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1732,9 +1732,9 @@ msgstr ""
 #: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
 #: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
 #: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:648
-#: lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853 lxc/remote.go:917
-#: lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:715
+#: lxc/remote.go:753 lxc/remote.go:839 lxc/remote.go:920 lxc/remote.go:984
+#: lxc/remote.go:1032 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1746,26 +1746,26 @@ msgstr ""
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
 #: lxc/storage_volume.go:169 lxc/storage_volume.go:283
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:605
-#: lxc/storage_volume.go:714 lxc/storage_volume.go:801
-#: lxc/storage_volume.go:899 lxc/storage_volume.go:996
-#: lxc/storage_volume.go:1217 lxc/storage_volume.go:1348
-#: lxc/storage_volume.go:1507 lxc/storage_volume.go:1591
-#: lxc/storage_volume.go:1844 lxc/storage_volume.go:1937
-#: lxc/storage_volume.go:2064 lxc/storage_volume.go:2222
-#: lxc/storage_volume.go:2343 lxc/storage_volume.go:2405
-#: lxc/storage_volume.go:2541 lxc/storage_volume.go:2624
-#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:611
+#: lxc/storage_volume.go:720 lxc/storage_volume.go:807
+#: lxc/storage_volume.go:905 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:1223 lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1513 lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1850 lxc/storage_volume.go:1943
+#: lxc/storage_volume.go:2070 lxc/storage_volume.go:2228
+#: lxc/storage_volume.go:2349 lxc/storage_volume.go:2411
+#: lxc/storage_volume.go:2547 lxc/storage_volume.go:2630
+#: lxc/storage_volume.go:2796 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1448
+#: lxc/storage_volume.go:1454
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:1849
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:1855
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1777,11 +1777,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:800 lxc/storage_volume.go:801
+#: lxc/storage_volume.go:806 lxc/storage_volume.go:807
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:898 lxc/storage_volume.go:899
+#: lxc/storage_volume.go:904 lxc/storage_volume.go:905
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -2007,7 +2007,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:995 lxc/storage_volume.go:996
+#: lxc/storage_volume.go:1001 lxc/storage_volume.go:1002
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2015,7 +2015,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1766
+#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1772
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2072,7 +2072,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2193
+#: lxc/storage_volume.go:2161 lxc/storage_volume.go:2199
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2086,8 +2086,8 @@ msgstr ""
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2149
-#: lxc/storage_volume.go:2187
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2155
+#: lxc/storage_volume.go:2193
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2129,8 +2129,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1508
-#: lxc/storage_volume.go:1558
+#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1514
+#: lxc/storage_volume.go:1564
 msgid "Expires at"
 msgstr ""
 
@@ -2154,7 +2154,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2623 lxc/storage_volume.go:2624
+#: lxc/storage_volume.go:2629 lxc/storage_volume.go:2630
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2166,11 +2166,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2627
+#: lxc/storage_volume.go:2633
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2756
+#: lxc/export.go:152 lxc/storage_volume.go:2762
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2287,11 +2287,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:191
+#: lxc/remote.go:203
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:242
+#: lxc/remote.go:254
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2301,7 +2301,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:232
+#: lxc/remote.go:244
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2311,12 +2311,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:260
+#: lxc/remote.go:486
 #, c-format
-msgid "Failed to create certificate: %w"
+msgid "Failed to decode trust token: %w"
 msgstr ""
 
-#: lxc/remote.go:267
+#: lxc/remote.go:292
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2341,7 +2341,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:237
+#: lxc/remote.go:249
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2428,9 +2428,9 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:690 lxc/storage.go:657
+#: lxc/project.go:919 lxc/remote.go:757 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1608 lxc/warning.go:94
+#: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2466,7 +2466,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:754
+#: lxc/remote.go:821
 msgid "GLOBAL"
 msgstr ""
 
@@ -2486,7 +2486,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:160 lxc/remote.go:401
+#: lxc/remote.go:165 lxc/remote.go:443
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2554,7 +2554,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1238
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2618,11 +2618,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1216 lxc/storage_volume.go:1217
+#: lxc/storage_volume.go:1222 lxc/storage_volume.go:1223
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:469
+#: lxc/storage_volume.go:475
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2746,7 +2746,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2415
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2421
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2760,7 +2760,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2414
+#: lxc/storage_volume.go:2420
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2810,7 +2810,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2790
+#: lxc/storage_volume.go:2796
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2818,7 +2818,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2789
+#: lxc/storage_volume.go:2795
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2840,11 +2840,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2797
+#: lxc/storage_volume.go:2803
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2871
+#: lxc/storage_volume.go:2877
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2910,7 +2910,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:353
+#: lxc/remote.go:395
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2970,7 +2970,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2000
+#: lxc/move.go:148 lxc/storage_volume.go:2006
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2978,7 +2978,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1996
+#: lxc/storage_volume.go:2002
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2991,14 +2991,14 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:342
+#: lxc/remote.go:384
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1064 lxc/storage_volume.go:1281
-#: lxc/storage_volume.go:1405 lxc/storage_volume.go:1985
-#: lxc/storage_volume.go:2132 lxc/storage_volume.go:2284
+#: lxc/storage_volume.go:1070 lxc/storage_volume.go:1287
+#: lxc/storage_volume.go:1411 lxc/storage_volume.go:1991
+#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2290
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3044,7 +3044,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1739 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1745 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3347,11 +3347,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1586
+#: lxc/storage_volume.go:1592
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1597
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3371,7 +3371,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:685 lxc/remote.go:686
+#: lxc/remote.go:752 lxc/remote.go:753
 msgid "List the available remotes"
 msgstr ""
 
@@ -3410,7 +3410,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1464
+#: lxc/info.go:489 lxc/storage_volume.go:1470
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3874,12 +3874,12 @@ msgstr ""
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:323 lxc/storage_volume.go:643
-#: lxc/storage_volume.go:750 lxc/storage_volume.go:841
-#: lxc/storage_volume.go:939 lxc/storage_volume.go:1053
-#: lxc/storage_volume.go:1270 lxc/storage_volume.go:1974
-#: lxc/storage_volume.go:2115 lxc/storage_volume.go:2273
-#: lxc/storage_volume.go:2464 lxc/storage_volume.go:2581
+#: lxc/storage_volume.go:323 lxc/storage_volume.go:649
+#: lxc/storage_volume.go:756 lxc/storage_volume.go:847
+#: lxc/storage_volume.go:945 lxc/storage_volume.go:1059
+#: lxc/storage_volume.go:1276 lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:2121 lxc/storage_volume.go:2279
+#: lxc/storage_volume.go:2470 lxc/storage_volume.go:2587
 msgid "Missing pool name"
 msgstr ""
 
@@ -3898,11 +3898,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:432 lxc/storage_volume.go:1884
+#: lxc/storage_volume.go:438 lxc/storage_volume.go:1890
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1394
+#: lxc/storage_volume.go:1400
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -3939,8 +3939,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:861
-#: lxc/storage_volume.go:958
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:867
+#: lxc/storage_volume.go:964
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -3977,7 +3977,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1843 lxc/storage_volume.go:1844
+#: lxc/storage_volume.go:1849 lxc/storage_volume.go:1850
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -3985,11 +3985,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1850
+#: lxc/storage_volume.go:1856
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:512
+#: lxc/storage_volume.go:518
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4015,8 +4015,8 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
-#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1731
+#: lxc/remote.go:815 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
 msgstr ""
 
@@ -4042,7 +4042,7 @@ msgstr ""
 
 #: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
+#: lxc/project.go:550 lxc/remote.go:775 lxc/remote.go:780 lxc/remote.go:785
 msgid "NO"
 msgstr ""
 
@@ -4064,8 +4064,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1506
-#: lxc/storage_volume.go:1556
+#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1512
+#: lxc/storage_volume.go:1562
 msgid "Name"
 msgstr ""
 
@@ -4073,7 +4073,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1446
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1452
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4217,7 +4217,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:870 lxc/storage_volume.go:967
+#: lxc/storage_volume.go:876 lxc/storage_volume.go:973
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4233,11 +4233,11 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/storage_volume.go:446 lxc/storage_volume.go:1893
+#: lxc/storage_volume.go:452 lxc/storage_volume.go:1899
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:496 lxc/storage_volume.go:1904
+#: lxc/storage_volume.go:502 lxc/storage_volume.go:1910
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4251,7 +4251,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2012
+#: lxc/storage_volume.go:2018
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4263,15 +4263,15 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2678
+#: lxc/storage_volume.go:2684
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2477
+#: lxc/storage_volume.go:2483
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:336
+#: lxc/remote.go:378
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4279,7 +4279,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1412
+#: lxc/storage_volume.go:1418
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4292,7 +4292,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:693 lxc/storage_volume.go:1560
+#: lxc/info.go:693 lxc/storage_volume.go:1566
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4322,7 +4322,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1756
 msgid "POOL"
 msgstr ""
 
@@ -4338,15 +4338,15 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:213
+#: lxc/list.go:567 lxc/storage_volume.go:1762 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:817
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:752
+#: lxc/image.go:1136 lxc/remote.go:819
 msgid "PUBLIC"
 msgstr ""
 
@@ -4375,7 +4375,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:183
+#: lxc/remote.go:195
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4387,8 +4387,8 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:466
-msgid "Please type 'y', 'n' or the fingerprint:"
+#: lxc/remote.go:536
+msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
 #: lxc/info.go:221
@@ -4412,8 +4412,8 @@ msgstr ""
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1151
-#: lxc/storage_volume.go:1183
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
+#: lxc/storage_volume.go:1189
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4530,7 +4530,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1350
+#: lxc/storage_volume.go:1356
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4544,7 +4544,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1219
+#: lxc/storage_volume.go:1225
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4560,7 +4560,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2224
+#: lxc/storage_volume.go:2230
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4581,7 +4581,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:998
+#: lxc/storage_volume.go:1004
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4590,7 +4590,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2069
+#: lxc/storage_volume.go:2075
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4603,7 +4603,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2345
+#: lxc/storage_volume.go:2351
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4707,33 +4707,33 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:810
+#: lxc/remote.go:877
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
-#: lxc/remote.go:994
+#: lxc/project.go:884 lxc/remote.go:868 lxc/remote.go:949 lxc/remote.go:1013
+#: lxc/remote.go:1061
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:305
+#: lxc/remote.go:345
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:890
+#: lxc/remote.go:957
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:805 lxc/remote.go:886 lxc/remote.go:998
+#: lxc/remote.go:872 lxc/remote.go:953 lxc/remote.go:1065
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:294
+#: lxc/remote.go:319
 msgid "Remote address must not be empty"
 msgstr ""
 
@@ -4741,7 +4741,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:299
+#: lxc/remote.go:339
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4827,7 +4827,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:852 lxc/remote.go:853
+#: lxc/remote.go:919 lxc/remote.go:920
 msgid "Remove remotes"
 msgstr ""
 
@@ -4884,19 +4884,19 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:771 lxc/remote.go:772
+#: lxc/remote.go:838 lxc/remote.go:839
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:1943
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1936
+#: lxc/storage_volume.go:1942
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2025 lxc/storage_volume.go:2045
+#: lxc/storage_volume.go:2031 lxc/storage_volume.go:2051
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4948,7 +4948,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2540 lxc/storage_volume.go:2541
+#: lxc/storage_volume.go:2546 lxc/storage_volume.go:2547
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5029,7 +5029,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:820
 msgid "STATIC"
 msgstr ""
 
@@ -5070,11 +5070,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:464
+#: lxc/remote.go:532
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:616
+#: lxc/remote.go:285 lxc/remote.go:683
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5272,11 +5272,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2063
+#: lxc/storage_volume.go:2069
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2064
+#: lxc/storage_volume.go:2070
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5285,7 +5285,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:964 lxc/remote.go:965
+#: lxc/remote.go:1031 lxc/remote.go:1032
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5361,7 +5361,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2080
+#: lxc/storage_volume.go:2086
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5510,11 +5510,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2221 lxc/storage_volume.go:2222
+#: lxc/storage_volume.go:2227 lxc/storage_volume.go:2228
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1347 lxc/storage_volume.go:1348
+#: lxc/storage_volume.go:1353 lxc/storage_volume.go:1354
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5528,7 +5528,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:647 lxc/remote.go:648
+#: lxc/remote.go:714 lxc/remote.go:715
 msgid "Show the default remote"
 msgstr ""
 
@@ -5582,15 +5582,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2404 lxc/storage_volume.go:2405
+#: lxc/storage_volume.go:2410 lxc/storage_volume.go:2411
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2167
+#: lxc/storage_volume.go:2173
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:607 lxc/storage_volume.go:1485
+#: lxc/info.go:607 lxc/storage_volume.go:1491
 msgid "Snapshots:"
 msgstr ""
 
@@ -5691,21 +5691,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:696
+#: lxc/storage_volume.go:702
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:784
+#: lxc/storage_volume.go:790
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:509
+#: lxc/storage_volume.go:515
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:513
+#: lxc/storage_volume.go:519
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5740,7 +5740,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:916 lxc/remote.go:917
+#: lxc/remote.go:983 lxc/remote.go:984
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5759,11 +5759,11 @@ msgstr ""
 #: lxc/auth.go:818 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
-#: lxc/storage_volume.go:1730 lxc/warning.go:216
+#: lxc/storage_volume.go:1736 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1557
+#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1563
 msgid "Taken at"
 msgstr ""
 
@@ -5773,6 +5773,12 @@ msgstr ""
 
 #: lxc/file.go:1256
 msgid "Target path must be a directory"
+msgstr ""
+
+#: lxc/remote.go:161 lxc/remote.go:334
+msgid ""
+"The --accept-certificate flag is not supported when adding a remote using a "
+"trust token"
 msgstr ""
 
 #: lxc/move.go:181
@@ -5914,15 +5920,20 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1323
+#: lxc/storage_volume.go:1329
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1300
+#: lxc/storage_volume.go:1306
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
+msgstr ""
+
+#: lxc/remote.go:527
+msgid ""
+"The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
 
 #: lxc/info.go:354
@@ -5933,8 +5944,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:875
-#: lxc/storage_volume.go:972
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:881
+#: lxc/storage_volume.go:978
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6009,7 +6020,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1470
+#: lxc/storage_volume.go:1476
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6024,7 +6035,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1847
+#: lxc/storage_volume.go:1853
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6058,7 +6069,15 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:571
+#: lxc/remote.go:329
+msgid "Trust token cannot be used for public remotes"
+msgstr ""
+
+#: lxc/remote.go:324
+msgid "Trust token cannot be used with OIDC authentication"
+msgstr ""
+
+#: lxc/remote.go:639
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6083,7 +6102,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1455
+#: lxc/storage_volume.go:1461
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6101,17 +6120,17 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:193 lxc/remote.go:749
+#: lxc/cluster.go:193 lxc/remote.go:816
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1735
+#: lxc/project.go:995 lxc/storage_volume.go:1741
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1734
+#: lxc/storage.go:724 lxc/storage_volume.go:1740
 msgid "USED BY"
 msgstr ""
 
@@ -6129,7 +6148,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:214 lxc/remote.go:248
+#: lxc/remote.go:226 lxc/remote.go:260
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6143,7 +6162,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1772
+#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1778
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6249,7 +6268,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2342 lxc/storage_volume.go:2343
+#: lxc/storage_volume.go:2348 lxc/storage_volume.go:2349
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6301,7 +6320,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2356
+#: lxc/storage_volume.go:2362
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6345,12 +6364,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1468
+#: lxc/storage_volume.go:1474
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2629
+#: lxc/export.go:42 lxc/storage_volume.go:2635
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6417,7 +6436,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1559
+#: lxc/storage_volume.go:1565
 msgid "Volume Only"
 msgstr ""
 
@@ -6452,7 +6471,7 @@ msgstr ""
 
 #: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
+#: lxc/project.go:552 lxc/remote.go:777 lxc/remote.go:782 lxc/remote.go:787
 msgid "YES"
 msgstr ""
 
@@ -6476,7 +6495,7 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:897
+#: lxc/storage_volume.go:903
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
@@ -6898,7 +6917,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2788
+#: lxc/storage_volume.go:2794
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -6933,13 +6952,13 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:1941
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:799
+#: lxc/storage_volume.go:805
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
@@ -6947,47 +6966,47 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2539
+#: lxc/storage_volume.go:2545
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2622
+#: lxc/storage_volume.go:2628
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2403
+#: lxc/storage_volume.go:2409
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:603
+#: lxc/storage_volume.go:609
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:711
+#: lxc/storage_volume.go:717
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:994 lxc/storage_volume.go:1346
+#: lxc/storage_volume.go:1000 lxc/storage_volume.go:1352
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2341
+#: lxc/storage_volume.go:2347
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2062
+#: lxc/storage_volume.go:2068
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2220
+#: lxc/storage_volume.go:2226
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1215
+#: lxc/storage_volume.go:1221
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1841
+#: lxc/storage_volume.go:1847
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7097,7 +7116,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1584
+#: lxc/storage_volume.go:1590
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7109,7 +7128,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:739
+#: lxc/project.go:557 lxc/remote.go:806
 msgid "current"
 msgstr ""
 
@@ -7569,7 +7588,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:607
+#: lxc/storage_volume.go:613
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7577,13 +7596,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2792
+#: lxc/storage_volume.go:2798
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2407
+#: lxc/storage_volume.go:2413
 msgid ""
 "lxc storage volume snapshot create default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7593,7 +7612,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:531
 msgid "n"
 msgstr ""
 
@@ -7605,7 +7624,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:510
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7642,7 +7661,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:465
+#: lxc/remote.go:519
 msgid "y"
 msgstr ""
 

--- a/po/te.po
+++ b/po/te.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-08 07:43+0100\n"
+"POT-Creation-Date: 2024-10-14 13:30+0000\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Telugu <https://hosted.weblate.org/projects/linux-containers/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1024
+#: lxc/storage_volume.go:1030
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -515,15 +515,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:850 lxc/remote.go:915
+#: lxc/remote.go:917 lxc/remote.go:982
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:963
+#: lxc/remote.go:1030
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:769
+#: lxc/remote.go:836
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -556,7 +556,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:751
+#: lxc/remote.go:818
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:581
+#: lxc/remote.go:648
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -738,11 +738,11 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1590
+#: lxc/storage_volume.go:1596
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:182
+#: lxc/remote.go:194
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -813,7 +813,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:552
+#: lxc/remote.go:621
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -849,16 +849,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2696
+#: lxc/storage_volume.go:2702
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2773
+#: lxc/export.go:192 lxc/storage_volume.go:2779
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:654 lxc/storage_volume.go:1521
+#: lxc/info.go:654 lxc/storage_volume.go:1527
 msgid "Backups:"
 msgstr ""
 
@@ -879,7 +879,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:679
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:685
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -922,7 +922,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1733
+#: lxc/storage_volume.go:1739
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -991,7 +991,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:894
+#: lxc/remote.go:961
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1007,7 +1007,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1749 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1024,12 +1024,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:486
+#: lxc/storage_volume.go:492
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:440
+#: lxc/storage_volume.go:446
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1057,11 +1057,11 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:509
 msgid "Certificate fingerprint"
 msgstr ""
 
-#: lxc/remote.go:219
+#: lxc/remote.go:231
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
@@ -1076,7 +1076,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:620
+#: lxc/remote.go:687
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1150,13 +1150,13 @@ msgstr ""
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
 #: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
-#: lxc/storage_volume.go:612 lxc/storage_volume.go:717
-#: lxc/storage_volume.go:1005 lxc/storage_volume.go:1231
-#: lxc/storage_volume.go:1360 lxc/storage_volume.go:1848
-#: lxc/storage_volume.go:1940 lxc/storage_volume.go:2079
-#: lxc/storage_volume.go:2239 lxc/storage_volume.go:2355
-#: lxc/storage_volume.go:2416 lxc/storage_volume.go:2543
-#: lxc/storage_volume.go:2631 lxc/storage_volume.go:2795
+#: lxc/storage_volume.go:618 lxc/storage_volume.go:723
+#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1237
+#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1854
+#: lxc/storage_volume.go:1946 lxc/storage_volume.go:2085
+#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2361
+#: lxc/storage_volume.go:2422 lxc/storage_volume.go:2549
+#: lxc/storage_volume.go:2637 lxc/storage_volume.go:2801
 msgid "Cluster member name"
 msgstr ""
 
@@ -1172,7 +1172,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1589
+#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1595
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1216,17 +1216,17 @@ msgstr ""
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1150
-#: lxc/storage_volume.go:1182
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
+#: lxc/storage_volume.go:1188
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:613
+#: lxc/storage_volume.go:619
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1467
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1310,7 +1310,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:508
+#: lxc/storage_volume.go:514
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1324,12 +1324,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:490
+#: lxc/remote.go:559
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:225 lxc/remote.go:474
+#: lxc/remote.go:237 lxc/remote.go:543
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1368,7 +1368,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:485
+#: lxc/remote.go:554
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1437,7 +1437,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:604 lxc/storage_volume.go:605
+#: lxc/storage_volume.go:610 lxc/storage_volume.go:611
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1489,7 +1489,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1475
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1481
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1524,7 +1524,7 @@ msgstr ""
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1732
+#: lxc/storage_volume.go:1738
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1544,7 +1544,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2630
+#: lxc/storage_volume.go:2636
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1640,7 +1640,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:713 lxc/storage_volume.go:714
+#: lxc/storage_volume.go:719 lxc/storage_volume.go:720
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1732,9 +1732,9 @@ msgstr ""
 #: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
 #: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
 #: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:648
-#: lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853 lxc/remote.go:917
-#: lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:715
+#: lxc/remote.go:753 lxc/remote.go:839 lxc/remote.go:920 lxc/remote.go:984
+#: lxc/remote.go:1032 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1746,26 +1746,26 @@ msgstr ""
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
 #: lxc/storage_volume.go:169 lxc/storage_volume.go:283
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:605
-#: lxc/storage_volume.go:714 lxc/storage_volume.go:801
-#: lxc/storage_volume.go:899 lxc/storage_volume.go:996
-#: lxc/storage_volume.go:1217 lxc/storage_volume.go:1348
-#: lxc/storage_volume.go:1507 lxc/storage_volume.go:1591
-#: lxc/storage_volume.go:1844 lxc/storage_volume.go:1937
-#: lxc/storage_volume.go:2064 lxc/storage_volume.go:2222
-#: lxc/storage_volume.go:2343 lxc/storage_volume.go:2405
-#: lxc/storage_volume.go:2541 lxc/storage_volume.go:2624
-#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:611
+#: lxc/storage_volume.go:720 lxc/storage_volume.go:807
+#: lxc/storage_volume.go:905 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:1223 lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1513 lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1850 lxc/storage_volume.go:1943
+#: lxc/storage_volume.go:2070 lxc/storage_volume.go:2228
+#: lxc/storage_volume.go:2349 lxc/storage_volume.go:2411
+#: lxc/storage_volume.go:2547 lxc/storage_volume.go:2630
+#: lxc/storage_volume.go:2796 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1448
+#: lxc/storage_volume.go:1454
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:1849
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:1855
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1777,11 +1777,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:800 lxc/storage_volume.go:801
+#: lxc/storage_volume.go:806 lxc/storage_volume.go:807
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:898 lxc/storage_volume.go:899
+#: lxc/storage_volume.go:904 lxc/storage_volume.go:905
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -2007,7 +2007,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:995 lxc/storage_volume.go:996
+#: lxc/storage_volume.go:1001 lxc/storage_volume.go:1002
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2015,7 +2015,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1766
+#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1772
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2072,7 +2072,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2193
+#: lxc/storage_volume.go:2161 lxc/storage_volume.go:2199
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2086,8 +2086,8 @@ msgstr ""
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2149
-#: lxc/storage_volume.go:2187
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2155
+#: lxc/storage_volume.go:2193
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2129,8 +2129,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1508
-#: lxc/storage_volume.go:1558
+#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1514
+#: lxc/storage_volume.go:1564
 msgid "Expires at"
 msgstr ""
 
@@ -2154,7 +2154,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2623 lxc/storage_volume.go:2624
+#: lxc/storage_volume.go:2629 lxc/storage_volume.go:2630
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2166,11 +2166,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2627
+#: lxc/storage_volume.go:2633
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2756
+#: lxc/export.go:152 lxc/storage_volume.go:2762
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2287,11 +2287,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:191
+#: lxc/remote.go:203
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:242
+#: lxc/remote.go:254
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2301,7 +2301,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:232
+#: lxc/remote.go:244
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2311,12 +2311,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:260
+#: lxc/remote.go:486
 #, c-format
-msgid "Failed to create certificate: %w"
+msgid "Failed to decode trust token: %w"
 msgstr ""
 
-#: lxc/remote.go:267
+#: lxc/remote.go:292
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2341,7 +2341,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:237
+#: lxc/remote.go:249
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2428,9 +2428,9 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:690 lxc/storage.go:657
+#: lxc/project.go:919 lxc/remote.go:757 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1608 lxc/warning.go:94
+#: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2466,7 +2466,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:754
+#: lxc/remote.go:821
 msgid "GLOBAL"
 msgstr ""
 
@@ -2486,7 +2486,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:160 lxc/remote.go:401
+#: lxc/remote.go:165 lxc/remote.go:443
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2554,7 +2554,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1238
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2618,11 +2618,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1216 lxc/storage_volume.go:1217
+#: lxc/storage_volume.go:1222 lxc/storage_volume.go:1223
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:469
+#: lxc/storage_volume.go:475
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2746,7 +2746,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2415
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2421
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2760,7 +2760,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2414
+#: lxc/storage_volume.go:2420
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2810,7 +2810,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2790
+#: lxc/storage_volume.go:2796
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2818,7 +2818,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2789
+#: lxc/storage_volume.go:2795
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2840,11 +2840,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2797
+#: lxc/storage_volume.go:2803
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2871
+#: lxc/storage_volume.go:2877
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2910,7 +2910,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:353
+#: lxc/remote.go:395
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2970,7 +2970,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2000
+#: lxc/move.go:148 lxc/storage_volume.go:2006
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2978,7 +2978,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1996
+#: lxc/storage_volume.go:2002
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2991,14 +2991,14 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:342
+#: lxc/remote.go:384
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1064 lxc/storage_volume.go:1281
-#: lxc/storage_volume.go:1405 lxc/storage_volume.go:1985
-#: lxc/storage_volume.go:2132 lxc/storage_volume.go:2284
+#: lxc/storage_volume.go:1070 lxc/storage_volume.go:1287
+#: lxc/storage_volume.go:1411 lxc/storage_volume.go:1991
+#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2290
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3044,7 +3044,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1739 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1745 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3347,11 +3347,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1586
+#: lxc/storage_volume.go:1592
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1597
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3371,7 +3371,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:685 lxc/remote.go:686
+#: lxc/remote.go:752 lxc/remote.go:753
 msgid "List the available remotes"
 msgstr ""
 
@@ -3410,7 +3410,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1464
+#: lxc/info.go:489 lxc/storage_volume.go:1470
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3874,12 +3874,12 @@ msgstr ""
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:323 lxc/storage_volume.go:643
-#: lxc/storage_volume.go:750 lxc/storage_volume.go:841
-#: lxc/storage_volume.go:939 lxc/storage_volume.go:1053
-#: lxc/storage_volume.go:1270 lxc/storage_volume.go:1974
-#: lxc/storage_volume.go:2115 lxc/storage_volume.go:2273
-#: lxc/storage_volume.go:2464 lxc/storage_volume.go:2581
+#: lxc/storage_volume.go:323 lxc/storage_volume.go:649
+#: lxc/storage_volume.go:756 lxc/storage_volume.go:847
+#: lxc/storage_volume.go:945 lxc/storage_volume.go:1059
+#: lxc/storage_volume.go:1276 lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:2121 lxc/storage_volume.go:2279
+#: lxc/storage_volume.go:2470 lxc/storage_volume.go:2587
 msgid "Missing pool name"
 msgstr ""
 
@@ -3898,11 +3898,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:432 lxc/storage_volume.go:1884
+#: lxc/storage_volume.go:438 lxc/storage_volume.go:1890
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1394
+#: lxc/storage_volume.go:1400
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -3939,8 +3939,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:861
-#: lxc/storage_volume.go:958
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:867
+#: lxc/storage_volume.go:964
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -3977,7 +3977,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1843 lxc/storage_volume.go:1844
+#: lxc/storage_volume.go:1849 lxc/storage_volume.go:1850
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -3985,11 +3985,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1850
+#: lxc/storage_volume.go:1856
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:512
+#: lxc/storage_volume.go:518
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4015,8 +4015,8 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
-#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1731
+#: lxc/remote.go:815 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
 msgstr ""
 
@@ -4042,7 +4042,7 @@ msgstr ""
 
 #: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
+#: lxc/project.go:550 lxc/remote.go:775 lxc/remote.go:780 lxc/remote.go:785
 msgid "NO"
 msgstr ""
 
@@ -4064,8 +4064,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1506
-#: lxc/storage_volume.go:1556
+#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1512
+#: lxc/storage_volume.go:1562
 msgid "Name"
 msgstr ""
 
@@ -4073,7 +4073,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1446
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1452
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4217,7 +4217,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:870 lxc/storage_volume.go:967
+#: lxc/storage_volume.go:876 lxc/storage_volume.go:973
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4233,11 +4233,11 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/storage_volume.go:446 lxc/storage_volume.go:1893
+#: lxc/storage_volume.go:452 lxc/storage_volume.go:1899
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:496 lxc/storage_volume.go:1904
+#: lxc/storage_volume.go:502 lxc/storage_volume.go:1910
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4251,7 +4251,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2012
+#: lxc/storage_volume.go:2018
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4263,15 +4263,15 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2678
+#: lxc/storage_volume.go:2684
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2477
+#: lxc/storage_volume.go:2483
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:336
+#: lxc/remote.go:378
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4279,7 +4279,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1412
+#: lxc/storage_volume.go:1418
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4292,7 +4292,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:693 lxc/storage_volume.go:1560
+#: lxc/info.go:693 lxc/storage_volume.go:1566
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4322,7 +4322,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1756
 msgid "POOL"
 msgstr ""
 
@@ -4338,15 +4338,15 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:213
+#: lxc/list.go:567 lxc/storage_volume.go:1762 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:817
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:752
+#: lxc/image.go:1136 lxc/remote.go:819
 msgid "PUBLIC"
 msgstr ""
 
@@ -4375,7 +4375,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:183
+#: lxc/remote.go:195
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4387,8 +4387,8 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:466
-msgid "Please type 'y', 'n' or the fingerprint:"
+#: lxc/remote.go:536
+msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
 #: lxc/info.go:221
@@ -4412,8 +4412,8 @@ msgstr ""
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1151
-#: lxc/storage_volume.go:1183
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
+#: lxc/storage_volume.go:1189
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4530,7 +4530,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1350
+#: lxc/storage_volume.go:1356
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4544,7 +4544,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1219
+#: lxc/storage_volume.go:1225
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4560,7 +4560,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2224
+#: lxc/storage_volume.go:2230
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4581,7 +4581,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:998
+#: lxc/storage_volume.go:1004
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4590,7 +4590,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2069
+#: lxc/storage_volume.go:2075
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4603,7 +4603,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2345
+#: lxc/storage_volume.go:2351
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4707,33 +4707,33 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:810
+#: lxc/remote.go:877
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
-#: lxc/remote.go:994
+#: lxc/project.go:884 lxc/remote.go:868 lxc/remote.go:949 lxc/remote.go:1013
+#: lxc/remote.go:1061
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:305
+#: lxc/remote.go:345
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:890
+#: lxc/remote.go:957
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:805 lxc/remote.go:886 lxc/remote.go:998
+#: lxc/remote.go:872 lxc/remote.go:953 lxc/remote.go:1065
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:294
+#: lxc/remote.go:319
 msgid "Remote address must not be empty"
 msgstr ""
 
@@ -4741,7 +4741,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:299
+#: lxc/remote.go:339
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4827,7 +4827,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:852 lxc/remote.go:853
+#: lxc/remote.go:919 lxc/remote.go:920
 msgid "Remove remotes"
 msgstr ""
 
@@ -4884,19 +4884,19 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:771 lxc/remote.go:772
+#: lxc/remote.go:838 lxc/remote.go:839
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:1943
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1936
+#: lxc/storage_volume.go:1942
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2025 lxc/storage_volume.go:2045
+#: lxc/storage_volume.go:2031 lxc/storage_volume.go:2051
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4948,7 +4948,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2540 lxc/storage_volume.go:2541
+#: lxc/storage_volume.go:2546 lxc/storage_volume.go:2547
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5029,7 +5029,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:820
 msgid "STATIC"
 msgstr ""
 
@@ -5070,11 +5070,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:464
+#: lxc/remote.go:532
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:616
+#: lxc/remote.go:285 lxc/remote.go:683
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5272,11 +5272,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2063
+#: lxc/storage_volume.go:2069
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2064
+#: lxc/storage_volume.go:2070
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5285,7 +5285,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:964 lxc/remote.go:965
+#: lxc/remote.go:1031 lxc/remote.go:1032
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5361,7 +5361,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2080
+#: lxc/storage_volume.go:2086
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5510,11 +5510,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2221 lxc/storage_volume.go:2222
+#: lxc/storage_volume.go:2227 lxc/storage_volume.go:2228
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1347 lxc/storage_volume.go:1348
+#: lxc/storage_volume.go:1353 lxc/storage_volume.go:1354
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5528,7 +5528,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:647 lxc/remote.go:648
+#: lxc/remote.go:714 lxc/remote.go:715
 msgid "Show the default remote"
 msgstr ""
 
@@ -5582,15 +5582,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2404 lxc/storage_volume.go:2405
+#: lxc/storage_volume.go:2410 lxc/storage_volume.go:2411
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2167
+#: lxc/storage_volume.go:2173
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:607 lxc/storage_volume.go:1485
+#: lxc/info.go:607 lxc/storage_volume.go:1491
 msgid "Snapshots:"
 msgstr ""
 
@@ -5691,21 +5691,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:696
+#: lxc/storage_volume.go:702
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:784
+#: lxc/storage_volume.go:790
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:509
+#: lxc/storage_volume.go:515
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:513
+#: lxc/storage_volume.go:519
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5740,7 +5740,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:916 lxc/remote.go:917
+#: lxc/remote.go:983 lxc/remote.go:984
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5759,11 +5759,11 @@ msgstr ""
 #: lxc/auth.go:818 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
-#: lxc/storage_volume.go:1730 lxc/warning.go:216
+#: lxc/storage_volume.go:1736 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1557
+#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1563
 msgid "Taken at"
 msgstr ""
 
@@ -5773,6 +5773,12 @@ msgstr ""
 
 #: lxc/file.go:1256
 msgid "Target path must be a directory"
+msgstr ""
+
+#: lxc/remote.go:161 lxc/remote.go:334
+msgid ""
+"The --accept-certificate flag is not supported when adding a remote using a "
+"trust token"
 msgstr ""
 
 #: lxc/move.go:181
@@ -5914,15 +5920,20 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1323
+#: lxc/storage_volume.go:1329
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1300
+#: lxc/storage_volume.go:1306
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
+msgstr ""
+
+#: lxc/remote.go:527
+msgid ""
+"The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
 
 #: lxc/info.go:354
@@ -5933,8 +5944,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:875
-#: lxc/storage_volume.go:972
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:881
+#: lxc/storage_volume.go:978
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6009,7 +6020,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1470
+#: lxc/storage_volume.go:1476
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6024,7 +6035,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1847
+#: lxc/storage_volume.go:1853
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6058,7 +6069,15 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:571
+#: lxc/remote.go:329
+msgid "Trust token cannot be used for public remotes"
+msgstr ""
+
+#: lxc/remote.go:324
+msgid "Trust token cannot be used with OIDC authentication"
+msgstr ""
+
+#: lxc/remote.go:639
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6083,7 +6102,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1455
+#: lxc/storage_volume.go:1461
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6101,17 +6120,17 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:193 lxc/remote.go:749
+#: lxc/cluster.go:193 lxc/remote.go:816
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1735
+#: lxc/project.go:995 lxc/storage_volume.go:1741
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1734
+#: lxc/storage.go:724 lxc/storage_volume.go:1740
 msgid "USED BY"
 msgstr ""
 
@@ -6129,7 +6148,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:214 lxc/remote.go:248
+#: lxc/remote.go:226 lxc/remote.go:260
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6143,7 +6162,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1772
+#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1778
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6249,7 +6268,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2342 lxc/storage_volume.go:2343
+#: lxc/storage_volume.go:2348 lxc/storage_volume.go:2349
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6301,7 +6320,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2356
+#: lxc/storage_volume.go:2362
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6345,12 +6364,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1468
+#: lxc/storage_volume.go:1474
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2629
+#: lxc/export.go:42 lxc/storage_volume.go:2635
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6417,7 +6436,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1559
+#: lxc/storage_volume.go:1565
 msgid "Volume Only"
 msgstr ""
 
@@ -6452,7 +6471,7 @@ msgstr ""
 
 #: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
+#: lxc/project.go:552 lxc/remote.go:777 lxc/remote.go:782 lxc/remote.go:787
 msgid "YES"
 msgstr ""
 
@@ -6476,7 +6495,7 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:897
+#: lxc/storage_volume.go:903
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
@@ -6898,7 +6917,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2788
+#: lxc/storage_volume.go:2794
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -6933,13 +6952,13 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:1941
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:799
+#: lxc/storage_volume.go:805
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
@@ -6947,47 +6966,47 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2539
+#: lxc/storage_volume.go:2545
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2622
+#: lxc/storage_volume.go:2628
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2403
+#: lxc/storage_volume.go:2409
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:603
+#: lxc/storage_volume.go:609
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:711
+#: lxc/storage_volume.go:717
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:994 lxc/storage_volume.go:1346
+#: lxc/storage_volume.go:1000 lxc/storage_volume.go:1352
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2341
+#: lxc/storage_volume.go:2347
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2062
+#: lxc/storage_volume.go:2068
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2220
+#: lxc/storage_volume.go:2226
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1215
+#: lxc/storage_volume.go:1221
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1841
+#: lxc/storage_volume.go:1847
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7097,7 +7116,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1584
+#: lxc/storage_volume.go:1590
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7109,7 +7128,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:739
+#: lxc/project.go:557 lxc/remote.go:806
 msgid "current"
 msgstr ""
 
@@ -7569,7 +7588,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:607
+#: lxc/storage_volume.go:613
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7577,13 +7596,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2792
+#: lxc/storage_volume.go:2798
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2407
+#: lxc/storage_volume.go:2413
 msgid ""
 "lxc storage volume snapshot create default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7593,7 +7612,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:531
 msgid "n"
 msgstr ""
 
@@ -7605,7 +7624,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:510
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7642,7 +7661,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:465
+#: lxc/remote.go:519
 msgid "y"
 msgstr ""
 

--- a/po/th.po
+++ b/po/th.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-08 07:43+0100\n"
+"POT-Creation-Date: 2024-10-14 13:30+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -46,7 +46,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1024
+#: lxc/storage_volume.go:1030
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -512,15 +512,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:850 lxc/remote.go:915
+#: lxc/remote.go:917 lxc/remote.go:982
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:963
+#: lxc/remote.go:1030
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:769
+#: lxc/remote.go:836
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -553,7 +553,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:751
+#: lxc/remote.go:818
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -702,7 +702,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:581
+#: lxc/remote.go:648
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -735,11 +735,11 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1590
+#: lxc/storage_volume.go:1596
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:182
+#: lxc/remote.go:194
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -810,7 +810,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:552
+#: lxc/remote.go:621
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -846,16 +846,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2696
+#: lxc/storage_volume.go:2702
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2773
+#: lxc/export.go:192 lxc/storage_volume.go:2779
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:654 lxc/storage_volume.go:1521
+#: lxc/info.go:654 lxc/storage_volume.go:1527
 msgid "Backups:"
 msgstr ""
 
@@ -876,7 +876,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:679
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:685
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -919,7 +919,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1733
+#: lxc/storage_volume.go:1739
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -988,7 +988,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:894
+#: lxc/remote.go:961
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1004,7 +1004,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1749 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1021,12 +1021,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:486
+#: lxc/storage_volume.go:492
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:440
+#: lxc/storage_volume.go:446
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1054,11 +1054,11 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:509
 msgid "Certificate fingerprint"
 msgstr ""
 
-#: lxc/remote.go:219
+#: lxc/remote.go:231
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
@@ -1073,7 +1073,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:620
+#: lxc/remote.go:687
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1147,13 +1147,13 @@ msgstr ""
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
 #: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
-#: lxc/storage_volume.go:612 lxc/storage_volume.go:717
-#: lxc/storage_volume.go:1005 lxc/storage_volume.go:1231
-#: lxc/storage_volume.go:1360 lxc/storage_volume.go:1848
-#: lxc/storage_volume.go:1940 lxc/storage_volume.go:2079
-#: lxc/storage_volume.go:2239 lxc/storage_volume.go:2355
-#: lxc/storage_volume.go:2416 lxc/storage_volume.go:2543
-#: lxc/storage_volume.go:2631 lxc/storage_volume.go:2795
+#: lxc/storage_volume.go:618 lxc/storage_volume.go:723
+#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1237
+#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1854
+#: lxc/storage_volume.go:1946 lxc/storage_volume.go:2085
+#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2361
+#: lxc/storage_volume.go:2422 lxc/storage_volume.go:2549
+#: lxc/storage_volume.go:2637 lxc/storage_volume.go:2801
 msgid "Cluster member name"
 msgstr ""
 
@@ -1169,7 +1169,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1589
+#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1595
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1213,17 +1213,17 @@ msgstr ""
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1150
-#: lxc/storage_volume.go:1182
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
+#: lxc/storage_volume.go:1188
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:613
+#: lxc/storage_volume.go:619
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1467
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1307,7 +1307,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:508
+#: lxc/storage_volume.go:514
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1321,12 +1321,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:490
+#: lxc/remote.go:559
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:225 lxc/remote.go:474
+#: lxc/remote.go:237 lxc/remote.go:543
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1365,7 +1365,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:485
+#: lxc/remote.go:554
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1434,7 +1434,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:604 lxc/storage_volume.go:605
+#: lxc/storage_volume.go:610 lxc/storage_volume.go:611
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1486,7 +1486,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1475
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1481
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1521,7 +1521,7 @@ msgstr ""
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1732
+#: lxc/storage_volume.go:1738
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1541,7 +1541,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2630
+#: lxc/storage_volume.go:2636
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1637,7 +1637,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:713 lxc/storage_volume.go:714
+#: lxc/storage_volume.go:719 lxc/storage_volume.go:720
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1729,9 +1729,9 @@ msgstr ""
 #: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
 #: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
 #: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:648
-#: lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853 lxc/remote.go:917
-#: lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:715
+#: lxc/remote.go:753 lxc/remote.go:839 lxc/remote.go:920 lxc/remote.go:984
+#: lxc/remote.go:1032 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1743,26 +1743,26 @@ msgstr ""
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
 #: lxc/storage_volume.go:169 lxc/storage_volume.go:283
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:605
-#: lxc/storage_volume.go:714 lxc/storage_volume.go:801
-#: lxc/storage_volume.go:899 lxc/storage_volume.go:996
-#: lxc/storage_volume.go:1217 lxc/storage_volume.go:1348
-#: lxc/storage_volume.go:1507 lxc/storage_volume.go:1591
-#: lxc/storage_volume.go:1844 lxc/storage_volume.go:1937
-#: lxc/storage_volume.go:2064 lxc/storage_volume.go:2222
-#: lxc/storage_volume.go:2343 lxc/storage_volume.go:2405
-#: lxc/storage_volume.go:2541 lxc/storage_volume.go:2624
-#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:611
+#: lxc/storage_volume.go:720 lxc/storage_volume.go:807
+#: lxc/storage_volume.go:905 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:1223 lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1513 lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1850 lxc/storage_volume.go:1943
+#: lxc/storage_volume.go:2070 lxc/storage_volume.go:2228
+#: lxc/storage_volume.go:2349 lxc/storage_volume.go:2411
+#: lxc/storage_volume.go:2547 lxc/storage_volume.go:2630
+#: lxc/storage_volume.go:2796 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1448
+#: lxc/storage_volume.go:1454
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:1849
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:1855
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1774,11 +1774,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:800 lxc/storage_volume.go:801
+#: lxc/storage_volume.go:806 lxc/storage_volume.go:807
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:898 lxc/storage_volume.go:899
+#: lxc/storage_volume.go:904 lxc/storage_volume.go:905
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -2004,7 +2004,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:995 lxc/storage_volume.go:996
+#: lxc/storage_volume.go:1001 lxc/storage_volume.go:1002
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2012,7 +2012,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1766
+#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1772
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2069,7 +2069,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2193
+#: lxc/storage_volume.go:2161 lxc/storage_volume.go:2199
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2083,8 +2083,8 @@ msgstr ""
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2149
-#: lxc/storage_volume.go:2187
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2155
+#: lxc/storage_volume.go:2193
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2126,8 +2126,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1508
-#: lxc/storage_volume.go:1558
+#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1514
+#: lxc/storage_volume.go:1564
 msgid "Expires at"
 msgstr ""
 
@@ -2151,7 +2151,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2623 lxc/storage_volume.go:2624
+#: lxc/storage_volume.go:2629 lxc/storage_volume.go:2630
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2163,11 +2163,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2627
+#: lxc/storage_volume.go:2633
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2756
+#: lxc/export.go:152 lxc/storage_volume.go:2762
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2284,11 +2284,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:191
+#: lxc/remote.go:203
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:242
+#: lxc/remote.go:254
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2298,7 +2298,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:232
+#: lxc/remote.go:244
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2308,12 +2308,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:260
+#: lxc/remote.go:486
 #, c-format
-msgid "Failed to create certificate: %w"
+msgid "Failed to decode trust token: %w"
 msgstr ""
 
-#: lxc/remote.go:267
+#: lxc/remote.go:292
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2338,7 +2338,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:237
+#: lxc/remote.go:249
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2425,9 +2425,9 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:690 lxc/storage.go:657
+#: lxc/project.go:919 lxc/remote.go:757 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1608 lxc/warning.go:94
+#: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2463,7 +2463,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:754
+#: lxc/remote.go:821
 msgid "GLOBAL"
 msgstr ""
 
@@ -2483,7 +2483,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:160 lxc/remote.go:401
+#: lxc/remote.go:165 lxc/remote.go:443
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2551,7 +2551,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1238
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2615,11 +2615,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1216 lxc/storage_volume.go:1217
+#: lxc/storage_volume.go:1222 lxc/storage_volume.go:1223
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:469
+#: lxc/storage_volume.go:475
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2743,7 +2743,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2415
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2421
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2757,7 +2757,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2414
+#: lxc/storage_volume.go:2420
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2807,7 +2807,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2790
+#: lxc/storage_volume.go:2796
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2815,7 +2815,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2789
+#: lxc/storage_volume.go:2795
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2837,11 +2837,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2797
+#: lxc/storage_volume.go:2803
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2871
+#: lxc/storage_volume.go:2877
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2907,7 +2907,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:353
+#: lxc/remote.go:395
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2967,7 +2967,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2000
+#: lxc/move.go:148 lxc/storage_volume.go:2006
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2975,7 +2975,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1996
+#: lxc/storage_volume.go:2002
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2988,14 +2988,14 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:342
+#: lxc/remote.go:384
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1064 lxc/storage_volume.go:1281
-#: lxc/storage_volume.go:1405 lxc/storage_volume.go:1985
-#: lxc/storage_volume.go:2132 lxc/storage_volume.go:2284
+#: lxc/storage_volume.go:1070 lxc/storage_volume.go:1287
+#: lxc/storage_volume.go:1411 lxc/storage_volume.go:1991
+#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2290
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3041,7 +3041,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1739 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1745 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3344,11 +3344,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1586
+#: lxc/storage_volume.go:1592
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1597
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3368,7 +3368,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:685 lxc/remote.go:686
+#: lxc/remote.go:752 lxc/remote.go:753
 msgid "List the available remotes"
 msgstr ""
 
@@ -3407,7 +3407,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1464
+#: lxc/info.go:489 lxc/storage_volume.go:1470
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3871,12 +3871,12 @@ msgstr ""
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:323 lxc/storage_volume.go:643
-#: lxc/storage_volume.go:750 lxc/storage_volume.go:841
-#: lxc/storage_volume.go:939 lxc/storage_volume.go:1053
-#: lxc/storage_volume.go:1270 lxc/storage_volume.go:1974
-#: lxc/storage_volume.go:2115 lxc/storage_volume.go:2273
-#: lxc/storage_volume.go:2464 lxc/storage_volume.go:2581
+#: lxc/storage_volume.go:323 lxc/storage_volume.go:649
+#: lxc/storage_volume.go:756 lxc/storage_volume.go:847
+#: lxc/storage_volume.go:945 lxc/storage_volume.go:1059
+#: lxc/storage_volume.go:1276 lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:2121 lxc/storage_volume.go:2279
+#: lxc/storage_volume.go:2470 lxc/storage_volume.go:2587
 msgid "Missing pool name"
 msgstr ""
 
@@ -3895,11 +3895,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:432 lxc/storage_volume.go:1884
+#: lxc/storage_volume.go:438 lxc/storage_volume.go:1890
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1394
+#: lxc/storage_volume.go:1400
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -3936,8 +3936,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:861
-#: lxc/storage_volume.go:958
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:867
+#: lxc/storage_volume.go:964
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -3974,7 +3974,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1843 lxc/storage_volume.go:1844
+#: lxc/storage_volume.go:1849 lxc/storage_volume.go:1850
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -3982,11 +3982,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1850
+#: lxc/storage_volume.go:1856
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:512
+#: lxc/storage_volume.go:518
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4012,8 +4012,8 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
-#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1731
+#: lxc/remote.go:815 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
 msgstr ""
 
@@ -4039,7 +4039,7 @@ msgstr ""
 
 #: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
+#: lxc/project.go:550 lxc/remote.go:775 lxc/remote.go:780 lxc/remote.go:785
 msgid "NO"
 msgstr ""
 
@@ -4061,8 +4061,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1506
-#: lxc/storage_volume.go:1556
+#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1512
+#: lxc/storage_volume.go:1562
 msgid "Name"
 msgstr ""
 
@@ -4070,7 +4070,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1446
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1452
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4214,7 +4214,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:870 lxc/storage_volume.go:967
+#: lxc/storage_volume.go:876 lxc/storage_volume.go:973
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4230,11 +4230,11 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/storage_volume.go:446 lxc/storage_volume.go:1893
+#: lxc/storage_volume.go:452 lxc/storage_volume.go:1899
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:496 lxc/storage_volume.go:1904
+#: lxc/storage_volume.go:502 lxc/storage_volume.go:1910
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4248,7 +4248,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2012
+#: lxc/storage_volume.go:2018
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4260,15 +4260,15 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2678
+#: lxc/storage_volume.go:2684
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2477
+#: lxc/storage_volume.go:2483
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:336
+#: lxc/remote.go:378
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4276,7 +4276,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1412
+#: lxc/storage_volume.go:1418
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4289,7 +4289,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:693 lxc/storage_volume.go:1560
+#: lxc/info.go:693 lxc/storage_volume.go:1566
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4319,7 +4319,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1756
 msgid "POOL"
 msgstr ""
 
@@ -4335,15 +4335,15 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:213
+#: lxc/list.go:567 lxc/storage_volume.go:1762 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:817
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:752
+#: lxc/image.go:1136 lxc/remote.go:819
 msgid "PUBLIC"
 msgstr ""
 
@@ -4372,7 +4372,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:183
+#: lxc/remote.go:195
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4384,8 +4384,8 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:466
-msgid "Please type 'y', 'n' or the fingerprint:"
+#: lxc/remote.go:536
+msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
 #: lxc/info.go:221
@@ -4409,8 +4409,8 @@ msgstr ""
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1151
-#: lxc/storage_volume.go:1183
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
+#: lxc/storage_volume.go:1189
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4527,7 +4527,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1350
+#: lxc/storage_volume.go:1356
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4541,7 +4541,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1219
+#: lxc/storage_volume.go:1225
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4557,7 +4557,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2224
+#: lxc/storage_volume.go:2230
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4578,7 +4578,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:998
+#: lxc/storage_volume.go:1004
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4587,7 +4587,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2069
+#: lxc/storage_volume.go:2075
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4600,7 +4600,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2345
+#: lxc/storage_volume.go:2351
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4704,33 +4704,33 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:810
+#: lxc/remote.go:877
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
-#: lxc/remote.go:994
+#: lxc/project.go:884 lxc/remote.go:868 lxc/remote.go:949 lxc/remote.go:1013
+#: lxc/remote.go:1061
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:305
+#: lxc/remote.go:345
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:890
+#: lxc/remote.go:957
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:805 lxc/remote.go:886 lxc/remote.go:998
+#: lxc/remote.go:872 lxc/remote.go:953 lxc/remote.go:1065
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:294
+#: lxc/remote.go:319
 msgid "Remote address must not be empty"
 msgstr ""
 
@@ -4738,7 +4738,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:299
+#: lxc/remote.go:339
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4824,7 +4824,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:852 lxc/remote.go:853
+#: lxc/remote.go:919 lxc/remote.go:920
 msgid "Remove remotes"
 msgstr ""
 
@@ -4881,19 +4881,19 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:771 lxc/remote.go:772
+#: lxc/remote.go:838 lxc/remote.go:839
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:1943
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1936
+#: lxc/storage_volume.go:1942
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2025 lxc/storage_volume.go:2045
+#: lxc/storage_volume.go:2031 lxc/storage_volume.go:2051
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4945,7 +4945,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2540 lxc/storage_volume.go:2541
+#: lxc/storage_volume.go:2546 lxc/storage_volume.go:2547
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5026,7 +5026,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:820
 msgid "STATIC"
 msgstr ""
 
@@ -5067,11 +5067,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:464
+#: lxc/remote.go:532
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:616
+#: lxc/remote.go:285 lxc/remote.go:683
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5269,11 +5269,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2063
+#: lxc/storage_volume.go:2069
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2064
+#: lxc/storage_volume.go:2070
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5282,7 +5282,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:964 lxc/remote.go:965
+#: lxc/remote.go:1031 lxc/remote.go:1032
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5358,7 +5358,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2080
+#: lxc/storage_volume.go:2086
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5507,11 +5507,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2221 lxc/storage_volume.go:2222
+#: lxc/storage_volume.go:2227 lxc/storage_volume.go:2228
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1347 lxc/storage_volume.go:1348
+#: lxc/storage_volume.go:1353 lxc/storage_volume.go:1354
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5525,7 +5525,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:647 lxc/remote.go:648
+#: lxc/remote.go:714 lxc/remote.go:715
 msgid "Show the default remote"
 msgstr ""
 
@@ -5579,15 +5579,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2404 lxc/storage_volume.go:2405
+#: lxc/storage_volume.go:2410 lxc/storage_volume.go:2411
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2167
+#: lxc/storage_volume.go:2173
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:607 lxc/storage_volume.go:1485
+#: lxc/info.go:607 lxc/storage_volume.go:1491
 msgid "Snapshots:"
 msgstr ""
 
@@ -5688,21 +5688,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:696
+#: lxc/storage_volume.go:702
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:784
+#: lxc/storage_volume.go:790
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:509
+#: lxc/storage_volume.go:515
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:513
+#: lxc/storage_volume.go:519
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5737,7 +5737,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:916 lxc/remote.go:917
+#: lxc/remote.go:983 lxc/remote.go:984
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5756,11 +5756,11 @@ msgstr ""
 #: lxc/auth.go:818 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
-#: lxc/storage_volume.go:1730 lxc/warning.go:216
+#: lxc/storage_volume.go:1736 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1557
+#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1563
 msgid "Taken at"
 msgstr ""
 
@@ -5770,6 +5770,12 @@ msgstr ""
 
 #: lxc/file.go:1256
 msgid "Target path must be a directory"
+msgstr ""
+
+#: lxc/remote.go:161 lxc/remote.go:334
+msgid ""
+"The --accept-certificate flag is not supported when adding a remote using a "
+"trust token"
 msgstr ""
 
 #: lxc/move.go:181
@@ -5911,15 +5917,20 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1323
+#: lxc/storage_volume.go:1329
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1300
+#: lxc/storage_volume.go:1306
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
+msgstr ""
+
+#: lxc/remote.go:527
+msgid ""
+"The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
 
 #: lxc/info.go:354
@@ -5930,8 +5941,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:875
-#: lxc/storage_volume.go:972
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:881
+#: lxc/storage_volume.go:978
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6006,7 +6017,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1470
+#: lxc/storage_volume.go:1476
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6021,7 +6032,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1847
+#: lxc/storage_volume.go:1853
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6055,7 +6066,15 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:571
+#: lxc/remote.go:329
+msgid "Trust token cannot be used for public remotes"
+msgstr ""
+
+#: lxc/remote.go:324
+msgid "Trust token cannot be used with OIDC authentication"
+msgstr ""
+
+#: lxc/remote.go:639
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6080,7 +6099,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1455
+#: lxc/storage_volume.go:1461
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6098,17 +6117,17 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:193 lxc/remote.go:749
+#: lxc/cluster.go:193 lxc/remote.go:816
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1735
+#: lxc/project.go:995 lxc/storage_volume.go:1741
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1734
+#: lxc/storage.go:724 lxc/storage_volume.go:1740
 msgid "USED BY"
 msgstr ""
 
@@ -6126,7 +6145,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:214 lxc/remote.go:248
+#: lxc/remote.go:226 lxc/remote.go:260
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6140,7 +6159,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1772
+#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1778
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6246,7 +6265,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2342 lxc/storage_volume.go:2343
+#: lxc/storage_volume.go:2348 lxc/storage_volume.go:2349
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6298,7 +6317,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2356
+#: lxc/storage_volume.go:2362
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6342,12 +6361,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1468
+#: lxc/storage_volume.go:1474
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2629
+#: lxc/export.go:42 lxc/storage_volume.go:2635
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6414,7 +6433,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1559
+#: lxc/storage_volume.go:1565
 msgid "Volume Only"
 msgstr ""
 
@@ -6449,7 +6468,7 @@ msgstr ""
 
 #: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
+#: lxc/project.go:552 lxc/remote.go:777 lxc/remote.go:782 lxc/remote.go:787
 msgid "YES"
 msgstr ""
 
@@ -6473,7 +6492,7 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:897
+#: lxc/storage_volume.go:903
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
@@ -6895,7 +6914,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2788
+#: lxc/storage_volume.go:2794
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -6930,13 +6949,13 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:1941
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:799
+#: lxc/storage_volume.go:805
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
@@ -6944,47 +6963,47 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2539
+#: lxc/storage_volume.go:2545
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2622
+#: lxc/storage_volume.go:2628
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2403
+#: lxc/storage_volume.go:2409
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:603
+#: lxc/storage_volume.go:609
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:711
+#: lxc/storage_volume.go:717
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:994 lxc/storage_volume.go:1346
+#: lxc/storage_volume.go:1000 lxc/storage_volume.go:1352
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2341
+#: lxc/storage_volume.go:2347
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2062
+#: lxc/storage_volume.go:2068
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2220
+#: lxc/storage_volume.go:2226
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1215
+#: lxc/storage_volume.go:1221
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1841
+#: lxc/storage_volume.go:1847
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7094,7 +7113,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1584
+#: lxc/storage_volume.go:1590
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7106,7 +7125,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:739
+#: lxc/project.go:557 lxc/remote.go:806
 msgid "current"
 msgstr ""
 
@@ -7566,7 +7585,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:607
+#: lxc/storage_volume.go:613
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7574,13 +7593,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2792
+#: lxc/storage_volume.go:2798
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2407
+#: lxc/storage_volume.go:2413
 msgid ""
 "lxc storage volume snapshot create default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7590,7 +7609,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:531
 msgid "n"
 msgstr ""
 
@@ -7602,7 +7621,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:510
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7639,7 +7658,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:465
+#: lxc/remote.go:519
 msgid "y"
 msgstr ""
 

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-08 07:43+0100\n"
+"POT-Creation-Date: 2024-10-14 13:30+0000\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Turkish <https://hosted.weblate.org/projects/linux-containers/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1024
+#: lxc/storage_volume.go:1030
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -515,15 +515,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:850 lxc/remote.go:915
+#: lxc/remote.go:917 lxc/remote.go:982
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:963
+#: lxc/remote.go:1030
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:769
+#: lxc/remote.go:836
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -556,7 +556,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:751
+#: lxc/remote.go:818
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:581
+#: lxc/remote.go:648
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -738,11 +738,11 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1590
+#: lxc/storage_volume.go:1596
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:182
+#: lxc/remote.go:194
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -813,7 +813,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:552
+#: lxc/remote.go:621
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -849,16 +849,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2696
+#: lxc/storage_volume.go:2702
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2773
+#: lxc/export.go:192 lxc/storage_volume.go:2779
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:654 lxc/storage_volume.go:1521
+#: lxc/info.go:654 lxc/storage_volume.go:1527
 msgid "Backups:"
 msgstr ""
 
@@ -879,7 +879,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:679
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:685
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -922,7 +922,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1733
+#: lxc/storage_volume.go:1739
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -991,7 +991,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:894
+#: lxc/remote.go:961
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1007,7 +1007,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1749 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1024,12 +1024,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:486
+#: lxc/storage_volume.go:492
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:440
+#: lxc/storage_volume.go:446
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1057,11 +1057,11 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:509
 msgid "Certificate fingerprint"
 msgstr ""
 
-#: lxc/remote.go:219
+#: lxc/remote.go:231
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
@@ -1076,7 +1076,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:620
+#: lxc/remote.go:687
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1150,13 +1150,13 @@ msgstr ""
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
 #: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
-#: lxc/storage_volume.go:612 lxc/storage_volume.go:717
-#: lxc/storage_volume.go:1005 lxc/storage_volume.go:1231
-#: lxc/storage_volume.go:1360 lxc/storage_volume.go:1848
-#: lxc/storage_volume.go:1940 lxc/storage_volume.go:2079
-#: lxc/storage_volume.go:2239 lxc/storage_volume.go:2355
-#: lxc/storage_volume.go:2416 lxc/storage_volume.go:2543
-#: lxc/storage_volume.go:2631 lxc/storage_volume.go:2795
+#: lxc/storage_volume.go:618 lxc/storage_volume.go:723
+#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1237
+#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1854
+#: lxc/storage_volume.go:1946 lxc/storage_volume.go:2085
+#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2361
+#: lxc/storage_volume.go:2422 lxc/storage_volume.go:2549
+#: lxc/storage_volume.go:2637 lxc/storage_volume.go:2801
 msgid "Cluster member name"
 msgstr ""
 
@@ -1172,7 +1172,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1589
+#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1595
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1216,17 +1216,17 @@ msgstr ""
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1150
-#: lxc/storage_volume.go:1182
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
+#: lxc/storage_volume.go:1188
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:613
+#: lxc/storage_volume.go:619
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1467
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1310,7 +1310,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:508
+#: lxc/storage_volume.go:514
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1324,12 +1324,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:490
+#: lxc/remote.go:559
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:225 lxc/remote.go:474
+#: lxc/remote.go:237 lxc/remote.go:543
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1368,7 +1368,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:485
+#: lxc/remote.go:554
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1437,7 +1437,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:604 lxc/storage_volume.go:605
+#: lxc/storage_volume.go:610 lxc/storage_volume.go:611
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1489,7 +1489,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1475
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1481
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1524,7 +1524,7 @@ msgstr ""
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1732
+#: lxc/storage_volume.go:1738
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1544,7 +1544,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2630
+#: lxc/storage_volume.go:2636
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1640,7 +1640,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:713 lxc/storage_volume.go:714
+#: lxc/storage_volume.go:719 lxc/storage_volume.go:720
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1732,9 +1732,9 @@ msgstr ""
 #: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
 #: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
 #: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:648
-#: lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853 lxc/remote.go:917
-#: lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:715
+#: lxc/remote.go:753 lxc/remote.go:839 lxc/remote.go:920 lxc/remote.go:984
+#: lxc/remote.go:1032 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1746,26 +1746,26 @@ msgstr ""
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
 #: lxc/storage_volume.go:169 lxc/storage_volume.go:283
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:605
-#: lxc/storage_volume.go:714 lxc/storage_volume.go:801
-#: lxc/storage_volume.go:899 lxc/storage_volume.go:996
-#: lxc/storage_volume.go:1217 lxc/storage_volume.go:1348
-#: lxc/storage_volume.go:1507 lxc/storage_volume.go:1591
-#: lxc/storage_volume.go:1844 lxc/storage_volume.go:1937
-#: lxc/storage_volume.go:2064 lxc/storage_volume.go:2222
-#: lxc/storage_volume.go:2343 lxc/storage_volume.go:2405
-#: lxc/storage_volume.go:2541 lxc/storage_volume.go:2624
-#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:611
+#: lxc/storage_volume.go:720 lxc/storage_volume.go:807
+#: lxc/storage_volume.go:905 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:1223 lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1513 lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1850 lxc/storage_volume.go:1943
+#: lxc/storage_volume.go:2070 lxc/storage_volume.go:2228
+#: lxc/storage_volume.go:2349 lxc/storage_volume.go:2411
+#: lxc/storage_volume.go:2547 lxc/storage_volume.go:2630
+#: lxc/storage_volume.go:2796 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1448
+#: lxc/storage_volume.go:1454
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:1849
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:1855
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1777,11 +1777,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:800 lxc/storage_volume.go:801
+#: lxc/storage_volume.go:806 lxc/storage_volume.go:807
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:898 lxc/storage_volume.go:899
+#: lxc/storage_volume.go:904 lxc/storage_volume.go:905
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -2007,7 +2007,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:995 lxc/storage_volume.go:996
+#: lxc/storage_volume.go:1001 lxc/storage_volume.go:1002
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2015,7 +2015,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1766
+#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1772
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2072,7 +2072,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2193
+#: lxc/storage_volume.go:2161 lxc/storage_volume.go:2199
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2086,8 +2086,8 @@ msgstr ""
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2149
-#: lxc/storage_volume.go:2187
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2155
+#: lxc/storage_volume.go:2193
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2129,8 +2129,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1508
-#: lxc/storage_volume.go:1558
+#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1514
+#: lxc/storage_volume.go:1564
 msgid "Expires at"
 msgstr ""
 
@@ -2154,7 +2154,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2623 lxc/storage_volume.go:2624
+#: lxc/storage_volume.go:2629 lxc/storage_volume.go:2630
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2166,11 +2166,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2627
+#: lxc/storage_volume.go:2633
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2756
+#: lxc/export.go:152 lxc/storage_volume.go:2762
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2287,11 +2287,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:191
+#: lxc/remote.go:203
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:242
+#: lxc/remote.go:254
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2301,7 +2301,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:232
+#: lxc/remote.go:244
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2311,12 +2311,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:260
+#: lxc/remote.go:486
 #, c-format
-msgid "Failed to create certificate: %w"
+msgid "Failed to decode trust token: %w"
 msgstr ""
 
-#: lxc/remote.go:267
+#: lxc/remote.go:292
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2341,7 +2341,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:237
+#: lxc/remote.go:249
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2428,9 +2428,9 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:690 lxc/storage.go:657
+#: lxc/project.go:919 lxc/remote.go:757 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1608 lxc/warning.go:94
+#: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2466,7 +2466,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:754
+#: lxc/remote.go:821
 msgid "GLOBAL"
 msgstr ""
 
@@ -2486,7 +2486,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:160 lxc/remote.go:401
+#: lxc/remote.go:165 lxc/remote.go:443
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2554,7 +2554,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1238
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2618,11 +2618,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1216 lxc/storage_volume.go:1217
+#: lxc/storage_volume.go:1222 lxc/storage_volume.go:1223
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:469
+#: lxc/storage_volume.go:475
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2746,7 +2746,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2415
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2421
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2760,7 +2760,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2414
+#: lxc/storage_volume.go:2420
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2810,7 +2810,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2790
+#: lxc/storage_volume.go:2796
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2818,7 +2818,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2789
+#: lxc/storage_volume.go:2795
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2840,11 +2840,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2797
+#: lxc/storage_volume.go:2803
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2871
+#: lxc/storage_volume.go:2877
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2910,7 +2910,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:353
+#: lxc/remote.go:395
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2970,7 +2970,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2000
+#: lxc/move.go:148 lxc/storage_volume.go:2006
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2978,7 +2978,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1996
+#: lxc/storage_volume.go:2002
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2991,14 +2991,14 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:342
+#: lxc/remote.go:384
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1064 lxc/storage_volume.go:1281
-#: lxc/storage_volume.go:1405 lxc/storage_volume.go:1985
-#: lxc/storage_volume.go:2132 lxc/storage_volume.go:2284
+#: lxc/storage_volume.go:1070 lxc/storage_volume.go:1287
+#: lxc/storage_volume.go:1411 lxc/storage_volume.go:1991
+#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2290
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3044,7 +3044,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1739 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1745 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3347,11 +3347,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1586
+#: lxc/storage_volume.go:1592
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1597
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3371,7 +3371,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:685 lxc/remote.go:686
+#: lxc/remote.go:752 lxc/remote.go:753
 msgid "List the available remotes"
 msgstr ""
 
@@ -3410,7 +3410,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1464
+#: lxc/info.go:489 lxc/storage_volume.go:1470
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3874,12 +3874,12 @@ msgstr ""
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:323 lxc/storage_volume.go:643
-#: lxc/storage_volume.go:750 lxc/storage_volume.go:841
-#: lxc/storage_volume.go:939 lxc/storage_volume.go:1053
-#: lxc/storage_volume.go:1270 lxc/storage_volume.go:1974
-#: lxc/storage_volume.go:2115 lxc/storage_volume.go:2273
-#: lxc/storage_volume.go:2464 lxc/storage_volume.go:2581
+#: lxc/storage_volume.go:323 lxc/storage_volume.go:649
+#: lxc/storage_volume.go:756 lxc/storage_volume.go:847
+#: lxc/storage_volume.go:945 lxc/storage_volume.go:1059
+#: lxc/storage_volume.go:1276 lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:2121 lxc/storage_volume.go:2279
+#: lxc/storage_volume.go:2470 lxc/storage_volume.go:2587
 msgid "Missing pool name"
 msgstr ""
 
@@ -3898,11 +3898,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:432 lxc/storage_volume.go:1884
+#: lxc/storage_volume.go:438 lxc/storage_volume.go:1890
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1394
+#: lxc/storage_volume.go:1400
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -3939,8 +3939,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:861
-#: lxc/storage_volume.go:958
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:867
+#: lxc/storage_volume.go:964
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -3977,7 +3977,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1843 lxc/storage_volume.go:1844
+#: lxc/storage_volume.go:1849 lxc/storage_volume.go:1850
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -3985,11 +3985,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1850
+#: lxc/storage_volume.go:1856
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:512
+#: lxc/storage_volume.go:518
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4015,8 +4015,8 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
-#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1731
+#: lxc/remote.go:815 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
 msgstr ""
 
@@ -4042,7 +4042,7 @@ msgstr ""
 
 #: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
+#: lxc/project.go:550 lxc/remote.go:775 lxc/remote.go:780 lxc/remote.go:785
 msgid "NO"
 msgstr ""
 
@@ -4064,8 +4064,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1506
-#: lxc/storage_volume.go:1556
+#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1512
+#: lxc/storage_volume.go:1562
 msgid "Name"
 msgstr ""
 
@@ -4073,7 +4073,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1446
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1452
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4217,7 +4217,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:870 lxc/storage_volume.go:967
+#: lxc/storage_volume.go:876 lxc/storage_volume.go:973
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4233,11 +4233,11 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/storage_volume.go:446 lxc/storage_volume.go:1893
+#: lxc/storage_volume.go:452 lxc/storage_volume.go:1899
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:496 lxc/storage_volume.go:1904
+#: lxc/storage_volume.go:502 lxc/storage_volume.go:1910
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4251,7 +4251,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2012
+#: lxc/storage_volume.go:2018
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4263,15 +4263,15 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2678
+#: lxc/storage_volume.go:2684
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2477
+#: lxc/storage_volume.go:2483
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:336
+#: lxc/remote.go:378
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4279,7 +4279,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1412
+#: lxc/storage_volume.go:1418
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4292,7 +4292,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:693 lxc/storage_volume.go:1560
+#: lxc/info.go:693 lxc/storage_volume.go:1566
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4322,7 +4322,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1756
 msgid "POOL"
 msgstr ""
 
@@ -4338,15 +4338,15 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:213
+#: lxc/list.go:567 lxc/storage_volume.go:1762 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:817
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:752
+#: lxc/image.go:1136 lxc/remote.go:819
 msgid "PUBLIC"
 msgstr ""
 
@@ -4375,7 +4375,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:183
+#: lxc/remote.go:195
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4387,8 +4387,8 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:466
-msgid "Please type 'y', 'n' or the fingerprint:"
+#: lxc/remote.go:536
+msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
 #: lxc/info.go:221
@@ -4412,8 +4412,8 @@ msgstr ""
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1151
-#: lxc/storage_volume.go:1183
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
+#: lxc/storage_volume.go:1189
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4530,7 +4530,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1350
+#: lxc/storage_volume.go:1356
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4544,7 +4544,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1219
+#: lxc/storage_volume.go:1225
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4560,7 +4560,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2224
+#: lxc/storage_volume.go:2230
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4581,7 +4581,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:998
+#: lxc/storage_volume.go:1004
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4590,7 +4590,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2069
+#: lxc/storage_volume.go:2075
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4603,7 +4603,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2345
+#: lxc/storage_volume.go:2351
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4707,33 +4707,33 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:810
+#: lxc/remote.go:877
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
-#: lxc/remote.go:994
+#: lxc/project.go:884 lxc/remote.go:868 lxc/remote.go:949 lxc/remote.go:1013
+#: lxc/remote.go:1061
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:305
+#: lxc/remote.go:345
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:890
+#: lxc/remote.go:957
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:805 lxc/remote.go:886 lxc/remote.go:998
+#: lxc/remote.go:872 lxc/remote.go:953 lxc/remote.go:1065
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:294
+#: lxc/remote.go:319
 msgid "Remote address must not be empty"
 msgstr ""
 
@@ -4741,7 +4741,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:299
+#: lxc/remote.go:339
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4827,7 +4827,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:852 lxc/remote.go:853
+#: lxc/remote.go:919 lxc/remote.go:920
 msgid "Remove remotes"
 msgstr ""
 
@@ -4884,19 +4884,19 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:771 lxc/remote.go:772
+#: lxc/remote.go:838 lxc/remote.go:839
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:1943
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1936
+#: lxc/storage_volume.go:1942
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2025 lxc/storage_volume.go:2045
+#: lxc/storage_volume.go:2031 lxc/storage_volume.go:2051
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4948,7 +4948,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2540 lxc/storage_volume.go:2541
+#: lxc/storage_volume.go:2546 lxc/storage_volume.go:2547
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5029,7 +5029,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:820
 msgid "STATIC"
 msgstr ""
 
@@ -5070,11 +5070,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:464
+#: lxc/remote.go:532
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:616
+#: lxc/remote.go:285 lxc/remote.go:683
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5272,11 +5272,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2063
+#: lxc/storage_volume.go:2069
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2064
+#: lxc/storage_volume.go:2070
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5285,7 +5285,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:964 lxc/remote.go:965
+#: lxc/remote.go:1031 lxc/remote.go:1032
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5361,7 +5361,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2080
+#: lxc/storage_volume.go:2086
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5510,11 +5510,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2221 lxc/storage_volume.go:2222
+#: lxc/storage_volume.go:2227 lxc/storage_volume.go:2228
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1347 lxc/storage_volume.go:1348
+#: lxc/storage_volume.go:1353 lxc/storage_volume.go:1354
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5528,7 +5528,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:647 lxc/remote.go:648
+#: lxc/remote.go:714 lxc/remote.go:715
 msgid "Show the default remote"
 msgstr ""
 
@@ -5582,15 +5582,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2404 lxc/storage_volume.go:2405
+#: lxc/storage_volume.go:2410 lxc/storage_volume.go:2411
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2167
+#: lxc/storage_volume.go:2173
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:607 lxc/storage_volume.go:1485
+#: lxc/info.go:607 lxc/storage_volume.go:1491
 msgid "Snapshots:"
 msgstr ""
 
@@ -5691,21 +5691,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:696
+#: lxc/storage_volume.go:702
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:784
+#: lxc/storage_volume.go:790
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:509
+#: lxc/storage_volume.go:515
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:513
+#: lxc/storage_volume.go:519
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5740,7 +5740,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:916 lxc/remote.go:917
+#: lxc/remote.go:983 lxc/remote.go:984
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5759,11 +5759,11 @@ msgstr ""
 #: lxc/auth.go:818 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
-#: lxc/storage_volume.go:1730 lxc/warning.go:216
+#: lxc/storage_volume.go:1736 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1557
+#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1563
 msgid "Taken at"
 msgstr ""
 
@@ -5773,6 +5773,12 @@ msgstr ""
 
 #: lxc/file.go:1256
 msgid "Target path must be a directory"
+msgstr ""
+
+#: lxc/remote.go:161 lxc/remote.go:334
+msgid ""
+"The --accept-certificate flag is not supported when adding a remote using a "
+"trust token"
 msgstr ""
 
 #: lxc/move.go:181
@@ -5914,15 +5920,20 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1323
+#: lxc/storage_volume.go:1329
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1300
+#: lxc/storage_volume.go:1306
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
+msgstr ""
+
+#: lxc/remote.go:527
+msgid ""
+"The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
 
 #: lxc/info.go:354
@@ -5933,8 +5944,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:875
-#: lxc/storage_volume.go:972
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:881
+#: lxc/storage_volume.go:978
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6009,7 +6020,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1470
+#: lxc/storage_volume.go:1476
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6024,7 +6035,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1847
+#: lxc/storage_volume.go:1853
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6058,7 +6069,15 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:571
+#: lxc/remote.go:329
+msgid "Trust token cannot be used for public remotes"
+msgstr ""
+
+#: lxc/remote.go:324
+msgid "Trust token cannot be used with OIDC authentication"
+msgstr ""
+
+#: lxc/remote.go:639
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6083,7 +6102,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1455
+#: lxc/storage_volume.go:1461
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6101,17 +6120,17 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:193 lxc/remote.go:749
+#: lxc/cluster.go:193 lxc/remote.go:816
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1735
+#: lxc/project.go:995 lxc/storage_volume.go:1741
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1734
+#: lxc/storage.go:724 lxc/storage_volume.go:1740
 msgid "USED BY"
 msgstr ""
 
@@ -6129,7 +6148,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:214 lxc/remote.go:248
+#: lxc/remote.go:226 lxc/remote.go:260
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6143,7 +6162,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1772
+#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1778
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6249,7 +6268,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2342 lxc/storage_volume.go:2343
+#: lxc/storage_volume.go:2348 lxc/storage_volume.go:2349
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6301,7 +6320,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2356
+#: lxc/storage_volume.go:2362
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6345,12 +6364,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1468
+#: lxc/storage_volume.go:1474
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2629
+#: lxc/export.go:42 lxc/storage_volume.go:2635
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6417,7 +6436,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1559
+#: lxc/storage_volume.go:1565
 msgid "Volume Only"
 msgstr ""
 
@@ -6452,7 +6471,7 @@ msgstr ""
 
 #: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
+#: lxc/project.go:552 lxc/remote.go:777 lxc/remote.go:782 lxc/remote.go:787
 msgid "YES"
 msgstr ""
 
@@ -6476,7 +6495,7 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:897
+#: lxc/storage_volume.go:903
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
@@ -6898,7 +6917,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2788
+#: lxc/storage_volume.go:2794
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -6933,13 +6952,13 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:1941
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:799
+#: lxc/storage_volume.go:805
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
@@ -6947,47 +6966,47 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2539
+#: lxc/storage_volume.go:2545
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2622
+#: lxc/storage_volume.go:2628
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2403
+#: lxc/storage_volume.go:2409
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:603
+#: lxc/storage_volume.go:609
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:711
+#: lxc/storage_volume.go:717
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:994 lxc/storage_volume.go:1346
+#: lxc/storage_volume.go:1000 lxc/storage_volume.go:1352
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2341
+#: lxc/storage_volume.go:2347
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2062
+#: lxc/storage_volume.go:2068
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2220
+#: lxc/storage_volume.go:2226
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1215
+#: lxc/storage_volume.go:1221
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1841
+#: lxc/storage_volume.go:1847
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7097,7 +7116,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1584
+#: lxc/storage_volume.go:1590
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7109,7 +7128,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:739
+#: lxc/project.go:557 lxc/remote.go:806
 msgid "current"
 msgstr ""
 
@@ -7569,7 +7588,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:607
+#: lxc/storage_volume.go:613
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7577,13 +7596,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2792
+#: lxc/storage_volume.go:2798
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2407
+#: lxc/storage_volume.go:2413
 msgid ""
 "lxc storage volume snapshot create default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7593,7 +7612,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:531
 msgid "n"
 msgstr ""
 
@@ -7605,7 +7624,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:510
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7642,7 +7661,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:465
+#: lxc/remote.go:519
 msgid "y"
 msgstr ""
 

--- a/po/tzm.po
+++ b/po/tzm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-08 07:43+0100\n"
+"POT-Creation-Date: 2024-10-14 13:30+0000\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Tamazight (Central Atlas) <https://hosted.weblate.org/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1024
+#: lxc/storage_volume.go:1030
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -515,15 +515,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:850 lxc/remote.go:915
+#: lxc/remote.go:917 lxc/remote.go:982
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:963
+#: lxc/remote.go:1030
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:769
+#: lxc/remote.go:836
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -556,7 +556,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:751
+#: lxc/remote.go:818
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:581
+#: lxc/remote.go:648
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -738,11 +738,11 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1590
+#: lxc/storage_volume.go:1596
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:182
+#: lxc/remote.go:194
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -813,7 +813,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:552
+#: lxc/remote.go:621
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -849,16 +849,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2696
+#: lxc/storage_volume.go:2702
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2773
+#: lxc/export.go:192 lxc/storage_volume.go:2779
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:654 lxc/storage_volume.go:1521
+#: lxc/info.go:654 lxc/storage_volume.go:1527
 msgid "Backups:"
 msgstr ""
 
@@ -879,7 +879,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:679
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:685
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -922,7 +922,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1733
+#: lxc/storage_volume.go:1739
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -991,7 +991,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:894
+#: lxc/remote.go:961
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1007,7 +1007,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1749 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1024,12 +1024,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:486
+#: lxc/storage_volume.go:492
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:440
+#: lxc/storage_volume.go:446
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1057,11 +1057,11 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:509
 msgid "Certificate fingerprint"
 msgstr ""
 
-#: lxc/remote.go:219
+#: lxc/remote.go:231
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
@@ -1076,7 +1076,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:620
+#: lxc/remote.go:687
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1150,13 +1150,13 @@ msgstr ""
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
 #: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
-#: lxc/storage_volume.go:612 lxc/storage_volume.go:717
-#: lxc/storage_volume.go:1005 lxc/storage_volume.go:1231
-#: lxc/storage_volume.go:1360 lxc/storage_volume.go:1848
-#: lxc/storage_volume.go:1940 lxc/storage_volume.go:2079
-#: lxc/storage_volume.go:2239 lxc/storage_volume.go:2355
-#: lxc/storage_volume.go:2416 lxc/storage_volume.go:2543
-#: lxc/storage_volume.go:2631 lxc/storage_volume.go:2795
+#: lxc/storage_volume.go:618 lxc/storage_volume.go:723
+#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1237
+#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1854
+#: lxc/storage_volume.go:1946 lxc/storage_volume.go:2085
+#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2361
+#: lxc/storage_volume.go:2422 lxc/storage_volume.go:2549
+#: lxc/storage_volume.go:2637 lxc/storage_volume.go:2801
 msgid "Cluster member name"
 msgstr ""
 
@@ -1172,7 +1172,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1589
+#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1595
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1216,17 +1216,17 @@ msgstr ""
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1150
-#: lxc/storage_volume.go:1182
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
+#: lxc/storage_volume.go:1188
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:613
+#: lxc/storage_volume.go:619
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1467
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1310,7 +1310,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:508
+#: lxc/storage_volume.go:514
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1324,12 +1324,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:490
+#: lxc/remote.go:559
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:225 lxc/remote.go:474
+#: lxc/remote.go:237 lxc/remote.go:543
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1368,7 +1368,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:485
+#: lxc/remote.go:554
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1437,7 +1437,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:604 lxc/storage_volume.go:605
+#: lxc/storage_volume.go:610 lxc/storage_volume.go:611
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1489,7 +1489,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1475
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1481
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1524,7 +1524,7 @@ msgstr ""
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1732
+#: lxc/storage_volume.go:1738
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1544,7 +1544,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2630
+#: lxc/storage_volume.go:2636
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1640,7 +1640,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:713 lxc/storage_volume.go:714
+#: lxc/storage_volume.go:719 lxc/storage_volume.go:720
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1732,9 +1732,9 @@ msgstr ""
 #: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
 #: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
 #: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:648
-#: lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853 lxc/remote.go:917
-#: lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:715
+#: lxc/remote.go:753 lxc/remote.go:839 lxc/remote.go:920 lxc/remote.go:984
+#: lxc/remote.go:1032 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1746,26 +1746,26 @@ msgstr ""
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
 #: lxc/storage_volume.go:169 lxc/storage_volume.go:283
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:605
-#: lxc/storage_volume.go:714 lxc/storage_volume.go:801
-#: lxc/storage_volume.go:899 lxc/storage_volume.go:996
-#: lxc/storage_volume.go:1217 lxc/storage_volume.go:1348
-#: lxc/storage_volume.go:1507 lxc/storage_volume.go:1591
-#: lxc/storage_volume.go:1844 lxc/storage_volume.go:1937
-#: lxc/storage_volume.go:2064 lxc/storage_volume.go:2222
-#: lxc/storage_volume.go:2343 lxc/storage_volume.go:2405
-#: lxc/storage_volume.go:2541 lxc/storage_volume.go:2624
-#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:611
+#: lxc/storage_volume.go:720 lxc/storage_volume.go:807
+#: lxc/storage_volume.go:905 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:1223 lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1513 lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1850 lxc/storage_volume.go:1943
+#: lxc/storage_volume.go:2070 lxc/storage_volume.go:2228
+#: lxc/storage_volume.go:2349 lxc/storage_volume.go:2411
+#: lxc/storage_volume.go:2547 lxc/storage_volume.go:2630
+#: lxc/storage_volume.go:2796 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1448
+#: lxc/storage_volume.go:1454
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:1849
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:1855
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1777,11 +1777,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:800 lxc/storage_volume.go:801
+#: lxc/storage_volume.go:806 lxc/storage_volume.go:807
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:898 lxc/storage_volume.go:899
+#: lxc/storage_volume.go:904 lxc/storage_volume.go:905
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -2007,7 +2007,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:995 lxc/storage_volume.go:996
+#: lxc/storage_volume.go:1001 lxc/storage_volume.go:1002
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2015,7 +2015,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1766
+#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1772
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2072,7 +2072,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2193
+#: lxc/storage_volume.go:2161 lxc/storage_volume.go:2199
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2086,8 +2086,8 @@ msgstr ""
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2149
-#: lxc/storage_volume.go:2187
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2155
+#: lxc/storage_volume.go:2193
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2129,8 +2129,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1508
-#: lxc/storage_volume.go:1558
+#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1514
+#: lxc/storage_volume.go:1564
 msgid "Expires at"
 msgstr ""
 
@@ -2154,7 +2154,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2623 lxc/storage_volume.go:2624
+#: lxc/storage_volume.go:2629 lxc/storage_volume.go:2630
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2166,11 +2166,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2627
+#: lxc/storage_volume.go:2633
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2756
+#: lxc/export.go:152 lxc/storage_volume.go:2762
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2287,11 +2287,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:191
+#: lxc/remote.go:203
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:242
+#: lxc/remote.go:254
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2301,7 +2301,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:232
+#: lxc/remote.go:244
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2311,12 +2311,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:260
+#: lxc/remote.go:486
 #, c-format
-msgid "Failed to create certificate: %w"
+msgid "Failed to decode trust token: %w"
 msgstr ""
 
-#: lxc/remote.go:267
+#: lxc/remote.go:292
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2341,7 +2341,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:237
+#: lxc/remote.go:249
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2428,9 +2428,9 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:690 lxc/storage.go:657
+#: lxc/project.go:919 lxc/remote.go:757 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1608 lxc/warning.go:94
+#: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2466,7 +2466,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:754
+#: lxc/remote.go:821
 msgid "GLOBAL"
 msgstr ""
 
@@ -2486,7 +2486,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:160 lxc/remote.go:401
+#: lxc/remote.go:165 lxc/remote.go:443
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2554,7 +2554,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1238
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2618,11 +2618,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1216 lxc/storage_volume.go:1217
+#: lxc/storage_volume.go:1222 lxc/storage_volume.go:1223
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:469
+#: lxc/storage_volume.go:475
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2746,7 +2746,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2415
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2421
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2760,7 +2760,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2414
+#: lxc/storage_volume.go:2420
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2810,7 +2810,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2790
+#: lxc/storage_volume.go:2796
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2818,7 +2818,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2789
+#: lxc/storage_volume.go:2795
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2840,11 +2840,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2797
+#: lxc/storage_volume.go:2803
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2871
+#: lxc/storage_volume.go:2877
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2910,7 +2910,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:353
+#: lxc/remote.go:395
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2970,7 +2970,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2000
+#: lxc/move.go:148 lxc/storage_volume.go:2006
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2978,7 +2978,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1996
+#: lxc/storage_volume.go:2002
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2991,14 +2991,14 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:342
+#: lxc/remote.go:384
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1064 lxc/storage_volume.go:1281
-#: lxc/storage_volume.go:1405 lxc/storage_volume.go:1985
-#: lxc/storage_volume.go:2132 lxc/storage_volume.go:2284
+#: lxc/storage_volume.go:1070 lxc/storage_volume.go:1287
+#: lxc/storage_volume.go:1411 lxc/storage_volume.go:1991
+#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2290
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3044,7 +3044,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1739 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1745 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3347,11 +3347,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1586
+#: lxc/storage_volume.go:1592
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1597
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3371,7 +3371,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:685 lxc/remote.go:686
+#: lxc/remote.go:752 lxc/remote.go:753
 msgid "List the available remotes"
 msgstr ""
 
@@ -3410,7 +3410,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1464
+#: lxc/info.go:489 lxc/storage_volume.go:1470
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3874,12 +3874,12 @@ msgstr ""
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:323 lxc/storage_volume.go:643
-#: lxc/storage_volume.go:750 lxc/storage_volume.go:841
-#: lxc/storage_volume.go:939 lxc/storage_volume.go:1053
-#: lxc/storage_volume.go:1270 lxc/storage_volume.go:1974
-#: lxc/storage_volume.go:2115 lxc/storage_volume.go:2273
-#: lxc/storage_volume.go:2464 lxc/storage_volume.go:2581
+#: lxc/storage_volume.go:323 lxc/storage_volume.go:649
+#: lxc/storage_volume.go:756 lxc/storage_volume.go:847
+#: lxc/storage_volume.go:945 lxc/storage_volume.go:1059
+#: lxc/storage_volume.go:1276 lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:2121 lxc/storage_volume.go:2279
+#: lxc/storage_volume.go:2470 lxc/storage_volume.go:2587
 msgid "Missing pool name"
 msgstr ""
 
@@ -3898,11 +3898,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:432 lxc/storage_volume.go:1884
+#: lxc/storage_volume.go:438 lxc/storage_volume.go:1890
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1394
+#: lxc/storage_volume.go:1400
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -3939,8 +3939,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:861
-#: lxc/storage_volume.go:958
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:867
+#: lxc/storage_volume.go:964
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -3977,7 +3977,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1843 lxc/storage_volume.go:1844
+#: lxc/storage_volume.go:1849 lxc/storage_volume.go:1850
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -3985,11 +3985,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1850
+#: lxc/storage_volume.go:1856
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:512
+#: lxc/storage_volume.go:518
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4015,8 +4015,8 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
-#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1731
+#: lxc/remote.go:815 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
 msgstr ""
 
@@ -4042,7 +4042,7 @@ msgstr ""
 
 #: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
+#: lxc/project.go:550 lxc/remote.go:775 lxc/remote.go:780 lxc/remote.go:785
 msgid "NO"
 msgstr ""
 
@@ -4064,8 +4064,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1506
-#: lxc/storage_volume.go:1556
+#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1512
+#: lxc/storage_volume.go:1562
 msgid "Name"
 msgstr ""
 
@@ -4073,7 +4073,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1446
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1452
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4217,7 +4217,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:870 lxc/storage_volume.go:967
+#: lxc/storage_volume.go:876 lxc/storage_volume.go:973
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4233,11 +4233,11 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/storage_volume.go:446 lxc/storage_volume.go:1893
+#: lxc/storage_volume.go:452 lxc/storage_volume.go:1899
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:496 lxc/storage_volume.go:1904
+#: lxc/storage_volume.go:502 lxc/storage_volume.go:1910
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4251,7 +4251,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2012
+#: lxc/storage_volume.go:2018
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4263,15 +4263,15 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2678
+#: lxc/storage_volume.go:2684
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2477
+#: lxc/storage_volume.go:2483
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:336
+#: lxc/remote.go:378
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4279,7 +4279,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1412
+#: lxc/storage_volume.go:1418
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4292,7 +4292,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:693 lxc/storage_volume.go:1560
+#: lxc/info.go:693 lxc/storage_volume.go:1566
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4322,7 +4322,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1756
 msgid "POOL"
 msgstr ""
 
@@ -4338,15 +4338,15 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:213
+#: lxc/list.go:567 lxc/storage_volume.go:1762 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:817
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:752
+#: lxc/image.go:1136 lxc/remote.go:819
 msgid "PUBLIC"
 msgstr ""
 
@@ -4375,7 +4375,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:183
+#: lxc/remote.go:195
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4387,8 +4387,8 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:466
-msgid "Please type 'y', 'n' or the fingerprint:"
+#: lxc/remote.go:536
+msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
 #: lxc/info.go:221
@@ -4412,8 +4412,8 @@ msgstr ""
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1151
-#: lxc/storage_volume.go:1183
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
+#: lxc/storage_volume.go:1189
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4530,7 +4530,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1350
+#: lxc/storage_volume.go:1356
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4544,7 +4544,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1219
+#: lxc/storage_volume.go:1225
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4560,7 +4560,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2224
+#: lxc/storage_volume.go:2230
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4581,7 +4581,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:998
+#: lxc/storage_volume.go:1004
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4590,7 +4590,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2069
+#: lxc/storage_volume.go:2075
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4603,7 +4603,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2345
+#: lxc/storage_volume.go:2351
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4707,33 +4707,33 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:810
+#: lxc/remote.go:877
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
-#: lxc/remote.go:994
+#: lxc/project.go:884 lxc/remote.go:868 lxc/remote.go:949 lxc/remote.go:1013
+#: lxc/remote.go:1061
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:305
+#: lxc/remote.go:345
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:890
+#: lxc/remote.go:957
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:805 lxc/remote.go:886 lxc/remote.go:998
+#: lxc/remote.go:872 lxc/remote.go:953 lxc/remote.go:1065
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:294
+#: lxc/remote.go:319
 msgid "Remote address must not be empty"
 msgstr ""
 
@@ -4741,7 +4741,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:299
+#: lxc/remote.go:339
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4827,7 +4827,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:852 lxc/remote.go:853
+#: lxc/remote.go:919 lxc/remote.go:920
 msgid "Remove remotes"
 msgstr ""
 
@@ -4884,19 +4884,19 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:771 lxc/remote.go:772
+#: lxc/remote.go:838 lxc/remote.go:839
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:1943
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1936
+#: lxc/storage_volume.go:1942
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2025 lxc/storage_volume.go:2045
+#: lxc/storage_volume.go:2031 lxc/storage_volume.go:2051
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4948,7 +4948,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2540 lxc/storage_volume.go:2541
+#: lxc/storage_volume.go:2546 lxc/storage_volume.go:2547
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5029,7 +5029,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:820
 msgid "STATIC"
 msgstr ""
 
@@ -5070,11 +5070,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:464
+#: lxc/remote.go:532
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:616
+#: lxc/remote.go:285 lxc/remote.go:683
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5272,11 +5272,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2063
+#: lxc/storage_volume.go:2069
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2064
+#: lxc/storage_volume.go:2070
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5285,7 +5285,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:964 lxc/remote.go:965
+#: lxc/remote.go:1031 lxc/remote.go:1032
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5361,7 +5361,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2080
+#: lxc/storage_volume.go:2086
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5510,11 +5510,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2221 lxc/storage_volume.go:2222
+#: lxc/storage_volume.go:2227 lxc/storage_volume.go:2228
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1347 lxc/storage_volume.go:1348
+#: lxc/storage_volume.go:1353 lxc/storage_volume.go:1354
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5528,7 +5528,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:647 lxc/remote.go:648
+#: lxc/remote.go:714 lxc/remote.go:715
 msgid "Show the default remote"
 msgstr ""
 
@@ -5582,15 +5582,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2404 lxc/storage_volume.go:2405
+#: lxc/storage_volume.go:2410 lxc/storage_volume.go:2411
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2167
+#: lxc/storage_volume.go:2173
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:607 lxc/storage_volume.go:1485
+#: lxc/info.go:607 lxc/storage_volume.go:1491
 msgid "Snapshots:"
 msgstr ""
 
@@ -5691,21 +5691,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:696
+#: lxc/storage_volume.go:702
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:784
+#: lxc/storage_volume.go:790
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:509
+#: lxc/storage_volume.go:515
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:513
+#: lxc/storage_volume.go:519
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5740,7 +5740,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:916 lxc/remote.go:917
+#: lxc/remote.go:983 lxc/remote.go:984
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5759,11 +5759,11 @@ msgstr ""
 #: lxc/auth.go:818 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
-#: lxc/storage_volume.go:1730 lxc/warning.go:216
+#: lxc/storage_volume.go:1736 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1557
+#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1563
 msgid "Taken at"
 msgstr ""
 
@@ -5773,6 +5773,12 @@ msgstr ""
 
 #: lxc/file.go:1256
 msgid "Target path must be a directory"
+msgstr ""
+
+#: lxc/remote.go:161 lxc/remote.go:334
+msgid ""
+"The --accept-certificate flag is not supported when adding a remote using a "
+"trust token"
 msgstr ""
 
 #: lxc/move.go:181
@@ -5914,15 +5920,20 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1323
+#: lxc/storage_volume.go:1329
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1300
+#: lxc/storage_volume.go:1306
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
+msgstr ""
+
+#: lxc/remote.go:527
+msgid ""
+"The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
 
 #: lxc/info.go:354
@@ -5933,8 +5944,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:875
-#: lxc/storage_volume.go:972
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:881
+#: lxc/storage_volume.go:978
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6009,7 +6020,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1470
+#: lxc/storage_volume.go:1476
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6024,7 +6035,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1847
+#: lxc/storage_volume.go:1853
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6058,7 +6069,15 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:571
+#: lxc/remote.go:329
+msgid "Trust token cannot be used for public remotes"
+msgstr ""
+
+#: lxc/remote.go:324
+msgid "Trust token cannot be used with OIDC authentication"
+msgstr ""
+
+#: lxc/remote.go:639
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6083,7 +6102,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1455
+#: lxc/storage_volume.go:1461
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6101,17 +6120,17 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:193 lxc/remote.go:749
+#: lxc/cluster.go:193 lxc/remote.go:816
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1735
+#: lxc/project.go:995 lxc/storage_volume.go:1741
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1734
+#: lxc/storage.go:724 lxc/storage_volume.go:1740
 msgid "USED BY"
 msgstr ""
 
@@ -6129,7 +6148,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:214 lxc/remote.go:248
+#: lxc/remote.go:226 lxc/remote.go:260
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6143,7 +6162,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1772
+#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1778
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6249,7 +6268,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2342 lxc/storage_volume.go:2343
+#: lxc/storage_volume.go:2348 lxc/storage_volume.go:2349
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6301,7 +6320,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2356
+#: lxc/storage_volume.go:2362
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6345,12 +6364,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1468
+#: lxc/storage_volume.go:1474
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2629
+#: lxc/export.go:42 lxc/storage_volume.go:2635
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6417,7 +6436,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1559
+#: lxc/storage_volume.go:1565
 msgid "Volume Only"
 msgstr ""
 
@@ -6452,7 +6471,7 @@ msgstr ""
 
 #: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
+#: lxc/project.go:552 lxc/remote.go:777 lxc/remote.go:782 lxc/remote.go:787
 msgid "YES"
 msgstr ""
 
@@ -6476,7 +6495,7 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:897
+#: lxc/storage_volume.go:903
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
@@ -6898,7 +6917,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2788
+#: lxc/storage_volume.go:2794
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -6933,13 +6952,13 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:1941
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:799
+#: lxc/storage_volume.go:805
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
@@ -6947,47 +6966,47 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2539
+#: lxc/storage_volume.go:2545
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2622
+#: lxc/storage_volume.go:2628
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2403
+#: lxc/storage_volume.go:2409
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:603
+#: lxc/storage_volume.go:609
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:711
+#: lxc/storage_volume.go:717
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:994 lxc/storage_volume.go:1346
+#: lxc/storage_volume.go:1000 lxc/storage_volume.go:1352
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2341
+#: lxc/storage_volume.go:2347
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2062
+#: lxc/storage_volume.go:2068
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2220
+#: lxc/storage_volume.go:2226
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1215
+#: lxc/storage_volume.go:1221
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1841
+#: lxc/storage_volume.go:1847
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7097,7 +7116,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1584
+#: lxc/storage_volume.go:1590
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7109,7 +7128,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:739
+#: lxc/project.go:557 lxc/remote.go:806
 msgid "current"
 msgstr ""
 
@@ -7569,7 +7588,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:607
+#: lxc/storage_volume.go:613
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7577,13 +7596,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2792
+#: lxc/storage_volume.go:2798
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2407
+#: lxc/storage_volume.go:2413
 msgid ""
 "lxc storage volume snapshot create default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7593,7 +7612,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:531
 msgid "n"
 msgstr ""
 
@@ -7605,7 +7624,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:510
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7642,7 +7661,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:465
+#: lxc/remote.go:519
 msgid "y"
 msgstr ""
 

--- a/po/ug.po
+++ b/po/ug.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-08 07:43+0100\n"
+"POT-Creation-Date: 2024-10-14 13:30+0000\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Uyghur <https://hosted.weblate.org/projects/linux-containers/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1024
+#: lxc/storage_volume.go:1030
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -515,15 +515,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:850 lxc/remote.go:915
+#: lxc/remote.go:917 lxc/remote.go:982
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:963
+#: lxc/remote.go:1030
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:769
+#: lxc/remote.go:836
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -556,7 +556,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:751
+#: lxc/remote.go:818
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:581
+#: lxc/remote.go:648
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -738,11 +738,11 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1590
+#: lxc/storage_volume.go:1596
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:182
+#: lxc/remote.go:194
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -813,7 +813,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:552
+#: lxc/remote.go:621
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -849,16 +849,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2696
+#: lxc/storage_volume.go:2702
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2773
+#: lxc/export.go:192 lxc/storage_volume.go:2779
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:654 lxc/storage_volume.go:1521
+#: lxc/info.go:654 lxc/storage_volume.go:1527
 msgid "Backups:"
 msgstr ""
 
@@ -879,7 +879,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:679
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:685
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -922,7 +922,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1733
+#: lxc/storage_volume.go:1739
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -991,7 +991,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:894
+#: lxc/remote.go:961
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1007,7 +1007,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1749 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1024,12 +1024,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:486
+#: lxc/storage_volume.go:492
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:440
+#: lxc/storage_volume.go:446
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1057,11 +1057,11 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:509
 msgid "Certificate fingerprint"
 msgstr ""
 
-#: lxc/remote.go:219
+#: lxc/remote.go:231
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
@@ -1076,7 +1076,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:620
+#: lxc/remote.go:687
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1150,13 +1150,13 @@ msgstr ""
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
 #: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
-#: lxc/storage_volume.go:612 lxc/storage_volume.go:717
-#: lxc/storage_volume.go:1005 lxc/storage_volume.go:1231
-#: lxc/storage_volume.go:1360 lxc/storage_volume.go:1848
-#: lxc/storage_volume.go:1940 lxc/storage_volume.go:2079
-#: lxc/storage_volume.go:2239 lxc/storage_volume.go:2355
-#: lxc/storage_volume.go:2416 lxc/storage_volume.go:2543
-#: lxc/storage_volume.go:2631 lxc/storage_volume.go:2795
+#: lxc/storage_volume.go:618 lxc/storage_volume.go:723
+#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1237
+#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1854
+#: lxc/storage_volume.go:1946 lxc/storage_volume.go:2085
+#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2361
+#: lxc/storage_volume.go:2422 lxc/storage_volume.go:2549
+#: lxc/storage_volume.go:2637 lxc/storage_volume.go:2801
 msgid "Cluster member name"
 msgstr ""
 
@@ -1172,7 +1172,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1589
+#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1595
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1216,17 +1216,17 @@ msgstr ""
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1150
-#: lxc/storage_volume.go:1182
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
+#: lxc/storage_volume.go:1188
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:613
+#: lxc/storage_volume.go:619
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1467
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1310,7 +1310,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:508
+#: lxc/storage_volume.go:514
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1324,12 +1324,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:490
+#: lxc/remote.go:559
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:225 lxc/remote.go:474
+#: lxc/remote.go:237 lxc/remote.go:543
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1368,7 +1368,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:485
+#: lxc/remote.go:554
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1437,7 +1437,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:604 lxc/storage_volume.go:605
+#: lxc/storage_volume.go:610 lxc/storage_volume.go:611
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1489,7 +1489,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1475
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1481
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1524,7 +1524,7 @@ msgstr ""
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1732
+#: lxc/storage_volume.go:1738
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1544,7 +1544,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2630
+#: lxc/storage_volume.go:2636
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1640,7 +1640,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:713 lxc/storage_volume.go:714
+#: lxc/storage_volume.go:719 lxc/storage_volume.go:720
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1732,9 +1732,9 @@ msgstr ""
 #: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
 #: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
 #: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:648
-#: lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853 lxc/remote.go:917
-#: lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:715
+#: lxc/remote.go:753 lxc/remote.go:839 lxc/remote.go:920 lxc/remote.go:984
+#: lxc/remote.go:1032 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1746,26 +1746,26 @@ msgstr ""
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
 #: lxc/storage_volume.go:169 lxc/storage_volume.go:283
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:605
-#: lxc/storage_volume.go:714 lxc/storage_volume.go:801
-#: lxc/storage_volume.go:899 lxc/storage_volume.go:996
-#: lxc/storage_volume.go:1217 lxc/storage_volume.go:1348
-#: lxc/storage_volume.go:1507 lxc/storage_volume.go:1591
-#: lxc/storage_volume.go:1844 lxc/storage_volume.go:1937
-#: lxc/storage_volume.go:2064 lxc/storage_volume.go:2222
-#: lxc/storage_volume.go:2343 lxc/storage_volume.go:2405
-#: lxc/storage_volume.go:2541 lxc/storage_volume.go:2624
-#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:611
+#: lxc/storage_volume.go:720 lxc/storage_volume.go:807
+#: lxc/storage_volume.go:905 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:1223 lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1513 lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1850 lxc/storage_volume.go:1943
+#: lxc/storage_volume.go:2070 lxc/storage_volume.go:2228
+#: lxc/storage_volume.go:2349 lxc/storage_volume.go:2411
+#: lxc/storage_volume.go:2547 lxc/storage_volume.go:2630
+#: lxc/storage_volume.go:2796 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1448
+#: lxc/storage_volume.go:1454
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:1849
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:1855
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1777,11 +1777,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:800 lxc/storage_volume.go:801
+#: lxc/storage_volume.go:806 lxc/storage_volume.go:807
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:898 lxc/storage_volume.go:899
+#: lxc/storage_volume.go:904 lxc/storage_volume.go:905
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -2007,7 +2007,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:995 lxc/storage_volume.go:996
+#: lxc/storage_volume.go:1001 lxc/storage_volume.go:1002
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2015,7 +2015,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1766
+#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1772
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2072,7 +2072,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2193
+#: lxc/storage_volume.go:2161 lxc/storage_volume.go:2199
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2086,8 +2086,8 @@ msgstr ""
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2149
-#: lxc/storage_volume.go:2187
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2155
+#: lxc/storage_volume.go:2193
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2129,8 +2129,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1508
-#: lxc/storage_volume.go:1558
+#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1514
+#: lxc/storage_volume.go:1564
 msgid "Expires at"
 msgstr ""
 
@@ -2154,7 +2154,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2623 lxc/storage_volume.go:2624
+#: lxc/storage_volume.go:2629 lxc/storage_volume.go:2630
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2166,11 +2166,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2627
+#: lxc/storage_volume.go:2633
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2756
+#: lxc/export.go:152 lxc/storage_volume.go:2762
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2287,11 +2287,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:191
+#: lxc/remote.go:203
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:242
+#: lxc/remote.go:254
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2301,7 +2301,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:232
+#: lxc/remote.go:244
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2311,12 +2311,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:260
+#: lxc/remote.go:486
 #, c-format
-msgid "Failed to create certificate: %w"
+msgid "Failed to decode trust token: %w"
 msgstr ""
 
-#: lxc/remote.go:267
+#: lxc/remote.go:292
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2341,7 +2341,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:237
+#: lxc/remote.go:249
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2428,9 +2428,9 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:690 lxc/storage.go:657
+#: lxc/project.go:919 lxc/remote.go:757 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1608 lxc/warning.go:94
+#: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2466,7 +2466,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:754
+#: lxc/remote.go:821
 msgid "GLOBAL"
 msgstr ""
 
@@ -2486,7 +2486,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:160 lxc/remote.go:401
+#: lxc/remote.go:165 lxc/remote.go:443
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2554,7 +2554,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1238
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2618,11 +2618,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1216 lxc/storage_volume.go:1217
+#: lxc/storage_volume.go:1222 lxc/storage_volume.go:1223
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:469
+#: lxc/storage_volume.go:475
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2746,7 +2746,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2415
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2421
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2760,7 +2760,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2414
+#: lxc/storage_volume.go:2420
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2810,7 +2810,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2790
+#: lxc/storage_volume.go:2796
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2818,7 +2818,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2789
+#: lxc/storage_volume.go:2795
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2840,11 +2840,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2797
+#: lxc/storage_volume.go:2803
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2871
+#: lxc/storage_volume.go:2877
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2910,7 +2910,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:353
+#: lxc/remote.go:395
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2970,7 +2970,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2000
+#: lxc/move.go:148 lxc/storage_volume.go:2006
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2978,7 +2978,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1996
+#: lxc/storage_volume.go:2002
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2991,14 +2991,14 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:342
+#: lxc/remote.go:384
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1064 lxc/storage_volume.go:1281
-#: lxc/storage_volume.go:1405 lxc/storage_volume.go:1985
-#: lxc/storage_volume.go:2132 lxc/storage_volume.go:2284
+#: lxc/storage_volume.go:1070 lxc/storage_volume.go:1287
+#: lxc/storage_volume.go:1411 lxc/storage_volume.go:1991
+#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2290
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3044,7 +3044,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1739 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1745 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3347,11 +3347,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1586
+#: lxc/storage_volume.go:1592
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1597
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3371,7 +3371,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:685 lxc/remote.go:686
+#: lxc/remote.go:752 lxc/remote.go:753
 msgid "List the available remotes"
 msgstr ""
 
@@ -3410,7 +3410,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1464
+#: lxc/info.go:489 lxc/storage_volume.go:1470
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3874,12 +3874,12 @@ msgstr ""
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:323 lxc/storage_volume.go:643
-#: lxc/storage_volume.go:750 lxc/storage_volume.go:841
-#: lxc/storage_volume.go:939 lxc/storage_volume.go:1053
-#: lxc/storage_volume.go:1270 lxc/storage_volume.go:1974
-#: lxc/storage_volume.go:2115 lxc/storage_volume.go:2273
-#: lxc/storage_volume.go:2464 lxc/storage_volume.go:2581
+#: lxc/storage_volume.go:323 lxc/storage_volume.go:649
+#: lxc/storage_volume.go:756 lxc/storage_volume.go:847
+#: lxc/storage_volume.go:945 lxc/storage_volume.go:1059
+#: lxc/storage_volume.go:1276 lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:2121 lxc/storage_volume.go:2279
+#: lxc/storage_volume.go:2470 lxc/storage_volume.go:2587
 msgid "Missing pool name"
 msgstr ""
 
@@ -3898,11 +3898,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:432 lxc/storage_volume.go:1884
+#: lxc/storage_volume.go:438 lxc/storage_volume.go:1890
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1394
+#: lxc/storage_volume.go:1400
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -3939,8 +3939,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:861
-#: lxc/storage_volume.go:958
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:867
+#: lxc/storage_volume.go:964
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -3977,7 +3977,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1843 lxc/storage_volume.go:1844
+#: lxc/storage_volume.go:1849 lxc/storage_volume.go:1850
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -3985,11 +3985,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1850
+#: lxc/storage_volume.go:1856
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:512
+#: lxc/storage_volume.go:518
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4015,8 +4015,8 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
-#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1731
+#: lxc/remote.go:815 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
 msgstr ""
 
@@ -4042,7 +4042,7 @@ msgstr ""
 
 #: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
+#: lxc/project.go:550 lxc/remote.go:775 lxc/remote.go:780 lxc/remote.go:785
 msgid "NO"
 msgstr ""
 
@@ -4064,8 +4064,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1506
-#: lxc/storage_volume.go:1556
+#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1512
+#: lxc/storage_volume.go:1562
 msgid "Name"
 msgstr ""
 
@@ -4073,7 +4073,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1446
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1452
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4217,7 +4217,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:870 lxc/storage_volume.go:967
+#: lxc/storage_volume.go:876 lxc/storage_volume.go:973
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4233,11 +4233,11 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/storage_volume.go:446 lxc/storage_volume.go:1893
+#: lxc/storage_volume.go:452 lxc/storage_volume.go:1899
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:496 lxc/storage_volume.go:1904
+#: lxc/storage_volume.go:502 lxc/storage_volume.go:1910
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4251,7 +4251,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2012
+#: lxc/storage_volume.go:2018
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4263,15 +4263,15 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2678
+#: lxc/storage_volume.go:2684
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2477
+#: lxc/storage_volume.go:2483
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:336
+#: lxc/remote.go:378
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4279,7 +4279,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1412
+#: lxc/storage_volume.go:1418
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4292,7 +4292,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:693 lxc/storage_volume.go:1560
+#: lxc/info.go:693 lxc/storage_volume.go:1566
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4322,7 +4322,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1756
 msgid "POOL"
 msgstr ""
 
@@ -4338,15 +4338,15 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:213
+#: lxc/list.go:567 lxc/storage_volume.go:1762 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:817
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:752
+#: lxc/image.go:1136 lxc/remote.go:819
 msgid "PUBLIC"
 msgstr ""
 
@@ -4375,7 +4375,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:183
+#: lxc/remote.go:195
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4387,8 +4387,8 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:466
-msgid "Please type 'y', 'n' or the fingerprint:"
+#: lxc/remote.go:536
+msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
 #: lxc/info.go:221
@@ -4412,8 +4412,8 @@ msgstr ""
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1151
-#: lxc/storage_volume.go:1183
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
+#: lxc/storage_volume.go:1189
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4530,7 +4530,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1350
+#: lxc/storage_volume.go:1356
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4544,7 +4544,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1219
+#: lxc/storage_volume.go:1225
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4560,7 +4560,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2224
+#: lxc/storage_volume.go:2230
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4581,7 +4581,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:998
+#: lxc/storage_volume.go:1004
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4590,7 +4590,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2069
+#: lxc/storage_volume.go:2075
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4603,7 +4603,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2345
+#: lxc/storage_volume.go:2351
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4707,33 +4707,33 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:810
+#: lxc/remote.go:877
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
-#: lxc/remote.go:994
+#: lxc/project.go:884 lxc/remote.go:868 lxc/remote.go:949 lxc/remote.go:1013
+#: lxc/remote.go:1061
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:305
+#: lxc/remote.go:345
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:890
+#: lxc/remote.go:957
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:805 lxc/remote.go:886 lxc/remote.go:998
+#: lxc/remote.go:872 lxc/remote.go:953 lxc/remote.go:1065
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:294
+#: lxc/remote.go:319
 msgid "Remote address must not be empty"
 msgstr ""
 
@@ -4741,7 +4741,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:299
+#: lxc/remote.go:339
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4827,7 +4827,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:852 lxc/remote.go:853
+#: lxc/remote.go:919 lxc/remote.go:920
 msgid "Remove remotes"
 msgstr ""
 
@@ -4884,19 +4884,19 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:771 lxc/remote.go:772
+#: lxc/remote.go:838 lxc/remote.go:839
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:1943
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1936
+#: lxc/storage_volume.go:1942
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2025 lxc/storage_volume.go:2045
+#: lxc/storage_volume.go:2031 lxc/storage_volume.go:2051
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4948,7 +4948,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2540 lxc/storage_volume.go:2541
+#: lxc/storage_volume.go:2546 lxc/storage_volume.go:2547
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5029,7 +5029,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:820
 msgid "STATIC"
 msgstr ""
 
@@ -5070,11 +5070,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:464
+#: lxc/remote.go:532
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:616
+#: lxc/remote.go:285 lxc/remote.go:683
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5272,11 +5272,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2063
+#: lxc/storage_volume.go:2069
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2064
+#: lxc/storage_volume.go:2070
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5285,7 +5285,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:964 lxc/remote.go:965
+#: lxc/remote.go:1031 lxc/remote.go:1032
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5361,7 +5361,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2080
+#: lxc/storage_volume.go:2086
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5510,11 +5510,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2221 lxc/storage_volume.go:2222
+#: lxc/storage_volume.go:2227 lxc/storage_volume.go:2228
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1347 lxc/storage_volume.go:1348
+#: lxc/storage_volume.go:1353 lxc/storage_volume.go:1354
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5528,7 +5528,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:647 lxc/remote.go:648
+#: lxc/remote.go:714 lxc/remote.go:715
 msgid "Show the default remote"
 msgstr ""
 
@@ -5582,15 +5582,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2404 lxc/storage_volume.go:2405
+#: lxc/storage_volume.go:2410 lxc/storage_volume.go:2411
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2167
+#: lxc/storage_volume.go:2173
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:607 lxc/storage_volume.go:1485
+#: lxc/info.go:607 lxc/storage_volume.go:1491
 msgid "Snapshots:"
 msgstr ""
 
@@ -5691,21 +5691,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:696
+#: lxc/storage_volume.go:702
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:784
+#: lxc/storage_volume.go:790
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:509
+#: lxc/storage_volume.go:515
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:513
+#: lxc/storage_volume.go:519
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5740,7 +5740,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:916 lxc/remote.go:917
+#: lxc/remote.go:983 lxc/remote.go:984
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5759,11 +5759,11 @@ msgstr ""
 #: lxc/auth.go:818 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
-#: lxc/storage_volume.go:1730 lxc/warning.go:216
+#: lxc/storage_volume.go:1736 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1557
+#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1563
 msgid "Taken at"
 msgstr ""
 
@@ -5773,6 +5773,12 @@ msgstr ""
 
 #: lxc/file.go:1256
 msgid "Target path must be a directory"
+msgstr ""
+
+#: lxc/remote.go:161 lxc/remote.go:334
+msgid ""
+"The --accept-certificate flag is not supported when adding a remote using a "
+"trust token"
 msgstr ""
 
 #: lxc/move.go:181
@@ -5914,15 +5920,20 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1323
+#: lxc/storage_volume.go:1329
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1300
+#: lxc/storage_volume.go:1306
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
+msgstr ""
+
+#: lxc/remote.go:527
+msgid ""
+"The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
 
 #: lxc/info.go:354
@@ -5933,8 +5944,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:875
-#: lxc/storage_volume.go:972
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:881
+#: lxc/storage_volume.go:978
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6009,7 +6020,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1470
+#: lxc/storage_volume.go:1476
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6024,7 +6035,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1847
+#: lxc/storage_volume.go:1853
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6058,7 +6069,15 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:571
+#: lxc/remote.go:329
+msgid "Trust token cannot be used for public remotes"
+msgstr ""
+
+#: lxc/remote.go:324
+msgid "Trust token cannot be used with OIDC authentication"
+msgstr ""
+
+#: lxc/remote.go:639
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6083,7 +6102,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1455
+#: lxc/storage_volume.go:1461
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6101,17 +6120,17 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:193 lxc/remote.go:749
+#: lxc/cluster.go:193 lxc/remote.go:816
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1735
+#: lxc/project.go:995 lxc/storage_volume.go:1741
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1734
+#: lxc/storage.go:724 lxc/storage_volume.go:1740
 msgid "USED BY"
 msgstr ""
 
@@ -6129,7 +6148,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:214 lxc/remote.go:248
+#: lxc/remote.go:226 lxc/remote.go:260
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6143,7 +6162,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1772
+#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1778
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6249,7 +6268,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2342 lxc/storage_volume.go:2343
+#: lxc/storage_volume.go:2348 lxc/storage_volume.go:2349
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6301,7 +6320,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2356
+#: lxc/storage_volume.go:2362
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6345,12 +6364,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1468
+#: lxc/storage_volume.go:1474
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2629
+#: lxc/export.go:42 lxc/storage_volume.go:2635
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6417,7 +6436,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1559
+#: lxc/storage_volume.go:1565
 msgid "Volume Only"
 msgstr ""
 
@@ -6452,7 +6471,7 @@ msgstr ""
 
 #: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
+#: lxc/project.go:552 lxc/remote.go:777 lxc/remote.go:782 lxc/remote.go:787
 msgid "YES"
 msgstr ""
 
@@ -6476,7 +6495,7 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:897
+#: lxc/storage_volume.go:903
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
@@ -6898,7 +6917,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2788
+#: lxc/storage_volume.go:2794
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -6933,13 +6952,13 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:1941
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:799
+#: lxc/storage_volume.go:805
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
@@ -6947,47 +6966,47 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2539
+#: lxc/storage_volume.go:2545
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2622
+#: lxc/storage_volume.go:2628
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2403
+#: lxc/storage_volume.go:2409
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:603
+#: lxc/storage_volume.go:609
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:711
+#: lxc/storage_volume.go:717
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:994 lxc/storage_volume.go:1346
+#: lxc/storage_volume.go:1000 lxc/storage_volume.go:1352
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2341
+#: lxc/storage_volume.go:2347
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2062
+#: lxc/storage_volume.go:2068
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2220
+#: lxc/storage_volume.go:2226
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1215
+#: lxc/storage_volume.go:1221
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1841
+#: lxc/storage_volume.go:1847
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7097,7 +7116,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1584
+#: lxc/storage_volume.go:1590
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7109,7 +7128,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:739
+#: lxc/project.go:557 lxc/remote.go:806
 msgid "current"
 msgstr ""
 
@@ -7569,7 +7588,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:607
+#: lxc/storage_volume.go:613
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7577,13 +7596,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2792
+#: lxc/storage_volume.go:2798
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2407
+#: lxc/storage_volume.go:2413
 msgid ""
 "lxc storage volume snapshot create default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7593,7 +7612,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:531
 msgid "n"
 msgstr ""
 
@@ -7605,7 +7624,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:510
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7642,7 +7661,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:465
+#: lxc/remote.go:519
 msgid "y"
 msgstr ""
 

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-08 07:43+0100\n"
+"POT-Creation-Date: 2024-10-14 13:30+0000\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Ukrainian <https://hosted.weblate.org/projects/linux-"
@@ -50,7 +50,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1024
+#: lxc/storage_volume.go:1030
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -516,15 +516,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:850 lxc/remote.go:915
+#: lxc/remote.go:917 lxc/remote.go:982
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:963
+#: lxc/remote.go:1030
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:769
+#: lxc/remote.go:836
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -557,7 +557,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:751
+#: lxc/remote.go:818
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -706,7 +706,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:581
+#: lxc/remote.go:648
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -739,11 +739,11 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1590
+#: lxc/storage_volume.go:1596
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:182
+#: lxc/remote.go:194
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -814,7 +814,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:552
+#: lxc/remote.go:621
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -850,16 +850,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2696
+#: lxc/storage_volume.go:2702
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2773
+#: lxc/export.go:192 lxc/storage_volume.go:2779
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:654 lxc/storage_volume.go:1521
+#: lxc/info.go:654 lxc/storage_volume.go:1527
 msgid "Backups:"
 msgstr ""
 
@@ -880,7 +880,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:679
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:685
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -923,7 +923,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1733
+#: lxc/storage_volume.go:1739
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -992,7 +992,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:894
+#: lxc/remote.go:961
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1008,7 +1008,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1749 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1025,12 +1025,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:486
+#: lxc/storage_volume.go:492
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:440
+#: lxc/storage_volume.go:446
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1058,11 +1058,11 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:509
 msgid "Certificate fingerprint"
 msgstr ""
 
-#: lxc/remote.go:219
+#: lxc/remote.go:231
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:620
+#: lxc/remote.go:687
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1151,13 +1151,13 @@ msgstr ""
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
 #: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
-#: lxc/storage_volume.go:612 lxc/storage_volume.go:717
-#: lxc/storage_volume.go:1005 lxc/storage_volume.go:1231
-#: lxc/storage_volume.go:1360 lxc/storage_volume.go:1848
-#: lxc/storage_volume.go:1940 lxc/storage_volume.go:2079
-#: lxc/storage_volume.go:2239 lxc/storage_volume.go:2355
-#: lxc/storage_volume.go:2416 lxc/storage_volume.go:2543
-#: lxc/storage_volume.go:2631 lxc/storage_volume.go:2795
+#: lxc/storage_volume.go:618 lxc/storage_volume.go:723
+#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1237
+#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1854
+#: lxc/storage_volume.go:1946 lxc/storage_volume.go:2085
+#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2361
+#: lxc/storage_volume.go:2422 lxc/storage_volume.go:2549
+#: lxc/storage_volume.go:2637 lxc/storage_volume.go:2801
 msgid "Cluster member name"
 msgstr ""
 
@@ -1173,7 +1173,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1589
+#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1595
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1217,17 +1217,17 @@ msgstr ""
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1150
-#: lxc/storage_volume.go:1182
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
+#: lxc/storage_volume.go:1188
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:613
+#: lxc/storage_volume.go:619
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1467
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1311,7 +1311,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:508
+#: lxc/storage_volume.go:514
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1325,12 +1325,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:490
+#: lxc/remote.go:559
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:225 lxc/remote.go:474
+#: lxc/remote.go:237 lxc/remote.go:543
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1369,7 +1369,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:485
+#: lxc/remote.go:554
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1438,7 +1438,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:604 lxc/storage_volume.go:605
+#: lxc/storage_volume.go:610 lxc/storage_volume.go:611
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1490,7 +1490,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1475
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1481
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1525,7 +1525,7 @@ msgstr ""
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1732
+#: lxc/storage_volume.go:1738
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1545,7 +1545,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2630
+#: lxc/storage_volume.go:2636
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1641,7 +1641,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:713 lxc/storage_volume.go:714
+#: lxc/storage_volume.go:719 lxc/storage_volume.go:720
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1733,9 +1733,9 @@ msgstr ""
 #: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
 #: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
 #: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:648
-#: lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853 lxc/remote.go:917
-#: lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:715
+#: lxc/remote.go:753 lxc/remote.go:839 lxc/remote.go:920 lxc/remote.go:984
+#: lxc/remote.go:1032 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1747,26 +1747,26 @@ msgstr ""
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
 #: lxc/storage_volume.go:169 lxc/storage_volume.go:283
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:605
-#: lxc/storage_volume.go:714 lxc/storage_volume.go:801
-#: lxc/storage_volume.go:899 lxc/storage_volume.go:996
-#: lxc/storage_volume.go:1217 lxc/storage_volume.go:1348
-#: lxc/storage_volume.go:1507 lxc/storage_volume.go:1591
-#: lxc/storage_volume.go:1844 lxc/storage_volume.go:1937
-#: lxc/storage_volume.go:2064 lxc/storage_volume.go:2222
-#: lxc/storage_volume.go:2343 lxc/storage_volume.go:2405
-#: lxc/storage_volume.go:2541 lxc/storage_volume.go:2624
-#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:611
+#: lxc/storage_volume.go:720 lxc/storage_volume.go:807
+#: lxc/storage_volume.go:905 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:1223 lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1513 lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1850 lxc/storage_volume.go:1943
+#: lxc/storage_volume.go:2070 lxc/storage_volume.go:2228
+#: lxc/storage_volume.go:2349 lxc/storage_volume.go:2411
+#: lxc/storage_volume.go:2547 lxc/storage_volume.go:2630
+#: lxc/storage_volume.go:2796 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1448
+#: lxc/storage_volume.go:1454
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:1849
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:1855
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1778,11 +1778,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:800 lxc/storage_volume.go:801
+#: lxc/storage_volume.go:806 lxc/storage_volume.go:807
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:898 lxc/storage_volume.go:899
+#: lxc/storage_volume.go:904 lxc/storage_volume.go:905
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -2008,7 +2008,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:995 lxc/storage_volume.go:996
+#: lxc/storage_volume.go:1001 lxc/storage_volume.go:1002
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2016,7 +2016,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1766
+#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1772
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2073,7 +2073,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2193
+#: lxc/storage_volume.go:2161 lxc/storage_volume.go:2199
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2087,8 +2087,8 @@ msgstr ""
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2149
-#: lxc/storage_volume.go:2187
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2155
+#: lxc/storage_volume.go:2193
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2130,8 +2130,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1508
-#: lxc/storage_volume.go:1558
+#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1514
+#: lxc/storage_volume.go:1564
 msgid "Expires at"
 msgstr ""
 
@@ -2155,7 +2155,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2623 lxc/storage_volume.go:2624
+#: lxc/storage_volume.go:2629 lxc/storage_volume.go:2630
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2167,11 +2167,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2627
+#: lxc/storage_volume.go:2633
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2756
+#: lxc/export.go:152 lxc/storage_volume.go:2762
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2288,11 +2288,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:191
+#: lxc/remote.go:203
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:242
+#: lxc/remote.go:254
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2302,7 +2302,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:232
+#: lxc/remote.go:244
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2312,12 +2312,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:260
+#: lxc/remote.go:486
 #, c-format
-msgid "Failed to create certificate: %w"
+msgid "Failed to decode trust token: %w"
 msgstr ""
 
-#: lxc/remote.go:267
+#: lxc/remote.go:292
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2342,7 +2342,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:237
+#: lxc/remote.go:249
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2429,9 +2429,9 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:690 lxc/storage.go:657
+#: lxc/project.go:919 lxc/remote.go:757 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1608 lxc/warning.go:94
+#: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2467,7 +2467,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:754
+#: lxc/remote.go:821
 msgid "GLOBAL"
 msgstr ""
 
@@ -2487,7 +2487,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:160 lxc/remote.go:401
+#: lxc/remote.go:165 lxc/remote.go:443
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2555,7 +2555,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1238
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2619,11 +2619,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1216 lxc/storage_volume.go:1217
+#: lxc/storage_volume.go:1222 lxc/storage_volume.go:1223
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:469
+#: lxc/storage_volume.go:475
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2747,7 +2747,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2415
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2421
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2761,7 +2761,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2414
+#: lxc/storage_volume.go:2420
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2811,7 +2811,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2790
+#: lxc/storage_volume.go:2796
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2819,7 +2819,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2789
+#: lxc/storage_volume.go:2795
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2841,11 +2841,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2797
+#: lxc/storage_volume.go:2803
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2871
+#: lxc/storage_volume.go:2877
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2911,7 +2911,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:353
+#: lxc/remote.go:395
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2971,7 +2971,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2000
+#: lxc/move.go:148 lxc/storage_volume.go:2006
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2979,7 +2979,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1996
+#: lxc/storage_volume.go:2002
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2992,14 +2992,14 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:342
+#: lxc/remote.go:384
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1064 lxc/storage_volume.go:1281
-#: lxc/storage_volume.go:1405 lxc/storage_volume.go:1985
-#: lxc/storage_volume.go:2132 lxc/storage_volume.go:2284
+#: lxc/storage_volume.go:1070 lxc/storage_volume.go:1287
+#: lxc/storage_volume.go:1411 lxc/storage_volume.go:1991
+#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2290
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3045,7 +3045,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1739 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1745 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3348,11 +3348,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1586
+#: lxc/storage_volume.go:1592
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1597
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3372,7 +3372,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:685 lxc/remote.go:686
+#: lxc/remote.go:752 lxc/remote.go:753
 msgid "List the available remotes"
 msgstr ""
 
@@ -3411,7 +3411,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1464
+#: lxc/info.go:489 lxc/storage_volume.go:1470
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3875,12 +3875,12 @@ msgstr ""
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:323 lxc/storage_volume.go:643
-#: lxc/storage_volume.go:750 lxc/storage_volume.go:841
-#: lxc/storage_volume.go:939 lxc/storage_volume.go:1053
-#: lxc/storage_volume.go:1270 lxc/storage_volume.go:1974
-#: lxc/storage_volume.go:2115 lxc/storage_volume.go:2273
-#: lxc/storage_volume.go:2464 lxc/storage_volume.go:2581
+#: lxc/storage_volume.go:323 lxc/storage_volume.go:649
+#: lxc/storage_volume.go:756 lxc/storage_volume.go:847
+#: lxc/storage_volume.go:945 lxc/storage_volume.go:1059
+#: lxc/storage_volume.go:1276 lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:2121 lxc/storage_volume.go:2279
+#: lxc/storage_volume.go:2470 lxc/storage_volume.go:2587
 msgid "Missing pool name"
 msgstr ""
 
@@ -3899,11 +3899,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:432 lxc/storage_volume.go:1884
+#: lxc/storage_volume.go:438 lxc/storage_volume.go:1890
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1394
+#: lxc/storage_volume.go:1400
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -3940,8 +3940,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:861
-#: lxc/storage_volume.go:958
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:867
+#: lxc/storage_volume.go:964
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -3978,7 +3978,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1843 lxc/storage_volume.go:1844
+#: lxc/storage_volume.go:1849 lxc/storage_volume.go:1850
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -3986,11 +3986,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1850
+#: lxc/storage_volume.go:1856
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:512
+#: lxc/storage_volume.go:518
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4016,8 +4016,8 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
-#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1731
+#: lxc/remote.go:815 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
 msgstr ""
 
@@ -4043,7 +4043,7 @@ msgstr ""
 
 #: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
+#: lxc/project.go:550 lxc/remote.go:775 lxc/remote.go:780 lxc/remote.go:785
 msgid "NO"
 msgstr ""
 
@@ -4065,8 +4065,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1506
-#: lxc/storage_volume.go:1556
+#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1512
+#: lxc/storage_volume.go:1562
 msgid "Name"
 msgstr ""
 
@@ -4074,7 +4074,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1446
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1452
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4218,7 +4218,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:870 lxc/storage_volume.go:967
+#: lxc/storage_volume.go:876 lxc/storage_volume.go:973
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4234,11 +4234,11 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/storage_volume.go:446 lxc/storage_volume.go:1893
+#: lxc/storage_volume.go:452 lxc/storage_volume.go:1899
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:496 lxc/storage_volume.go:1904
+#: lxc/storage_volume.go:502 lxc/storage_volume.go:1910
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4252,7 +4252,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2012
+#: lxc/storage_volume.go:2018
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4264,15 +4264,15 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2678
+#: lxc/storage_volume.go:2684
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2477
+#: lxc/storage_volume.go:2483
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:336
+#: lxc/remote.go:378
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4280,7 +4280,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1412
+#: lxc/storage_volume.go:1418
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4293,7 +4293,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:693 lxc/storage_volume.go:1560
+#: lxc/info.go:693 lxc/storage_volume.go:1566
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4323,7 +4323,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1756
 msgid "POOL"
 msgstr ""
 
@@ -4339,15 +4339,15 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:213
+#: lxc/list.go:567 lxc/storage_volume.go:1762 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:817
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:752
+#: lxc/image.go:1136 lxc/remote.go:819
 msgid "PUBLIC"
 msgstr ""
 
@@ -4376,7 +4376,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:183
+#: lxc/remote.go:195
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4388,8 +4388,8 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:466
-msgid "Please type 'y', 'n' or the fingerprint:"
+#: lxc/remote.go:536
+msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
 #: lxc/info.go:221
@@ -4413,8 +4413,8 @@ msgstr ""
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1151
-#: lxc/storage_volume.go:1183
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
+#: lxc/storage_volume.go:1189
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4531,7 +4531,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1350
+#: lxc/storage_volume.go:1356
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4545,7 +4545,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1219
+#: lxc/storage_volume.go:1225
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4561,7 +4561,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2224
+#: lxc/storage_volume.go:2230
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4582,7 +4582,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:998
+#: lxc/storage_volume.go:1004
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4591,7 +4591,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2069
+#: lxc/storage_volume.go:2075
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4604,7 +4604,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2345
+#: lxc/storage_volume.go:2351
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4708,33 +4708,33 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:810
+#: lxc/remote.go:877
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
-#: lxc/remote.go:994
+#: lxc/project.go:884 lxc/remote.go:868 lxc/remote.go:949 lxc/remote.go:1013
+#: lxc/remote.go:1061
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:305
+#: lxc/remote.go:345
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:890
+#: lxc/remote.go:957
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:805 lxc/remote.go:886 lxc/remote.go:998
+#: lxc/remote.go:872 lxc/remote.go:953 lxc/remote.go:1065
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:294
+#: lxc/remote.go:319
 msgid "Remote address must not be empty"
 msgstr ""
 
@@ -4742,7 +4742,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:299
+#: lxc/remote.go:339
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4828,7 +4828,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:852 lxc/remote.go:853
+#: lxc/remote.go:919 lxc/remote.go:920
 msgid "Remove remotes"
 msgstr ""
 
@@ -4885,19 +4885,19 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:771 lxc/remote.go:772
+#: lxc/remote.go:838 lxc/remote.go:839
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:1943
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1936
+#: lxc/storage_volume.go:1942
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2025 lxc/storage_volume.go:2045
+#: lxc/storage_volume.go:2031 lxc/storage_volume.go:2051
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4949,7 +4949,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2540 lxc/storage_volume.go:2541
+#: lxc/storage_volume.go:2546 lxc/storage_volume.go:2547
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5030,7 +5030,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:820
 msgid "STATIC"
 msgstr ""
 
@@ -5071,11 +5071,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:464
+#: lxc/remote.go:532
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:616
+#: lxc/remote.go:285 lxc/remote.go:683
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5273,11 +5273,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2063
+#: lxc/storage_volume.go:2069
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2064
+#: lxc/storage_volume.go:2070
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5286,7 +5286,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:964 lxc/remote.go:965
+#: lxc/remote.go:1031 lxc/remote.go:1032
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5362,7 +5362,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2080
+#: lxc/storage_volume.go:2086
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5511,11 +5511,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2221 lxc/storage_volume.go:2222
+#: lxc/storage_volume.go:2227 lxc/storage_volume.go:2228
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1347 lxc/storage_volume.go:1348
+#: lxc/storage_volume.go:1353 lxc/storage_volume.go:1354
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5529,7 +5529,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:647 lxc/remote.go:648
+#: lxc/remote.go:714 lxc/remote.go:715
 msgid "Show the default remote"
 msgstr ""
 
@@ -5583,15 +5583,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2404 lxc/storage_volume.go:2405
+#: lxc/storage_volume.go:2410 lxc/storage_volume.go:2411
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2167
+#: lxc/storage_volume.go:2173
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:607 lxc/storage_volume.go:1485
+#: lxc/info.go:607 lxc/storage_volume.go:1491
 msgid "Snapshots:"
 msgstr ""
 
@@ -5692,21 +5692,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:696
+#: lxc/storage_volume.go:702
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:784
+#: lxc/storage_volume.go:790
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:509
+#: lxc/storage_volume.go:515
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:513
+#: lxc/storage_volume.go:519
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5741,7 +5741,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:916 lxc/remote.go:917
+#: lxc/remote.go:983 lxc/remote.go:984
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5760,11 +5760,11 @@ msgstr ""
 #: lxc/auth.go:818 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
-#: lxc/storage_volume.go:1730 lxc/warning.go:216
+#: lxc/storage_volume.go:1736 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1557
+#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1563
 msgid "Taken at"
 msgstr ""
 
@@ -5774,6 +5774,12 @@ msgstr ""
 
 #: lxc/file.go:1256
 msgid "Target path must be a directory"
+msgstr ""
+
+#: lxc/remote.go:161 lxc/remote.go:334
+msgid ""
+"The --accept-certificate flag is not supported when adding a remote using a "
+"trust token"
 msgstr ""
 
 #: lxc/move.go:181
@@ -5915,15 +5921,20 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1323
+#: lxc/storage_volume.go:1329
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1300
+#: lxc/storage_volume.go:1306
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
+msgstr ""
+
+#: lxc/remote.go:527
+msgid ""
+"The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
 
 #: lxc/info.go:354
@@ -5934,8 +5945,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:875
-#: lxc/storage_volume.go:972
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:881
+#: lxc/storage_volume.go:978
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6010,7 +6021,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1470
+#: lxc/storage_volume.go:1476
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6025,7 +6036,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1847
+#: lxc/storage_volume.go:1853
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6059,7 +6070,15 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:571
+#: lxc/remote.go:329
+msgid "Trust token cannot be used for public remotes"
+msgstr ""
+
+#: lxc/remote.go:324
+msgid "Trust token cannot be used with OIDC authentication"
+msgstr ""
+
+#: lxc/remote.go:639
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6084,7 +6103,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1455
+#: lxc/storage_volume.go:1461
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6102,17 +6121,17 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:193 lxc/remote.go:749
+#: lxc/cluster.go:193 lxc/remote.go:816
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1735
+#: lxc/project.go:995 lxc/storage_volume.go:1741
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1734
+#: lxc/storage.go:724 lxc/storage_volume.go:1740
 msgid "USED BY"
 msgstr ""
 
@@ -6130,7 +6149,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:214 lxc/remote.go:248
+#: lxc/remote.go:226 lxc/remote.go:260
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6144,7 +6163,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1772
+#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1778
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6250,7 +6269,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2342 lxc/storage_volume.go:2343
+#: lxc/storage_volume.go:2348 lxc/storage_volume.go:2349
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6302,7 +6321,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2356
+#: lxc/storage_volume.go:2362
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6346,12 +6365,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1468
+#: lxc/storage_volume.go:1474
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2629
+#: lxc/export.go:42 lxc/storage_volume.go:2635
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6418,7 +6437,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1559
+#: lxc/storage_volume.go:1565
 msgid "Volume Only"
 msgstr ""
 
@@ -6453,7 +6472,7 @@ msgstr ""
 
 #: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
+#: lxc/project.go:552 lxc/remote.go:777 lxc/remote.go:782 lxc/remote.go:787
 msgid "YES"
 msgstr ""
 
@@ -6477,7 +6496,7 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:897
+#: lxc/storage_volume.go:903
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
@@ -6899,7 +6918,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2788
+#: lxc/storage_volume.go:2794
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -6934,13 +6953,13 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:1941
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:799
+#: lxc/storage_volume.go:805
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
@@ -6948,47 +6967,47 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2539
+#: lxc/storage_volume.go:2545
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2622
+#: lxc/storage_volume.go:2628
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2403
+#: lxc/storage_volume.go:2409
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:603
+#: lxc/storage_volume.go:609
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:711
+#: lxc/storage_volume.go:717
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:994 lxc/storage_volume.go:1346
+#: lxc/storage_volume.go:1000 lxc/storage_volume.go:1352
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2341
+#: lxc/storage_volume.go:2347
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2062
+#: lxc/storage_volume.go:2068
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2220
+#: lxc/storage_volume.go:2226
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1215
+#: lxc/storage_volume.go:1221
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1841
+#: lxc/storage_volume.go:1847
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7098,7 +7117,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1584
+#: lxc/storage_volume.go:1590
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7110,7 +7129,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:739
+#: lxc/project.go:557 lxc/remote.go:806
 msgid "current"
 msgstr ""
 
@@ -7570,7 +7589,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:607
+#: lxc/storage_volume.go:613
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7578,13 +7597,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2792
+#: lxc/storage_volume.go:2798
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2407
+#: lxc/storage_volume.go:2413
 msgid ""
 "lxc storage volume snapshot create default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7594,7 +7613,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:531
 msgid "n"
 msgstr ""
 
@@ -7606,7 +7625,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:510
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7643,7 +7662,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:465
+#: lxc/remote.go:519
 msgid "y"
 msgstr ""
 

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-08 07:43+0100\n"
+"POT-Creation-Date: 2024-10-14 13:30+0000\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: 0x0916 <w@laoqinren.net>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -73,7 +73,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/storage_volume.go:1024
+#: lxc/storage_volume.go:1030
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -676,15 +676,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:850 lxc/remote.go:915
+#: lxc/remote.go:917 lxc/remote.go:982
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:963
+#: lxc/remote.go:1030
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:769
+#: lxc/remote.go:836
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -717,7 +717,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:751
+#: lxc/remote.go:818
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -866,7 +866,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:581
+#: lxc/remote.go:648
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -899,11 +899,11 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1590
+#: lxc/storage_volume.go:1596
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:182
+#: lxc/remote.go:194
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -974,7 +974,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:552
+#: lxc/remote.go:621
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -1010,16 +1010,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2696
+#: lxc/storage_volume.go:2702
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2773
+#: lxc/export.go:192 lxc/storage_volume.go:2779
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:654 lxc/storage_volume.go:1521
+#: lxc/info.go:654 lxc/storage_volume.go:1527
 msgid "Backups:"
 msgstr ""
 
@@ -1040,7 +1040,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:679
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:685
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -1083,7 +1083,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1733
+#: lxc/storage_volume.go:1739
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1152,7 +1152,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:894
+#: lxc/remote.go:961
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1168,7 +1168,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1749 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1185,12 +1185,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:486
+#: lxc/storage_volume.go:492
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:440
+#: lxc/storage_volume.go:446
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1218,11 +1218,11 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:509
 msgid "Certificate fingerprint"
 msgstr ""
 
-#: lxc/remote.go:219
+#: lxc/remote.go:231
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
@@ -1237,7 +1237,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:620
+#: lxc/remote.go:687
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1311,13 +1311,13 @@ msgstr ""
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
 #: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
-#: lxc/storage_volume.go:612 lxc/storage_volume.go:717
-#: lxc/storage_volume.go:1005 lxc/storage_volume.go:1231
-#: lxc/storage_volume.go:1360 lxc/storage_volume.go:1848
-#: lxc/storage_volume.go:1940 lxc/storage_volume.go:2079
-#: lxc/storage_volume.go:2239 lxc/storage_volume.go:2355
-#: lxc/storage_volume.go:2416 lxc/storage_volume.go:2543
-#: lxc/storage_volume.go:2631 lxc/storage_volume.go:2795
+#: lxc/storage_volume.go:618 lxc/storage_volume.go:723
+#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1237
+#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1854
+#: lxc/storage_volume.go:1946 lxc/storage_volume.go:2085
+#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2361
+#: lxc/storage_volume.go:2422 lxc/storage_volume.go:2549
+#: lxc/storage_volume.go:2637 lxc/storage_volume.go:2801
 msgid "Cluster member name"
 msgstr ""
 
@@ -1333,7 +1333,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1589
+#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1595
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1377,17 +1377,17 @@ msgstr ""
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1150
-#: lxc/storage_volume.go:1182
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
+#: lxc/storage_volume.go:1188
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:613
+#: lxc/storage_volume.go:619
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1467
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1471,7 +1471,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:508
+#: lxc/storage_volume.go:514
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1485,12 +1485,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:490
+#: lxc/remote.go:559
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:225 lxc/remote.go:474
+#: lxc/remote.go:237 lxc/remote.go:543
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1529,7 +1529,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:485
+#: lxc/remote.go:554
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1598,7 +1598,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:604 lxc/storage_volume.go:605
+#: lxc/storage_volume.go:610 lxc/storage_volume.go:611
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1650,7 +1650,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1475
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1481
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1685,7 +1685,7 @@ msgstr ""
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1732
+#: lxc/storage_volume.go:1738
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1705,7 +1705,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2630
+#: lxc/storage_volume.go:2636
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1801,7 +1801,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:713 lxc/storage_volume.go:714
+#: lxc/storage_volume.go:719 lxc/storage_volume.go:720
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1893,9 +1893,9 @@ msgstr ""
 #: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
 #: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
 #: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:648
-#: lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853 lxc/remote.go:917
-#: lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:715
+#: lxc/remote.go:753 lxc/remote.go:839 lxc/remote.go:920 lxc/remote.go:984
+#: lxc/remote.go:1032 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1907,26 +1907,26 @@ msgstr ""
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
 #: lxc/storage_volume.go:169 lxc/storage_volume.go:283
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:605
-#: lxc/storage_volume.go:714 lxc/storage_volume.go:801
-#: lxc/storage_volume.go:899 lxc/storage_volume.go:996
-#: lxc/storage_volume.go:1217 lxc/storage_volume.go:1348
-#: lxc/storage_volume.go:1507 lxc/storage_volume.go:1591
-#: lxc/storage_volume.go:1844 lxc/storage_volume.go:1937
-#: lxc/storage_volume.go:2064 lxc/storage_volume.go:2222
-#: lxc/storage_volume.go:2343 lxc/storage_volume.go:2405
-#: lxc/storage_volume.go:2541 lxc/storage_volume.go:2624
-#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:611
+#: lxc/storage_volume.go:720 lxc/storage_volume.go:807
+#: lxc/storage_volume.go:905 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:1223 lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1513 lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1850 lxc/storage_volume.go:1943
+#: lxc/storage_volume.go:2070 lxc/storage_volume.go:2228
+#: lxc/storage_volume.go:2349 lxc/storage_volume.go:2411
+#: lxc/storage_volume.go:2547 lxc/storage_volume.go:2630
+#: lxc/storage_volume.go:2796 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1448
+#: lxc/storage_volume.go:1454
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:1849
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:1855
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1938,11 +1938,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:800 lxc/storage_volume.go:801
+#: lxc/storage_volume.go:806 lxc/storage_volume.go:807
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:898 lxc/storage_volume.go:899
+#: lxc/storage_volume.go:904 lxc/storage_volume.go:905
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -2168,7 +2168,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:995 lxc/storage_volume.go:996
+#: lxc/storage_volume.go:1001 lxc/storage_volume.go:1002
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2176,7 +2176,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1766
+#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1772
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2233,7 +2233,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2193
+#: lxc/storage_volume.go:2161 lxc/storage_volume.go:2199
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2247,8 +2247,8 @@ msgstr ""
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2149
-#: lxc/storage_volume.go:2187
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2155
+#: lxc/storage_volume.go:2193
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2290,8 +2290,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1508
-#: lxc/storage_volume.go:1558
+#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1514
+#: lxc/storage_volume.go:1564
 msgid "Expires at"
 msgstr ""
 
@@ -2315,7 +2315,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2623 lxc/storage_volume.go:2624
+#: lxc/storage_volume.go:2629 lxc/storage_volume.go:2630
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2327,11 +2327,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2627
+#: lxc/storage_volume.go:2633
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2756
+#: lxc/export.go:152 lxc/storage_volume.go:2762
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2448,11 +2448,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:191
+#: lxc/remote.go:203
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:242
+#: lxc/remote.go:254
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2462,7 +2462,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:232
+#: lxc/remote.go:244
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2472,12 +2472,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:260
+#: lxc/remote.go:486
 #, c-format
-msgid "Failed to create certificate: %w"
+msgid "Failed to decode trust token: %w"
 msgstr ""
 
-#: lxc/remote.go:267
+#: lxc/remote.go:292
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2502,7 +2502,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:237
+#: lxc/remote.go:249
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2589,9 +2589,9 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:690 lxc/storage.go:657
+#: lxc/project.go:919 lxc/remote.go:757 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1608 lxc/warning.go:94
+#: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2627,7 +2627,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:754
+#: lxc/remote.go:821
 msgid "GLOBAL"
 msgstr ""
 
@@ -2647,7 +2647,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:160 lxc/remote.go:401
+#: lxc/remote.go:165 lxc/remote.go:443
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2715,7 +2715,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1238
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2779,11 +2779,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1216 lxc/storage_volume.go:1217
+#: lxc/storage_volume.go:1222 lxc/storage_volume.go:1223
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:469
+#: lxc/storage_volume.go:475
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2907,7 +2907,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2415
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2421
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2921,7 +2921,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2414
+#: lxc/storage_volume.go:2420
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2971,7 +2971,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2790
+#: lxc/storage_volume.go:2796
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2979,7 +2979,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2789
+#: lxc/storage_volume.go:2795
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -3001,11 +3001,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2797
+#: lxc/storage_volume.go:2803
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2871
+#: lxc/storage_volume.go:2877
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3071,7 +3071,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:353
+#: lxc/remote.go:395
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3131,7 +3131,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2000
+#: lxc/move.go:148 lxc/storage_volume.go:2006
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -3139,7 +3139,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1996
+#: lxc/storage_volume.go:2002
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3152,14 +3152,14 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:342
+#: lxc/remote.go:384
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1064 lxc/storage_volume.go:1281
-#: lxc/storage_volume.go:1405 lxc/storage_volume.go:1985
-#: lxc/storage_volume.go:2132 lxc/storage_volume.go:2284
+#: lxc/storage_volume.go:1070 lxc/storage_volume.go:1287
+#: lxc/storage_volume.go:1411 lxc/storage_volume.go:1991
+#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2290
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3205,7 +3205,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1739 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1745 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3508,11 +3508,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1586
+#: lxc/storage_volume.go:1592
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1597
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3532,7 +3532,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:685 lxc/remote.go:686
+#: lxc/remote.go:752 lxc/remote.go:753
 msgid "List the available remotes"
 msgstr ""
 
@@ -3571,7 +3571,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1464
+#: lxc/info.go:489 lxc/storage_volume.go:1470
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -4035,12 +4035,12 @@ msgstr ""
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:323 lxc/storage_volume.go:643
-#: lxc/storage_volume.go:750 lxc/storage_volume.go:841
-#: lxc/storage_volume.go:939 lxc/storage_volume.go:1053
-#: lxc/storage_volume.go:1270 lxc/storage_volume.go:1974
-#: lxc/storage_volume.go:2115 lxc/storage_volume.go:2273
-#: lxc/storage_volume.go:2464 lxc/storage_volume.go:2581
+#: lxc/storage_volume.go:323 lxc/storage_volume.go:649
+#: lxc/storage_volume.go:756 lxc/storage_volume.go:847
+#: lxc/storage_volume.go:945 lxc/storage_volume.go:1059
+#: lxc/storage_volume.go:1276 lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:2121 lxc/storage_volume.go:2279
+#: lxc/storage_volume.go:2470 lxc/storage_volume.go:2587
 msgid "Missing pool name"
 msgstr ""
 
@@ -4059,11 +4059,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:432 lxc/storage_volume.go:1884
+#: lxc/storage_volume.go:438 lxc/storage_volume.go:1890
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1394
+#: lxc/storage_volume.go:1400
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -4100,8 +4100,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:861
-#: lxc/storage_volume.go:958
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:867
+#: lxc/storage_volume.go:964
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4138,7 +4138,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1843 lxc/storage_volume.go:1844
+#: lxc/storage_volume.go:1849 lxc/storage_volume.go:1850
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4146,11 +4146,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1850
+#: lxc/storage_volume.go:1856
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:512
+#: lxc/storage_volume.go:518
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4176,8 +4176,8 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
-#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1731
+#: lxc/remote.go:815 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
 msgstr ""
 
@@ -4203,7 +4203,7 @@ msgstr ""
 
 #: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
+#: lxc/project.go:550 lxc/remote.go:775 lxc/remote.go:780 lxc/remote.go:785
 msgid "NO"
 msgstr ""
 
@@ -4225,8 +4225,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1506
-#: lxc/storage_volume.go:1556
+#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1512
+#: lxc/storage_volume.go:1562
 msgid "Name"
 msgstr ""
 
@@ -4234,7 +4234,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1446
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1452
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4378,7 +4378,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:870 lxc/storage_volume.go:967
+#: lxc/storage_volume.go:876 lxc/storage_volume.go:973
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4394,11 +4394,11 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/storage_volume.go:446 lxc/storage_volume.go:1893
+#: lxc/storage_volume.go:452 lxc/storage_volume.go:1899
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:496 lxc/storage_volume.go:1904
+#: lxc/storage_volume.go:502 lxc/storage_volume.go:1910
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4412,7 +4412,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2012
+#: lxc/storage_volume.go:2018
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4424,15 +4424,15 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2678
+#: lxc/storage_volume.go:2684
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2477
+#: lxc/storage_volume.go:2483
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:336
+#: lxc/remote.go:378
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4440,7 +4440,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1412
+#: lxc/storage_volume.go:1418
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4453,7 +4453,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:693 lxc/storage_volume.go:1560
+#: lxc/info.go:693 lxc/storage_volume.go:1566
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4483,7 +4483,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1756
 msgid "POOL"
 msgstr ""
 
@@ -4499,15 +4499,15 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:213
+#: lxc/list.go:567 lxc/storage_volume.go:1762 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:817
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:752
+#: lxc/image.go:1136 lxc/remote.go:819
 msgid "PUBLIC"
 msgstr ""
 
@@ -4536,7 +4536,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:183
+#: lxc/remote.go:195
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4548,8 +4548,8 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:466
-msgid "Please type 'y', 'n' or the fingerprint:"
+#: lxc/remote.go:536
+msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
 #: lxc/info.go:221
@@ -4573,8 +4573,8 @@ msgstr ""
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1151
-#: lxc/storage_volume.go:1183
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
+#: lxc/storage_volume.go:1189
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4691,7 +4691,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1350
+#: lxc/storage_volume.go:1356
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4705,7 +4705,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1219
+#: lxc/storage_volume.go:1225
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4721,7 +4721,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2224
+#: lxc/storage_volume.go:2230
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4742,7 +4742,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:998
+#: lxc/storage_volume.go:1004
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4751,7 +4751,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2069
+#: lxc/storage_volume.go:2075
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4764,7 +4764,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2345
+#: lxc/storage_volume.go:2351
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4868,33 +4868,33 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:810
+#: lxc/remote.go:877
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
-#: lxc/remote.go:994
+#: lxc/project.go:884 lxc/remote.go:868 lxc/remote.go:949 lxc/remote.go:1013
+#: lxc/remote.go:1061
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:305
+#: lxc/remote.go:345
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:890
+#: lxc/remote.go:957
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:805 lxc/remote.go:886 lxc/remote.go:998
+#: lxc/remote.go:872 lxc/remote.go:953 lxc/remote.go:1065
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:294
+#: lxc/remote.go:319
 msgid "Remote address must not be empty"
 msgstr ""
 
@@ -4902,7 +4902,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:299
+#: lxc/remote.go:339
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4988,7 +4988,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:852 lxc/remote.go:853
+#: lxc/remote.go:919 lxc/remote.go:920
 msgid "Remove remotes"
 msgstr ""
 
@@ -5045,19 +5045,19 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:771 lxc/remote.go:772
+#: lxc/remote.go:838 lxc/remote.go:839
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:1943
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1936
+#: lxc/storage_volume.go:1942
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2025 lxc/storage_volume.go:2045
+#: lxc/storage_volume.go:2031 lxc/storage_volume.go:2051
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5109,7 +5109,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2540 lxc/storage_volume.go:2541
+#: lxc/storage_volume.go:2546 lxc/storage_volume.go:2547
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5190,7 +5190,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:820
 msgid "STATIC"
 msgstr ""
 
@@ -5231,11 +5231,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:464
+#: lxc/remote.go:532
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:616
+#: lxc/remote.go:285 lxc/remote.go:683
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5433,11 +5433,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2063
+#: lxc/storage_volume.go:2069
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2064
+#: lxc/storage_volume.go:2070
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5446,7 +5446,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:964 lxc/remote.go:965
+#: lxc/remote.go:1031 lxc/remote.go:1032
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5522,7 +5522,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2080
+#: lxc/storage_volume.go:2086
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5671,11 +5671,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2221 lxc/storage_volume.go:2222
+#: lxc/storage_volume.go:2227 lxc/storage_volume.go:2228
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1347 lxc/storage_volume.go:1348
+#: lxc/storage_volume.go:1353 lxc/storage_volume.go:1354
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5689,7 +5689,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:647 lxc/remote.go:648
+#: lxc/remote.go:714 lxc/remote.go:715
 msgid "Show the default remote"
 msgstr ""
 
@@ -5743,15 +5743,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2404 lxc/storage_volume.go:2405
+#: lxc/storage_volume.go:2410 lxc/storage_volume.go:2411
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2167
+#: lxc/storage_volume.go:2173
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:607 lxc/storage_volume.go:1485
+#: lxc/info.go:607 lxc/storage_volume.go:1491
 msgid "Snapshots:"
 msgstr ""
 
@@ -5852,21 +5852,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:696
+#: lxc/storage_volume.go:702
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:784
+#: lxc/storage_volume.go:790
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:509
+#: lxc/storage_volume.go:515
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:513
+#: lxc/storage_volume.go:519
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5901,7 +5901,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:916 lxc/remote.go:917
+#: lxc/remote.go:983 lxc/remote.go:984
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5920,11 +5920,11 @@ msgstr ""
 #: lxc/auth.go:818 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
-#: lxc/storage_volume.go:1730 lxc/warning.go:216
+#: lxc/storage_volume.go:1736 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1557
+#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1563
 msgid "Taken at"
 msgstr ""
 
@@ -5934,6 +5934,12 @@ msgstr ""
 
 #: lxc/file.go:1256
 msgid "Target path must be a directory"
+msgstr ""
+
+#: lxc/remote.go:161 lxc/remote.go:334
+msgid ""
+"The --accept-certificate flag is not supported when adding a remote using a "
+"trust token"
 msgstr ""
 
 #: lxc/move.go:181
@@ -6075,15 +6081,20 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1323
+#: lxc/storage_volume.go:1329
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1300
+#: lxc/storage_volume.go:1306
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
+msgstr ""
+
+#: lxc/remote.go:527
+msgid ""
+"The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
 
 #: lxc/info.go:354
@@ -6094,8 +6105,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:875
-#: lxc/storage_volume.go:972
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:881
+#: lxc/storage_volume.go:978
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6170,7 +6181,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1470
+#: lxc/storage_volume.go:1476
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6185,7 +6196,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1847
+#: lxc/storage_volume.go:1853
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6219,7 +6230,15 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:571
+#: lxc/remote.go:329
+msgid "Trust token cannot be used for public remotes"
+msgstr ""
+
+#: lxc/remote.go:324
+msgid "Trust token cannot be used with OIDC authentication"
+msgstr ""
+
+#: lxc/remote.go:639
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6244,7 +6263,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1455
+#: lxc/storage_volume.go:1461
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6262,17 +6281,17 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:193 lxc/remote.go:749
+#: lxc/cluster.go:193 lxc/remote.go:816
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1735
+#: lxc/project.go:995 lxc/storage_volume.go:1741
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1734
+#: lxc/storage.go:724 lxc/storage_volume.go:1740
 msgid "USED BY"
 msgstr ""
 
@@ -6290,7 +6309,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:214 lxc/remote.go:248
+#: lxc/remote.go:226 lxc/remote.go:260
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6304,7 +6323,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1772
+#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1778
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6410,7 +6429,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2342 lxc/storage_volume.go:2343
+#: lxc/storage_volume.go:2348 lxc/storage_volume.go:2349
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6462,7 +6481,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2356
+#: lxc/storage_volume.go:2362
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6506,12 +6525,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1468
+#: lxc/storage_volume.go:1474
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2629
+#: lxc/export.go:42 lxc/storage_volume.go:2635
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6578,7 +6597,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1559
+#: lxc/storage_volume.go:1565
 msgid "Volume Only"
 msgstr ""
 
@@ -6613,7 +6632,7 @@ msgstr ""
 
 #: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
+#: lxc/project.go:552 lxc/remote.go:777 lxc/remote.go:782 lxc/remote.go:787
 msgid "YES"
 msgstr ""
 
@@ -6637,7 +6656,7 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:897
+#: lxc/storage_volume.go:903
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
@@ -7059,7 +7078,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2788
+#: lxc/storage_volume.go:2794
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7094,13 +7113,13 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:1941
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:799
+#: lxc/storage_volume.go:805
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
@@ -7108,47 +7127,47 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2539
+#: lxc/storage_volume.go:2545
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2622
+#: lxc/storage_volume.go:2628
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2403
+#: lxc/storage_volume.go:2409
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:603
+#: lxc/storage_volume.go:609
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:711
+#: lxc/storage_volume.go:717
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:994 lxc/storage_volume.go:1346
+#: lxc/storage_volume.go:1000 lxc/storage_volume.go:1352
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2341
+#: lxc/storage_volume.go:2347
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2062
+#: lxc/storage_volume.go:2068
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2220
+#: lxc/storage_volume.go:2226
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1215
+#: lxc/storage_volume.go:1221
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1841
+#: lxc/storage_volume.go:1847
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7258,7 +7277,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1584
+#: lxc/storage_volume.go:1590
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7270,7 +7289,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:739
+#: lxc/project.go:557 lxc/remote.go:806
 msgid "current"
 msgstr ""
 
@@ -7730,7 +7749,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:607
+#: lxc/storage_volume.go:613
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7738,13 +7757,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2792
+#: lxc/storage_volume.go:2798
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2407
+#: lxc/storage_volume.go:2413
 msgid ""
 "lxc storage volume snapshot create default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7754,7 +7773,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:531
 msgid "n"
 msgstr ""
 
@@ -7766,7 +7785,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:510
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7803,7 +7822,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:465
+#: lxc/remote.go:519
 msgid "y"
 msgstr ""
 

--- a/po/zh_Hant.po
+++ b/po/zh_Hant.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-08 07:43+0100\n"
+"POT-Creation-Date: 2024-10-14 13:30+0000\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Chinese (Traditional) <https://hosted.weblate.org/projects/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1024
+#: lxc/storage_volume.go:1030
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -515,15 +515,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:850 lxc/remote.go:915
+#: lxc/remote.go:917 lxc/remote.go:982
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:963
+#: lxc/remote.go:1030
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:769
+#: lxc/remote.go:836
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -556,7 +556,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:751
+#: lxc/remote.go:818
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:581
+#: lxc/remote.go:648
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -738,11 +738,11 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1590
+#: lxc/storage_volume.go:1596
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:182
+#: lxc/remote.go:194
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -813,7 +813,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:552
+#: lxc/remote.go:621
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -849,16 +849,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2696
+#: lxc/storage_volume.go:2702
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2773
+#: lxc/export.go:192 lxc/storage_volume.go:2779
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:654 lxc/storage_volume.go:1521
+#: lxc/info.go:654 lxc/storage_volume.go:1527
 msgid "Backups:"
 msgstr ""
 
@@ -879,7 +879,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:679
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:685
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -922,7 +922,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1733
+#: lxc/storage_volume.go:1739
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -991,7 +991,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:894
+#: lxc/remote.go:961
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1007,7 +1007,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1743 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1749 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1024,12 +1024,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:486
+#: lxc/storage_volume.go:492
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:440
+#: lxc/storage_volume.go:446
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1057,11 +1057,11 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:455
+#: lxc/remote.go:509
 msgid "Certificate fingerprint"
 msgstr ""
 
-#: lxc/remote.go:219
+#: lxc/remote.go:231
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
@@ -1076,7 +1076,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:620
+#: lxc/remote.go:687
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1150,13 +1150,13 @@ msgstr ""
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
 #: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
-#: lxc/storage_volume.go:612 lxc/storage_volume.go:717
-#: lxc/storage_volume.go:1005 lxc/storage_volume.go:1231
-#: lxc/storage_volume.go:1360 lxc/storage_volume.go:1848
-#: lxc/storage_volume.go:1940 lxc/storage_volume.go:2079
-#: lxc/storage_volume.go:2239 lxc/storage_volume.go:2355
-#: lxc/storage_volume.go:2416 lxc/storage_volume.go:2543
-#: lxc/storage_volume.go:2631 lxc/storage_volume.go:2795
+#: lxc/storage_volume.go:618 lxc/storage_volume.go:723
+#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1237
+#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1854
+#: lxc/storage_volume.go:1946 lxc/storage_volume.go:2085
+#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2361
+#: lxc/storage_volume.go:2422 lxc/storage_volume.go:2549
+#: lxc/storage_volume.go:2637 lxc/storage_volume.go:2801
 msgid "Cluster member name"
 msgstr ""
 
@@ -1172,7 +1172,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1589
+#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1595
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1216,17 +1216,17 @@ msgstr ""
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1150
-#: lxc/storage_volume.go:1182
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
+#: lxc/storage_volume.go:1188
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:613
+#: lxc/storage_volume.go:619
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1467
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1310,7 +1310,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:508
+#: lxc/storage_volume.go:514
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1324,12 +1324,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:490
+#: lxc/remote.go:559
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:225 lxc/remote.go:474
+#: lxc/remote.go:237 lxc/remote.go:543
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1368,7 +1368,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:485
+#: lxc/remote.go:554
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1437,7 +1437,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:604 lxc/storage_volume.go:605
+#: lxc/storage_volume.go:610 lxc/storage_volume.go:611
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1489,7 +1489,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1475
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1481
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1524,7 +1524,7 @@ msgstr ""
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1732
+#: lxc/storage_volume.go:1738
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1544,7 +1544,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2630
+#: lxc/storage_volume.go:2636
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1640,7 +1640,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:713 lxc/storage_volume.go:714
+#: lxc/storage_volume.go:719 lxc/storage_volume.go:720
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1732,9 +1732,9 @@ msgstr ""
 #: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
 #: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
 #: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:648
-#: lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853 lxc/remote.go:917
-#: lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:715
+#: lxc/remote.go:753 lxc/remote.go:839 lxc/remote.go:920 lxc/remote.go:984
+#: lxc/remote.go:1032 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1746,26 +1746,26 @@ msgstr ""
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
 #: lxc/storage_volume.go:169 lxc/storage_volume.go:283
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:605
-#: lxc/storage_volume.go:714 lxc/storage_volume.go:801
-#: lxc/storage_volume.go:899 lxc/storage_volume.go:996
-#: lxc/storage_volume.go:1217 lxc/storage_volume.go:1348
-#: lxc/storage_volume.go:1507 lxc/storage_volume.go:1591
-#: lxc/storage_volume.go:1844 lxc/storage_volume.go:1937
-#: lxc/storage_volume.go:2064 lxc/storage_volume.go:2222
-#: lxc/storage_volume.go:2343 lxc/storage_volume.go:2405
-#: lxc/storage_volume.go:2541 lxc/storage_volume.go:2624
-#: lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:611
+#: lxc/storage_volume.go:720 lxc/storage_volume.go:807
+#: lxc/storage_volume.go:905 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:1223 lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1513 lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1850 lxc/storage_volume.go:1943
+#: lxc/storage_volume.go:2070 lxc/storage_volume.go:2228
+#: lxc/storage_volume.go:2349 lxc/storage_volume.go:2411
+#: lxc/storage_volume.go:2547 lxc/storage_volume.go:2630
+#: lxc/storage_volume.go:2796 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1448
+#: lxc/storage_volume.go:1454
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:1849
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:1855
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1777,11 +1777,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:800 lxc/storage_volume.go:801
+#: lxc/storage_volume.go:806 lxc/storage_volume.go:807
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:898 lxc/storage_volume.go:899
+#: lxc/storage_volume.go:904 lxc/storage_volume.go:905
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -2007,7 +2007,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:995 lxc/storage_volume.go:996
+#: lxc/storage_volume.go:1001 lxc/storage_volume.go:1002
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2015,7 +2015,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1766
+#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1772
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2072,7 +2072,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2193
+#: lxc/storage_volume.go:2161 lxc/storage_volume.go:2199
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2086,8 +2086,8 @@ msgstr ""
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2149
-#: lxc/storage_volume.go:2187
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2155
+#: lxc/storage_volume.go:2193
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2129,8 +2129,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1508
-#: lxc/storage_volume.go:1558
+#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1514
+#: lxc/storage_volume.go:1564
 msgid "Expires at"
 msgstr ""
 
@@ -2154,7 +2154,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2623 lxc/storage_volume.go:2624
+#: lxc/storage_volume.go:2629 lxc/storage_volume.go:2630
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2166,11 +2166,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2627
+#: lxc/storage_volume.go:2633
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2756
+#: lxc/export.go:152 lxc/storage_volume.go:2762
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2287,11 +2287,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:191
+#: lxc/remote.go:203
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:242
+#: lxc/remote.go:254
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2301,7 +2301,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:232
+#: lxc/remote.go:244
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2311,12 +2311,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:260
+#: lxc/remote.go:486
 #, c-format
-msgid "Failed to create certificate: %w"
+msgid "Failed to decode trust token: %w"
 msgstr ""
 
-#: lxc/remote.go:267
+#: lxc/remote.go:292
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2341,7 +2341,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:237
+#: lxc/remote.go:249
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2428,9 +2428,9 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:690 lxc/storage.go:657
+#: lxc/project.go:919 lxc/remote.go:757 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1608 lxc/warning.go:94
+#: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2466,7 +2466,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:754
+#: lxc/remote.go:821
 msgid "GLOBAL"
 msgstr ""
 
@@ -2486,7 +2486,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:160 lxc/remote.go:401
+#: lxc/remote.go:165 lxc/remote.go:443
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2554,7 +2554,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1238
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2618,11 +2618,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1216 lxc/storage_volume.go:1217
+#: lxc/storage_volume.go:1222 lxc/storage_volume.go:1223
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:469
+#: lxc/storage_volume.go:475
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2746,7 +2746,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2415
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2421
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2760,7 +2760,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2414
+#: lxc/storage_volume.go:2420
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2810,7 +2810,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2790
+#: lxc/storage_volume.go:2796
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2818,7 +2818,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2789
+#: lxc/storage_volume.go:2795
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2840,11 +2840,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2797
+#: lxc/storage_volume.go:2803
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2871
+#: lxc/storage_volume.go:2877
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2910,7 +2910,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:353
+#: lxc/remote.go:395
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2970,7 +2970,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2000
+#: lxc/move.go:148 lxc/storage_volume.go:2006
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2978,7 +2978,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1996
+#: lxc/storage_volume.go:2002
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2991,14 +2991,14 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:342
+#: lxc/remote.go:384
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1064 lxc/storage_volume.go:1281
-#: lxc/storage_volume.go:1405 lxc/storage_volume.go:1985
-#: lxc/storage_volume.go:2132 lxc/storage_volume.go:2284
+#: lxc/storage_volume.go:1070 lxc/storage_volume.go:1287
+#: lxc/storage_volume.go:1411 lxc/storage_volume.go:1991
+#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2290
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3044,7 +3044,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1739 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1745 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3347,11 +3347,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1586
+#: lxc/storage_volume.go:1592
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1597
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3371,7 +3371,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:685 lxc/remote.go:686
+#: lxc/remote.go:752 lxc/remote.go:753
 msgid "List the available remotes"
 msgstr ""
 
@@ -3410,7 +3410,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1464
+#: lxc/info.go:489 lxc/storage_volume.go:1470
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3874,12 +3874,12 @@ msgstr ""
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:323 lxc/storage_volume.go:643
-#: lxc/storage_volume.go:750 lxc/storage_volume.go:841
-#: lxc/storage_volume.go:939 lxc/storage_volume.go:1053
-#: lxc/storage_volume.go:1270 lxc/storage_volume.go:1974
-#: lxc/storage_volume.go:2115 lxc/storage_volume.go:2273
-#: lxc/storage_volume.go:2464 lxc/storage_volume.go:2581
+#: lxc/storage_volume.go:323 lxc/storage_volume.go:649
+#: lxc/storage_volume.go:756 lxc/storage_volume.go:847
+#: lxc/storage_volume.go:945 lxc/storage_volume.go:1059
+#: lxc/storage_volume.go:1276 lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:2121 lxc/storage_volume.go:2279
+#: lxc/storage_volume.go:2470 lxc/storage_volume.go:2587
 msgid "Missing pool name"
 msgstr ""
 
@@ -3898,11 +3898,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:432 lxc/storage_volume.go:1884
+#: lxc/storage_volume.go:438 lxc/storage_volume.go:1890
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1394
+#: lxc/storage_volume.go:1400
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -3939,8 +3939,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:861
-#: lxc/storage_volume.go:958
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:867
+#: lxc/storage_volume.go:964
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -3977,7 +3977,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1843 lxc/storage_volume.go:1844
+#: lxc/storage_volume.go:1849 lxc/storage_volume.go:1850
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -3985,11 +3985,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1850
+#: lxc/storage_volume.go:1856
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:512
+#: lxc/storage_volume.go:518
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4015,8 +4015,8 @@ msgstr ""
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
-#: lxc/remote.go:748 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1731
+#: lxc/remote.go:815 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
 msgstr ""
 
@@ -4042,7 +4042,7 @@ msgstr ""
 
 #: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:708 lxc/remote.go:713 lxc/remote.go:718
+#: lxc/project.go:550 lxc/remote.go:775 lxc/remote.go:780 lxc/remote.go:785
 msgid "NO"
 msgstr ""
 
@@ -4064,8 +4064,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1506
-#: lxc/storage_volume.go:1556
+#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1512
+#: lxc/storage_volume.go:1562
 msgid "Name"
 msgstr ""
 
@@ -4073,7 +4073,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1446
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1452
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4217,7 +4217,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:870 lxc/storage_volume.go:967
+#: lxc/storage_volume.go:876 lxc/storage_volume.go:973
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4233,11 +4233,11 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/storage_volume.go:446 lxc/storage_volume.go:1893
+#: lxc/storage_volume.go:452 lxc/storage_volume.go:1899
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:496 lxc/storage_volume.go:1904
+#: lxc/storage_volume.go:502 lxc/storage_volume.go:1910
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4251,7 +4251,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2012
+#: lxc/storage_volume.go:2018
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4263,15 +4263,15 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2678
+#: lxc/storage_volume.go:2684
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2477
+#: lxc/storage_volume.go:2483
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:336
+#: lxc/remote.go:378
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4279,7 +4279,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1412
+#: lxc/storage_volume.go:1418
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4292,7 +4292,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:693 lxc/storage_volume.go:1560
+#: lxc/info.go:693 lxc/storage_volume.go:1566
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4322,7 +4322,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1756
 msgid "POOL"
 msgstr ""
 
@@ -4338,15 +4338,15 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:567 lxc/storage_volume.go:1756 lxc/warning.go:213
+#: lxc/list.go:567 lxc/storage_volume.go:1762 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:750
+#: lxc/remote.go:817
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:752
+#: lxc/image.go:1136 lxc/remote.go:819
 msgid "PUBLIC"
 msgstr ""
 
@@ -4375,7 +4375,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:183
+#: lxc/remote.go:195
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4387,8 +4387,8 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:466
-msgid "Please type 'y', 'n' or the fingerprint:"
+#: lxc/remote.go:536
+msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
 #: lxc/info.go:221
@@ -4412,8 +4412,8 @@ msgstr ""
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1151
-#: lxc/storage_volume.go:1183
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
+#: lxc/storage_volume.go:1189
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4530,7 +4530,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1350
+#: lxc/storage_volume.go:1356
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4544,7 +4544,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1219
+#: lxc/storage_volume.go:1225
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4560,7 +4560,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2224
+#: lxc/storage_volume.go:2230
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4581,7 +4581,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:998
+#: lxc/storage_volume.go:1004
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4590,7 +4590,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2069
+#: lxc/storage_volume.go:2075
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4603,7 +4603,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2345
+#: lxc/storage_volume.go:2351
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4707,33 +4707,33 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:810
+#: lxc/remote.go:877
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:801 lxc/remote.go:882 lxc/remote.go:946
-#: lxc/remote.go:994
+#: lxc/project.go:884 lxc/remote.go:868 lxc/remote.go:949 lxc/remote.go:1013
+#: lxc/remote.go:1061
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:305
+#: lxc/remote.go:345
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:890
+#: lxc/remote.go:957
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:805 lxc/remote.go:886 lxc/remote.go:998
+#: lxc/remote.go:872 lxc/remote.go:953 lxc/remote.go:1065
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:294
+#: lxc/remote.go:319
 msgid "Remote address must not be empty"
 msgstr ""
 
@@ -4741,7 +4741,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:299
+#: lxc/remote.go:339
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4827,7 +4827,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:852 lxc/remote.go:853
+#: lxc/remote.go:919 lxc/remote.go:920
 msgid "Remove remotes"
 msgstr ""
 
@@ -4884,19 +4884,19 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:771 lxc/remote.go:772
+#: lxc/remote.go:838 lxc/remote.go:839
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:1943
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1936
+#: lxc/storage_volume.go:1942
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2025 lxc/storage_volume.go:2045
+#: lxc/storage_volume.go:2031 lxc/storage_volume.go:2051
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4948,7 +4948,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2540 lxc/storage_volume.go:2541
+#: lxc/storage_volume.go:2546 lxc/storage_volume.go:2547
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5029,7 +5029,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:753
+#: lxc/remote.go:820
 msgid "STATIC"
 msgstr ""
 
@@ -5070,11 +5070,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:464
+#: lxc/remote.go:532
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:616
+#: lxc/remote.go:285 lxc/remote.go:683
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5272,11 +5272,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2063
+#: lxc/storage_volume.go:2069
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2064
+#: lxc/storage_volume.go:2070
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5285,7 +5285,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:964 lxc/remote.go:965
+#: lxc/remote.go:1031 lxc/remote.go:1032
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5361,7 +5361,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2080
+#: lxc/storage_volume.go:2086
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5510,11 +5510,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2221 lxc/storage_volume.go:2222
+#: lxc/storage_volume.go:2227 lxc/storage_volume.go:2228
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1347 lxc/storage_volume.go:1348
+#: lxc/storage_volume.go:1353 lxc/storage_volume.go:1354
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5528,7 +5528,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:647 lxc/remote.go:648
+#: lxc/remote.go:714 lxc/remote.go:715
 msgid "Show the default remote"
 msgstr ""
 
@@ -5582,15 +5582,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2404 lxc/storage_volume.go:2405
+#: lxc/storage_volume.go:2410 lxc/storage_volume.go:2411
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2167
+#: lxc/storage_volume.go:2173
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:607 lxc/storage_volume.go:1485
+#: lxc/info.go:607 lxc/storage_volume.go:1491
 msgid "Snapshots:"
 msgstr ""
 
@@ -5691,21 +5691,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:696
+#: lxc/storage_volume.go:702
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:784
+#: lxc/storage_volume.go:790
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:509
+#: lxc/storage_volume.go:515
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:513
+#: lxc/storage_volume.go:519
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5740,7 +5740,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:916 lxc/remote.go:917
+#: lxc/remote.go:983 lxc/remote.go:984
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5759,11 +5759,11 @@ msgstr ""
 #: lxc/auth.go:818 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
-#: lxc/storage_volume.go:1730 lxc/warning.go:216
+#: lxc/storage_volume.go:1736 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1557
+#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1563
 msgid "Taken at"
 msgstr ""
 
@@ -5773,6 +5773,12 @@ msgstr ""
 
 #: lxc/file.go:1256
 msgid "Target path must be a directory"
+msgstr ""
+
+#: lxc/remote.go:161 lxc/remote.go:334
+msgid ""
+"The --accept-certificate flag is not supported when adding a remote using a "
+"trust token"
 msgstr ""
 
 #: lxc/move.go:181
@@ -5914,15 +5920,20 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1323
+#: lxc/storage_volume.go:1329
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1300
+#: lxc/storage_volume.go:1306
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
+msgstr ""
+
+#: lxc/remote.go:527
+msgid ""
+"The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
 
 #: lxc/info.go:354
@@ -5933,8 +5944,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:875
-#: lxc/storage_volume.go:972
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:881
+#: lxc/storage_volume.go:978
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6009,7 +6020,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1470
+#: lxc/storage_volume.go:1476
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6024,7 +6035,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1847
+#: lxc/storage_volume.go:1853
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6058,7 +6069,15 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:571
+#: lxc/remote.go:329
+msgid "Trust token cannot be used for public remotes"
+msgstr ""
+
+#: lxc/remote.go:324
+msgid "Trust token cannot be used with OIDC authentication"
+msgstr ""
+
+#: lxc/remote.go:639
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6083,7 +6102,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1455
+#: lxc/storage_volume.go:1461
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6101,17 +6120,17 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:193 lxc/remote.go:749
+#: lxc/cluster.go:193 lxc/remote.go:816
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1735
+#: lxc/project.go:995 lxc/storage_volume.go:1741
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1734
+#: lxc/storage.go:724 lxc/storage_volume.go:1740
 msgid "USED BY"
 msgstr ""
 
@@ -6129,7 +6148,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:214 lxc/remote.go:248
+#: lxc/remote.go:226 lxc/remote.go:260
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6143,7 +6162,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1772
+#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1778
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6249,7 +6268,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2342 lxc/storage_volume.go:2343
+#: lxc/storage_volume.go:2348 lxc/storage_volume.go:2349
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6301,7 +6320,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2356
+#: lxc/storage_volume.go:2362
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6345,12 +6364,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1468
+#: lxc/storage_volume.go:1474
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2629
+#: lxc/export.go:42 lxc/storage_volume.go:2635
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6417,7 +6436,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1559
+#: lxc/storage_volume.go:1565
 msgid "Volume Only"
 msgstr ""
 
@@ -6452,7 +6471,7 @@ msgstr ""
 
 #: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
+#: lxc/project.go:552 lxc/remote.go:777 lxc/remote.go:782 lxc/remote.go:787
 msgid "YES"
 msgstr ""
 
@@ -6476,7 +6495,7 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:897
+#: lxc/storage_volume.go:903
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
@@ -6898,7 +6917,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2788
+#: lxc/storage_volume.go:2794
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -6933,13 +6952,13 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1935
+#: lxc/storage_volume.go:1941
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:799
+#: lxc/storage_volume.go:805
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
@@ -6947,47 +6966,47 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2539
+#: lxc/storage_volume.go:2545
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2622
+#: lxc/storage_volume.go:2628
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2403
+#: lxc/storage_volume.go:2409
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:603
+#: lxc/storage_volume.go:609
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:711
+#: lxc/storage_volume.go:717
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:994 lxc/storage_volume.go:1346
+#: lxc/storage_volume.go:1000 lxc/storage_volume.go:1352
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2341
+#: lxc/storage_volume.go:2347
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2062
+#: lxc/storage_volume.go:2068
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2220
+#: lxc/storage_volume.go:2226
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1215
+#: lxc/storage_volume.go:1221
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1841
+#: lxc/storage_volume.go:1847
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7097,7 +7116,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1584
+#: lxc/storage_volume.go:1590
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7109,7 +7128,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:739
+#: lxc/project.go:557 lxc/remote.go:806
 msgid "current"
 msgstr ""
 
@@ -7569,7 +7588,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:607
+#: lxc/storage_volume.go:613
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7577,13 +7596,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2792
+#: lxc/storage_volume.go:2798
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2407
+#: lxc/storage_volume.go:2413
 msgid ""
 "lxc storage volume snapshot create default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7593,7 +7612,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:463
+#: lxc/remote.go:531
 msgid "n"
 msgstr ""
 
@@ -7605,7 +7624,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:456
+#: lxc/remote.go:510
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7642,7 +7661,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:465
+#: lxc/remote.go:519
 msgid "y"
 msgstr ""
 

--- a/test/includes/setup.sh
+++ b/test/includes/setup.sh
@@ -4,7 +4,7 @@ ensure_has_localhost_remote() {
     local addr="${1}"
     if ! lxc remote list | grep -q "localhost"; then
         token="$(lxc config trust add --name foo -q)"
-        lxc remote add localhost "https://${addr}" --accept-certificate --token "${token}"
+        lxc remote add localhost "https://${addr}" --token "${token}"
     fi
 }
 

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -2763,7 +2763,6 @@ test_clustering_image_refresh() {
   LXD_DIR="${LXD_REMOTE_DIR}" lxc config set core.https_address "10.1.1.104:8443"
 
   # Add remotes
-  token="$(LXD_DIR="${LXD_ONE_DIR}" lxc config trust add --name foo --quiet)"
   lxc remote add public "https://10.1.1.104:8443" --accept-certificate --token foo --public
   token="$(LXD_DIR="${LXD_ONE_DIR}" lxc config trust add --name foo --quiet)"
   lxc remote add cluster "https://10.1.1.101:8443" --token "${token}"

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -2763,7 +2763,7 @@ test_clustering_image_refresh() {
   LXD_DIR="${LXD_REMOTE_DIR}" lxc config set core.https_address "10.1.1.104:8443"
 
   # Add remotes
-  lxc remote add public "https://10.1.1.104:8443" --accept-certificate --token foo --public
+  lxc remote add public "https://10.1.1.104:8443" --accept-certificate --public
   token="$(LXD_DIR="${LXD_ONE_DIR}" lxc config trust add --name foo --quiet)"
   lxc remote add cluster "https://10.1.1.101:8443" --token "${token}"
 

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -250,7 +250,7 @@ test_clustering_membership() {
 
   # Client certificate are shared across all nodes.
   token="$(LXD_DIR=${LXD_ONE_DIR} lxc config trust add --name foo -q)"
-  lxc remote add cluster 10.1.1.101:8443 --accept-certificate --token="${token}"
+  lxc remote add cluster 10.1.1.101:8443 --token="${token}"
   lxc remote set-url cluster https://10.1.1.102:8443
   lxc network list cluster: | grep -q "${bridge}"
   lxc remote remove cluster
@@ -1895,7 +1895,7 @@ test_clustering_address() {
   # that the REST API is exposed.
   url="https://10.1.1.101:8443"
   token="$(LXD_DIR="${LXD_ONE_DIR}" lxc config trust add --name foo --quiet)"
-  lxc remote add cluster --token "${token}" --accept-certificate "${url}"
+  lxc remote add cluster --token "${token}" "${url}"
   lxc storage list cluster: | grep -q data
 
   # Add a newline at the end of each line. YAML as weird rules..
@@ -2766,7 +2766,7 @@ test_clustering_image_refresh() {
   token="$(LXD_DIR="${LXD_ONE_DIR}" lxc config trust add --name foo --quiet)"
   lxc remote add public "https://10.1.1.104:8443" --accept-certificate --token foo --public
   token="$(LXD_DIR="${LXD_ONE_DIR}" lxc config trust add --name foo --quiet)"
-  lxc remote add cluster "https://10.1.1.101:8443" --accept-certificate --token "${token}"
+  lxc remote add cluster "https://10.1.1.101:8443" --token "${token}"
 
   LXD_DIR="${LXD_REMOTE_DIR}" lxc init testimage c1
 
@@ -3461,7 +3461,7 @@ test_clustering_groups() {
   spawn_lxd_and_join_cluster "${ns3}" "${bridge}" "${cert}" 3 1 "${LXD_THREE_DIR}" "${LXD_ONE_DIR}"
 
   token="$(LXD_DIR="${LXD_ONE_DIR}" lxc config trust add --name foo --quiet)"
-  lxc remote add cluster --token "${token}" --accept-certificate "https://10.1.1.101:8443"
+  lxc remote add cluster --token "${token}" "https://10.1.1.101:8443"
 
   # Initially, there is only the default group
   lxc cluster group show cluster:default
@@ -3929,7 +3929,7 @@ test_clustering_trust_add() {
   # and query LXD_ONE for it. LXD_TWO should cancel the operation by sending a DELETE /1.0/operations/{uuid} to LXD_ONE
   # and needs to parse the metadata of the operation into the correct type to complete the trust process.
   # The expiry time should be parsed and found to be expired so the add action should fail.
-  ! lxc remote add lxd_two "${lxd_two_address}" --accept-certificate --token "${lxd_one_token}" || false
+  ! lxc remote add lxd_two "${lxd_two_address}" --token "${lxd_one_token}" || false
 
   # Expect the operation to be cancelled.
   LXD_DIR="${LXD_ONE_DIR}" lxc operation list --format csv | grep -qF "${operation_uuid},TOKEN,Executing operation,CANCELLED"
@@ -3955,7 +3955,7 @@ test_clustering_trust_add() {
   # LXD_TWO does not have the operation running locally, so it should find the UUID of the operation in the database
   # and query LXD_ONE for it. LXD_TWO should cancel the operation by sending a DELETE /1.0/operations/{uuid} to LXD_ONE
   # and needs to parse the metadata of the operation into the correct type to complete the trust process.
-  lxc remote add lxd_two "${lxd_two_address}" --accept-certificate --token "${lxd_one_token}"
+  lxc remote add lxd_two "${lxd_two_address}" --token "${lxd_one_token}"
 
   # Expect the operation to be cancelled.
   LXD_DIR="${LXD_ONE_DIR}" lxc operation list --format csv | grep -qF "${operation_uuid},TOKEN,Executing operation,CANCELLED"

--- a/test/suites/image.sh
+++ b/test/suites/image.sh
@@ -9,10 +9,10 @@ test_image_expiry() {
 
   token="$(lxc config trust add --name foo -q)"
   # shellcheck disable=2153
-  lxc_remote remote add l1 "${LXD_ADDR}" --accept-certificate --token "${token}"
+  lxc_remote remote add l1 "${LXD_ADDR}" --token "${token}"
 
   token="$(LXD_DIR=${LXD2_DIR} lxc config trust add --name foo -q)"
-  lxc_remote remote add l2 "${LXD2_ADDR}" --accept-certificate --token "${token}"
+  lxc_remote remote add l2 "${LXD2_ADDR}" --token "${token}"
 
   # Create containers from a remote image in two projects.
   lxc_remote project create l2:p1 -c features.images=true -c features.profiles=false
@@ -133,7 +133,7 @@ test_image_refresh() {
   ensure_import_testimage
 
   token="$(LXD_DIR=${LXD2_DIR} lxc config trust add --name foo -q)"
-  lxc_remote remote add l2 "${LXD2_ADDR}" --accept-certificate --token "${token}"
+  lxc_remote remote add l2 "${LXD2_ADDR}" --token "${token}"
 
   poolDriver="$(lxc storage show "$(lxc profile device get default root pool)" | awk '/^driver:/ {print $2}')"
 

--- a/test/suites/image_auto_update.sh
+++ b/test/suites/image_auto_update.sh
@@ -13,7 +13,7 @@ test_image_auto_update() {
   fp1="$(LXD_DIR=${LXD2_DIR} lxc image info testimage | awk '/^Fingerprint/ {print $2}')"
 
   token="$(LXD_DIR=${LXD2_DIR} lxc config trust add --name foo -q)"
-  lxc remote add l2 "${LXD2_ADDR}" --accept-certificate --token "${token}"
+  lxc remote add l2 "${LXD2_ADDR}" --token "${token}"
   lxc init l2:testimage c1
 
   # Now the first image image is in the local store, since it was

--- a/test/suites/image_prefer_cached.sh
+++ b/test/suites/image_prefer_cached.sh
@@ -16,7 +16,7 @@ test_image_prefer_cached() {
   fp1="$(LXD_DIR=${LXD2_DIR} lxc image info testimage | awk '/^Fingerprint/ {print $2}')"
 
   token="$(LXD_DIR=${LXD2_DIR} lxc config trust add --name foo -q)"
-  lxc remote add l2 "${LXD2_ADDR}" --accept-certificate --token "${token}"
+  lxc remote add l2 "${LXD2_ADDR}" --token "${token}"
   lxc init l2:testimage c1
 
   # Now the first image image is in the local store, since it was

--- a/test/suites/migration.sh
+++ b/test/suites/migration.sh
@@ -14,10 +14,10 @@ test_migration() {
 
   token="$(lxc config trust add --name foo -q)"
   # shellcheck disable=2153
-  lxc_remote remote add l1 "${LXD_ADDR}" --accept-certificate --token "${token}"
+  lxc_remote remote add l1 "${LXD_ADDR}" --token "${token}"
 
   token="$(LXD_DIR=${LXD2_DIR} lxc config trust add --name foo -q)"
-  lxc_remote remote add l2 "${LXD2_ADDR}" --accept-certificate --token "${token}"
+  lxc_remote remote add l2 "${LXD2_ADDR}" --token "${token}"
 
   migration "$LXD2_DIR"
 

--- a/test/suites/pki.sh
+++ b/test/suites/pki.sh
@@ -197,16 +197,6 @@ test_pki() {
     # Client cert should not be present in trust store.
     [ "$(lxc config trust list --format csv | wc -l)" = 1 ]
 
-    # Remove remote
-    lxc_remote remote remove pki-lxd
-
-    # Add the remote again using an incorrect token.
-    # This should succeed as is the same as the test above but with an incorrect token rather than no token.
-    lxc_remote remote add pki-lxd "${LXD5_ADDR}" --token=bar
-
-    # Client cert should not be present in trust store.
-    [ "$(lxc config trust list --format csv | wc -l)" = 1 ]
-
     # The certificate is trusted as root because `core.trust_ca_certificates` is enabled.
     lxc_remote info pki-lxd: | grep -F 'core.https_address'
     curl -s --cert "${LXD_CONF}/client.pem" --cacert "${LXD5_DIR}/server.crt" "https://${LXD5_ADDR}/1.0" | jq -e '.metadata.config."core.https_address"'

--- a/test/suites/projects.sh
+++ b/test/suites/projects.sh
@@ -802,7 +802,7 @@ test_projects_limits() {
     (LXD_DIR=${LXD_REMOTE_DIR} deps/import-busybox --alias remoteimage --template start --public)
 
     token="$(LXD_DIR=${LXD_REMOTE_DIR} lxc config trust add --name foo -q)"
-    lxc remote add l2 "${LXD_REMOTE_ADDR}" --accept-certificate --token "${token}"
+    lxc remote add l2 "${LXD_REMOTE_ADDR}" --token "${token}"
 
     # Relax all constraints except the disk limits, which won't be enough for the
     # image to be downloaded.

--- a/test/suites/remote.sh
+++ b/test/suites/remote.sh
@@ -3,7 +3,7 @@ test_remote_url() {
   # shellcheck disable=2153
   for url in "${LXD_ADDR}" "https://${LXD_ADDR}"; do
     token="$(lxc config trust add --name foo -q)"
-    lxc_remote remote add test "${url}" --accept-certificate --token "${token}"
+    lxc_remote remote add test "${url}" --token "${token}"
     lxc_remote info test:
     lxc_remote config trust list | awk '/@/ {print $8}' | while read -r line ; do
       lxc_remote config trust remove "\"${line}\""
@@ -19,7 +19,7 @@ test_remote_url() {
   urls="${LXD_DIR}/unix.socket unix:${LXD_DIR}/unix.socket unix://${LXD_DIR}/unix.socket"
 
   # an invalid protocol returns an error
-  ! lxc_remote remote add test "${url}" --accept-certificate --token foo --protocol foo || false
+  ! lxc_remote remote add test "${url}" --token foo --protocol foo || false
 
   for url in ${urls}; do
     lxc_remote remote add test "${url}"
@@ -147,11 +147,11 @@ test_remote_url_with_token() {
 }
 
 test_remote_admin() {
-  ! lxc_remote remote add badpass "${LXD_ADDR}" --accept-certificate --token badtoken || false
+  ! lxc_remote remote add badpass "${LXD_ADDR}" --token badtoken || false
   ! lxc_remote list badpass: || false
 
   token="$(lxc config trust add --name foo -q)"
-  lxc_remote remote add foo "${LXD_ADDR}" --accept-certificate --token "${token}"
+  lxc_remote remote add foo "${LXD_ADDR}" --token "${token}"
   lxc_remote remote list | grep 'foo'
 
   lxc_remote remote set-default foo
@@ -177,7 +177,7 @@ test_remote_admin() {
 
   # Test for #623
   token="$(lxc config trust add --name foo -q)"
-  lxc_remote remote add test-623 "${LXD_ADDR}" --accept-certificate --token "${token}"
+  lxc_remote remote add test-623 "${LXD_ADDR}" --token "${token}"
   lxc_remote remote remove test-623
 
   # now re-add under a different alias
@@ -199,7 +199,7 @@ test_remote_usage() {
   ensure_has_localhost_remote "${LXD_ADDR}"
 
   token="$(LXD_DIR=${LXD2_DIR} lxc config trust add --name foo -q)"
-  lxc_remote remote add lxd2 "${LXD2_ADDR}" --accept-certificate --token "${token}"
+  lxc_remote remote add lxd2 "${LXD2_ADDR}" --token "${token}"
 
   # we need a public image on localhost
 

--- a/test/suites/remote.sh
+++ b/test/suites/remote.sh
@@ -151,6 +151,10 @@ test_remote_admin() {
   ! lxc_remote list badpass: || false
 
   token="$(lxc config trust add --name foo -q)"
+
+  # Ensure trust token cannot be used with --accept-certificate.
+  ! lxc_remote remote add foo "${LXD_ADDR}" --accept-certificate --token "${token}" || false
+
   lxc_remote remote add foo "${LXD_ADDR}" --token "${token}"
   lxc_remote remote list | grep 'foo'
 


### PR DESCRIPTION
This PR prevents `--accept-certificate` to be used with a trust token. Whenever the token is provided, the fingerprint from the token is compared to the remote certificate fingerprint.

In addition, validation for mutually exclusive flags is added, more specifically trust token cannot be used with public remotes or when auth-type is OIDC.

Finally, two minor fixes; do not stop interactive mode on wrong input, and do not fail if remote is already trusting us. 

Closes #13973
Closes #13891