### PR TITLE
tests: Don't over-provision test volume (from Incus)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -230,8 +230,6 @@ jobs:
         go: ["1.22.x"]
         suite: ["cluster", "standalone"]
         backend: ["dir", "btrfs", "lvm", "zfs", "ceph", "random"]
-        event_name:
-         - ${{ github.event_name }}
         include:
           - go: stable
             suite: cluster
@@ -239,20 +237,6 @@ jobs:
           - go: stable
             suite: standalone
             backend: dir
-        # FIXME: These exclusions must be removed when https://bugs.launchpad.net/ubuntu/+source/linux/+bug/2081231 is fixed.
-        exclude:
-          - event_name: push
-            backend: ceph
-          - event_name: push
-            backend: lvm
-          - event_name: push
-            backend: random
-          - event_name: schedule
-            backend: ceph
-          - event_name: schedule
-            backend: lvm
-          - event_name: schedule
-            backend: random
 
     steps:
       - name: Checkout

--- a/test/suites/projects.sh
+++ b/test/suites/projects.sh
@@ -1099,7 +1099,7 @@ test_projects_usage() {
     limits.cpu=1 \
     limits.memory=512MiB \
     limits.processes=20
-  lxc profile device set default root size=3GiB --project test-usage
+  lxc profile device set default root size=300MiB --project test-usage
 
   # Spin up a container
   deps/import-busybox --project test-usage --alias testimage
@@ -1108,7 +1108,7 @@ test_projects_usage() {
 
   lxc project info test-usage --format csv | grep -q "CONTAINERS,UNLIMITED,1"
   lxc project info test-usage --format csv | grep -q "CPU,5,1"
-  lxc project info test-usage --format csv | grep -q "DISK,10.00GiB,3.00GiB"
+  lxc project info test-usage --format csv | grep -q "DISK,10.00GiB,300.00MiB"
   lxc project info test-usage --format csv | grep -q "INSTANCES,UNLIMITED,1"
   lxc project info test-usage --format csv | grep -q "MEMORY,1.00GiB,512.00MiB"
   lxc project info test-usage --format csv | grep -q "NETWORKS,3,0"

--- a/test/suites/projects.sh
+++ b/test/suites/projects.sh
@@ -1133,7 +1133,7 @@ EOF
     limits.cpu=1 \
     limits.memory=512MiB
 
-  lxc profile device set default root size=3GiB --project test-project-yaml
+  lxc profile device set default root size=300MiB --project test-project-yaml
   deps/import-busybox --project test-project-yaml --alias testimage
 
   lxc init testimage c1 --project test-project-yaml


### PR DESCRIPTION
Workaround our test failures related to https://bugs.launchpad.net/ubuntu/+source/linux/+bug/2081231

Reverts https://github.com/canonical/lxd/pull/14146

This PR contains commits cherry-picked from https://github.com/lxc/incus/pull/1246