### PR TITLE
Remove fanotify warning on ubuntu pro fsmonitor initialisation

### DIFF
--- a/lxd/fsmonitor/drivers/driver_fanotify.go
+++ b/lxd/fsmonitor/drivers/driver_fanotify.go
@@ -76,7 +76,7 @@ func (d *fanotify) eventMask() (uint64, error) {
 
 // DriverName returns the name of the driver.
 func (d *fanotify) DriverName() string {
-	return "fanotify"
+	return fsmonitor.DriverNameFANotify
 }
 
 func (d *fanotify) load(ctx context.Context) error {

--- a/lxd/fsmonitor/drivers/driver_inotify.go
+++ b/lxd/fsmonitor/drivers/driver_inotify.go
@@ -75,7 +75,7 @@ func (d *inotify) eventMask() (uint32, error) {
 
 // DriverName returns the name of the driver.
 func (d *inotify) DriverName() string {
-	return "inotify"
+	return fsmonitor.DriverNameINotify
 }
 
 func (d *inotify) load(ctx context.Context) error {

--- a/lxd/fsmonitor/drivers/load.go
+++ b/lxd/fsmonitor/drivers/load.go
@@ -11,8 +11,8 @@ import (
 )
 
 var drivers = map[string]func() driver{
-	"inotify":  func() driver { return &inotify{} },
-	"fanotify": func() driver { return &fanotify{} },
+	fsmonitor.DriverNameINotify:  func() driver { return &inotify{} },
+	fsmonitor.DriverNameFANotify: func() driver { return &fanotify{} },
 }
 
 // Load returns a new fsmonitor.FSMonitor with an applicable Driver.
@@ -46,10 +46,10 @@ func Load(ctx context.Context, path string, events ...fsmonitor.Event) (fsmonito
 		return startMonitor(driverName)
 	}
 
-	driver, err := startMonitor("fanotify")
+	driver, err := startMonitor(fsmonitor.DriverNameFANotify)
 	if err != nil {
 		logger.Warn("Failed to initialize fanotify, falling back on inotify", logger.Ctx{"err": err})
-		driver, err = startMonitor("inotify")
+		driver, err = startMonitor(fsmonitor.DriverNameINotify)
 		if err != nil {
 			return nil, err
 		}

--- a/lxd/fsmonitor/fsmonitor_interface.go
+++ b/lxd/fsmonitor/fsmonitor_interface.go
@@ -1,5 +1,17 @@
 package fsmonitor
 
+const (
+	// DriverNameFANotify is the name of the FANotify driver.
+	//
+	// FANotify should be preferred over INotify because it is more performant and does not need to recursively watch
+	// subdirectories. However, it is not possible to use fanotify if the specified path is not a mountpoint because we
+	// need to use the unix.FAN_MARK_FILESYSTEM flag for this functionality.
+	DriverNameFANotify = "fanotify"
+
+	// DriverNameINotify is the name of the inotify driver.
+	DriverNameINotify = "inotify"
+)
+
 // FSMonitor represents a filesystem monitor.
 type FSMonitor interface {
 	DriverName() string


### PR DESCRIPTION
This change allows the caller to specify a driver when loading an fsmonitor, or they can specify "any" to try to load fanotify but fallback to inotify if it fails.