### PR TITLE
Add support for image aliases of the same name for containers and virtual machines

### DIFF
--- a/client/interfaces.go
+++ b/client/interfaces.go
@@ -61,7 +61,7 @@ type ImageServer interface {
 	GetImageAliases() (aliases []api.ImageAliasesEntry, err error)
 	GetImageAliasNames() (names []string, err error)
 
-	GetImageAlias(name string) (alias *api.ImageAliasesEntry, ETag string, err error)
+	GetImageAlias(name string, instanceType api.InstanceType) (alias *api.ImageAliasesEntry, ETag string, err error)
 	GetImageAliasType(imageType string, name string) (alias *api.ImageAliasesEntry, ETag string, err error)
 	GetImageAliasArchitectures(imageType string, name string) (entries map[string]*api.ImageAliasesEntry, err error)
 

--- a/client/simplestreams_images.go
+++ b/client/simplestreams_images.go
@@ -253,7 +253,7 @@ func (r *ProtocolSimpleStreams) GetImageAliasNames() ([]string, error) {
 }
 
 // GetImageAlias returns an existing alias as an ImageAliasesEntry struct.
-func (r *ProtocolSimpleStreams) GetImageAlias(name string) (*api.ImageAliasesEntry, string, error) {
+func (r *ProtocolSimpleStreams) GetImageAlias(name string, _ api.InstanceType) (*api.ImageAliasesEntry, string, error) {
 	alias, err := r.ssClient.GetAlias("container", name)
 	if err != nil {
 		alias, err = r.ssClient.GetAlias("virtual-machine", name)
@@ -268,7 +268,7 @@ func (r *ProtocolSimpleStreams) GetImageAlias(name string) (*api.ImageAliasesEnt
 // GetImageAliasType returns an existing alias as an ImageAliasesEntry struct.
 func (r *ProtocolSimpleStreams) GetImageAliasType(imageType string, name string) (*api.ImageAliasesEntry, string, error) {
 	if imageType == "" {
-		return r.GetImageAlias(name)
+		return r.GetImageAlias(name, "")
 	}
 
 	alias, err := r.ssClient.GetAlias(imageType, name)

--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -973,6 +973,11 @@ definitions:
                 example: ubuntu-24.04
                 type: string
                 x-go-name: Name
+            type:
+                description: Alias type (container or virtual-machine)
+                example: container
+                type: string
+                x-go-name: Type
         type: object
         x-go-package: github.com/canonical/lxd/shared/api
     ImageAliasesEntry:
@@ -1008,6 +1013,11 @@ definitions:
                 example: ubuntu-24.04
                 type: string
                 x-go-name: Name
+            type:
+                description: Alias type (container or virtual-machine)
+                example: container
+                type: string
+                x-go-name: Type
         type: object
         x-go-package: github.com/canonical/lxd/shared/api
     ImageAliasesEntryPut:
@@ -1023,6 +1033,11 @@ definitions:
                 example: 06b86454720d36b20f94e31c6812e05ec51c1b568cf3a8abd273769d213394bb
                 type: string
                 x-go-name: Target
+            type:
+                description: Alias type (container or virtual-machine)
+                example: container
+                type: string
+                x-go-name: Type
         type: object
         x-go-package: github.com/canonical/lxd/shared/api
     ImageAliasesPost:

--- a/lxc/image.go
+++ b/lxc/image.go
@@ -234,7 +234,7 @@ func (c *cmdImageCopy) run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Resolve image type
-	imageType := ""
+	imageType := "container"
 	if c.flagVM {
 		imageType = "virtual-machine"
 	}
@@ -253,6 +253,7 @@ func (c *cmdImageCopy) run(cmd *cobra.Command, args []string) error {
 		imgInfo = &api.Image{}
 		imgInfo.Fingerprint = name
 		imgInfo.Public = true
+		imgInfo.Type = imageType
 	} else {
 		// Resolve any alias and then grab the image information from the source
 		imgInfo, _, err = c.image.dereferenceAlias(sourceServer, imageType, name)
@@ -308,11 +309,15 @@ func (c *cmdImageCopy) run(cmd *cobra.Command, args []string) error {
 	aliases := make([]api.ImageAlias, len(c.flagAliases))
 	for i, entry := range c.flagAliases {
 		aliases[i].Name = entry
+		aliases[i].Type = imageType
 	}
 
 	if c.flagCopyAliases {
 		// Also add the original aliases
 		aliases = append(aliases, imgInfo.Aliases...)
+		for i := range aliases {
+			aliases[i].Type = imageType
+		}
 	}
 
 	err = ensureImageAliases(destinationServer, aliases, fp)
@@ -922,6 +927,7 @@ func (c *cmdImageImport) run(cmd *cobra.Command, args []string) error {
 		aliases := make([]api.ImageAlias, len(c.flagAliases))
 		for i, entry := range c.flagAliases {
 			aliases[i].Name = entry
+			aliases[i].Type = imageType
 		}
 
 		err = ensureImageAliases(d, aliases, fingerprint)

--- a/lxc/init.go
+++ b/lxc/init.go
@@ -324,15 +324,20 @@ func (c *cmdInit) create(conf *config.Config, args []string, launch bool) (lxd.I
 
 	var opInfo api.Operation
 	if !c.flagEmpty {
+		imageType := api.InstanceTypeContainer
+		if c.flagVM {
+			imageType = api.InstanceTypeVM
+		}
+
 		// Get the image server and image info
-		iremote, image = guessImage(conf, d, remote, iremote, image)
+		iremote, image = guessImage(conf, d, remote, iremote, image, imageType)
 
 		// Deal with the default image
 		if image == "" {
 			image = "default"
 		}
 
-		imgRemote, imgInfo, err := getImgInfo(d, conf, iremote, remote, image, &req.Source)
+		imgRemote, imgInfo, err := getImgInfo(d, conf, iremote, remote, image, imageType, &req.Source)
 		if err != nil {
 			return nil, "", err
 		}

--- a/lxc/rebuild.go
+++ b/lxc/rebuild.go
@@ -120,8 +120,13 @@ func (c *cmdRebuild) rebuild(conf *config.Config, args []string) error {
 			return errors.New(i18n.G("You need to specify an image name or use --empty"))
 		}
 
-		iremote, image := guessImage(conf, d, remote, iremote, image)
-		imgRemote, imgInfo, err := getImgInfo(d, conf, iremote, remote, image, &req.Source)
+		imageType := api.InstanceTypeContainer
+		if current.Type == "virtual-machine" {
+			imageType = api.InstanceTypeVM
+		}
+
+		iremote, image := guessImage(conf, d, remote, iremote, image, imageType)
+		imgRemote, imgInfo, err := getImgInfo(d, conf, iremote, remote, image, imageType, &req.Source)
 		if err != nil {
 			return err
 		}

--- a/lxc/utils.go
+++ b/lxc/utils.go
@@ -191,19 +191,6 @@ func ensureImageAliases(client lxd.InstanceServer, aliases []api.ImageAlias, fin
 
 	sort.Strings(names)
 
-	resp, err := client.GetImageAliases()
-	if err != nil {
-		return err
-	}
-
-	// Delete existing aliases that match provided ones
-	for _, alias := range GetExistingAliases(names, resp) {
-		err := client.DeleteImageAlias(alias.Name)
-		if err != nil {
-			return fmt.Errorf(i18n.G("Failed to remove alias %s: %w"), alias.Name, err)
-		}
-	}
-
 	// Create new aliases.
 	for _, alias := range aliases {
 		aliasPost := api.ImageAliasesPost{}

--- a/lxd-benchmark/benchmark/benchmark.go
+++ b/lxd-benchmark/benchmark/benchmark.go
@@ -245,7 +245,7 @@ func ensureImage(c lxd.ContainerServer, image string) (string, error) {
 			fingerprint = "default"
 		}
 
-		alias, _, err := imageServer.GetImageAlias(fingerprint)
+		alias, _, err := imageServer.GetImageAlias(fingerprint, "container")
 		if err == nil {
 			fingerprint = alias.Target
 		}
@@ -267,7 +267,7 @@ func ensureImage(c lxd.ContainerServer, image string) (string, error) {
 		}
 	} else {
 		fingerprint = image
-		alias, _, err := c.GetImageAlias(image)
+		alias, _, err := c.GetImageAlias(image, "container")
 		if err == nil {
 			fingerprint = alias.Target
 		} else {

--- a/lxd/db/db_internal_test.go
+++ b/lxd/db/db_internal_test.go
@@ -242,7 +242,7 @@ func (s *dbTestSuite) Test_ImageExists_false() {
 
 func (s *dbTestSuite) Test_GetImageAlias_alias_exists() {
 	_ = s.db.Transaction(context.Background(), func(ctx context.Context, tx *ClusterTx) error {
-		_, alias, err := tx.GetImageAlias(ctx, "default", "somealias", true)
+		_, alias, err := tx.GetImageAlias(ctx, "default", "somealias", "container", true)
 		s.Nil(err)
 		s.Equal(alias.Target, "fingerprint")
 
@@ -252,7 +252,7 @@ func (s *dbTestSuite) Test_GetImageAlias_alias_exists() {
 
 func (s *dbTestSuite) Test_GetImageAlias_alias_does_not_exists() {
 	_ = s.db.Transaction(context.Background(), func(ctx context.Context, tx *ClusterTx) error {
-		_, _, err := tx.GetImageAlias(ctx, "default", "whatever", true)
+		_, _, err := tx.GetImageAlias(ctx, "default", "whatever", "container", true)
 		s.True(api.StatusErrorCheck(err, http.StatusNotFound))
 
 		return nil
@@ -264,7 +264,7 @@ func (s *dbTestSuite) Test_CreateImageAlias() {
 		err := tx.CreateImageAlias(ctx, "default", "Chaosphere", 1, "Someone will like the name")
 		s.Nil(err)
 
-		_, alias, err := tx.GetImageAlias(ctx, "default", "Chaosphere", true)
+		_, alias, err := tx.GetImageAlias(ctx, "default", "Chaosphere", "container", true)
 		s.Nil(err)
 		s.Equal(alias.Target, "fingerprint")
 

--- a/lxd/db/images.go
+++ b/lxd/db/images.go
@@ -713,8 +713,8 @@ func (c *ClusterTx) MoveImageAlias(ctx context.Context, source int, destination 
 
 // CreateImageAlias inserts an alias ento the database.
 func (c *ClusterTx) CreateImageAlias(ctx context.Context, projectName, aliasName string, imageID int, desc string) error {
-	stmt := `INSERT INTO images_aliases (name, image_id, description, project_id)
-VALUES (?, ?, ?, (SELECT id FROM projects WHERE name = ?))
+	stmt := `INSERT INTO images_aliases (name, image_id, description, project_id, image_type)
+VALUES (?, ?, ?, (SELECT id FROM projects WHERE name = ?), (SELECT type from images where id = ?))
 `
 	enabled, err := cluster.ProjectHasImages(ctx, c.tx, projectName)
 	if err != nil {
@@ -725,7 +725,7 @@ VALUES (?, ?, ?, (SELECT id FROM projects WHERE name = ?))
 		projectName = "default"
 	}
 
-	_, err = c.tx.Exec(stmt, aliasName, imageID, desc, projectName)
+	_, err = c.tx.Exec(stmt, aliasName, imageID, desc, projectName, imageID)
 	if err != nil {
 		return err
 	}

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -3396,14 +3396,16 @@ func imageAliasesPost(d *Daemon, r *http.Request) response.Response {
 	}
 
 	err = s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
-		// This is just to see if the alias name already exists.
-		_, _, err = tx.GetImageAlias(ctx, projectName, req.Name, true)
+		// This is just to see if the alias already exists.
+		_, entry, err := tx.GetImageAlias(ctx, projectName, req.Name, true)
 		if !response.IsNotFoundError(err) {
 			if err != nil {
 				return err
 			}
 
-			return api.StatusErrorf(http.StatusConflict, "Alias %q already exists", req.Name)
+			if req.Type == entry.Type {
+				return api.StatusErrorf(http.StatusConflict, "Alias %q already exists for %q", req.Name, req.Type)
+			}
 		}
 
 		imgID, _, err := tx.GetImageByFingerprintPrefix(ctx, req.Target, dbCluster.ImageFilter{Project: &projectName})
@@ -4012,14 +4014,16 @@ func imageAliasPost(d *Daemon, r *http.Request) response.Response {
 	}
 
 	err = s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
-		// This is just to see if the alias name already exists.
-		_, _, err := tx.GetImageAlias(ctx, projectName, req.Name, true)
+		// This is just to see if the alias already exists.
+		_, entry, err := tx.GetImageAlias(ctx, projectName, req.Name, true)
 		if !response.IsNotFoundError(err) {
 			if err != nil {
 				return err
 			}
 
-			return api.StatusErrorf(http.StatusConflict, "Alias %q already exists", req.Name)
+			if req.Type == entry.Type {
+				return api.StatusErrorf(http.StatusConflict, "Alias %q already exists for %q", req.Name, req.Type)
+			}
 		}
 
 		imgAliasID, _, err := tx.GetImageAlias(ctx, projectName, name, true)

--- a/lxd/instance.go
+++ b/lxd/instance.go
@@ -729,7 +729,7 @@ func pruneExpiredAndAutoCreateInstanceSnapshotsTask(d *Daemon) (task.Func, task.
 // getSourceImageFromInstanceSource returns the image to use for an instance source.
 func getSourceImageFromInstanceSource(ctx context.Context, s *state.State, tx *db.ClusterTx, project string, source api.InstanceSource, imageRef *string, instType string) (*api.Image, error) {
 	// Resolve the image.
-	sourceImageRefUpdate, err := instance.ResolveImage(ctx, tx, project, source)
+	sourceImageRefUpdate, err := instance.ResolveImage(ctx, tx, project, source, instType)
 	if err != nil {
 		return nil, err
 	}

--- a/lxd/instance/instance_utils.go
+++ b/lxd/instance/instance_utils.go
@@ -464,7 +464,7 @@ func BackupLoadByName(s *state.State, project, name string) (*backup.InstanceBac
 }
 
 // ResolveImage takes an instance source and returns a hash suitable for instance creation or download.
-func ResolveImage(ctx context.Context, tx *db.ClusterTx, projectName string, source api.InstanceSource) (string, error) {
+func ResolveImage(ctx context.Context, tx *db.ClusterTx, projectName string, source api.InstanceSource, instType string) (string, error) {
 	if source.Fingerprint != "" {
 		return source.Fingerprint, nil
 	}
@@ -474,7 +474,7 @@ func ResolveImage(ctx context.Context, tx *db.ClusterTx, projectName string, sou
 			return source.Alias, nil
 		}
 
-		_, alias, err := tx.GetImageAlias(ctx, projectName, source.Alias, true)
+		_, alias, err := tx.GetImageAlias(ctx, projectName, source.Alias, instType, true)
 		if err != nil {
 			return "", err
 		}

--- a/po/ar.po
+++ b/po/ar.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-19 13:11-0600\n"
+"POT-Creation-Date: 2024-09-25 18:38-0600\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -192,7 +192,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:419
+#: lxc/image.go:424
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -420,7 +420,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1168
+#: lxc/image.go:1174
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -528,7 +528,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:695
+#: lxc/image.go:700
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -541,15 +541,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1138 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1133
+#: lxc/image.go:1139
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1144 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -731,7 +731,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1045
+#: lxc/image.go:1051
 msgid "Aliases:"
 msgstr ""
 
@@ -747,7 +747,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1022 lxc/info.go:486
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -766,11 +766,11 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:342 lxc/rebuild.go:131
+#: lxc/init.go:347 lxc/rebuild.go:136
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/init.go:346
+#: lxc/init.go:351
 msgid "Asked for a container but image is of type VM"
 msgstr ""
 
@@ -828,7 +828,7 @@ msgstr ""
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1061
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -885,7 +885,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:816
+#: lxc/image.go:821
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -966,7 +966,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1060
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -987,7 +987,7 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:239 lxc/utils.go:259
+#: lxc/utils.go:227 lxc/utils.go:247
 #, c-format
 msgid "Can't read from stdin: %w"
 msgstr ""
@@ -1021,7 +1021,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:166
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1173,7 +1173,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1589
+#: lxc/image.go:1121 lxc/list.go:132 lxc/storage_volume.go:1589
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1212,7 +1212,7 @@ msgstr ""
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1327 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/config_trust.go:314 lxc/image.go:496 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
@@ -1306,7 +1306,7 @@ msgstr ""
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1486,7 +1486,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1475
+#: lxc/image.go:1029 lxc/info.go:497 lxc/storage_volume.go:1475
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1510,7 +1510,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1143 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -1568,7 +1568,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:341 lxc/image.go:342
 msgid "Delete images"
 msgstr ""
 
@@ -1671,9 +1671,9 @@ msgstr ""
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
 #: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
-#: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
-#: lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090 lxc/image.go:1417
-#: lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638 lxc/image.go:1701
+#: lxc/image.go:159 lxc/image.go:342 lxc/image.go:401 lxc/image.go:530
+#: lxc/image.go:702 lxc/image.go:954 lxc/image.go:1096 lxc/image.go:1423
+#: lxc/image.go:1514 lxc/image.go:1580 lxc/image.go:1644 lxc/image.go:1707
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
@@ -1818,11 +1818,11 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:406
+#: lxc/init.go:411
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:726
+#: lxc/image.go:731
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1926,7 +1926,7 @@ msgstr ""
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:400 lxc/image.go:401
 msgid "Edit image properties"
 msgstr ""
 
@@ -2002,7 +2002,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1766
+#: lxc/image.go:1155 lxc/list.go:622 lxc/storage_volume.go:1766
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2121,20 +2121,20 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:1029
+#: lxc/image.go:1035
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1037
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:524
+#: lxc/image.go:529
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:530
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2162,7 +2162,7 @@ msgstr ""
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:604
+#: lxc/image.go:609
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2175,7 +2175,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
+#: lxc/config_trust.go:411 lxc/image.go:1140 lxc/image.go:1141
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2194,12 +2194,12 @@ msgstr ""
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/utils.go:296
+#: lxc/utils.go:284
 #, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/utils.go:288
+#: lxc/utils.go:276
 #, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
@@ -2293,7 +2293,7 @@ msgstr ""
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: lxc/utils.go:214
+#: lxc/utils.go:202
 #, c-format
 msgid "Failed to create alias %s: %w"
 msgstr ""
@@ -2318,11 +2318,6 @@ msgstr ""
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
 
-#: lxc/utils.go:203
-#, c-format
-msgid "Failed to remove alias %s: %w"
-msgstr ""
-
 #: lxc/file.go:821
 #, c-format
 msgid "Failed to walk path for %s: %s"
@@ -2342,7 +2337,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:1014
+#: lxc/image.go:1020
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2406,7 +2401,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:770 lxc/auth.go:1697
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1122 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:57
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2481,7 +2476,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1573 lxc/image.go:1574
+#: lxc/image.go:1579 lxc/image.go:1580
 msgid "Get image properties"
 msgstr ""
 
@@ -2755,11 +2750,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1489
+#: lxc/image.go:1495
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2767,25 +2762,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:680
+#: lxc/image.go:685
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1444
+#: lxc/image.go:369 lxc/image.go:1450
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1670
+#: lxc/image.go:449 lxc/image.go:1676
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:918
+#: lxc/image.go:923
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1493
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2805,7 +2800,7 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:697
+#: lxc/image.go:702
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -2815,7 +2810,7 @@ msgid ""
 "os=Ubuntu release=noble variant=cloud."
 msgstr ""
 
-#: lxc/image.go:696
+#: lxc/image.go:701
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2866,7 +2861,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:417
+#: lxc/init.go:422
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2932,7 +2927,7 @@ msgstr ""
 msgid "Invalid instance path: %q"
 msgstr ""
 
-#: lxc/utils.go:253
+#: lxc/utils.go:241
 #, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr ""
@@ -3044,12 +3039,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:1035
+#: lxc/image.go:1041
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:1037
+#: lxc/image.go:1043
 msgid "Last used: never"
 msgstr ""
 
@@ -3167,11 +3162,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1089
+#: lxc/image.go:1095
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1096
 msgid ""
 "List images\n"
 "\n"
@@ -3465,7 +3460,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:165 lxc/image.go:709
 msgid "Make image public"
 msgstr ""
 
@@ -3979,7 +3974,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:728
+#: lxc/image.go:733
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4172,7 +4167,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:168 lxc/image.go:710
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4252,7 +4247,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:805
+#: lxc/image.go:810
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4323,7 +4318,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:752
+#: lxc/image.go:1142 lxc/remote.go:752
 msgid "PUBLIC"
 msgstr ""
 
@@ -4384,7 +4379,7 @@ msgstr ""
 #: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/config_trust.go:315 lxc/image.go:497 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
@@ -4472,11 +4467,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1067
+#: lxc/image.go:1073
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1065
+#: lxc/image.go:1071
 msgid "Profiles: "
 msgstr ""
 
@@ -4499,11 +4494,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1046
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1621
+#: lxc/image.go:1627
 msgid "Property not found"
 msgstr ""
 
@@ -4597,7 +4592,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1024
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4633,7 +4628,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
+#: lxc/image.go:535 lxc/image.go:957 lxc/image.go:1517
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4670,7 +4665,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1416 lxc/image.go:1417
+#: lxc/image.go:1422 lxc/image.go:1423
 msgid "Refresh images"
 msgstr ""
 
@@ -4679,7 +4674,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1453
+#: lxc/image.go:1459
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4942,7 +4937,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:365
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -4975,7 +4970,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1139
+#: lxc/image.go:1145
 msgid "SIZE"
 msgstr ""
 
@@ -5098,7 +5093,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1637 lxc/image.go:1638
+#: lxc/image.go:1643 lxc/image.go:1644
 msgid "Set image properties"
 msgstr ""
 
@@ -5391,7 +5386,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1507 lxc/image.go:1508
+#: lxc/image.go:1513 lxc/image.go:1514
 msgid "Show image properties"
 msgstr ""
 
@@ -5525,7 +5520,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:953 lxc/image.go:954
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5537,7 +5532,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1021
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5569,7 +5564,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:1058
+#: lxc/image.go:1064
 msgid "Source:"
 msgstr ""
 
@@ -5717,7 +5712,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
 #: lxc/storage_volume.go:1730 lxc/warning.go:216
@@ -5782,7 +5777,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:438
+#: lxc/init.go:443
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5791,12 +5786,12 @@ msgstr ""
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
 
-#: lxc/utils.go:376
+#: lxc/utils.go:364
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:%q' instead."
 msgstr ""
 
-#: lxc/utils.go:372
+#: lxc/utils.go:360
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
@@ -5939,15 +5934,15 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1025
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:440
+#: lxc/init.go:445
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:439
+#: lxc/init.go:444
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6001,7 +5996,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:827
+#: lxc/image.go:832
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
@@ -6039,7 +6034,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1023 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1455
 #, c-format
 msgid "Type: %s"
@@ -6054,7 +6049,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1140
+#: lxc/image.go:1146
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6100,7 +6095,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:631 lxc/storage_volume.go:1772
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6142,7 +6137,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1700 lxc/image.go:1701
+#: lxc/image.go:1706 lxc/image.go:1707
 msgid "Unset image properties"
 msgstr ""
 
@@ -6293,7 +6288,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1032
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6466,7 +6461,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1087 lxc/list.go:46
+#: lxc/image.go:1093 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6579,15 +6574,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
+#: lxc/image.go:399 lxc/image.go:952 lxc/image.go:1512
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1572 lxc/image.go:1699
+#: lxc/image.go:1578 lxc/image.go:1705
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1636
+#: lxc/image.go:1642
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6603,11 +6598,11 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:523
+#: lxc/image.go:528
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1415
+#: lxc/image.go:339 lxc/image.go:1421
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -7070,7 +7065,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1010
 msgid "disabled"
 msgstr ""
 
@@ -7078,7 +7073,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1012
 msgid "enabled"
 msgstr ""
 
@@ -7219,7 +7214,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:398
+#: lxc/image.go:403
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7546,7 +7541,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
+#: lxc/image.go:1000 lxc/image.go:1005 lxc/image.go:1203
 msgid "no"
 msgstr ""
 
@@ -7591,7 +7586,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1194
+#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:1002 lxc/image.go:1007
+#: lxc/image.go:1200
 msgid "yes"
 msgstr ""

--- a/po/ber.po
+++ b/po/ber.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-19 13:11-0600\n"
+"POT-Creation-Date: 2024-09-25 18:38-0600\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Berber <https://hosted.weblate.org/projects/linux-containers/"
@@ -195,7 +195,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:419
+#: lxc/image.go:424
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -423,7 +423,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1168
+#: lxc/image.go:1174
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -531,7 +531,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:695
+#: lxc/image.go:700
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -544,15 +544,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1138 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1133
+#: lxc/image.go:1139
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1144 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -734,7 +734,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1045
+#: lxc/image.go:1051
 msgid "Aliases:"
 msgstr ""
 
@@ -750,7 +750,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1022 lxc/info.go:486
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -769,11 +769,11 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:342 lxc/rebuild.go:131
+#: lxc/init.go:347 lxc/rebuild.go:136
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/init.go:346
+#: lxc/init.go:351
 msgid "Asked for a container but image is of type VM"
 msgstr ""
 
@@ -831,7 +831,7 @@ msgstr ""
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1061
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -888,7 +888,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:816
+#: lxc/image.go:821
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -969,7 +969,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1060
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -990,7 +990,7 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:239 lxc/utils.go:259
+#: lxc/utils.go:227 lxc/utils.go:247
 #, c-format
 msgid "Can't read from stdin: %w"
 msgstr ""
@@ -1024,7 +1024,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:166
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1176,7 +1176,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1589
+#: lxc/image.go:1121 lxc/list.go:132 lxc/storage_volume.go:1589
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1215,7 +1215,7 @@ msgstr ""
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1327 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/config_trust.go:314 lxc/image.go:496 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
@@ -1309,7 +1309,7 @@ msgstr ""
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1489,7 +1489,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1475
+#: lxc/image.go:1029 lxc/info.go:497 lxc/storage_volume.go:1475
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1513,7 +1513,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1143 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -1571,7 +1571,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:341 lxc/image.go:342
 msgid "Delete images"
 msgstr ""
 
@@ -1674,9 +1674,9 @@ msgstr ""
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
 #: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
-#: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
-#: lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090 lxc/image.go:1417
-#: lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638 lxc/image.go:1701
+#: lxc/image.go:159 lxc/image.go:342 lxc/image.go:401 lxc/image.go:530
+#: lxc/image.go:702 lxc/image.go:954 lxc/image.go:1096 lxc/image.go:1423
+#: lxc/image.go:1514 lxc/image.go:1580 lxc/image.go:1644 lxc/image.go:1707
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
@@ -1821,11 +1821,11 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:406
+#: lxc/init.go:411
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:726
+#: lxc/image.go:731
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1929,7 +1929,7 @@ msgstr ""
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:400 lxc/image.go:401
 msgid "Edit image properties"
 msgstr ""
 
@@ -2005,7 +2005,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1766
+#: lxc/image.go:1155 lxc/list.go:622 lxc/storage_volume.go:1766
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2124,20 +2124,20 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:1029
+#: lxc/image.go:1035
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1037
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:524
+#: lxc/image.go:529
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:530
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2165,7 +2165,7 @@ msgstr ""
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:604
+#: lxc/image.go:609
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2178,7 +2178,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
+#: lxc/config_trust.go:411 lxc/image.go:1140 lxc/image.go:1141
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2197,12 +2197,12 @@ msgstr ""
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/utils.go:296
+#: lxc/utils.go:284
 #, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/utils.go:288
+#: lxc/utils.go:276
 #, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
@@ -2296,7 +2296,7 @@ msgstr ""
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: lxc/utils.go:214
+#: lxc/utils.go:202
 #, c-format
 msgid "Failed to create alias %s: %w"
 msgstr ""
@@ -2321,11 +2321,6 @@ msgstr ""
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
 
-#: lxc/utils.go:203
-#, c-format
-msgid "Failed to remove alias %s: %w"
-msgstr ""
-
 #: lxc/file.go:821
 #, c-format
 msgid "Failed to walk path for %s: %s"
@@ -2345,7 +2340,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:1014
+#: lxc/image.go:1020
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2409,7 +2404,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:770 lxc/auth.go:1697
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1122 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:57
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2484,7 +2479,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1573 lxc/image.go:1574
+#: lxc/image.go:1579 lxc/image.go:1580
 msgid "Get image properties"
 msgstr ""
 
@@ -2758,11 +2753,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1489
+#: lxc/image.go:1495
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2770,25 +2765,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:680
+#: lxc/image.go:685
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1444
+#: lxc/image.go:369 lxc/image.go:1450
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1670
+#: lxc/image.go:449 lxc/image.go:1676
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:918
+#: lxc/image.go:923
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1493
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2808,7 +2803,7 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:697
+#: lxc/image.go:702
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -2818,7 +2813,7 @@ msgid ""
 "os=Ubuntu release=noble variant=cloud."
 msgstr ""
 
-#: lxc/image.go:696
+#: lxc/image.go:701
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2869,7 +2864,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:417
+#: lxc/init.go:422
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2935,7 +2930,7 @@ msgstr ""
 msgid "Invalid instance path: %q"
 msgstr ""
 
-#: lxc/utils.go:253
+#: lxc/utils.go:241
 #, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr ""
@@ -3047,12 +3042,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:1035
+#: lxc/image.go:1041
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:1037
+#: lxc/image.go:1043
 msgid "Last used: never"
 msgstr ""
 
@@ -3170,11 +3165,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1089
+#: lxc/image.go:1095
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1096
 msgid ""
 "List images\n"
 "\n"
@@ -3468,7 +3463,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:165 lxc/image.go:709
 msgid "Make image public"
 msgstr ""
 
@@ -3982,7 +3977,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:728
+#: lxc/image.go:733
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4175,7 +4170,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:168 lxc/image.go:710
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4255,7 +4250,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:805
+#: lxc/image.go:810
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4326,7 +4321,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:752
+#: lxc/image.go:1142 lxc/remote.go:752
 msgid "PUBLIC"
 msgstr ""
 
@@ -4387,7 +4382,7 @@ msgstr ""
 #: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/config_trust.go:315 lxc/image.go:497 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
@@ -4475,11 +4470,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1067
+#: lxc/image.go:1073
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1065
+#: lxc/image.go:1071
 msgid "Profiles: "
 msgstr ""
 
@@ -4502,11 +4497,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1046
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1621
+#: lxc/image.go:1627
 msgid "Property not found"
 msgstr ""
 
@@ -4600,7 +4595,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1024
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4636,7 +4631,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
+#: lxc/image.go:535 lxc/image.go:957 lxc/image.go:1517
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4673,7 +4668,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1416 lxc/image.go:1417
+#: lxc/image.go:1422 lxc/image.go:1423
 msgid "Refresh images"
 msgstr ""
 
@@ -4682,7 +4677,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1453
+#: lxc/image.go:1459
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4945,7 +4940,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:365
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -4978,7 +4973,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1139
+#: lxc/image.go:1145
 msgid "SIZE"
 msgstr ""
 
@@ -5101,7 +5096,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1637 lxc/image.go:1638
+#: lxc/image.go:1643 lxc/image.go:1644
 msgid "Set image properties"
 msgstr ""
 
@@ -5394,7 +5389,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1507 lxc/image.go:1508
+#: lxc/image.go:1513 lxc/image.go:1514
 msgid "Show image properties"
 msgstr ""
 
@@ -5528,7 +5523,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:953 lxc/image.go:954
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5540,7 +5535,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1021
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5572,7 +5567,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:1058
+#: lxc/image.go:1064
 msgid "Source:"
 msgstr ""
 
@@ -5720,7 +5715,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
 #: lxc/storage_volume.go:1730 lxc/warning.go:216
@@ -5785,7 +5780,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:438
+#: lxc/init.go:443
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5794,12 +5789,12 @@ msgstr ""
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
 
-#: lxc/utils.go:376
+#: lxc/utils.go:364
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:%q' instead."
 msgstr ""
 
-#: lxc/utils.go:372
+#: lxc/utils.go:360
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
@@ -5942,15 +5937,15 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1025
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:440
+#: lxc/init.go:445
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:439
+#: lxc/init.go:444
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6004,7 +5999,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:827
+#: lxc/image.go:832
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
@@ -6042,7 +6037,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1023 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1455
 #, c-format
 msgid "Type: %s"
@@ -6057,7 +6052,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1140
+#: lxc/image.go:1146
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6103,7 +6098,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:631 lxc/storage_volume.go:1772
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6145,7 +6140,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1700 lxc/image.go:1701
+#: lxc/image.go:1706 lxc/image.go:1707
 msgid "Unset image properties"
 msgstr ""
 
@@ -6296,7 +6291,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1032
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6469,7 +6464,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1087 lxc/list.go:46
+#: lxc/image.go:1093 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6582,15 +6577,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
+#: lxc/image.go:399 lxc/image.go:952 lxc/image.go:1512
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1572 lxc/image.go:1699
+#: lxc/image.go:1578 lxc/image.go:1705
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1636
+#: lxc/image.go:1642
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6606,11 +6601,11 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:523
+#: lxc/image.go:528
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1415
+#: lxc/image.go:339 lxc/image.go:1421
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -7073,7 +7068,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1010
 msgid "disabled"
 msgstr ""
 
@@ -7081,7 +7076,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1012
 msgid "enabled"
 msgstr ""
 
@@ -7222,7 +7217,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:398
+#: lxc/image.go:403
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7549,7 +7544,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
+#: lxc/image.go:1000 lxc/image.go:1005 lxc/image.go:1203
 msgid "no"
 msgstr ""
 
@@ -7594,7 +7589,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1194
+#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:1002 lxc/image.go:1007
+#: lxc/image.go:1200
 msgid "yes"
 msgstr ""

--- a/po/bg.po
+++ b/po/bg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-19 13:11-0600\n"
+"POT-Creation-Date: 2024-09-25 18:38-0600\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Bulgarian <https://hosted.weblate.org/projects/linux-"
@@ -195,7 +195,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:419
+#: lxc/image.go:424
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -423,7 +423,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1168
+#: lxc/image.go:1174
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -531,7 +531,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:695
+#: lxc/image.go:700
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -544,15 +544,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1138 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1133
+#: lxc/image.go:1139
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1144 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -734,7 +734,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1045
+#: lxc/image.go:1051
 msgid "Aliases:"
 msgstr ""
 
@@ -750,7 +750,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1022 lxc/info.go:486
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -769,11 +769,11 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:342 lxc/rebuild.go:131
+#: lxc/init.go:347 lxc/rebuild.go:136
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/init.go:346
+#: lxc/init.go:351
 msgid "Asked for a container but image is of type VM"
 msgstr ""
 
@@ -831,7 +831,7 @@ msgstr ""
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1061
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -888,7 +888,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:816
+#: lxc/image.go:821
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -969,7 +969,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1060
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -990,7 +990,7 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:239 lxc/utils.go:259
+#: lxc/utils.go:227 lxc/utils.go:247
 #, c-format
 msgid "Can't read from stdin: %w"
 msgstr ""
@@ -1024,7 +1024,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:166
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1176,7 +1176,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1589
+#: lxc/image.go:1121 lxc/list.go:132 lxc/storage_volume.go:1589
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1215,7 +1215,7 @@ msgstr ""
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1327 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/config_trust.go:314 lxc/image.go:496 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
@@ -1309,7 +1309,7 @@ msgstr ""
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1489,7 +1489,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1475
+#: lxc/image.go:1029 lxc/info.go:497 lxc/storage_volume.go:1475
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1513,7 +1513,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1143 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -1571,7 +1571,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:341 lxc/image.go:342
 msgid "Delete images"
 msgstr ""
 
@@ -1674,9 +1674,9 @@ msgstr ""
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
 #: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
-#: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
-#: lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090 lxc/image.go:1417
-#: lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638 lxc/image.go:1701
+#: lxc/image.go:159 lxc/image.go:342 lxc/image.go:401 lxc/image.go:530
+#: lxc/image.go:702 lxc/image.go:954 lxc/image.go:1096 lxc/image.go:1423
+#: lxc/image.go:1514 lxc/image.go:1580 lxc/image.go:1644 lxc/image.go:1707
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
@@ -1821,11 +1821,11 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:406
+#: lxc/init.go:411
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:726
+#: lxc/image.go:731
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1929,7 +1929,7 @@ msgstr ""
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:400 lxc/image.go:401
 msgid "Edit image properties"
 msgstr ""
 
@@ -2005,7 +2005,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1766
+#: lxc/image.go:1155 lxc/list.go:622 lxc/storage_volume.go:1766
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2124,20 +2124,20 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:1029
+#: lxc/image.go:1035
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1037
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:524
+#: lxc/image.go:529
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:530
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2165,7 +2165,7 @@ msgstr ""
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:604
+#: lxc/image.go:609
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2178,7 +2178,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
+#: lxc/config_trust.go:411 lxc/image.go:1140 lxc/image.go:1141
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2197,12 +2197,12 @@ msgstr ""
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/utils.go:296
+#: lxc/utils.go:284
 #, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/utils.go:288
+#: lxc/utils.go:276
 #, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
@@ -2296,7 +2296,7 @@ msgstr ""
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: lxc/utils.go:214
+#: lxc/utils.go:202
 #, c-format
 msgid "Failed to create alias %s: %w"
 msgstr ""
@@ -2321,11 +2321,6 @@ msgstr ""
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
 
-#: lxc/utils.go:203
-#, c-format
-msgid "Failed to remove alias %s: %w"
-msgstr ""
-
 #: lxc/file.go:821
 #, c-format
 msgid "Failed to walk path for %s: %s"
@@ -2345,7 +2340,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:1014
+#: lxc/image.go:1020
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2409,7 +2404,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:770 lxc/auth.go:1697
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1122 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:57
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2484,7 +2479,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1573 lxc/image.go:1574
+#: lxc/image.go:1579 lxc/image.go:1580
 msgid "Get image properties"
 msgstr ""
 
@@ -2758,11 +2753,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1489
+#: lxc/image.go:1495
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2770,25 +2765,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:680
+#: lxc/image.go:685
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1444
+#: lxc/image.go:369 lxc/image.go:1450
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1670
+#: lxc/image.go:449 lxc/image.go:1676
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:918
+#: lxc/image.go:923
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1493
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2808,7 +2803,7 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:697
+#: lxc/image.go:702
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -2818,7 +2813,7 @@ msgid ""
 "os=Ubuntu release=noble variant=cloud."
 msgstr ""
 
-#: lxc/image.go:696
+#: lxc/image.go:701
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2869,7 +2864,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:417
+#: lxc/init.go:422
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2935,7 +2930,7 @@ msgstr ""
 msgid "Invalid instance path: %q"
 msgstr ""
 
-#: lxc/utils.go:253
+#: lxc/utils.go:241
 #, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr ""
@@ -3047,12 +3042,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:1035
+#: lxc/image.go:1041
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:1037
+#: lxc/image.go:1043
 msgid "Last used: never"
 msgstr ""
 
@@ -3170,11 +3165,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1089
+#: lxc/image.go:1095
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1096
 msgid ""
 "List images\n"
 "\n"
@@ -3468,7 +3463,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:165 lxc/image.go:709
 msgid "Make image public"
 msgstr ""
 
@@ -3982,7 +3977,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:728
+#: lxc/image.go:733
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4175,7 +4170,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:168 lxc/image.go:710
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4255,7 +4250,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:805
+#: lxc/image.go:810
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4326,7 +4321,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:752
+#: lxc/image.go:1142 lxc/remote.go:752
 msgid "PUBLIC"
 msgstr ""
 
@@ -4387,7 +4382,7 @@ msgstr ""
 #: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/config_trust.go:315 lxc/image.go:497 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
@@ -4475,11 +4470,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1067
+#: lxc/image.go:1073
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1065
+#: lxc/image.go:1071
 msgid "Profiles: "
 msgstr ""
 
@@ -4502,11 +4497,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1046
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1621
+#: lxc/image.go:1627
 msgid "Property not found"
 msgstr ""
 
@@ -4600,7 +4595,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1024
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4636,7 +4631,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
+#: lxc/image.go:535 lxc/image.go:957 lxc/image.go:1517
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4673,7 +4668,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1416 lxc/image.go:1417
+#: lxc/image.go:1422 lxc/image.go:1423
 msgid "Refresh images"
 msgstr ""
 
@@ -4682,7 +4677,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1453
+#: lxc/image.go:1459
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4945,7 +4940,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:365
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -4978,7 +4973,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1139
+#: lxc/image.go:1145
 msgid "SIZE"
 msgstr ""
 
@@ -5101,7 +5096,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1637 lxc/image.go:1638
+#: lxc/image.go:1643 lxc/image.go:1644
 msgid "Set image properties"
 msgstr ""
 
@@ -5394,7 +5389,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1507 lxc/image.go:1508
+#: lxc/image.go:1513 lxc/image.go:1514
 msgid "Show image properties"
 msgstr ""
 
@@ -5528,7 +5523,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:953 lxc/image.go:954
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5540,7 +5535,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1021
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5572,7 +5567,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:1058
+#: lxc/image.go:1064
 msgid "Source:"
 msgstr ""
 
@@ -5720,7 +5715,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
 #: lxc/storage_volume.go:1730 lxc/warning.go:216
@@ -5785,7 +5780,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:438
+#: lxc/init.go:443
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5794,12 +5789,12 @@ msgstr ""
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
 
-#: lxc/utils.go:376
+#: lxc/utils.go:364
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:%q' instead."
 msgstr ""
 
-#: lxc/utils.go:372
+#: lxc/utils.go:360
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
@@ -5942,15 +5937,15 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1025
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:440
+#: lxc/init.go:445
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:439
+#: lxc/init.go:444
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6004,7 +5999,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:827
+#: lxc/image.go:832
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
@@ -6042,7 +6037,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1023 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1455
 #, c-format
 msgid "Type: %s"
@@ -6057,7 +6052,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1140
+#: lxc/image.go:1146
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6103,7 +6098,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:631 lxc/storage_volume.go:1772
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6145,7 +6140,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1700 lxc/image.go:1701
+#: lxc/image.go:1706 lxc/image.go:1707
 msgid "Unset image properties"
 msgstr ""
 
@@ -6296,7 +6291,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1032
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6469,7 +6464,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1087 lxc/list.go:46
+#: lxc/image.go:1093 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6582,15 +6577,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
+#: lxc/image.go:399 lxc/image.go:952 lxc/image.go:1512
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1572 lxc/image.go:1699
+#: lxc/image.go:1578 lxc/image.go:1705
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1636
+#: lxc/image.go:1642
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6606,11 +6601,11 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:523
+#: lxc/image.go:528
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1415
+#: lxc/image.go:339 lxc/image.go:1421
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -7073,7 +7068,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1010
 msgid "disabled"
 msgstr ""
 
@@ -7081,7 +7076,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1012
 msgid "enabled"
 msgstr ""
 
@@ -7222,7 +7217,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:398
+#: lxc/image.go:403
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7549,7 +7544,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
+#: lxc/image.go:1000 lxc/image.go:1005 lxc/image.go:1203
 msgid "no"
 msgstr ""
 
@@ -7594,7 +7589,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1194
+#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:1002 lxc/image.go:1007
+#: lxc/image.go:1200
 msgid "yes"
 msgstr ""

--- a/po/ca.po
+++ b/po/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-19 13:11-0600\n"
+"POT-Creation-Date: 2024-09-25 18:38-0600\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Catalan <https://hosted.weblate.org/projects/linux-containers/"
@@ -195,7 +195,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:419
+#: lxc/image.go:424
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -423,7 +423,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1168
+#: lxc/image.go:1174
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -531,7 +531,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:695
+#: lxc/image.go:700
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -544,15 +544,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1138 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1133
+#: lxc/image.go:1139
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1144 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -734,7 +734,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1045
+#: lxc/image.go:1051
 msgid "Aliases:"
 msgstr ""
 
@@ -750,7 +750,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1022 lxc/info.go:486
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -769,11 +769,11 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:342 lxc/rebuild.go:131
+#: lxc/init.go:347 lxc/rebuild.go:136
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/init.go:346
+#: lxc/init.go:351
 msgid "Asked for a container but image is of type VM"
 msgstr ""
 
@@ -831,7 +831,7 @@ msgstr ""
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1061
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -888,7 +888,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:816
+#: lxc/image.go:821
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -969,7 +969,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1060
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -990,7 +990,7 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:239 lxc/utils.go:259
+#: lxc/utils.go:227 lxc/utils.go:247
 #, c-format
 msgid "Can't read from stdin: %w"
 msgstr ""
@@ -1024,7 +1024,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:166
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1176,7 +1176,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1589
+#: lxc/image.go:1121 lxc/list.go:132 lxc/storage_volume.go:1589
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1215,7 +1215,7 @@ msgstr ""
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1327 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/config_trust.go:314 lxc/image.go:496 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
@@ -1309,7 +1309,7 @@ msgstr ""
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1489,7 +1489,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1475
+#: lxc/image.go:1029 lxc/info.go:497 lxc/storage_volume.go:1475
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1513,7 +1513,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1143 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -1571,7 +1571,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:341 lxc/image.go:342
 msgid "Delete images"
 msgstr ""
 
@@ -1674,9 +1674,9 @@ msgstr ""
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
 #: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
-#: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
-#: lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090 lxc/image.go:1417
-#: lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638 lxc/image.go:1701
+#: lxc/image.go:159 lxc/image.go:342 lxc/image.go:401 lxc/image.go:530
+#: lxc/image.go:702 lxc/image.go:954 lxc/image.go:1096 lxc/image.go:1423
+#: lxc/image.go:1514 lxc/image.go:1580 lxc/image.go:1644 lxc/image.go:1707
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
@@ -1821,11 +1821,11 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:406
+#: lxc/init.go:411
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:726
+#: lxc/image.go:731
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1929,7 +1929,7 @@ msgstr ""
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:400 lxc/image.go:401
 msgid "Edit image properties"
 msgstr ""
 
@@ -2005,7 +2005,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1766
+#: lxc/image.go:1155 lxc/list.go:622 lxc/storage_volume.go:1766
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2124,20 +2124,20 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:1029
+#: lxc/image.go:1035
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1037
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:524
+#: lxc/image.go:529
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:530
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2165,7 +2165,7 @@ msgstr ""
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:604
+#: lxc/image.go:609
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2178,7 +2178,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
+#: lxc/config_trust.go:411 lxc/image.go:1140 lxc/image.go:1141
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2197,12 +2197,12 @@ msgstr ""
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/utils.go:296
+#: lxc/utils.go:284
 #, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/utils.go:288
+#: lxc/utils.go:276
 #, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
@@ -2296,7 +2296,7 @@ msgstr ""
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: lxc/utils.go:214
+#: lxc/utils.go:202
 #, c-format
 msgid "Failed to create alias %s: %w"
 msgstr ""
@@ -2321,11 +2321,6 @@ msgstr ""
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
 
-#: lxc/utils.go:203
-#, c-format
-msgid "Failed to remove alias %s: %w"
-msgstr ""
-
 #: lxc/file.go:821
 #, c-format
 msgid "Failed to walk path for %s: %s"
@@ -2345,7 +2340,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:1014
+#: lxc/image.go:1020
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2409,7 +2404,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:770 lxc/auth.go:1697
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1122 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:57
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2484,7 +2479,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1573 lxc/image.go:1574
+#: lxc/image.go:1579 lxc/image.go:1580
 msgid "Get image properties"
 msgstr ""
 
@@ -2758,11 +2753,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1489
+#: lxc/image.go:1495
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2770,25 +2765,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:680
+#: lxc/image.go:685
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1444
+#: lxc/image.go:369 lxc/image.go:1450
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1670
+#: lxc/image.go:449 lxc/image.go:1676
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:918
+#: lxc/image.go:923
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1493
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2808,7 +2803,7 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:697
+#: lxc/image.go:702
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -2818,7 +2813,7 @@ msgid ""
 "os=Ubuntu release=noble variant=cloud."
 msgstr ""
 
-#: lxc/image.go:696
+#: lxc/image.go:701
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2869,7 +2864,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:417
+#: lxc/init.go:422
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2935,7 +2930,7 @@ msgstr ""
 msgid "Invalid instance path: %q"
 msgstr ""
 
-#: lxc/utils.go:253
+#: lxc/utils.go:241
 #, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr ""
@@ -3047,12 +3042,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:1035
+#: lxc/image.go:1041
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:1037
+#: lxc/image.go:1043
 msgid "Last used: never"
 msgstr ""
 
@@ -3170,11 +3165,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1089
+#: lxc/image.go:1095
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1096
 msgid ""
 "List images\n"
 "\n"
@@ -3468,7 +3463,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:165 lxc/image.go:709
 msgid "Make image public"
 msgstr ""
 
@@ -3982,7 +3977,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:728
+#: lxc/image.go:733
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4175,7 +4170,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:168 lxc/image.go:710
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4255,7 +4250,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:805
+#: lxc/image.go:810
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4326,7 +4321,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:752
+#: lxc/image.go:1142 lxc/remote.go:752
 msgid "PUBLIC"
 msgstr ""
 
@@ -4387,7 +4382,7 @@ msgstr ""
 #: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/config_trust.go:315 lxc/image.go:497 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
@@ -4475,11 +4470,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1067
+#: lxc/image.go:1073
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1065
+#: lxc/image.go:1071
 msgid "Profiles: "
 msgstr ""
 
@@ -4502,11 +4497,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1046
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1621
+#: lxc/image.go:1627
 msgid "Property not found"
 msgstr ""
 
@@ -4600,7 +4595,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1024
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4636,7 +4631,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
+#: lxc/image.go:535 lxc/image.go:957 lxc/image.go:1517
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4673,7 +4668,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1416 lxc/image.go:1417
+#: lxc/image.go:1422 lxc/image.go:1423
 msgid "Refresh images"
 msgstr ""
 
@@ -4682,7 +4677,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1453
+#: lxc/image.go:1459
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4945,7 +4940,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:365
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -4978,7 +4973,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1139
+#: lxc/image.go:1145
 msgid "SIZE"
 msgstr ""
 
@@ -5101,7 +5096,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1637 lxc/image.go:1638
+#: lxc/image.go:1643 lxc/image.go:1644
 msgid "Set image properties"
 msgstr ""
 
@@ -5394,7 +5389,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1507 lxc/image.go:1508
+#: lxc/image.go:1513 lxc/image.go:1514
 msgid "Show image properties"
 msgstr ""
 
@@ -5528,7 +5523,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:953 lxc/image.go:954
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5540,7 +5535,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1021
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5572,7 +5567,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:1058
+#: lxc/image.go:1064
 msgid "Source:"
 msgstr ""
 
@@ -5720,7 +5715,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
 #: lxc/storage_volume.go:1730 lxc/warning.go:216
@@ -5785,7 +5780,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:438
+#: lxc/init.go:443
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5794,12 +5789,12 @@ msgstr ""
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
 
-#: lxc/utils.go:376
+#: lxc/utils.go:364
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:%q' instead."
 msgstr ""
 
-#: lxc/utils.go:372
+#: lxc/utils.go:360
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
@@ -5942,15 +5937,15 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1025
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:440
+#: lxc/init.go:445
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:439
+#: lxc/init.go:444
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6004,7 +5999,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:827
+#: lxc/image.go:832
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
@@ -6042,7 +6037,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1023 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1455
 #, c-format
 msgid "Type: %s"
@@ -6057,7 +6052,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1140
+#: lxc/image.go:1146
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6103,7 +6098,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:631 lxc/storage_volume.go:1772
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6145,7 +6140,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1700 lxc/image.go:1701
+#: lxc/image.go:1706 lxc/image.go:1707
 msgid "Unset image properties"
 msgstr ""
 
@@ -6296,7 +6291,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1032
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6469,7 +6464,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1087 lxc/list.go:46
+#: lxc/image.go:1093 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6582,15 +6577,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
+#: lxc/image.go:399 lxc/image.go:952 lxc/image.go:1512
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1572 lxc/image.go:1699
+#: lxc/image.go:1578 lxc/image.go:1705
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1636
+#: lxc/image.go:1642
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6606,11 +6601,11 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:523
+#: lxc/image.go:528
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1415
+#: lxc/image.go:339 lxc/image.go:1421
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -7073,7 +7068,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1010
 msgid "disabled"
 msgstr ""
 
@@ -7081,7 +7076,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1012
 msgid "enabled"
 msgstr ""
 
@@ -7222,7 +7217,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:398
+#: lxc/image.go:403
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7549,7 +7544,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
+#: lxc/image.go:1000 lxc/image.go:1005 lxc/image.go:1203
 msgid "no"
 msgstr ""
 
@@ -7594,7 +7589,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1194
+#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:1002 lxc/image.go:1007
+#: lxc/image.go:1200
 msgid "yes"
 msgstr ""

--- a/po/cs.po
+++ b/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-19 13:11-0600\n"
+"POT-Creation-Date: 2024-09-25 18:38-0600\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Czech <https://hosted.weblate.org/projects/linux-containers/"
@@ -195,7 +195,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:419
+#: lxc/image.go:424
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -423,7 +423,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1168
+#: lxc/image.go:1174
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -531,7 +531,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:695
+#: lxc/image.go:700
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -544,15 +544,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1138 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1133
+#: lxc/image.go:1139
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1144 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -734,7 +734,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1045
+#: lxc/image.go:1051
 msgid "Aliases:"
 msgstr ""
 
@@ -750,7 +750,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1022 lxc/info.go:486
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -769,11 +769,11 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:342 lxc/rebuild.go:131
+#: lxc/init.go:347 lxc/rebuild.go:136
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/init.go:346
+#: lxc/init.go:351
 msgid "Asked for a container but image is of type VM"
 msgstr ""
 
@@ -831,7 +831,7 @@ msgstr ""
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1061
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -888,7 +888,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:816
+#: lxc/image.go:821
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -969,7 +969,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1060
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -990,7 +990,7 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:239 lxc/utils.go:259
+#: lxc/utils.go:227 lxc/utils.go:247
 #, c-format
 msgid "Can't read from stdin: %w"
 msgstr ""
@@ -1024,7 +1024,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:166
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1176,7 +1176,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1589
+#: lxc/image.go:1121 lxc/list.go:132 lxc/storage_volume.go:1589
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1215,7 +1215,7 @@ msgstr ""
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1327 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/config_trust.go:314 lxc/image.go:496 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
@@ -1309,7 +1309,7 @@ msgstr ""
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1489,7 +1489,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1475
+#: lxc/image.go:1029 lxc/info.go:497 lxc/storage_volume.go:1475
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1513,7 +1513,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1143 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -1571,7 +1571,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:341 lxc/image.go:342
 msgid "Delete images"
 msgstr ""
 
@@ -1674,9 +1674,9 @@ msgstr ""
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
 #: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
-#: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
-#: lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090 lxc/image.go:1417
-#: lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638 lxc/image.go:1701
+#: lxc/image.go:159 lxc/image.go:342 lxc/image.go:401 lxc/image.go:530
+#: lxc/image.go:702 lxc/image.go:954 lxc/image.go:1096 lxc/image.go:1423
+#: lxc/image.go:1514 lxc/image.go:1580 lxc/image.go:1644 lxc/image.go:1707
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
@@ -1821,11 +1821,11 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:406
+#: lxc/init.go:411
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:726
+#: lxc/image.go:731
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1929,7 +1929,7 @@ msgstr ""
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:400 lxc/image.go:401
 msgid "Edit image properties"
 msgstr ""
 
@@ -2005,7 +2005,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1766
+#: lxc/image.go:1155 lxc/list.go:622 lxc/storage_volume.go:1766
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2124,20 +2124,20 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:1029
+#: lxc/image.go:1035
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1037
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:524
+#: lxc/image.go:529
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:530
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2165,7 +2165,7 @@ msgstr ""
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:604
+#: lxc/image.go:609
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2178,7 +2178,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
+#: lxc/config_trust.go:411 lxc/image.go:1140 lxc/image.go:1141
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2197,12 +2197,12 @@ msgstr ""
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/utils.go:296
+#: lxc/utils.go:284
 #, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/utils.go:288
+#: lxc/utils.go:276
 #, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
@@ -2296,7 +2296,7 @@ msgstr ""
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: lxc/utils.go:214
+#: lxc/utils.go:202
 #, c-format
 msgid "Failed to create alias %s: %w"
 msgstr ""
@@ -2321,11 +2321,6 @@ msgstr ""
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
 
-#: lxc/utils.go:203
-#, c-format
-msgid "Failed to remove alias %s: %w"
-msgstr ""
-
 #: lxc/file.go:821
 #, c-format
 msgid "Failed to walk path for %s: %s"
@@ -2345,7 +2340,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:1014
+#: lxc/image.go:1020
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2409,7 +2404,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:770 lxc/auth.go:1697
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1122 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:57
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2484,7 +2479,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1573 lxc/image.go:1574
+#: lxc/image.go:1579 lxc/image.go:1580
 msgid "Get image properties"
 msgstr ""
 
@@ -2758,11 +2753,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1489
+#: lxc/image.go:1495
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2770,25 +2765,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:680
+#: lxc/image.go:685
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1444
+#: lxc/image.go:369 lxc/image.go:1450
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1670
+#: lxc/image.go:449 lxc/image.go:1676
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:918
+#: lxc/image.go:923
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1493
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2808,7 +2803,7 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:697
+#: lxc/image.go:702
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -2818,7 +2813,7 @@ msgid ""
 "os=Ubuntu release=noble variant=cloud."
 msgstr ""
 
-#: lxc/image.go:696
+#: lxc/image.go:701
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2869,7 +2864,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:417
+#: lxc/init.go:422
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2935,7 +2930,7 @@ msgstr ""
 msgid "Invalid instance path: %q"
 msgstr ""
 
-#: lxc/utils.go:253
+#: lxc/utils.go:241
 #, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr ""
@@ -3047,12 +3042,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:1035
+#: lxc/image.go:1041
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:1037
+#: lxc/image.go:1043
 msgid "Last used: never"
 msgstr ""
 
@@ -3170,11 +3165,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1089
+#: lxc/image.go:1095
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1096
 msgid ""
 "List images\n"
 "\n"
@@ -3468,7 +3463,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:165 lxc/image.go:709
 msgid "Make image public"
 msgstr ""
 
@@ -3982,7 +3977,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:728
+#: lxc/image.go:733
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4175,7 +4170,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:168 lxc/image.go:710
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4255,7 +4250,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:805
+#: lxc/image.go:810
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4326,7 +4321,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:752
+#: lxc/image.go:1142 lxc/remote.go:752
 msgid "PUBLIC"
 msgstr ""
 
@@ -4387,7 +4382,7 @@ msgstr ""
 #: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/config_trust.go:315 lxc/image.go:497 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
@@ -4475,11 +4470,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1067
+#: lxc/image.go:1073
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1065
+#: lxc/image.go:1071
 msgid "Profiles: "
 msgstr ""
 
@@ -4502,11 +4497,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1046
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1621
+#: lxc/image.go:1627
 msgid "Property not found"
 msgstr ""
 
@@ -4600,7 +4595,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1024
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4636,7 +4631,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
+#: lxc/image.go:535 lxc/image.go:957 lxc/image.go:1517
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4673,7 +4668,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1416 lxc/image.go:1417
+#: lxc/image.go:1422 lxc/image.go:1423
 msgid "Refresh images"
 msgstr ""
 
@@ -4682,7 +4677,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1453
+#: lxc/image.go:1459
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4945,7 +4940,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:365
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -4978,7 +4973,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1139
+#: lxc/image.go:1145
 msgid "SIZE"
 msgstr ""
 
@@ -5101,7 +5096,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1637 lxc/image.go:1638
+#: lxc/image.go:1643 lxc/image.go:1644
 msgid "Set image properties"
 msgstr ""
 
@@ -5394,7 +5389,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1507 lxc/image.go:1508
+#: lxc/image.go:1513 lxc/image.go:1514
 msgid "Show image properties"
 msgstr ""
 
@@ -5528,7 +5523,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:953 lxc/image.go:954
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5540,7 +5535,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1021
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5572,7 +5567,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:1058
+#: lxc/image.go:1064
 msgid "Source:"
 msgstr ""
 
@@ -5720,7 +5715,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
 #: lxc/storage_volume.go:1730 lxc/warning.go:216
@@ -5785,7 +5780,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:438
+#: lxc/init.go:443
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5794,12 +5789,12 @@ msgstr ""
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
 
-#: lxc/utils.go:376
+#: lxc/utils.go:364
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:%q' instead."
 msgstr ""
 
-#: lxc/utils.go:372
+#: lxc/utils.go:360
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
@@ -5942,15 +5937,15 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1025
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:440
+#: lxc/init.go:445
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:439
+#: lxc/init.go:444
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6004,7 +5999,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:827
+#: lxc/image.go:832
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
@@ -6042,7 +6037,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1023 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1455
 #, c-format
 msgid "Type: %s"
@@ -6057,7 +6052,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1140
+#: lxc/image.go:1146
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6103,7 +6098,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:631 lxc/storage_volume.go:1772
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6145,7 +6140,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1700 lxc/image.go:1701
+#: lxc/image.go:1706 lxc/image.go:1707
 msgid "Unset image properties"
 msgstr ""
 
@@ -6296,7 +6291,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1032
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6469,7 +6464,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1087 lxc/list.go:46
+#: lxc/image.go:1093 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6582,15 +6577,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
+#: lxc/image.go:399 lxc/image.go:952 lxc/image.go:1512
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1572 lxc/image.go:1699
+#: lxc/image.go:1578 lxc/image.go:1705
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1636
+#: lxc/image.go:1642
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6606,11 +6601,11 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:523
+#: lxc/image.go:528
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1415
+#: lxc/image.go:339 lxc/image.go:1421
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -7073,7 +7068,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1010
 msgid "disabled"
 msgstr ""
 
@@ -7081,7 +7076,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1012
 msgid "enabled"
 msgstr ""
 
@@ -7222,7 +7217,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:398
+#: lxc/image.go:403
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7549,7 +7544,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
+#: lxc/image.go:1000 lxc/image.go:1005 lxc/image.go:1203
 msgid "no"
 msgstr ""
 
@@ -7594,7 +7589,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1194
+#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:1002 lxc/image.go:1007
+#: lxc/image.go:1200
 msgid "yes"
 msgstr ""

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-19 13:11-0600\n"
+"POT-Creation-Date: 2024-09-25 18:38-0600\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Krombel <krombel@krombel.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/linux-containers/"
@@ -267,7 +267,7 @@ msgstr ""
 "### Zum Beispiel:\n"
 "###  description: Mein eigenes Abbild\n"
 
-#: lxc/image.go:419
+#: lxc/image.go:424
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the image properties.\n"
@@ -672,7 +672,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr "%d (ID: %d, Online: %v, NUMA-Knoten: %v)"
 
-#: lxc/image.go:1168
+#: lxc/image.go:1174
 #, c-format
 msgid "%s (%d more)"
 msgstr "%s (%d mehr)"
@@ -795,7 +795,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/image.go:695
+#: lxc/image.go:700
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -808,15 +808,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1138 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr "ALIAS"
 
-#: lxc/image.go:1133
+#: lxc/image.go:1139
 msgid "ALIASES"
 msgstr "ALIASES"
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1144 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr "ARCHITEKTUR"
 
@@ -1008,7 +1008,7 @@ msgstr "Aliasname fehlt"
 msgid "Aliases already exists: %s"
 msgstr "entfernte Instanz %s existiert bereits"
 
-#: lxc/image.go:1045
+#: lxc/image.go:1051
 #, fuzzy
 msgid "Aliases:"
 msgstr "Aliasse:\n"
@@ -1027,7 +1027,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1022 lxc/info.go:486
 #, fuzzy, c-format
 msgid "Architecture: %s"
 msgstr "Architektur: %s\n"
@@ -1046,11 +1046,11 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:342 lxc/rebuild.go:131
+#: lxc/init.go:347 lxc/rebuild.go:136
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/init.go:346
+#: lxc/init.go:351
 msgid "Asked for a container but image is of type VM"
 msgstr ""
 
@@ -1114,7 +1114,7 @@ msgstr ""
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1061
 #, c-format
 msgid "Auto update: %s"
 msgstr "automatisches Update: %s"
@@ -1173,7 +1173,7 @@ msgstr "Alternatives config Verzeichnis."
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:816
+#: lxc/image.go:821
 #, fuzzy, c-format
 msgid "Bad property: %s"
 msgstr "Ungültige Abbild Eigenschaft: %s\n"
@@ -1256,7 +1256,7 @@ msgstr "ERSTELLT AM"
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1060
 #, fuzzy, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -1286,7 +1286,7 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:239 lxc/utils.go:259
+#: lxc/utils.go:227 lxc/utils.go:247
 #, c-format
 msgid "Can't read from stdin: %w"
 msgstr ""
@@ -1320,7 +1320,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:166
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1478,7 +1478,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1589
+#: lxc/image.go:1121 lxc/list.go:132 lxc/storage_volume.go:1589
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr "Spalten"
@@ -1520,7 +1520,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1327 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/config_trust.go:314 lxc/image.go:496 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
@@ -1618,7 +1618,7 @@ msgstr ""
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1819,7 +1819,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Create the instance with no profiles applied"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1475
+#: lxc/image.go:1029 lxc/info.go:497 lxc/storage_volume.go:1475
 #, c-format
 msgid "Created: %s"
 msgstr "Erstellt: %s"
@@ -1844,7 +1844,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1143 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -1904,7 +1904,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:341 lxc/image.go:342
 msgid "Delete images"
 msgstr ""
 
@@ -2016,9 +2016,9 @@ msgstr ""
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
 #: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
-#: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
-#: lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090 lxc/image.go:1417
-#: lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638 lxc/image.go:1701
+#: lxc/image.go:159 lxc/image.go:342 lxc/image.go:401 lxc/image.go:530
+#: lxc/image.go:702 lxc/image.go:954 lxc/image.go:1096 lxc/image.go:1423
+#: lxc/image.go:1514 lxc/image.go:1580 lxc/image.go:1644 lxc/image.go:1707
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
@@ -2171,13 +2171,13 @@ msgstr ""
 "Optionen:\n"
 "\n"
 
-#: lxc/init.go:406
+#: lxc/init.go:411
 #, fuzzy
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 "Falsche Anzahl an Objekten im Abbild, Container oder Sicherungspunkt gelesen."
 
-#: lxc/image.go:726
+#: lxc/image.go:731
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -2290,7 +2290,7 @@ msgstr "Alternatives config Verzeichnis."
 msgid "Edit identity provider groups as YAML"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:400 lxc/image.go:401
 msgid "Edit image properties"
 msgstr ""
 
@@ -2378,7 +2378,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1766
+#: lxc/image.go:1155 lxc/list.go:622 lxc/storage_volume.go:1766
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2507,20 +2507,20 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:1029
+#: lxc/image.go:1035
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1037
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:524
+#: lxc/image.go:529
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:530
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2552,7 +2552,7 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Exporting the backup: %s"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/image.go:604
+#: lxc/image.go:609
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2565,7 +2565,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
+#: lxc/config_trust.go:411 lxc/image.go:1140 lxc/image.go:1141
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr "FINGERABDRUCK"
@@ -2584,12 +2584,12 @@ msgstr ""
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/utils.go:296
+#: lxc/utils.go:284
 #, fuzzy, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/utils.go:288
+#: lxc/utils.go:276
 #, fuzzy, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -2683,7 +2683,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: lxc/utils.go:214
+#: lxc/utils.go:202
 #, fuzzy, c-format
 msgid "Failed to create alias %s: %w"
 msgstr "Akzeptiere Zertifikat"
@@ -2708,11 +2708,6 @@ msgstr "Akzeptiere Zertifikat"
 msgid "Failed to refresh target instance '%s': %v"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/utils.go:203
-#, fuzzy, c-format
-msgid "Failed to remove alias %s: %w"
-msgstr "Akzeptiere Zertifikat"
-
 #: lxc/file.go:821
 #, c-format
 msgid "Failed to walk path for %s: %s"
@@ -2735,7 +2730,7 @@ msgstr ""
 "Anzeigen von Informationen über entfernte Instanzen wird noch nicht "
 "unterstützt\n"
 
-#: lxc/image.go:1014
+#: lxc/image.go:1020
 #, fuzzy, c-format
 msgid "Fingerprint: %s"
 msgstr "Fingerabdruck: %s\n"
@@ -2800,7 +2795,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:770 lxc/auth.go:1697
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1122 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:57
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2877,7 +2872,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1573 lxc/image.go:1574
+#: lxc/image.go:1579 lxc/image.go:1580
 msgid "Get image properties"
 msgstr ""
 
@@ -3174,11 +3169,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/image.go:1489
+#: lxc/image.go:1495
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -3186,25 +3181,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:680
+#: lxc/image.go:685
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1444
+#: lxc/image.go:369 lxc/image.go:1450
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1670
+#: lxc/image.go:449 lxc/image.go:1676
 #, fuzzy, c-format
 msgid "Image identifier missing: %s"
 msgstr "Abbild mit Fingerabdruck %s importiert\n"
 
-#: lxc/image.go:918
+#: lxc/image.go:923
 #, fuzzy, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr "Abbild mit Fingerabdruck %s importiert\n"
 
-#: lxc/image.go:1487
+#: lxc/image.go:1493
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3226,7 +3221,7 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/image.go:697
+#: lxc/image.go:702
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -3236,7 +3231,7 @@ msgid ""
 "os=Ubuntu release=noble variant=cloud."
 msgstr ""
 
-#: lxc/image.go:696
+#: lxc/image.go:701
 msgid "Import images into the image store"
 msgstr ""
 
@@ -3289,7 +3284,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:417
+#: lxc/init.go:422
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -3356,7 +3351,7 @@ msgstr "Ungültige Quelle %s"
 msgid "Invalid instance path: %q"
 msgstr "Ungültige Quelle %s"
 
-#: lxc/utils.go:253
+#: lxc/utils.go:241
 #, fuzzy, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr "Alternatives config Verzeichnis."
@@ -3475,12 +3470,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr "Erstellt: %s"
 
-#: lxc/image.go:1035
+#: lxc/image.go:1041
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:1037
+#: lxc/image.go:1043
 msgid "Last used: never"
 msgstr ""
 
@@ -3607,11 +3602,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1089
+#: lxc/image.go:1095
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1096
 msgid ""
 "List images\n"
 "\n"
@@ -3935,7 +3930,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:165 lxc/image.go:709
 msgid "Make image public"
 msgstr "Veröffentliche Abbild"
 
@@ -4510,7 +4505,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:728
+#: lxc/image.go:733
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4706,7 +4701,7 @@ msgstr "Profil %s gelöscht\n"
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:168 lxc/image.go:710
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4790,7 +4785,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:805
+#: lxc/image.go:810
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4861,7 +4856,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:752
+#: lxc/image.go:1142 lxc/remote.go:752
 msgid "PUBLIC"
 msgstr ""
 
@@ -4925,7 +4920,7 @@ msgstr ""
 #: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/config_trust.go:315 lxc/image.go:497 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
@@ -5016,12 +5011,12 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Profiles %s applied to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
 
-#: lxc/image.go:1067
+#: lxc/image.go:1073
 #, fuzzy
 msgid "Profiles:"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/image.go:1065
+#: lxc/image.go:1071
 #, fuzzy
 msgid "Profiles: "
 msgstr "Profil %s erstellt\n"
@@ -5045,12 +5040,12 @@ msgstr "Profil %s wurde auf %s angewandt\n"
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1046
 #, fuzzy
 msgid "Properties:"
 msgstr "Eigenschaften:\n"
 
-#: lxc/image.go:1621
+#: lxc/image.go:1627
 msgid "Property not found"
 msgstr ""
 
@@ -5144,7 +5139,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1024
 #, fuzzy, c-format
 msgid "Public: %s"
 msgstr "Öffentlich: %s\n"
@@ -5183,7 +5178,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
+#: lxc/image.go:535 lxc/image.go:957 lxc/image.go:1517
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -5223,7 +5218,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/image.go:1416 lxc/image.go:1417
+#: lxc/image.go:1422 lxc/image.go:1423
 msgid "Refresh images"
 msgstr ""
 
@@ -5232,7 +5227,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/image.go:1453
+#: lxc/image.go:1459
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5522,7 +5517,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/init.go:360
+#: lxc/init.go:365
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5558,7 +5553,7 @@ msgstr "Fehlerhafte Profil URL %s"
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1139
+#: lxc/image.go:1145
 msgid "SIZE"
 msgstr ""
 
@@ -5686,7 +5681,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1637 lxc/image.go:1638
+#: lxc/image.go:1643 lxc/image.go:1644
 msgid "Set image properties"
 msgstr ""
 
@@ -6002,7 +5997,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1507 lxc/image.go:1508
+#: lxc/image.go:1513 lxc/image.go:1514
 msgid "Show image properties"
 msgstr ""
 
@@ -6155,7 +6150,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Show useful information about a cluster member"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:953 lxc/image.go:954
 msgid "Show useful information about images"
 msgstr ""
 
@@ -6167,7 +6162,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1021
 #, fuzzy, c-format
 msgid "Size: %.2fMiB"
 msgstr "Größe: %.2vMB\n"
@@ -6200,7 +6195,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/image.go:1058
+#: lxc/image.go:1064
 msgid "Source:"
 msgstr ""
 
@@ -6356,7 +6351,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
 #: lxc/storage_volume.go:1730 lxc/warning.go:216
@@ -6426,7 +6421,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:438
+#: lxc/init.go:443
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -6435,12 +6430,12 @@ msgstr ""
 msgid "The key %q does not exist on cluster member %q"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/utils.go:376
+#: lxc/utils.go:364
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:%q' instead."
 msgstr ""
 
-#: lxc/utils.go:372
+#: lxc/utils.go:360
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
@@ -6588,16 +6583,16 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr "Wartezeit bevor der Container gestoppt wird."
 
-#: lxc/image.go:1019
+#: lxc/image.go:1025
 #, fuzzy
 msgid "Timestamps:"
 msgstr "Zeitstempel:\n"
 
-#: lxc/init.go:440
+#: lxc/init.go:445
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:439
+#: lxc/init.go:444
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6651,7 +6646,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:827
+#: lxc/image.go:832
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
@@ -6690,7 +6685,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1023 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1455
 #, c-format
 msgid "Type: %s"
@@ -6705,7 +6700,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1140
+#: lxc/image.go:1146
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6752,7 +6747,7 @@ msgstr "Unbekannter Befehl %s für Abbild"
 msgid "Unknown channel type for client %q: %s"
 msgstr "Unbekannter Befehl %s für Abbild"
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:631 lxc/storage_volume.go:1772
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6798,7 +6793,7 @@ msgstr "nicht alle Profile der Quelle sind am Ziel vorhanden."
 msgid "Unset device configuration keys"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/image.go:1700 lxc/image.go:1701
+#: lxc/image.go:1706 lxc/image.go:1707
 msgid "Unset image properties"
 msgstr ""
 
@@ -6972,7 +6967,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1032
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -7189,7 +7184,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/image.go:1087 lxc/list.go:46
+#: lxc/image.go:1093 lxc/list.go:46
 #, fuzzy
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
@@ -7404,7 +7399,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
+#: lxc/image.go:399 lxc/image.go:952 lxc/image.go:1512
 #, fuzzy
 msgid "[<remote>:]<image>"
 msgstr ""
@@ -7413,7 +7408,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/image.go:1572 lxc/image.go:1699
+#: lxc/image.go:1578 lxc/image.go:1705
 #, fuzzy
 msgid "[<remote>:]<image> <key>"
 msgstr ""
@@ -7422,7 +7417,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/image.go:1636
+#: lxc/image.go:1642
 #, fuzzy
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
@@ -7454,7 +7449,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/image.go:523
+#: lxc/image.go:528
 #, fuzzy
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
@@ -7462,7 +7457,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/image.go:334 lxc/image.go:1415
+#: lxc/image.go:339 lxc/image.go:1421
 #, fuzzy
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
@@ -8379,7 +8374,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1010
 msgid "disabled"
 msgstr ""
 
@@ -8387,7 +8382,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1012
 msgid "enabled"
 msgstr ""
 
@@ -8528,7 +8523,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:398
+#: lxc/image.go:403
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -8859,7 +8854,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
+#: lxc/image.go:1000 lxc/image.go:1005 lxc/image.go:1203
 msgid "no"
 msgstr ""
 
@@ -8904,10 +8899,14 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1194
+#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:1002 lxc/image.go:1007
+#: lxc/image.go:1200
 msgid "yes"
 msgstr ""
+
+#, fuzzy, c-format
+#~ msgid "Failed to remove alias %s: %w"
+#~ msgstr "Akzeptiere Zertifikat"
 
 #, fuzzy
 #~ msgid "Make the image public"

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-19 13:11-0600\n"
+"POT-Creation-Date: 2024-09-25 18:38-0600\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/linux-containers/"
@@ -195,7 +195,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:419
+#: lxc/image.go:424
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -423,7 +423,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1168
+#: lxc/image.go:1174
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -531,7 +531,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:695
+#: lxc/image.go:700
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -544,15 +544,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1138 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1133
+#: lxc/image.go:1139
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1144 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -737,7 +737,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1045
+#: lxc/image.go:1051
 msgid "Aliases:"
 msgstr ""
 
@@ -753,7 +753,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1022 lxc/info.go:486
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -772,11 +772,11 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:342 lxc/rebuild.go:131
+#: lxc/init.go:347 lxc/rebuild.go:136
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/init.go:346
+#: lxc/init.go:351
 msgid "Asked for a container but image is of type VM"
 msgstr ""
 
@@ -834,7 +834,7 @@ msgstr ""
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1061
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -891,7 +891,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:816
+#: lxc/image.go:821
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -973,7 +973,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1060
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -994,7 +994,7 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:239 lxc/utils.go:259
+#: lxc/utils.go:227 lxc/utils.go:247
 #, c-format
 msgid "Can't read from stdin: %w"
 msgstr ""
@@ -1028,7 +1028,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:166
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1180,7 +1180,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1589
+#: lxc/image.go:1121 lxc/list.go:132 lxc/storage_volume.go:1589
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1219,7 +1219,7 @@ msgstr ""
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1327 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/config_trust.go:314 lxc/image.go:496 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
@@ -1313,7 +1313,7 @@ msgstr ""
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1496,7 +1496,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1475
+#: lxc/image.go:1029 lxc/info.go:497 lxc/storage_volume.go:1475
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1520,7 +1520,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1143 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -1579,7 +1579,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:341 lxc/image.go:342
 msgid "Delete images"
 msgstr ""
 
@@ -1686,9 +1686,9 @@ msgstr ""
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
 #: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
-#: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
-#: lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090 lxc/image.go:1417
-#: lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638 lxc/image.go:1701
+#: lxc/image.go:159 lxc/image.go:342 lxc/image.go:401 lxc/image.go:530
+#: lxc/image.go:702 lxc/image.go:954 lxc/image.go:1096 lxc/image.go:1423
+#: lxc/image.go:1514 lxc/image.go:1580 lxc/image.go:1644 lxc/image.go:1707
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
@@ -1834,11 +1834,11 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:406
+#: lxc/init.go:411
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:726
+#: lxc/image.go:731
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1946,7 +1946,7 @@ msgstr ""
 msgid "Edit identity provider groups as YAML"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:400 lxc/image.go:401
 msgid "Edit image properties"
 msgstr ""
 
@@ -2027,7 +2027,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1766
+#: lxc/image.go:1155 lxc/list.go:622 lxc/storage_volume.go:1766
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2146,20 +2146,20 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:1029
+#: lxc/image.go:1035
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1037
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:524
+#: lxc/image.go:529
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:530
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2187,7 +2187,7 @@ msgstr ""
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:604
+#: lxc/image.go:609
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2200,7 +2200,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
+#: lxc/config_trust.go:411 lxc/image.go:1140 lxc/image.go:1141
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2219,12 +2219,12 @@ msgstr ""
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/utils.go:296
+#: lxc/utils.go:284
 #, fuzzy, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/utils.go:288
+#: lxc/utils.go:276
 #, fuzzy, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "  Χρήση δικτύου:"
@@ -2318,7 +2318,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: lxc/utils.go:214
+#: lxc/utils.go:202
 #, c-format
 msgid "Failed to create alias %s: %w"
 msgstr ""
@@ -2343,11 +2343,6 @@ msgstr ""
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
 
-#: lxc/utils.go:203
-#, c-format
-msgid "Failed to remove alias %s: %w"
-msgstr ""
-
 #: lxc/file.go:821
 #, c-format
 msgid "Failed to walk path for %s: %s"
@@ -2367,7 +2362,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:1014
+#: lxc/image.go:1020
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2431,7 +2426,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:770 lxc/auth.go:1697
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1122 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:57
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2506,7 +2501,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1573 lxc/image.go:1574
+#: lxc/image.go:1579 lxc/image.go:1580
 msgid "Get image properties"
 msgstr ""
 
@@ -2793,11 +2788,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1489
+#: lxc/image.go:1495
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2805,25 +2800,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:680
+#: lxc/image.go:685
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1444
+#: lxc/image.go:369 lxc/image.go:1450
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1670
+#: lxc/image.go:449 lxc/image.go:1676
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:918
+#: lxc/image.go:923
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1493
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2843,7 +2838,7 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:697
+#: lxc/image.go:702
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -2853,7 +2848,7 @@ msgid ""
 "os=Ubuntu release=noble variant=cloud."
 msgstr ""
 
-#: lxc/image.go:696
+#: lxc/image.go:701
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2904,7 +2899,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:417
+#: lxc/init.go:422
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2970,7 +2965,7 @@ msgstr ""
 msgid "Invalid instance path: %q"
 msgstr ""
 
-#: lxc/utils.go:253
+#: lxc/utils.go:241
 #, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr ""
@@ -3082,12 +3077,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:1035
+#: lxc/image.go:1041
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:1037
+#: lxc/image.go:1043
 msgid "Last used: never"
 msgstr ""
 
@@ -3207,11 +3202,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1089
+#: lxc/image.go:1095
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1096
 msgid ""
 "List images\n"
 "\n"
@@ -3505,7 +3500,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:165 lxc/image.go:709
 msgid "Make image public"
 msgstr ""
 
@@ -4044,7 +4039,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:728
+#: lxc/image.go:733
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4239,7 +4234,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:168 lxc/image.go:710
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4319,7 +4314,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:805
+#: lxc/image.go:810
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4390,7 +4385,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:752
+#: lxc/image.go:1142 lxc/remote.go:752
 msgid "PUBLIC"
 msgstr ""
 
@@ -4452,7 +4447,7 @@ msgstr ""
 #: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/config_trust.go:315 lxc/image.go:497 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
@@ -4540,11 +4535,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1067
+#: lxc/image.go:1073
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1065
+#: lxc/image.go:1071
 msgid "Profiles: "
 msgstr ""
 
@@ -4567,11 +4562,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1046
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1621
+#: lxc/image.go:1627
 msgid "Property not found"
 msgstr ""
 
@@ -4665,7 +4660,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1024
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4701,7 +4696,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
+#: lxc/image.go:535 lxc/image.go:957 lxc/image.go:1517
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4738,7 +4733,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1416 lxc/image.go:1417
+#: lxc/image.go:1422 lxc/image.go:1423
 msgid "Refresh images"
 msgstr ""
 
@@ -4747,7 +4742,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1453
+#: lxc/image.go:1459
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5015,7 +5010,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:365
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5049,7 +5044,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1139
+#: lxc/image.go:1145
 msgid "SIZE"
 msgstr ""
 
@@ -5173,7 +5168,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1637 lxc/image.go:1638
+#: lxc/image.go:1643 lxc/image.go:1644
 msgid "Set image properties"
 msgstr ""
 
@@ -5480,7 +5475,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1507 lxc/image.go:1508
+#: lxc/image.go:1513 lxc/image.go:1514
 msgid "Show image properties"
 msgstr ""
 
@@ -5623,7 +5618,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:953 lxc/image.go:954
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5635,7 +5630,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1021
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5667,7 +5662,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:1058
+#: lxc/image.go:1064
 msgid "Source:"
 msgstr ""
 
@@ -5815,7 +5810,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
 #: lxc/storage_volume.go:1730 lxc/warning.go:216
@@ -5880,7 +5875,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:438
+#: lxc/init.go:443
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5889,12 +5884,12 @@ msgstr ""
 msgid "The key %q does not exist on cluster member %q"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/utils.go:376
+#: lxc/utils.go:364
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:%q' instead."
 msgstr ""
 
-#: lxc/utils.go:372
+#: lxc/utils.go:360
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
@@ -6038,15 +6033,15 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1025
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:440
+#: lxc/init.go:445
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:439
+#: lxc/init.go:444
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6100,7 +6095,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:827
+#: lxc/image.go:832
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
@@ -6138,7 +6133,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1023 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1455
 #, c-format
 msgid "Type: %s"
@@ -6153,7 +6148,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1140
+#: lxc/image.go:1146
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6199,7 +6194,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:631 lxc/storage_volume.go:1772
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6242,7 +6237,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1700 lxc/image.go:1701
+#: lxc/image.go:1706 lxc/image.go:1707
 msgid "Unset image properties"
 msgstr ""
 
@@ -6409,7 +6404,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1032
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6582,7 +6577,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1087 lxc/list.go:46
+#: lxc/image.go:1093 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6695,15 +6690,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
+#: lxc/image.go:399 lxc/image.go:952 lxc/image.go:1512
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1572 lxc/image.go:1699
+#: lxc/image.go:1578 lxc/image.go:1705
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1636
+#: lxc/image.go:1642
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6719,11 +6714,11 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:523
+#: lxc/image.go:528
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1415
+#: lxc/image.go:339 lxc/image.go:1421
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -7186,7 +7181,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1010
 msgid "disabled"
 msgstr ""
 
@@ -7194,7 +7189,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1012
 msgid "enabled"
 msgstr ""
 
@@ -7335,7 +7330,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:398
+#: lxc/image.go:403
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7662,7 +7657,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
+#: lxc/image.go:1000 lxc/image.go:1005 lxc/image.go:1203
 msgid "no"
 msgstr ""
 
@@ -7707,8 +7702,8 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1194
+#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:1002 lxc/image.go:1007
+#: lxc/image.go:1200
 msgid "yes"
 msgstr ""
 

--- a/po/eo.po
+++ b/po/eo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-19 13:11-0600\n"
+"POT-Creation-Date: 2024-09-25 18:38-0600\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Esperanto <https://hosted.weblate.org/projects/linux-"
@@ -195,7 +195,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:419
+#: lxc/image.go:424
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -423,7 +423,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1168
+#: lxc/image.go:1174
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -531,7 +531,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:695
+#: lxc/image.go:700
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -544,15 +544,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1138 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1133
+#: lxc/image.go:1139
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1144 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -734,7 +734,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1045
+#: lxc/image.go:1051
 msgid "Aliases:"
 msgstr ""
 
@@ -750,7 +750,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1022 lxc/info.go:486
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -769,11 +769,11 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:342 lxc/rebuild.go:131
+#: lxc/init.go:347 lxc/rebuild.go:136
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/init.go:346
+#: lxc/init.go:351
 msgid "Asked for a container but image is of type VM"
 msgstr ""
 
@@ -831,7 +831,7 @@ msgstr ""
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1061
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -888,7 +888,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:816
+#: lxc/image.go:821
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -969,7 +969,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1060
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -990,7 +990,7 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:239 lxc/utils.go:259
+#: lxc/utils.go:227 lxc/utils.go:247
 #, c-format
 msgid "Can't read from stdin: %w"
 msgstr ""
@@ -1024,7 +1024,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:166
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1176,7 +1176,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1589
+#: lxc/image.go:1121 lxc/list.go:132 lxc/storage_volume.go:1589
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1215,7 +1215,7 @@ msgstr ""
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1327 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/config_trust.go:314 lxc/image.go:496 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
@@ -1309,7 +1309,7 @@ msgstr ""
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1489,7 +1489,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1475
+#: lxc/image.go:1029 lxc/info.go:497 lxc/storage_volume.go:1475
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1513,7 +1513,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1143 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -1571,7 +1571,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:341 lxc/image.go:342
 msgid "Delete images"
 msgstr ""
 
@@ -1674,9 +1674,9 @@ msgstr ""
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
 #: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
-#: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
-#: lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090 lxc/image.go:1417
-#: lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638 lxc/image.go:1701
+#: lxc/image.go:159 lxc/image.go:342 lxc/image.go:401 lxc/image.go:530
+#: lxc/image.go:702 lxc/image.go:954 lxc/image.go:1096 lxc/image.go:1423
+#: lxc/image.go:1514 lxc/image.go:1580 lxc/image.go:1644 lxc/image.go:1707
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
@@ -1821,11 +1821,11 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:406
+#: lxc/init.go:411
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:726
+#: lxc/image.go:731
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1929,7 +1929,7 @@ msgstr ""
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:400 lxc/image.go:401
 msgid "Edit image properties"
 msgstr ""
 
@@ -2005,7 +2005,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1766
+#: lxc/image.go:1155 lxc/list.go:622 lxc/storage_volume.go:1766
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2124,20 +2124,20 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:1029
+#: lxc/image.go:1035
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1037
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:524
+#: lxc/image.go:529
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:530
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2165,7 +2165,7 @@ msgstr ""
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:604
+#: lxc/image.go:609
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2178,7 +2178,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
+#: lxc/config_trust.go:411 lxc/image.go:1140 lxc/image.go:1141
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2197,12 +2197,12 @@ msgstr ""
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/utils.go:296
+#: lxc/utils.go:284
 #, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/utils.go:288
+#: lxc/utils.go:276
 #, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
@@ -2296,7 +2296,7 @@ msgstr ""
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: lxc/utils.go:214
+#: lxc/utils.go:202
 #, c-format
 msgid "Failed to create alias %s: %w"
 msgstr ""
@@ -2321,11 +2321,6 @@ msgstr ""
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
 
-#: lxc/utils.go:203
-#, c-format
-msgid "Failed to remove alias %s: %w"
-msgstr ""
-
 #: lxc/file.go:821
 #, c-format
 msgid "Failed to walk path for %s: %s"
@@ -2345,7 +2340,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:1014
+#: lxc/image.go:1020
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2409,7 +2404,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:770 lxc/auth.go:1697
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1122 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:57
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2484,7 +2479,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1573 lxc/image.go:1574
+#: lxc/image.go:1579 lxc/image.go:1580
 msgid "Get image properties"
 msgstr ""
 
@@ -2758,11 +2753,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1489
+#: lxc/image.go:1495
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2770,25 +2765,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:680
+#: lxc/image.go:685
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1444
+#: lxc/image.go:369 lxc/image.go:1450
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1670
+#: lxc/image.go:449 lxc/image.go:1676
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:918
+#: lxc/image.go:923
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1493
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2808,7 +2803,7 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:697
+#: lxc/image.go:702
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -2818,7 +2813,7 @@ msgid ""
 "os=Ubuntu release=noble variant=cloud."
 msgstr ""
 
-#: lxc/image.go:696
+#: lxc/image.go:701
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2869,7 +2864,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:417
+#: lxc/init.go:422
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2935,7 +2930,7 @@ msgstr ""
 msgid "Invalid instance path: %q"
 msgstr ""
 
-#: lxc/utils.go:253
+#: lxc/utils.go:241
 #, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr ""
@@ -3047,12 +3042,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:1035
+#: lxc/image.go:1041
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:1037
+#: lxc/image.go:1043
 msgid "Last used: never"
 msgstr ""
 
@@ -3170,11 +3165,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1089
+#: lxc/image.go:1095
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1096
 msgid ""
 "List images\n"
 "\n"
@@ -3468,7 +3463,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:165 lxc/image.go:709
 msgid "Make image public"
 msgstr ""
 
@@ -3982,7 +3977,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:728
+#: lxc/image.go:733
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4175,7 +4170,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:168 lxc/image.go:710
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4255,7 +4250,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:805
+#: lxc/image.go:810
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4326,7 +4321,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:752
+#: lxc/image.go:1142 lxc/remote.go:752
 msgid "PUBLIC"
 msgstr ""
 
@@ -4387,7 +4382,7 @@ msgstr ""
 #: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/config_trust.go:315 lxc/image.go:497 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
@@ -4475,11 +4470,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1067
+#: lxc/image.go:1073
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1065
+#: lxc/image.go:1071
 msgid "Profiles: "
 msgstr ""
 
@@ -4502,11 +4497,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1046
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1621
+#: lxc/image.go:1627
 msgid "Property not found"
 msgstr ""
 
@@ -4600,7 +4595,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1024
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4636,7 +4631,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
+#: lxc/image.go:535 lxc/image.go:957 lxc/image.go:1517
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4673,7 +4668,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1416 lxc/image.go:1417
+#: lxc/image.go:1422 lxc/image.go:1423
 msgid "Refresh images"
 msgstr ""
 
@@ -4682,7 +4677,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1453
+#: lxc/image.go:1459
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4945,7 +4940,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:365
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -4978,7 +4973,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1139
+#: lxc/image.go:1145
 msgid "SIZE"
 msgstr ""
 
@@ -5101,7 +5096,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1637 lxc/image.go:1638
+#: lxc/image.go:1643 lxc/image.go:1644
 msgid "Set image properties"
 msgstr ""
 
@@ -5394,7 +5389,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1507 lxc/image.go:1508
+#: lxc/image.go:1513 lxc/image.go:1514
 msgid "Show image properties"
 msgstr ""
 
@@ -5528,7 +5523,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:953 lxc/image.go:954
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5540,7 +5535,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1021
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5572,7 +5567,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:1058
+#: lxc/image.go:1064
 msgid "Source:"
 msgstr ""
 
@@ -5720,7 +5715,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
 #: lxc/storage_volume.go:1730 lxc/warning.go:216
@@ -5785,7 +5780,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:438
+#: lxc/init.go:443
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5794,12 +5789,12 @@ msgstr ""
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
 
-#: lxc/utils.go:376
+#: lxc/utils.go:364
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:%q' instead."
 msgstr ""
 
-#: lxc/utils.go:372
+#: lxc/utils.go:360
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
@@ -5942,15 +5937,15 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1025
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:440
+#: lxc/init.go:445
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:439
+#: lxc/init.go:444
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6004,7 +5999,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:827
+#: lxc/image.go:832
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
@@ -6042,7 +6037,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1023 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1455
 #, c-format
 msgid "Type: %s"
@@ -6057,7 +6052,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1140
+#: lxc/image.go:1146
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6103,7 +6098,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:631 lxc/storage_volume.go:1772
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6145,7 +6140,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1700 lxc/image.go:1701
+#: lxc/image.go:1706 lxc/image.go:1707
 msgid "Unset image properties"
 msgstr ""
 
@@ -6296,7 +6291,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1032
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6469,7 +6464,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1087 lxc/list.go:46
+#: lxc/image.go:1093 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6582,15 +6577,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
+#: lxc/image.go:399 lxc/image.go:952 lxc/image.go:1512
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1572 lxc/image.go:1699
+#: lxc/image.go:1578 lxc/image.go:1705
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1636
+#: lxc/image.go:1642
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6606,11 +6601,11 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:523
+#: lxc/image.go:528
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1415
+#: lxc/image.go:339 lxc/image.go:1421
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -7073,7 +7068,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1010
 msgid "disabled"
 msgstr ""
 
@@ -7081,7 +7076,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1012
 msgid "enabled"
 msgstr ""
 
@@ -7222,7 +7217,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:398
+#: lxc/image.go:403
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7549,7 +7544,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
+#: lxc/image.go:1000 lxc/image.go:1005 lxc/image.go:1203
 msgid "no"
 msgstr ""
 
@@ -7594,7 +7589,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1194
+#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:1002 lxc/image.go:1007
+#: lxc/image.go:1200
 msgid "yes"
 msgstr ""

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-19 13:11-0600\n"
+"POT-Creation-Date: 2024-09-25 18:38-0600\n"
 "PO-Revision-Date: 2023-06-16 20:55+0000\n"
 "Last-Translator: Francisco Serrador <fserrador@gmail.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -269,7 +269,7 @@ msgstr ""
 "###\n"
 "### Observe que la huella se muestra pero no puede modificarse"
 
-#: lxc/image.go:419
+#: lxc/image.go:424
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the image properties.\n"
@@ -660,7 +660,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1168
+#: lxc/image.go:1174
 #, c-format
 msgid "%s (%d more)"
 msgstr "%s (%d más)"
@@ -774,7 +774,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/image.go:695
+#: lxc/image.go:700
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -787,15 +787,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1138 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr "ALIAS"
 
-#: lxc/image.go:1133
+#: lxc/image.go:1139
 msgid "ALIASES"
 msgstr "ALIASES"
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1144 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr "ARQUITECTURA"
 
@@ -981,7 +981,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr "El dispostivo ya existe: %s"
 
-#: lxc/image.go:1045
+#: lxc/image.go:1051
 msgid "Aliases:"
 msgstr "Aliases:"
 
@@ -998,7 +998,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr "Acepta certificado"
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1022 lxc/info.go:486
 #, c-format
 msgid "Architecture: %s"
 msgstr "Arquitectura: %s"
@@ -1017,11 +1017,11 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:342 lxc/rebuild.go:131
+#: lxc/init.go:347 lxc/rebuild.go:136
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/init.go:346
+#: lxc/init.go:351
 msgid "Asked for a container but image is of type VM"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1061
 #, c-format
 msgid "Auto update: %s"
 msgstr "Auto actualización: %s"
@@ -1137,7 +1137,7 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:816
+#: lxc/image.go:821
 #, c-format
 msgid "Bad property: %s"
 msgstr "Propiedad mala: %s"
@@ -1219,7 +1219,7 @@ msgstr "CREADO EN"
 msgid "CUDA Version: %v"
 msgstr "Versión de CUDA: %v"
 
-#: lxc/image.go:1054
+#: lxc/image.go:1060
 #, c-format
 msgid "Cached: %s"
 msgstr "Cacheado: %s"
@@ -1243,7 +1243,7 @@ msgstr "No se puede proporcionar un nombre para la imagen de destino"
 msgid "Can't pull a directory without --recursive"
 msgstr "No se puede jalar un directorio sin - recursivo"
 
-#: lxc/utils.go:239 lxc/utils.go:259
+#: lxc/utils.go:227 lxc/utils.go:247
 #, fuzzy, c-format
 msgid "Can't read from stdin: %w"
 msgstr "No se peude leer desde stdin: %s"
@@ -1278,7 +1278,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:166
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1589
+#: lxc/image.go:1121 lxc/list.go:132 lxc/storage_volume.go:1589
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr "Columnas"
@@ -1473,7 +1473,7 @@ msgstr "Perfil para aplicar al nuevo contenedor"
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1327 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/config_trust.go:314 lxc/image.go:496 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
@@ -1568,7 +1568,7 @@ msgstr ""
 msgid "Copy virtual machine images"
 msgstr "Copiando la imagen: %s"
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr "Copiando la imagen: %s"
@@ -1756,7 +1756,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1475
+#: lxc/image.go:1029 lxc/info.go:497 lxc/storage_volume.go:1475
 #, c-format
 msgid "Created: %s"
 msgstr "Creado: %s"
@@ -1781,7 +1781,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1143 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -1840,7 +1840,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr "Eliminar alias de imagen"
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:341 lxc/image.go:342
 msgid "Delete images"
 msgstr "Eliminar imágenes"
 
@@ -1948,9 +1948,9 @@ msgstr ""
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
 #: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
-#: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
-#: lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090 lxc/image.go:1417
-#: lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638 lxc/image.go:1701
+#: lxc/image.go:159 lxc/image.go:342 lxc/image.go:401 lxc/image.go:530
+#: lxc/image.go:702 lxc/image.go:954 lxc/image.go:1096 lxc/image.go:1423
+#: lxc/image.go:1514 lxc/image.go:1580 lxc/image.go:1644 lxc/image.go:1707
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
@@ -2097,11 +2097,11 @@ msgstr ""
 msgid "Device: %s"
 msgstr "Dispositivo: %s"
 
-#: lxc/init.go:406
+#: lxc/init.go:411
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:726
+#: lxc/image.go:731
 msgid "Directory import is not available on this platform"
 msgstr "El directorio importado no está disponible en esta plataforma"
 
@@ -2208,7 +2208,7 @@ msgstr ""
 msgid "Edit identity provider groups as YAML"
 msgstr "Perfil %s creado"
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:400 lxc/image.go:401
 msgid "Edit image properties"
 msgstr ""
 
@@ -2289,7 +2289,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1766
+#: lxc/image.go:1155 lxc/list.go:622 lxc/storage_volume.go:1766
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2410,20 +2410,20 @@ msgstr ""
 msgid "Expires at"
 msgstr "Expira: %s"
 
-#: lxc/image.go:1029
+#: lxc/image.go:1035
 #, c-format
 msgid "Expires: %s"
 msgstr "Expira: %s"
 
-#: lxc/image.go:1031
+#: lxc/image.go:1037
 msgid "Expires: never"
 msgstr "Expira: nunca"
 
-#: lxc/image.go:524
+#: lxc/image.go:529
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:530
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2453,7 +2453,7 @@ msgstr ""
 msgid "Exporting the backup: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/image.go:604
+#: lxc/image.go:609
 #, c-format
 msgid "Exporting the image: %s"
 msgstr "Exportando la imagen: %s"
@@ -2466,7 +2466,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
+#: lxc/config_trust.go:411 lxc/image.go:1140 lxc/image.go:1141
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr "HUELLA DIGITAL"
@@ -2485,12 +2485,12 @@ msgstr ""
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/utils.go:296
+#: lxc/utils.go:284
 #, fuzzy, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/utils.go:288
+#: lxc/utils.go:276
 #, fuzzy, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "Nombre del Miembro del Cluster"
@@ -2584,7 +2584,7 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: lxc/utils.go:214
+#: lxc/utils.go:202
 #, fuzzy, c-format
 msgid "Failed to create alias %s: %w"
 msgstr "Acepta certificado"
@@ -2609,11 +2609,6 @@ msgstr "Acepta certificado"
 msgid "Failed to refresh target instance '%s': %v"
 msgstr "Perfil para aplicar al nuevo contenedor"
 
-#: lxc/utils.go:203
-#, fuzzy, c-format
-msgid "Failed to remove alias %s: %w"
-msgstr "Acepta certificado"
-
 #: lxc/file.go:821
 #, c-format
 msgid "Failed to walk path for %s: %s"
@@ -2633,7 +2628,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr "El filtrado no está soportado aún"
 
-#: lxc/image.go:1014
+#: lxc/image.go:1020
 #, c-format
 msgid "Fingerprint: %s"
 msgstr "Huella dactilar: %s"
@@ -2698,7 +2693,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:770 lxc/auth.go:1697
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1122 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:57
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2774,7 +2769,7 @@ msgstr "Aliases:"
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1573 lxc/image.go:1574
+#: lxc/image.go:1579 lxc/image.go:1580
 msgid "Get image properties"
 msgstr ""
 
@@ -3064,11 +3059,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1489
+#: lxc/image.go:1495
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -3076,25 +3071,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:680
+#: lxc/image.go:685
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1444
+#: lxc/image.go:369 lxc/image.go:1450
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1670
+#: lxc/image.go:449 lxc/image.go:1676
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:918
+#: lxc/image.go:923
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1493
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3114,7 +3109,7 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:697
+#: lxc/image.go:702
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -3124,7 +3119,7 @@ msgid ""
 "os=Ubuntu release=noble variant=cloud."
 msgstr ""
 
-#: lxc/image.go:696
+#: lxc/image.go:701
 msgid "Import images into the image store"
 msgstr ""
 
@@ -3178,7 +3173,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr "Nombre del contenedor es obligatorio"
 
-#: lxc/init.go:417
+#: lxc/init.go:422
 #, fuzzy, c-format
 msgid "Instance name is: %s"
 msgstr "Nombre del contenedor es: %s"
@@ -3245,7 +3240,7 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Invalid instance path: %q"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/utils.go:253
+#: lxc/utils.go:241
 #, fuzzy, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr "Nombre del contenedor es: %s"
@@ -3359,12 +3354,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr "Creado: %s"
 
-#: lxc/image.go:1035
+#: lxc/image.go:1041
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:1037
+#: lxc/image.go:1043
 msgid "Last used: never"
 msgstr ""
 
@@ -3491,11 +3486,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1089
+#: lxc/image.go:1095
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1096
 msgid ""
 "List images\n"
 "\n"
@@ -3795,7 +3790,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:165 lxc/image.go:709
 msgid "Make image public"
 msgstr ""
 
@@ -4344,7 +4339,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:728
+#: lxc/image.go:733
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4537,7 +4532,7 @@ msgstr "Perfil %s eliminado"
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:168 lxc/image.go:710
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4617,7 +4612,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:805
+#: lxc/image.go:810
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4688,7 +4683,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:752
+#: lxc/image.go:1142 lxc/remote.go:752
 msgid "PUBLIC"
 msgstr ""
 
@@ -4750,7 +4745,7 @@ msgstr ""
 #: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/config_trust.go:315 lxc/image.go:497 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
@@ -4841,11 +4836,11 @@ msgstr "Perfil para aplicar al nuevo contenedor"
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1067
+#: lxc/image.go:1073
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1065
+#: lxc/image.go:1071
 #, fuzzy
 msgid "Profiles: "
 msgstr "Perfil %s creado"
@@ -4869,11 +4864,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1046
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1621
+#: lxc/image.go:1627
 msgid "Property not found"
 msgstr ""
 
@@ -4967,7 +4962,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1024
 #, c-format
 msgid "Public: %s"
 msgstr "Público: %s"
@@ -5003,7 +4998,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
+#: lxc/image.go:535 lxc/image.go:957 lxc/image.go:1517
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -5042,7 +5037,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1416 lxc/image.go:1417
+#: lxc/image.go:1422 lxc/image.go:1423
 msgid "Refresh images"
 msgstr ""
 
@@ -5051,7 +5046,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/image.go:1453
+#: lxc/image.go:1459
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr "Refrescando la imagen: %s"
@@ -5325,7 +5320,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:365
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5361,7 +5356,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1139
+#: lxc/image.go:1145
 msgid "SIZE"
 msgstr ""
 
@@ -5486,7 +5481,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1637 lxc/image.go:1638
+#: lxc/image.go:1643 lxc/image.go:1644
 msgid "Set image properties"
 msgstr ""
 
@@ -5793,7 +5788,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1507 lxc/image.go:1508
+#: lxc/image.go:1513 lxc/image.go:1514
 msgid "Show image properties"
 msgstr ""
 
@@ -5937,7 +5932,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:953 lxc/image.go:954
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5949,7 +5944,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1021
 #, fuzzy, c-format
 msgid "Size: %.2fMiB"
 msgstr "Auto actualización: %s"
@@ -5981,7 +5976,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr "Dispositivo %s añadido a %s"
 
-#: lxc/image.go:1058
+#: lxc/image.go:1064
 msgid "Source:"
 msgstr ""
 
@@ -6130,7 +6125,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
 #: lxc/storage_volume.go:1730 lxc/warning.go:216
@@ -6197,7 +6192,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:438
+#: lxc/init.go:443
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -6206,12 +6201,12 @@ msgstr ""
 msgid "The key %q does not exist on cluster member %q"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/utils.go:376
+#: lxc/utils.go:364
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:%q' instead."
 msgstr ""
 
-#: lxc/utils.go:372
+#: lxc/utils.go:360
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
@@ -6356,15 +6351,15 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1025
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:440
+#: lxc/init.go:445
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:439
+#: lxc/init.go:444
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6418,7 +6413,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:827
+#: lxc/image.go:832
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
@@ -6458,7 +6453,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1023 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1455
 #, fuzzy, c-format
 msgid "Type: %s"
@@ -6473,7 +6468,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1140
+#: lxc/image.go:1146
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6519,7 +6514,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:631 lxc/storage_volume.go:1772
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6563,7 +6558,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1700 lxc/image.go:1701
+#: lxc/image.go:1706 lxc/image.go:1707
 msgid "Unset image properties"
 msgstr ""
 
@@ -6731,7 +6726,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1032
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6911,7 +6906,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:] [<cert>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/image.go:1087 lxc/list.go:46
+#: lxc/image.go:1093 lxc/list.go:46
 #, fuzzy
 msgid "[<remote>:] [<filter>...]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7048,17 +7043,17 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
+#: lxc/image.go:399 lxc/image.go:952 lxc/image.go:1512
 #, fuzzy
 msgid "[<remote>:]<image>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/image.go:1572 lxc/image.go:1699
+#: lxc/image.go:1578 lxc/image.go:1705
 #, fuzzy
 msgid "[<remote>:]<image> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/image.go:1636
+#: lxc/image.go:1642
 #, fuzzy
 msgid "[<remote>:]<image> <key> <value>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7078,12 +7073,12 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/image.go:523
+#: lxc/image.go:528
 #, fuzzy
 msgid "[<remote>:]<image> [<target>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/image.go:334 lxc/image.go:1415
+#: lxc/image.go:339 lxc/image.go:1421
 #, fuzzy
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7651,7 +7646,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1010
 msgid "disabled"
 msgstr ""
 
@@ -7659,7 +7654,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1012
 msgid "enabled"
 msgstr ""
 
@@ -7800,7 +7795,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:398
+#: lxc/image.go:403
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -8127,7 +8122,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
+#: lxc/image.go:1000 lxc/image.go:1005 lxc/image.go:1203
 msgid "no"
 msgstr ""
 
@@ -8172,10 +8167,14 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1194
+#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:1002 lxc/image.go:1007
+#: lxc/image.go:1200
 msgid "yes"
 msgstr ""
+
+#, fuzzy, c-format
+#~ msgid "Failed to remove alias %s: %w"
+#~ msgstr "Acepta certificado"
 
 #, fuzzy
 #~ msgid "[<remote>:]<cluster member>"

--- a/po/fa.po
+++ b/po/fa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-19 13:11-0600\n"
+"POT-Creation-Date: 2024-09-25 18:38-0600\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Persian <https://hosted.weblate.org/projects/linux-containers/"
@@ -195,7 +195,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:419
+#: lxc/image.go:424
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -423,7 +423,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1168
+#: lxc/image.go:1174
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -531,7 +531,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:695
+#: lxc/image.go:700
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -544,15 +544,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1138 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1133
+#: lxc/image.go:1139
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1144 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -734,7 +734,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1045
+#: lxc/image.go:1051
 msgid "Aliases:"
 msgstr ""
 
@@ -750,7 +750,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1022 lxc/info.go:486
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -769,11 +769,11 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:342 lxc/rebuild.go:131
+#: lxc/init.go:347 lxc/rebuild.go:136
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/init.go:346
+#: lxc/init.go:351
 msgid "Asked for a container but image is of type VM"
 msgstr ""
 
@@ -831,7 +831,7 @@ msgstr ""
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1061
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -888,7 +888,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:816
+#: lxc/image.go:821
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -969,7 +969,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1060
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -990,7 +990,7 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:239 lxc/utils.go:259
+#: lxc/utils.go:227 lxc/utils.go:247
 #, c-format
 msgid "Can't read from stdin: %w"
 msgstr ""
@@ -1024,7 +1024,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:166
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1176,7 +1176,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1589
+#: lxc/image.go:1121 lxc/list.go:132 lxc/storage_volume.go:1589
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1215,7 +1215,7 @@ msgstr ""
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1327 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/config_trust.go:314 lxc/image.go:496 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
@@ -1309,7 +1309,7 @@ msgstr ""
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1489,7 +1489,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1475
+#: lxc/image.go:1029 lxc/info.go:497 lxc/storage_volume.go:1475
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1513,7 +1513,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1143 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -1571,7 +1571,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:341 lxc/image.go:342
 msgid "Delete images"
 msgstr ""
 
@@ -1674,9 +1674,9 @@ msgstr ""
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
 #: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
-#: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
-#: lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090 lxc/image.go:1417
-#: lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638 lxc/image.go:1701
+#: lxc/image.go:159 lxc/image.go:342 lxc/image.go:401 lxc/image.go:530
+#: lxc/image.go:702 lxc/image.go:954 lxc/image.go:1096 lxc/image.go:1423
+#: lxc/image.go:1514 lxc/image.go:1580 lxc/image.go:1644 lxc/image.go:1707
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
@@ -1821,11 +1821,11 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:406
+#: lxc/init.go:411
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:726
+#: lxc/image.go:731
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1929,7 +1929,7 @@ msgstr ""
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:400 lxc/image.go:401
 msgid "Edit image properties"
 msgstr ""
 
@@ -2005,7 +2005,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1766
+#: lxc/image.go:1155 lxc/list.go:622 lxc/storage_volume.go:1766
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2124,20 +2124,20 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:1029
+#: lxc/image.go:1035
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1037
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:524
+#: lxc/image.go:529
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:530
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2165,7 +2165,7 @@ msgstr ""
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:604
+#: lxc/image.go:609
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2178,7 +2178,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
+#: lxc/config_trust.go:411 lxc/image.go:1140 lxc/image.go:1141
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2197,12 +2197,12 @@ msgstr ""
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/utils.go:296
+#: lxc/utils.go:284
 #, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/utils.go:288
+#: lxc/utils.go:276
 #, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
@@ -2296,7 +2296,7 @@ msgstr ""
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: lxc/utils.go:214
+#: lxc/utils.go:202
 #, c-format
 msgid "Failed to create alias %s: %w"
 msgstr ""
@@ -2321,11 +2321,6 @@ msgstr ""
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
 
-#: lxc/utils.go:203
-#, c-format
-msgid "Failed to remove alias %s: %w"
-msgstr ""
-
 #: lxc/file.go:821
 #, c-format
 msgid "Failed to walk path for %s: %s"
@@ -2345,7 +2340,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:1014
+#: lxc/image.go:1020
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2409,7 +2404,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:770 lxc/auth.go:1697
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1122 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:57
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2484,7 +2479,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1573 lxc/image.go:1574
+#: lxc/image.go:1579 lxc/image.go:1580
 msgid "Get image properties"
 msgstr ""
 
@@ -2758,11 +2753,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1489
+#: lxc/image.go:1495
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2770,25 +2765,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:680
+#: lxc/image.go:685
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1444
+#: lxc/image.go:369 lxc/image.go:1450
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1670
+#: lxc/image.go:449 lxc/image.go:1676
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:918
+#: lxc/image.go:923
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1493
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2808,7 +2803,7 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:697
+#: lxc/image.go:702
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -2818,7 +2813,7 @@ msgid ""
 "os=Ubuntu release=noble variant=cloud."
 msgstr ""
 
-#: lxc/image.go:696
+#: lxc/image.go:701
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2869,7 +2864,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:417
+#: lxc/init.go:422
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2935,7 +2930,7 @@ msgstr ""
 msgid "Invalid instance path: %q"
 msgstr ""
 
-#: lxc/utils.go:253
+#: lxc/utils.go:241
 #, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr ""
@@ -3047,12 +3042,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:1035
+#: lxc/image.go:1041
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:1037
+#: lxc/image.go:1043
 msgid "Last used: never"
 msgstr ""
 
@@ -3170,11 +3165,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1089
+#: lxc/image.go:1095
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1096
 msgid ""
 "List images\n"
 "\n"
@@ -3468,7 +3463,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:165 lxc/image.go:709
 msgid "Make image public"
 msgstr ""
 
@@ -3982,7 +3977,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:728
+#: lxc/image.go:733
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4175,7 +4170,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:168 lxc/image.go:710
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4255,7 +4250,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:805
+#: lxc/image.go:810
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4326,7 +4321,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:752
+#: lxc/image.go:1142 lxc/remote.go:752
 msgid "PUBLIC"
 msgstr ""
 
@@ -4387,7 +4382,7 @@ msgstr ""
 #: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/config_trust.go:315 lxc/image.go:497 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
@@ -4475,11 +4470,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1067
+#: lxc/image.go:1073
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1065
+#: lxc/image.go:1071
 msgid "Profiles: "
 msgstr ""
 
@@ -4502,11 +4497,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1046
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1621
+#: lxc/image.go:1627
 msgid "Property not found"
 msgstr ""
 
@@ -4600,7 +4595,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1024
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4636,7 +4631,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
+#: lxc/image.go:535 lxc/image.go:957 lxc/image.go:1517
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4673,7 +4668,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1416 lxc/image.go:1417
+#: lxc/image.go:1422 lxc/image.go:1423
 msgid "Refresh images"
 msgstr ""
 
@@ -4682,7 +4677,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1453
+#: lxc/image.go:1459
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4945,7 +4940,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:365
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -4978,7 +4973,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1139
+#: lxc/image.go:1145
 msgid "SIZE"
 msgstr ""
 
@@ -5101,7 +5096,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1637 lxc/image.go:1638
+#: lxc/image.go:1643 lxc/image.go:1644
 msgid "Set image properties"
 msgstr ""
 
@@ -5394,7 +5389,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1507 lxc/image.go:1508
+#: lxc/image.go:1513 lxc/image.go:1514
 msgid "Show image properties"
 msgstr ""
 
@@ -5528,7 +5523,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:953 lxc/image.go:954
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5540,7 +5535,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1021
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5572,7 +5567,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:1058
+#: lxc/image.go:1064
 msgid "Source:"
 msgstr ""
 
@@ -5720,7 +5715,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
 #: lxc/storage_volume.go:1730 lxc/warning.go:216
@@ -5785,7 +5780,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:438
+#: lxc/init.go:443
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5794,12 +5789,12 @@ msgstr ""
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
 
-#: lxc/utils.go:376
+#: lxc/utils.go:364
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:%q' instead."
 msgstr ""
 
-#: lxc/utils.go:372
+#: lxc/utils.go:360
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
@@ -5942,15 +5937,15 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1025
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:440
+#: lxc/init.go:445
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:439
+#: lxc/init.go:444
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6004,7 +5999,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:827
+#: lxc/image.go:832
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
@@ -6042,7 +6037,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1023 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1455
 #, c-format
 msgid "Type: %s"
@@ -6057,7 +6052,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1140
+#: lxc/image.go:1146
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6103,7 +6098,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:631 lxc/storage_volume.go:1772
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6145,7 +6140,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1700 lxc/image.go:1701
+#: lxc/image.go:1706 lxc/image.go:1707
 msgid "Unset image properties"
 msgstr ""
 
@@ -6296,7 +6291,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1032
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6469,7 +6464,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1087 lxc/list.go:46
+#: lxc/image.go:1093 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6582,15 +6577,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
+#: lxc/image.go:399 lxc/image.go:952 lxc/image.go:1512
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1572 lxc/image.go:1699
+#: lxc/image.go:1578 lxc/image.go:1705
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1636
+#: lxc/image.go:1642
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6606,11 +6601,11 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:523
+#: lxc/image.go:528
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1415
+#: lxc/image.go:339 lxc/image.go:1421
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -7073,7 +7068,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1010
 msgid "disabled"
 msgstr ""
 
@@ -7081,7 +7076,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1012
 msgid "enabled"
 msgstr ""
 
@@ -7222,7 +7217,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:398
+#: lxc/image.go:403
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7549,7 +7544,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
+#: lxc/image.go:1000 lxc/image.go:1005 lxc/image.go:1203
 msgid "no"
 msgstr ""
 
@@ -7594,7 +7589,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1194
+#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:1002 lxc/image.go:1007
+#: lxc/image.go:1200
 msgid "yes"
 msgstr ""

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-19 13:11-0600\n"
+"POT-Creation-Date: 2024-09-25 18:38-0600\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/linux-containers/"
@@ -195,7 +195,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:419
+#: lxc/image.go:424
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -423,7 +423,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1168
+#: lxc/image.go:1174
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -531,7 +531,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:695
+#: lxc/image.go:700
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -544,15 +544,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1138 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1133
+#: lxc/image.go:1139
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1144 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -734,7 +734,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1045
+#: lxc/image.go:1051
 msgid "Aliases:"
 msgstr ""
 
@@ -750,7 +750,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1022 lxc/info.go:486
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -769,11 +769,11 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:342 lxc/rebuild.go:131
+#: lxc/init.go:347 lxc/rebuild.go:136
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/init.go:346
+#: lxc/init.go:351
 msgid "Asked for a container but image is of type VM"
 msgstr ""
 
@@ -831,7 +831,7 @@ msgstr ""
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1061
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -888,7 +888,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:816
+#: lxc/image.go:821
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -969,7 +969,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1060
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -990,7 +990,7 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:239 lxc/utils.go:259
+#: lxc/utils.go:227 lxc/utils.go:247
 #, c-format
 msgid "Can't read from stdin: %w"
 msgstr ""
@@ -1024,7 +1024,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:166
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1176,7 +1176,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1589
+#: lxc/image.go:1121 lxc/list.go:132 lxc/storage_volume.go:1589
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1215,7 +1215,7 @@ msgstr ""
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1327 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/config_trust.go:314 lxc/image.go:496 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
@@ -1309,7 +1309,7 @@ msgstr ""
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1489,7 +1489,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1475
+#: lxc/image.go:1029 lxc/info.go:497 lxc/storage_volume.go:1475
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1513,7 +1513,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1143 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -1571,7 +1571,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:341 lxc/image.go:342
 msgid "Delete images"
 msgstr ""
 
@@ -1674,9 +1674,9 @@ msgstr ""
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
 #: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
-#: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
-#: lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090 lxc/image.go:1417
-#: lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638 lxc/image.go:1701
+#: lxc/image.go:159 lxc/image.go:342 lxc/image.go:401 lxc/image.go:530
+#: lxc/image.go:702 lxc/image.go:954 lxc/image.go:1096 lxc/image.go:1423
+#: lxc/image.go:1514 lxc/image.go:1580 lxc/image.go:1644 lxc/image.go:1707
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
@@ -1821,11 +1821,11 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:406
+#: lxc/init.go:411
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:726
+#: lxc/image.go:731
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1929,7 +1929,7 @@ msgstr ""
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:400 lxc/image.go:401
 msgid "Edit image properties"
 msgstr ""
 
@@ -2005,7 +2005,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1766
+#: lxc/image.go:1155 lxc/list.go:622 lxc/storage_volume.go:1766
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2124,20 +2124,20 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:1029
+#: lxc/image.go:1035
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1037
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:524
+#: lxc/image.go:529
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:530
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2165,7 +2165,7 @@ msgstr ""
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:604
+#: lxc/image.go:609
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2178,7 +2178,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
+#: lxc/config_trust.go:411 lxc/image.go:1140 lxc/image.go:1141
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2197,12 +2197,12 @@ msgstr ""
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/utils.go:296
+#: lxc/utils.go:284
 #, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/utils.go:288
+#: lxc/utils.go:276
 #, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
@@ -2296,7 +2296,7 @@ msgstr ""
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: lxc/utils.go:214
+#: lxc/utils.go:202
 #, c-format
 msgid "Failed to create alias %s: %w"
 msgstr ""
@@ -2321,11 +2321,6 @@ msgstr ""
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
 
-#: lxc/utils.go:203
-#, c-format
-msgid "Failed to remove alias %s: %w"
-msgstr ""
-
 #: lxc/file.go:821
 #, c-format
 msgid "Failed to walk path for %s: %s"
@@ -2345,7 +2340,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:1014
+#: lxc/image.go:1020
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2409,7 +2404,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:770 lxc/auth.go:1697
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1122 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:57
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2484,7 +2479,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1573 lxc/image.go:1574
+#: lxc/image.go:1579 lxc/image.go:1580
 msgid "Get image properties"
 msgstr ""
 
@@ -2758,11 +2753,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1489
+#: lxc/image.go:1495
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2770,25 +2765,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:680
+#: lxc/image.go:685
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1444
+#: lxc/image.go:369 lxc/image.go:1450
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1670
+#: lxc/image.go:449 lxc/image.go:1676
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:918
+#: lxc/image.go:923
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1493
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2808,7 +2803,7 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:697
+#: lxc/image.go:702
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -2818,7 +2813,7 @@ msgid ""
 "os=Ubuntu release=noble variant=cloud."
 msgstr ""
 
-#: lxc/image.go:696
+#: lxc/image.go:701
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2869,7 +2864,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:417
+#: lxc/init.go:422
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2935,7 +2930,7 @@ msgstr ""
 msgid "Invalid instance path: %q"
 msgstr ""
 
-#: lxc/utils.go:253
+#: lxc/utils.go:241
 #, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr ""
@@ -3047,12 +3042,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:1035
+#: lxc/image.go:1041
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:1037
+#: lxc/image.go:1043
 msgid "Last used: never"
 msgstr ""
 
@@ -3170,11 +3165,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1089
+#: lxc/image.go:1095
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1096
 msgid ""
 "List images\n"
 "\n"
@@ -3468,7 +3463,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:165 lxc/image.go:709
 msgid "Make image public"
 msgstr ""
 
@@ -3982,7 +3977,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:728
+#: lxc/image.go:733
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4175,7 +4170,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:168 lxc/image.go:710
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4255,7 +4250,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:805
+#: lxc/image.go:810
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4326,7 +4321,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:752
+#: lxc/image.go:1142 lxc/remote.go:752
 msgid "PUBLIC"
 msgstr ""
 
@@ -4387,7 +4382,7 @@ msgstr ""
 #: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/config_trust.go:315 lxc/image.go:497 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
@@ -4475,11 +4470,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1067
+#: lxc/image.go:1073
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1065
+#: lxc/image.go:1071
 msgid "Profiles: "
 msgstr ""
 
@@ -4502,11 +4497,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1046
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1621
+#: lxc/image.go:1627
 msgid "Property not found"
 msgstr ""
 
@@ -4600,7 +4595,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1024
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4636,7 +4631,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
+#: lxc/image.go:535 lxc/image.go:957 lxc/image.go:1517
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4673,7 +4668,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1416 lxc/image.go:1417
+#: lxc/image.go:1422 lxc/image.go:1423
 msgid "Refresh images"
 msgstr ""
 
@@ -4682,7 +4677,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1453
+#: lxc/image.go:1459
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4945,7 +4940,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:365
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -4978,7 +4973,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1139
+#: lxc/image.go:1145
 msgid "SIZE"
 msgstr ""
 
@@ -5101,7 +5096,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1637 lxc/image.go:1638
+#: lxc/image.go:1643 lxc/image.go:1644
 msgid "Set image properties"
 msgstr ""
 
@@ -5394,7 +5389,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1507 lxc/image.go:1508
+#: lxc/image.go:1513 lxc/image.go:1514
 msgid "Show image properties"
 msgstr ""
 
@@ -5528,7 +5523,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:953 lxc/image.go:954
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5540,7 +5535,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1021
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5572,7 +5567,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:1058
+#: lxc/image.go:1064
 msgid "Source:"
 msgstr ""
 
@@ -5720,7 +5715,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
 #: lxc/storage_volume.go:1730 lxc/warning.go:216
@@ -5785,7 +5780,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:438
+#: lxc/init.go:443
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5794,12 +5789,12 @@ msgstr ""
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
 
-#: lxc/utils.go:376
+#: lxc/utils.go:364
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:%q' instead."
 msgstr ""
 
-#: lxc/utils.go:372
+#: lxc/utils.go:360
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
@@ -5942,15 +5937,15 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1025
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:440
+#: lxc/init.go:445
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:439
+#: lxc/init.go:444
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6004,7 +5999,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:827
+#: lxc/image.go:832
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
@@ -6042,7 +6037,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1023 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1455
 #, c-format
 msgid "Type: %s"
@@ -6057,7 +6052,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1140
+#: lxc/image.go:1146
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6103,7 +6098,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:631 lxc/storage_volume.go:1772
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6145,7 +6140,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1700 lxc/image.go:1701
+#: lxc/image.go:1706 lxc/image.go:1707
 msgid "Unset image properties"
 msgstr ""
 
@@ -6296,7 +6291,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1032
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6469,7 +6464,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1087 lxc/list.go:46
+#: lxc/image.go:1093 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6582,15 +6577,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
+#: lxc/image.go:399 lxc/image.go:952 lxc/image.go:1512
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1572 lxc/image.go:1699
+#: lxc/image.go:1578 lxc/image.go:1705
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1636
+#: lxc/image.go:1642
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6606,11 +6601,11 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:523
+#: lxc/image.go:528
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1415
+#: lxc/image.go:339 lxc/image.go:1421
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -7073,7 +7068,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1010
 msgid "disabled"
 msgstr ""
 
@@ -7081,7 +7076,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1012
 msgid "enabled"
 msgstr ""
 
@@ -7222,7 +7217,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:398
+#: lxc/image.go:403
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7549,7 +7544,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
+#: lxc/image.go:1000 lxc/image.go:1005 lxc/image.go:1203
 msgid "no"
 msgstr ""
 
@@ -7594,7 +7589,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1194
+#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:1002 lxc/image.go:1007
+#: lxc/image.go:1200
 msgid "yes"
 msgstr ""

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-19 13:11-0600\n"
+"POT-Creation-Date: 2024-09-25 18:38-0600\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Wivik <seb+weblate@zedas.fr>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/linux-containers/"
@@ -268,7 +268,7 @@ msgstr ""
 "### Prenez note que l'empreinte digitale (fingerprint ) est affichée mais ne "
 "peut pas être modifiée"
 
-#: lxc/image.go:419
+#: lxc/image.go:424
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -669,7 +669,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr "%d (id: %d, online: %v, NUMA node: %v)"
 
-#: lxc/image.go:1168
+#: lxc/image.go:1174
 #, c-format
 msgid "%s (%d more)"
 msgstr "%s (%d de plus)"
@@ -790,7 +790,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/image.go:695
+#: lxc/image.go:700
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -804,16 +804,16 @@ msgstr "<cible>"
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1138 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr "ALIAS"
 
-#: lxc/image.go:1133
+#: lxc/image.go:1139
 #, fuzzy
 msgid "ALIASES"
 msgstr "ALIAS"
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1144 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr "ARCHITECTURE"
 
@@ -1013,7 +1013,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr "le serveur distant %s existe déjà"
 
-#: lxc/image.go:1045
+#: lxc/image.go:1051
 msgid "Aliases:"
 msgstr "Alias :"
 
@@ -1031,7 +1031,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr "Accepter le certificat"
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1022 lxc/info.go:486
 #, c-format
 msgid "Architecture: %s"
 msgstr "Architecture : %s"
@@ -1050,11 +1050,11 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:342 lxc/rebuild.go:131
+#: lxc/init.go:347 lxc/rebuild.go:136
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/init.go:346
+#: lxc/init.go:351
 msgid "Asked for a container but image is of type VM"
 msgstr ""
 
@@ -1117,7 +1117,7 @@ msgstr ""
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1061
 #, c-format
 msgid "Auto update: %s"
 msgstr "Mise à jour auto. : %s"
@@ -1176,7 +1176,7 @@ msgstr "Clé de configuration invalide"
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:816
+#: lxc/image.go:821
 #, c-format
 msgid "Bad property: %s"
 msgstr "Mauvaise propriété : %s"
@@ -1258,7 +1258,7 @@ msgstr "CRÉÉ À"
 msgid "CUDA Version: %v"
 msgstr "Afficher la version du client"
 
-#: lxc/image.go:1054
+#: lxc/image.go:1060
 #, fuzzy, c-format
 msgid "Cached: %s"
 msgstr "Créé : %s"
@@ -1281,7 +1281,7 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr "impossible de récupérer un répertoire sans --recursive"
 
-#: lxc/utils.go:239 lxc/utils.go:259
+#: lxc/utils.go:227 lxc/utils.go:247
 #, fuzzy, c-format
 msgid "Can't read from stdin: %w"
 msgstr "Impossible de lire depuis stdin : %s"
@@ -1318,7 +1318,7 @@ msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 "Impossible de désaffecter la clé '%s', elle n'est pas définie actuellement."
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:166
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1472,7 +1472,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1589
+#: lxc/image.go:1121 lxc/list.go:132 lxc/storage_volume.go:1589
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr "Colonnes"
@@ -1522,7 +1522,7 @@ msgstr "Clé/valeur de configuration à appliquer au nouveau conteneur"
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1327 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/config_trust.go:314 lxc/image.go:496 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
@@ -1621,7 +1621,7 @@ msgstr ""
 msgid "Copy virtual machine images"
 msgstr "Copie de l'image : %s"
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr "Copie de l'image : %s"
@@ -1838,7 +1838,7 @@ msgstr "Copie de l'image : %s"
 msgid "Create the instance with no profiles applied"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1475
+#: lxc/image.go:1029 lxc/info.go:497 lxc/storage_volume.go:1475
 #, c-format
 msgid "Created: %s"
 msgstr "Créé : %s"
@@ -1863,7 +1863,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1143 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -1925,7 +1925,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:341 lxc/image.go:342
 #, fuzzy
 msgid "Delete images"
 msgstr "Récupération de l'image : %s"
@@ -2040,9 +2040,9 @@ msgstr "Récupération de l'image : %s"
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
 #: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
-#: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
-#: lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090 lxc/image.go:1417
-#: lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638 lxc/image.go:1701
+#: lxc/image.go:159 lxc/image.go:342 lxc/image.go:401 lxc/image.go:530
+#: lxc/image.go:702 lxc/image.go:954 lxc/image.go:1096 lxc/image.go:1423
+#: lxc/image.go:1514 lxc/image.go:1580 lxc/image.go:1644 lxc/image.go:1707
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
@@ -2190,12 +2190,12 @@ msgstr ""
 msgid "Device: %s"
 msgstr "Serveur distant : %s"
 
-#: lxc/init.go:406
+#: lxc/init.go:411
 #, fuzzy
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr "pas d'image, conteneur ou instantané affecté sur ce serveur"
 
-#: lxc/image.go:726
+#: lxc/image.go:731
 msgid "Directory import is not available on this platform"
 msgstr "L'importation de répertoire n'est pas disponible sur cette plateforme"
 
@@ -2309,7 +2309,7 @@ msgstr "Clé de configuration invalide"
 msgid "Edit identity provider groups as YAML"
 msgstr "Clé de configuration invalide"
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:400 lxc/image.go:401
 msgid "Edit image properties"
 msgstr ""
 
@@ -2398,7 +2398,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr "Clé de configuration invalide"
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1766
+#: lxc/image.go:1155 lxc/list.go:622 lxc/storage_volume.go:1766
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2536,21 +2536,21 @@ msgstr ""
 msgid "Expires at"
 msgstr "Expire : %s"
 
-#: lxc/image.go:1029
+#: lxc/image.go:1035
 #, c-format
 msgid "Expires: %s"
 msgstr "Expire : %s"
 
-#: lxc/image.go:1031
+#: lxc/image.go:1037
 msgid "Expires: never"
 msgstr "N'expire jamais"
 
-#: lxc/image.go:524
+#: lxc/image.go:529
 #, fuzzy
 msgid "Export and download images"
 msgstr "Import de l'image : %s"
 
-#: lxc/image.go:525
+#: lxc/image.go:530
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2582,7 +2582,7 @@ msgstr "Copiez le conteneur sans ses instantanés"
 msgid "Exporting the backup: %s"
 msgstr "Import de l'image : %s"
 
-#: lxc/image.go:604
+#: lxc/image.go:609
 #, fuzzy, c-format
 msgid "Exporting the image: %s"
 msgstr "Import de l'image : %s"
@@ -2596,7 +2596,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr "NOM"
 
-#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
+#: lxc/config_trust.go:411 lxc/image.go:1140 lxc/image.go:1141
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr "EMPREINTE"
@@ -2615,12 +2615,12 @@ msgstr ""
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/utils.go:296
+#: lxc/utils.go:284
 #, fuzzy, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr "Profil à appliquer au nouveau conteneur"
 
-#: lxc/utils.go:288
+#: lxc/utils.go:276
 #, fuzzy, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "Profil à appliquer au nouveau conteneur"
@@ -2715,7 +2715,7 @@ msgstr "Profil à appliquer au nouveau conteneur"
 msgid "Failed to create %q: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
-#: lxc/utils.go:214
+#: lxc/utils.go:202
 #, fuzzy, c-format
 msgid "Failed to create alias %s: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
@@ -2740,11 +2740,6 @@ msgstr "Échec lors de la génération de 'lxc.1': %v"
 msgid "Failed to refresh target instance '%s': %v"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
-#: lxc/utils.go:203
-#, fuzzy, c-format
-msgid "Failed to remove alias %s: %w"
-msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
-
 #: lxc/file.go:821
 #, c-format
 msgid "Failed to walk path for %s: %s"
@@ -2765,7 +2760,7 @@ msgstr "Mode rapide (identique à --columns=nsacPt"
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:1014
+#: lxc/image.go:1020
 #, c-format
 msgid "Fingerprint: %s"
 msgstr "Empreinte : %s"
@@ -2833,7 +2828,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:770 lxc/auth.go:1697
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1122 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:57
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2909,7 +2904,7 @@ msgstr "Création du conteneur"
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1573 lxc/image.go:1574
+#: lxc/image.go:1579 lxc/image.go:1580
 msgid "Get image properties"
 msgstr ""
 
@@ -3213,11 +3208,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
 
-#: lxc/image.go:1489
+#: lxc/image.go:1495
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr "Image copiée avec succès !"
 
@@ -3225,26 +3220,26 @@ msgstr "Image copiée avec succès !"
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:680
+#: lxc/image.go:685
 #, fuzzy
 msgid "Image exported successfully!"
 msgstr "Image copiée avec succès !"
 
-#: lxc/image.go:364 lxc/image.go:1444
+#: lxc/image.go:369 lxc/image.go:1450
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1670
+#: lxc/image.go:449 lxc/image.go:1676
 #, fuzzy, c-format
 msgid "Image identifier missing: %s"
 msgstr "Image importée avec l'empreinte : %s"
 
-#: lxc/image.go:918
+#: lxc/image.go:923
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr "Image importée avec l'empreinte : %s"
 
-#: lxc/image.go:1487
+#: lxc/image.go:1493
 #, fuzzy
 msgid "Image refreshed successfully!"
 msgstr "Image copiée avec succès !"
@@ -3267,7 +3262,7 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr "Copie de l'image : %s"
 
-#: lxc/image.go:697
+#: lxc/image.go:702
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -3277,7 +3272,7 @@ msgid ""
 "os=Ubuntu release=noble variant=cloud."
 msgstr ""
 
-#: lxc/image.go:696
+#: lxc/image.go:701
 #, fuzzy
 msgid "Import images into the image store"
 msgstr "Import de l'image : %s"
@@ -3333,7 +3328,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr "Le nom du conteneur est obligatoire"
 
-#: lxc/init.go:417
+#: lxc/init.go:422
 #, fuzzy, c-format
 msgid "Instance name is: %s"
 msgstr "Le nom du conteneur est : %s"
@@ -3400,7 +3395,7 @@ msgstr "Le nom du conteneur est : %s"
 msgid "Invalid instance path: %q"
 msgstr "Le nom du conteneur est : %s"
 
-#: lxc/utils.go:253
+#: lxc/utils.go:241
 #, fuzzy, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr "Clé de configuration invalide"
@@ -3516,12 +3511,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr "Dernière utilisation : %s"
 
-#: lxc/image.go:1035
+#: lxc/image.go:1041
 #, c-format
 msgid "Last used: %s"
 msgstr "Dernière utilisation : %s"
 
-#: lxc/image.go:1037
+#: lxc/image.go:1043
 msgid "Last used: never"
 msgstr "Dernière utilisation : jamais"
 
@@ -3648,11 +3643,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1089
+#: lxc/image.go:1095
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1096
 msgid ""
 "List images\n"
 "\n"
@@ -4018,7 +4013,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:165 lxc/image.go:709
 msgid "Make image public"
 msgstr "Rendre l'image publique"
 
@@ -4598,7 +4593,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:728
+#: lxc/image.go:733
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4795,7 +4790,7 @@ msgstr "Le réseau %s a été supprimé"
 msgid "New alias to define at target"
 msgstr "Nouvel alias à définir sur la cible"
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:168 lxc/image.go:710
 #, fuzzy
 msgid "New aliases to add to the image"
 msgstr "Nouvel alias à définir sur la cible"
@@ -4885,7 +4880,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr "Seules les URLs https sont supportées par simplestreams"
 
-#: lxc/image.go:805
+#: lxc/image.go:810
 #, fuzzy
 msgid "Only https:// is supported for remote image import"
 msgstr "Seul https:// est supporté par l'import d'images distantes."
@@ -4961,7 +4956,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr "PROTOCOLE"
 
-#: lxc/image.go:1136 lxc/remote.go:752
+#: lxc/image.go:1142 lxc/remote.go:752
 msgid "PUBLIC"
 msgstr "PUBLIC"
 
@@ -5026,7 +5021,7 @@ msgstr ""
 #: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/config_trust.go:315 lxc/image.go:497 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
@@ -5118,12 +5113,12 @@ msgstr "Profil à appliquer au nouveau conteneur"
 msgid "Profiles %s applied to %s"
 msgstr "Profils %s appliqués à %s"
 
-#: lxc/image.go:1067
+#: lxc/image.go:1073
 #, fuzzy
 msgid "Profiles:"
 msgstr "Profils : %s"
 
-#: lxc/image.go:1065
+#: lxc/image.go:1071
 #, fuzzy
 msgid "Profiles: "
 msgstr "Profils : %s"
@@ -5147,11 +5142,11 @@ msgstr "Profil %s ajouté à %s"
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1046
 msgid "Properties:"
 msgstr "Propriétés :"
 
-#: lxc/image.go:1621
+#: lxc/image.go:1627
 msgid "Property not found"
 msgstr ""
 
@@ -5245,7 +5240,7 @@ msgstr ""
 msgid "Public image server"
 msgstr "Serveur d'images public"
 
-#: lxc/image.go:1018
+#: lxc/image.go:1024
 #, c-format
 msgid "Public: %s"
 msgstr "Public : %s"
@@ -5284,7 +5279,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
+#: lxc/image.go:535 lxc/image.go:957 lxc/image.go:1517
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -5326,7 +5321,7 @@ msgstr "Pousser ou récupérer des fichiers récursivement"
 msgid "Refresh and update the existing storage volume copies"
 msgstr "Copie de l'image : %s"
 
-#: lxc/image.go:1416 lxc/image.go:1417
+#: lxc/image.go:1422 lxc/image.go:1423
 #, fuzzy
 msgid "Refresh images"
 msgstr "Récupération de l'image : %s"
@@ -5336,7 +5331,7 @@ msgstr "Récupération de l'image : %s"
 msgid "Refreshing instance: %s"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
 
-#: lxc/image.go:1453
+#: lxc/image.go:1459
 #, fuzzy, c-format
 msgid "Refreshing the image: %s"
 msgstr "Récupération de l'image : %s"
@@ -5644,7 +5639,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
 
-#: lxc/init.go:360
+#: lxc/init.go:365
 #, c-format
 msgid "Retrieving image: %s"
 msgstr "Récupération de l'image : %s"
@@ -5680,7 +5675,7 @@ msgstr "Rendre l'image publique"
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1139
+#: lxc/image.go:1145
 msgid "SIZE"
 msgstr "TAILLE"
 
@@ -5811,7 +5806,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1637 lxc/image.go:1638
+#: lxc/image.go:1643 lxc/image.go:1644
 msgid "Set image properties"
 msgstr ""
 
@@ -6129,7 +6124,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1507 lxc/image.go:1508
+#: lxc/image.go:1513 lxc/image.go:1514
 msgid "Show image properties"
 msgstr ""
 
@@ -6288,7 +6283,7 @@ msgstr "Afficher la configuration étendue"
 msgid "Show useful information about a cluster member"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:953 lxc/image.go:954
 msgid "Show useful information about images"
 msgstr ""
 
@@ -6300,7 +6295,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1021
 #, fuzzy, c-format
 msgid "Size: %.2fMiB"
 msgstr "Taille : %.2f Mo"
@@ -6333,7 +6328,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/image.go:1058
+#: lxc/image.go:1064
 msgid "Source:"
 msgstr "Source :"
 
@@ -6492,7 +6487,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
 #: lxc/storage_volume.go:1730 lxc/warning.go:216
@@ -6564,7 +6559,7 @@ msgstr ""
 "Le conteneur est en cours d'exécution. Utiliser --force pour qu'il soit "
 "arrêté et redémarré."
 
-#: lxc/init.go:438
+#: lxc/init.go:443
 #, fuzzy
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
@@ -6575,12 +6570,12 @@ msgstr ""
 msgid "The key %q does not exist on cluster member %q"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/utils.go:376
+#: lxc/utils.go:364
 #, fuzzy, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:%q' instead."
 msgstr "L'image locale '%s' n'a pas été trouvée, essayer '%s:' à la place."
 
-#: lxc/utils.go:372
+#: lxc/utils.go:360
 #, fuzzy, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr "L'image locale '%s' n'a pas été trouvée, essayer '%s:' à la place."
@@ -6727,16 +6722,16 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr "Temps d'attente du conteneur avant de le tuer"
 
-#: lxc/image.go:1019
+#: lxc/image.go:1025
 msgid "Timestamps:"
 msgstr "Horodatage :"
 
-#: lxc/init.go:440
+#: lxc/init.go:445
 #, fuzzy
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr "Pour attacher un réseau à un conteneur, utiliser : lxc network attach"
 
-#: lxc/init.go:439
+#: lxc/init.go:444
 msgid "To create a new network, use: lxc network create"
 msgstr "Pour créer un réseau, utiliser : lxc network create"
 
@@ -6792,7 +6787,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:827
+#: lxc/image.go:832
 #, c-format
 msgid "Transferring image: %s"
 msgstr "Transfert de l'image : %s"
@@ -6832,7 +6827,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1023 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1455
 #, fuzzy, c-format
 msgid "Type: %s"
@@ -6847,7 +6842,7 @@ msgstr "Type : éphémère"
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1140
+#: lxc/image.go:1146
 msgid "UPLOAD DATE"
 msgstr "DATE DE PUBLICATION"
 
@@ -6894,7 +6889,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:631 lxc/storage_volume.go:1772
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6940,7 +6935,7 @@ msgstr "tous les profils de la source n'existent pas sur la cible"
 msgid "Unset device configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/image.go:1700 lxc/image.go:1701
+#: lxc/image.go:1706 lxc/image.go:1707
 msgid "Unset image properties"
 msgstr ""
 
@@ -7117,7 +7112,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1032
 #, c-format
 msgid "Uploaded: %s"
 msgstr "Publié : %s"
@@ -7335,7 +7330,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/image.go:1087 lxc/list.go:46
+#: lxc/image.go:1093 lxc/list.go:46
 #, fuzzy
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
@@ -7565,7 +7560,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
+#: lxc/image.go:399 lxc/image.go:952 lxc/image.go:1512
 #, fuzzy
 msgid "[<remote>:]<image>"
 msgstr ""
@@ -7577,7 +7572,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/image.go:1572 lxc/image.go:1699
+#: lxc/image.go:1578 lxc/image.go:1705
 #, fuzzy
 msgid "[<remote>:]<image> <key>"
 msgstr ""
@@ -7589,7 +7584,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/image.go:1636
+#: lxc/image.go:1642
 #, fuzzy
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
@@ -7621,7 +7616,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/image.go:523
+#: lxc/image.go:528
 #, fuzzy
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
@@ -7629,7 +7624,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/image.go:334 lxc/image.go:1415
+#: lxc/image.go:339 lxc/image.go:1421
 #, fuzzy
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
@@ -8634,7 +8629,7 @@ msgstr "Swap (courant)"
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1010
 msgid "disabled"
 msgstr "désactivé"
 
@@ -8642,7 +8637,7 @@ msgstr "désactivé"
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1012
 msgid "enabled"
 msgstr "activé"
 
@@ -8783,7 +8778,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:398
+#: lxc/image.go:403
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -9133,7 +9128,7 @@ msgstr "non"
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
+#: lxc/image.go:1000 lxc/image.go:1005 lxc/image.go:1203
 msgid "no"
 msgstr "non"
 
@@ -9178,10 +9173,14 @@ msgstr "utilisé par"
 msgid "y"
 msgstr "o"
 
-#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1194
+#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:1002 lxc/image.go:1007
+#: lxc/image.go:1200
 msgid "yes"
 msgstr "oui"
+
+#, fuzzy, c-format
+#~ msgid "Failed to remove alias %s: %w"
+#~ msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
 #~ msgid "Make the image public"
 #~ msgstr "Rendre l'image publique"

--- a/po/he.po
+++ b/po/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-19 13:11-0600\n"
+"POT-Creation-Date: 2024-09-25 18:38-0600\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hebrew <https://hosted.weblate.org/projects/linux-containers/"
@@ -196,7 +196,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:419
+#: lxc/image.go:424
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -424,7 +424,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1168
+#: lxc/image.go:1174
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -532,7 +532,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:695
+#: lxc/image.go:700
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -545,15 +545,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1138 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1133
+#: lxc/image.go:1139
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1144 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -735,7 +735,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1045
+#: lxc/image.go:1051
 msgid "Aliases:"
 msgstr ""
 
@@ -751,7 +751,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1022 lxc/info.go:486
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -770,11 +770,11 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:342 lxc/rebuild.go:131
+#: lxc/init.go:347 lxc/rebuild.go:136
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/init.go:346
+#: lxc/init.go:351
 msgid "Asked for a container but image is of type VM"
 msgstr ""
 
@@ -832,7 +832,7 @@ msgstr ""
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1061
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -889,7 +889,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:816
+#: lxc/image.go:821
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -970,7 +970,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1060
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -991,7 +991,7 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:239 lxc/utils.go:259
+#: lxc/utils.go:227 lxc/utils.go:247
 #, c-format
 msgid "Can't read from stdin: %w"
 msgstr ""
@@ -1025,7 +1025,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:166
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1177,7 +1177,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1589
+#: lxc/image.go:1121 lxc/list.go:132 lxc/storage_volume.go:1589
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1216,7 +1216,7 @@ msgstr ""
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1327 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/config_trust.go:314 lxc/image.go:496 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
@@ -1310,7 +1310,7 @@ msgstr ""
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1490,7 +1490,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1475
+#: lxc/image.go:1029 lxc/info.go:497 lxc/storage_volume.go:1475
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1514,7 +1514,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1143 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -1572,7 +1572,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:341 lxc/image.go:342
 msgid "Delete images"
 msgstr ""
 
@@ -1675,9 +1675,9 @@ msgstr ""
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
 #: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
-#: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
-#: lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090 lxc/image.go:1417
-#: lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638 lxc/image.go:1701
+#: lxc/image.go:159 lxc/image.go:342 lxc/image.go:401 lxc/image.go:530
+#: lxc/image.go:702 lxc/image.go:954 lxc/image.go:1096 lxc/image.go:1423
+#: lxc/image.go:1514 lxc/image.go:1580 lxc/image.go:1644 lxc/image.go:1707
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
@@ -1822,11 +1822,11 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:406
+#: lxc/init.go:411
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:726
+#: lxc/image.go:731
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1930,7 +1930,7 @@ msgstr ""
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:400 lxc/image.go:401
 msgid "Edit image properties"
 msgstr ""
 
@@ -2006,7 +2006,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1766
+#: lxc/image.go:1155 lxc/list.go:622 lxc/storage_volume.go:1766
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2125,20 +2125,20 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:1029
+#: lxc/image.go:1035
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1037
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:524
+#: lxc/image.go:529
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:530
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2166,7 +2166,7 @@ msgstr ""
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:604
+#: lxc/image.go:609
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2179,7 +2179,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
+#: lxc/config_trust.go:411 lxc/image.go:1140 lxc/image.go:1141
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2198,12 +2198,12 @@ msgstr ""
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/utils.go:296
+#: lxc/utils.go:284
 #, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/utils.go:288
+#: lxc/utils.go:276
 #, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
@@ -2297,7 +2297,7 @@ msgstr ""
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: lxc/utils.go:214
+#: lxc/utils.go:202
 #, c-format
 msgid "Failed to create alias %s: %w"
 msgstr ""
@@ -2322,11 +2322,6 @@ msgstr ""
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
 
-#: lxc/utils.go:203
-#, c-format
-msgid "Failed to remove alias %s: %w"
-msgstr ""
-
 #: lxc/file.go:821
 #, c-format
 msgid "Failed to walk path for %s: %s"
@@ -2346,7 +2341,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:1014
+#: lxc/image.go:1020
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2410,7 +2405,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:770 lxc/auth.go:1697
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1122 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:57
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2485,7 +2480,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1573 lxc/image.go:1574
+#: lxc/image.go:1579 lxc/image.go:1580
 msgid "Get image properties"
 msgstr ""
 
@@ -2759,11 +2754,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1489
+#: lxc/image.go:1495
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2771,25 +2766,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:680
+#: lxc/image.go:685
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1444
+#: lxc/image.go:369 lxc/image.go:1450
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1670
+#: lxc/image.go:449 lxc/image.go:1676
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:918
+#: lxc/image.go:923
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1493
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2809,7 +2804,7 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:697
+#: lxc/image.go:702
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -2819,7 +2814,7 @@ msgid ""
 "os=Ubuntu release=noble variant=cloud."
 msgstr ""
 
-#: lxc/image.go:696
+#: lxc/image.go:701
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2870,7 +2865,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:417
+#: lxc/init.go:422
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2936,7 +2931,7 @@ msgstr ""
 msgid "Invalid instance path: %q"
 msgstr ""
 
-#: lxc/utils.go:253
+#: lxc/utils.go:241
 #, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr ""
@@ -3048,12 +3043,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:1035
+#: lxc/image.go:1041
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:1037
+#: lxc/image.go:1043
 msgid "Last used: never"
 msgstr ""
 
@@ -3171,11 +3166,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1089
+#: lxc/image.go:1095
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1096
 msgid ""
 "List images\n"
 "\n"
@@ -3469,7 +3464,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:165 lxc/image.go:709
 msgid "Make image public"
 msgstr ""
 
@@ -3983,7 +3978,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:728
+#: lxc/image.go:733
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4176,7 +4171,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:168 lxc/image.go:710
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4256,7 +4251,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:805
+#: lxc/image.go:810
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4327,7 +4322,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:752
+#: lxc/image.go:1142 lxc/remote.go:752
 msgid "PUBLIC"
 msgstr ""
 
@@ -4388,7 +4383,7 @@ msgstr ""
 #: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/config_trust.go:315 lxc/image.go:497 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
@@ -4476,11 +4471,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1067
+#: lxc/image.go:1073
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1065
+#: lxc/image.go:1071
 msgid "Profiles: "
 msgstr ""
 
@@ -4503,11 +4498,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1046
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1621
+#: lxc/image.go:1627
 msgid "Property not found"
 msgstr ""
 
@@ -4601,7 +4596,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1024
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4637,7 +4632,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
+#: lxc/image.go:535 lxc/image.go:957 lxc/image.go:1517
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4674,7 +4669,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1416 lxc/image.go:1417
+#: lxc/image.go:1422 lxc/image.go:1423
 msgid "Refresh images"
 msgstr ""
 
@@ -4683,7 +4678,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1453
+#: lxc/image.go:1459
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4946,7 +4941,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:365
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -4979,7 +4974,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1139
+#: lxc/image.go:1145
 msgid "SIZE"
 msgstr ""
 
@@ -5102,7 +5097,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1637 lxc/image.go:1638
+#: lxc/image.go:1643 lxc/image.go:1644
 msgid "Set image properties"
 msgstr ""
 
@@ -5395,7 +5390,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1507 lxc/image.go:1508
+#: lxc/image.go:1513 lxc/image.go:1514
 msgid "Show image properties"
 msgstr ""
 
@@ -5529,7 +5524,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:953 lxc/image.go:954
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5541,7 +5536,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1021
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5573,7 +5568,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:1058
+#: lxc/image.go:1064
 msgid "Source:"
 msgstr ""
 
@@ -5721,7 +5716,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
 #: lxc/storage_volume.go:1730 lxc/warning.go:216
@@ -5786,7 +5781,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:438
+#: lxc/init.go:443
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5795,12 +5790,12 @@ msgstr ""
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
 
-#: lxc/utils.go:376
+#: lxc/utils.go:364
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:%q' instead."
 msgstr ""
 
-#: lxc/utils.go:372
+#: lxc/utils.go:360
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
@@ -5943,15 +5938,15 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1025
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:440
+#: lxc/init.go:445
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:439
+#: lxc/init.go:444
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6005,7 +6000,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:827
+#: lxc/image.go:832
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
@@ -6043,7 +6038,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1023 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1455
 #, c-format
 msgid "Type: %s"
@@ -6058,7 +6053,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1140
+#: lxc/image.go:1146
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6104,7 +6099,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:631 lxc/storage_volume.go:1772
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6146,7 +6141,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1700 lxc/image.go:1701
+#: lxc/image.go:1706 lxc/image.go:1707
 msgid "Unset image properties"
 msgstr ""
 
@@ -6297,7 +6292,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1032
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6470,7 +6465,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1087 lxc/list.go:46
+#: lxc/image.go:1093 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6583,15 +6578,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
+#: lxc/image.go:399 lxc/image.go:952 lxc/image.go:1512
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1572 lxc/image.go:1699
+#: lxc/image.go:1578 lxc/image.go:1705
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1636
+#: lxc/image.go:1642
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6607,11 +6602,11 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:523
+#: lxc/image.go:528
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1415
+#: lxc/image.go:339 lxc/image.go:1421
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -7074,7 +7069,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1010
 msgid "disabled"
 msgstr ""
 
@@ -7082,7 +7077,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1012
 msgid "enabled"
 msgstr ""
 
@@ -7223,7 +7218,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:398
+#: lxc/image.go:403
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7550,7 +7545,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
+#: lxc/image.go:1000 lxc/image.go:1005 lxc/image.go:1203
 msgid "no"
 msgstr ""
 
@@ -7595,7 +7590,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1194
+#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:1002 lxc/image.go:1007
+#: lxc/image.go:1200
 msgid "yes"
 msgstr ""

--- a/po/hi.po
+++ b/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-19 13:11-0600\n"
+"POT-Creation-Date: 2024-09-25 18:38-0600\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hindi <https://hosted.weblate.org/projects/linux-containers/"
@@ -195,7 +195,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:419
+#: lxc/image.go:424
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -423,7 +423,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1168
+#: lxc/image.go:1174
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -531,7 +531,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:695
+#: lxc/image.go:700
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -544,15 +544,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1138 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1133
+#: lxc/image.go:1139
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1144 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -734,7 +734,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1045
+#: lxc/image.go:1051
 msgid "Aliases:"
 msgstr ""
 
@@ -750,7 +750,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1022 lxc/info.go:486
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -769,11 +769,11 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:342 lxc/rebuild.go:131
+#: lxc/init.go:347 lxc/rebuild.go:136
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/init.go:346
+#: lxc/init.go:351
 msgid "Asked for a container but image is of type VM"
 msgstr ""
 
@@ -831,7 +831,7 @@ msgstr ""
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1061
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -888,7 +888,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:816
+#: lxc/image.go:821
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -969,7 +969,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1060
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -990,7 +990,7 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:239 lxc/utils.go:259
+#: lxc/utils.go:227 lxc/utils.go:247
 #, c-format
 msgid "Can't read from stdin: %w"
 msgstr ""
@@ -1024,7 +1024,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:166
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1176,7 +1176,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1589
+#: lxc/image.go:1121 lxc/list.go:132 lxc/storage_volume.go:1589
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1215,7 +1215,7 @@ msgstr ""
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1327 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/config_trust.go:314 lxc/image.go:496 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
@@ -1309,7 +1309,7 @@ msgstr ""
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1489,7 +1489,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1475
+#: lxc/image.go:1029 lxc/info.go:497 lxc/storage_volume.go:1475
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1513,7 +1513,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1143 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -1571,7 +1571,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:341 lxc/image.go:342
 msgid "Delete images"
 msgstr ""
 
@@ -1674,9 +1674,9 @@ msgstr ""
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
 #: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
-#: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
-#: lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090 lxc/image.go:1417
-#: lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638 lxc/image.go:1701
+#: lxc/image.go:159 lxc/image.go:342 lxc/image.go:401 lxc/image.go:530
+#: lxc/image.go:702 lxc/image.go:954 lxc/image.go:1096 lxc/image.go:1423
+#: lxc/image.go:1514 lxc/image.go:1580 lxc/image.go:1644 lxc/image.go:1707
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
@@ -1821,11 +1821,11 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:406
+#: lxc/init.go:411
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:726
+#: lxc/image.go:731
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1929,7 +1929,7 @@ msgstr ""
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:400 lxc/image.go:401
 msgid "Edit image properties"
 msgstr ""
 
@@ -2005,7 +2005,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1766
+#: lxc/image.go:1155 lxc/list.go:622 lxc/storage_volume.go:1766
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2124,20 +2124,20 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:1029
+#: lxc/image.go:1035
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1037
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:524
+#: lxc/image.go:529
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:530
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2165,7 +2165,7 @@ msgstr ""
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:604
+#: lxc/image.go:609
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2178,7 +2178,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
+#: lxc/config_trust.go:411 lxc/image.go:1140 lxc/image.go:1141
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2197,12 +2197,12 @@ msgstr ""
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/utils.go:296
+#: lxc/utils.go:284
 #, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/utils.go:288
+#: lxc/utils.go:276
 #, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
@@ -2296,7 +2296,7 @@ msgstr ""
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: lxc/utils.go:214
+#: lxc/utils.go:202
 #, c-format
 msgid "Failed to create alias %s: %w"
 msgstr ""
@@ -2321,11 +2321,6 @@ msgstr ""
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
 
-#: lxc/utils.go:203
-#, c-format
-msgid "Failed to remove alias %s: %w"
-msgstr ""
-
 #: lxc/file.go:821
 #, c-format
 msgid "Failed to walk path for %s: %s"
@@ -2345,7 +2340,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:1014
+#: lxc/image.go:1020
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2409,7 +2404,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:770 lxc/auth.go:1697
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1122 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:57
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2484,7 +2479,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1573 lxc/image.go:1574
+#: lxc/image.go:1579 lxc/image.go:1580
 msgid "Get image properties"
 msgstr ""
 
@@ -2758,11 +2753,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1489
+#: lxc/image.go:1495
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2770,25 +2765,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:680
+#: lxc/image.go:685
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1444
+#: lxc/image.go:369 lxc/image.go:1450
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1670
+#: lxc/image.go:449 lxc/image.go:1676
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:918
+#: lxc/image.go:923
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1493
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2808,7 +2803,7 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:697
+#: lxc/image.go:702
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -2818,7 +2813,7 @@ msgid ""
 "os=Ubuntu release=noble variant=cloud."
 msgstr ""
 
-#: lxc/image.go:696
+#: lxc/image.go:701
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2869,7 +2864,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:417
+#: lxc/init.go:422
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2935,7 +2930,7 @@ msgstr ""
 msgid "Invalid instance path: %q"
 msgstr ""
 
-#: lxc/utils.go:253
+#: lxc/utils.go:241
 #, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr ""
@@ -3047,12 +3042,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:1035
+#: lxc/image.go:1041
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:1037
+#: lxc/image.go:1043
 msgid "Last used: never"
 msgstr ""
 
@@ -3170,11 +3165,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1089
+#: lxc/image.go:1095
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1096
 msgid ""
 "List images\n"
 "\n"
@@ -3468,7 +3463,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:165 lxc/image.go:709
 msgid "Make image public"
 msgstr ""
 
@@ -3982,7 +3977,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:728
+#: lxc/image.go:733
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4175,7 +4170,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:168 lxc/image.go:710
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4255,7 +4250,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:805
+#: lxc/image.go:810
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4326,7 +4321,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:752
+#: lxc/image.go:1142 lxc/remote.go:752
 msgid "PUBLIC"
 msgstr ""
 
@@ -4387,7 +4382,7 @@ msgstr ""
 #: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/config_trust.go:315 lxc/image.go:497 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
@@ -4475,11 +4470,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1067
+#: lxc/image.go:1073
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1065
+#: lxc/image.go:1071
 msgid "Profiles: "
 msgstr ""
 
@@ -4502,11 +4497,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1046
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1621
+#: lxc/image.go:1627
 msgid "Property not found"
 msgstr ""
 
@@ -4600,7 +4595,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1024
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4636,7 +4631,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
+#: lxc/image.go:535 lxc/image.go:957 lxc/image.go:1517
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4673,7 +4668,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1416 lxc/image.go:1417
+#: lxc/image.go:1422 lxc/image.go:1423
 msgid "Refresh images"
 msgstr ""
 
@@ -4682,7 +4677,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1453
+#: lxc/image.go:1459
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4945,7 +4940,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:365
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -4978,7 +4973,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1139
+#: lxc/image.go:1145
 msgid "SIZE"
 msgstr ""
 
@@ -5101,7 +5096,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1637 lxc/image.go:1638
+#: lxc/image.go:1643 lxc/image.go:1644
 msgid "Set image properties"
 msgstr ""
 
@@ -5394,7 +5389,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1507 lxc/image.go:1508
+#: lxc/image.go:1513 lxc/image.go:1514
 msgid "Show image properties"
 msgstr ""
 
@@ -5528,7 +5523,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:953 lxc/image.go:954
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5540,7 +5535,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1021
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5572,7 +5567,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:1058
+#: lxc/image.go:1064
 msgid "Source:"
 msgstr ""
 
@@ -5720,7 +5715,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
 #: lxc/storage_volume.go:1730 lxc/warning.go:216
@@ -5785,7 +5780,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:438
+#: lxc/init.go:443
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5794,12 +5789,12 @@ msgstr ""
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
 
-#: lxc/utils.go:376
+#: lxc/utils.go:364
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:%q' instead."
 msgstr ""
 
-#: lxc/utils.go:372
+#: lxc/utils.go:360
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
@@ -5942,15 +5937,15 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1025
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:440
+#: lxc/init.go:445
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:439
+#: lxc/init.go:444
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6004,7 +5999,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:827
+#: lxc/image.go:832
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
@@ -6042,7 +6037,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1023 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1455
 #, c-format
 msgid "Type: %s"
@@ -6057,7 +6052,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1140
+#: lxc/image.go:1146
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6103,7 +6098,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:631 lxc/storage_volume.go:1772
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6145,7 +6140,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1700 lxc/image.go:1701
+#: lxc/image.go:1706 lxc/image.go:1707
 msgid "Unset image properties"
 msgstr ""
 
@@ -6296,7 +6291,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1032
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6469,7 +6464,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1087 lxc/list.go:46
+#: lxc/image.go:1093 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6582,15 +6577,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
+#: lxc/image.go:399 lxc/image.go:952 lxc/image.go:1512
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1572 lxc/image.go:1699
+#: lxc/image.go:1578 lxc/image.go:1705
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1636
+#: lxc/image.go:1642
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6606,11 +6601,11 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:523
+#: lxc/image.go:528
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1415
+#: lxc/image.go:339 lxc/image.go:1421
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -7073,7 +7068,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1010
 msgid "disabled"
 msgstr ""
 
@@ -7081,7 +7076,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1012
 msgid "enabled"
 msgstr ""
 
@@ -7222,7 +7217,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:398
+#: lxc/image.go:403
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7549,7 +7544,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
+#: lxc/image.go:1000 lxc/image.go:1005 lxc/image.go:1203
 msgid "no"
 msgstr ""
 
@@ -7594,7 +7589,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1194
+#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:1002 lxc/image.go:1007
+#: lxc/image.go:1200
 msgid "yes"
 msgstr ""

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-19 13:11-0600\n"
+"POT-Creation-Date: 2024-09-25 18:38-0600\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Indonesian <https://hosted.weblate.org/projects/linux-"
@@ -195,7 +195,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:419
+#: lxc/image.go:424
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -423,7 +423,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1168
+#: lxc/image.go:1174
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -531,7 +531,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:695
+#: lxc/image.go:700
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -544,15 +544,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1138 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1133
+#: lxc/image.go:1139
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1144 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -734,7 +734,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1045
+#: lxc/image.go:1051
 msgid "Aliases:"
 msgstr ""
 
@@ -750,7 +750,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1022 lxc/info.go:486
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -769,11 +769,11 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:342 lxc/rebuild.go:131
+#: lxc/init.go:347 lxc/rebuild.go:136
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/init.go:346
+#: lxc/init.go:351
 msgid "Asked for a container but image is of type VM"
 msgstr ""
 
@@ -831,7 +831,7 @@ msgstr ""
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1061
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -888,7 +888,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:816
+#: lxc/image.go:821
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -969,7 +969,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1060
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -990,7 +990,7 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:239 lxc/utils.go:259
+#: lxc/utils.go:227 lxc/utils.go:247
 #, c-format
 msgid "Can't read from stdin: %w"
 msgstr ""
@@ -1024,7 +1024,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:166
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1176,7 +1176,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1589
+#: lxc/image.go:1121 lxc/list.go:132 lxc/storage_volume.go:1589
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1215,7 +1215,7 @@ msgstr ""
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1327 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/config_trust.go:314 lxc/image.go:496 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
@@ -1309,7 +1309,7 @@ msgstr ""
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1489,7 +1489,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1475
+#: lxc/image.go:1029 lxc/info.go:497 lxc/storage_volume.go:1475
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1513,7 +1513,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1143 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -1571,7 +1571,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:341 lxc/image.go:342
 msgid "Delete images"
 msgstr ""
 
@@ -1674,9 +1674,9 @@ msgstr ""
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
 #: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
-#: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
-#: lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090 lxc/image.go:1417
-#: lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638 lxc/image.go:1701
+#: lxc/image.go:159 lxc/image.go:342 lxc/image.go:401 lxc/image.go:530
+#: lxc/image.go:702 lxc/image.go:954 lxc/image.go:1096 lxc/image.go:1423
+#: lxc/image.go:1514 lxc/image.go:1580 lxc/image.go:1644 lxc/image.go:1707
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
@@ -1821,11 +1821,11 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:406
+#: lxc/init.go:411
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:726
+#: lxc/image.go:731
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1929,7 +1929,7 @@ msgstr ""
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:400 lxc/image.go:401
 msgid "Edit image properties"
 msgstr ""
 
@@ -2005,7 +2005,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1766
+#: lxc/image.go:1155 lxc/list.go:622 lxc/storage_volume.go:1766
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2124,20 +2124,20 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:1029
+#: lxc/image.go:1035
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1037
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:524
+#: lxc/image.go:529
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:530
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2165,7 +2165,7 @@ msgstr ""
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:604
+#: lxc/image.go:609
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2178,7 +2178,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
+#: lxc/config_trust.go:411 lxc/image.go:1140 lxc/image.go:1141
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2197,12 +2197,12 @@ msgstr ""
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/utils.go:296
+#: lxc/utils.go:284
 #, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/utils.go:288
+#: lxc/utils.go:276
 #, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
@@ -2296,7 +2296,7 @@ msgstr ""
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: lxc/utils.go:214
+#: lxc/utils.go:202
 #, c-format
 msgid "Failed to create alias %s: %w"
 msgstr ""
@@ -2321,11 +2321,6 @@ msgstr ""
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
 
-#: lxc/utils.go:203
-#, c-format
-msgid "Failed to remove alias %s: %w"
-msgstr ""
-
 #: lxc/file.go:821
 #, c-format
 msgid "Failed to walk path for %s: %s"
@@ -2345,7 +2340,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:1014
+#: lxc/image.go:1020
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2409,7 +2404,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:770 lxc/auth.go:1697
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1122 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:57
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2484,7 +2479,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1573 lxc/image.go:1574
+#: lxc/image.go:1579 lxc/image.go:1580
 msgid "Get image properties"
 msgstr ""
 
@@ -2758,11 +2753,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1489
+#: lxc/image.go:1495
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2770,25 +2765,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:680
+#: lxc/image.go:685
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1444
+#: lxc/image.go:369 lxc/image.go:1450
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1670
+#: lxc/image.go:449 lxc/image.go:1676
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:918
+#: lxc/image.go:923
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1493
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2808,7 +2803,7 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:697
+#: lxc/image.go:702
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -2818,7 +2813,7 @@ msgid ""
 "os=Ubuntu release=noble variant=cloud."
 msgstr ""
 
-#: lxc/image.go:696
+#: lxc/image.go:701
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2869,7 +2864,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:417
+#: lxc/init.go:422
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2935,7 +2930,7 @@ msgstr ""
 msgid "Invalid instance path: %q"
 msgstr ""
 
-#: lxc/utils.go:253
+#: lxc/utils.go:241
 #, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr ""
@@ -3047,12 +3042,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:1035
+#: lxc/image.go:1041
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:1037
+#: lxc/image.go:1043
 msgid "Last used: never"
 msgstr ""
 
@@ -3170,11 +3165,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1089
+#: lxc/image.go:1095
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1096
 msgid ""
 "List images\n"
 "\n"
@@ -3468,7 +3463,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:165 lxc/image.go:709
 msgid "Make image public"
 msgstr ""
 
@@ -3982,7 +3977,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:728
+#: lxc/image.go:733
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4175,7 +4170,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:168 lxc/image.go:710
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4255,7 +4250,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:805
+#: lxc/image.go:810
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4326,7 +4321,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:752
+#: lxc/image.go:1142 lxc/remote.go:752
 msgid "PUBLIC"
 msgstr ""
 
@@ -4387,7 +4382,7 @@ msgstr ""
 #: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/config_trust.go:315 lxc/image.go:497 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
@@ -4475,11 +4470,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1067
+#: lxc/image.go:1073
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1065
+#: lxc/image.go:1071
 msgid "Profiles: "
 msgstr ""
 
@@ -4502,11 +4497,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1046
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1621
+#: lxc/image.go:1627
 msgid "Property not found"
 msgstr ""
 
@@ -4600,7 +4595,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1024
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4636,7 +4631,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
+#: lxc/image.go:535 lxc/image.go:957 lxc/image.go:1517
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4673,7 +4668,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1416 lxc/image.go:1417
+#: lxc/image.go:1422 lxc/image.go:1423
 msgid "Refresh images"
 msgstr ""
 
@@ -4682,7 +4677,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1453
+#: lxc/image.go:1459
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4945,7 +4940,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:365
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -4978,7 +4973,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1139
+#: lxc/image.go:1145
 msgid "SIZE"
 msgstr ""
 
@@ -5101,7 +5096,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1637 lxc/image.go:1638
+#: lxc/image.go:1643 lxc/image.go:1644
 msgid "Set image properties"
 msgstr ""
 
@@ -5394,7 +5389,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1507 lxc/image.go:1508
+#: lxc/image.go:1513 lxc/image.go:1514
 msgid "Show image properties"
 msgstr ""
 
@@ -5528,7 +5523,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:953 lxc/image.go:954
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5540,7 +5535,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1021
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5572,7 +5567,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:1058
+#: lxc/image.go:1064
 msgid "Source:"
 msgstr ""
 
@@ -5720,7 +5715,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
 #: lxc/storage_volume.go:1730 lxc/warning.go:216
@@ -5785,7 +5780,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:438
+#: lxc/init.go:443
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5794,12 +5789,12 @@ msgstr ""
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
 
-#: lxc/utils.go:376
+#: lxc/utils.go:364
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:%q' instead."
 msgstr ""
 
-#: lxc/utils.go:372
+#: lxc/utils.go:360
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
@@ -5942,15 +5937,15 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1025
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:440
+#: lxc/init.go:445
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:439
+#: lxc/init.go:444
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6004,7 +5999,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:827
+#: lxc/image.go:832
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
@@ -6042,7 +6037,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1023 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1455
 #, c-format
 msgid "Type: %s"
@@ -6057,7 +6052,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1140
+#: lxc/image.go:1146
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6103,7 +6098,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:631 lxc/storage_volume.go:1772
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6145,7 +6140,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1700 lxc/image.go:1701
+#: lxc/image.go:1706 lxc/image.go:1707
 msgid "Unset image properties"
 msgstr ""
 
@@ -6296,7 +6291,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1032
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6469,7 +6464,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1087 lxc/list.go:46
+#: lxc/image.go:1093 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6582,15 +6577,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
+#: lxc/image.go:399 lxc/image.go:952 lxc/image.go:1512
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1572 lxc/image.go:1699
+#: lxc/image.go:1578 lxc/image.go:1705
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1636
+#: lxc/image.go:1642
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6606,11 +6601,11 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:523
+#: lxc/image.go:528
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1415
+#: lxc/image.go:339 lxc/image.go:1421
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -7073,7 +7068,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1010
 msgid "disabled"
 msgstr ""
 
@@ -7081,7 +7076,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1012
 msgid "enabled"
 msgstr ""
 
@@ -7222,7 +7217,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:398
+#: lxc/image.go:403
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7549,7 +7544,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
+#: lxc/image.go:1000 lxc/image.go:1005 lxc/image.go:1203
 msgid "no"
 msgstr ""
 
@@ -7594,7 +7589,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1194
+#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:1002 lxc/image.go:1007
+#: lxc/image.go:1200
 msgid "yes"
 msgstr ""

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-19 13:11-0600\n"
+"POT-Creation-Date: 2024-09-25 18:38-0600\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Luigi Operoso <brokenpip3@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/linux-containers/"
@@ -279,7 +279,7 @@ msgstr ""
 "### Un esempio è il seguente:\n"
 "###  description: My custom image"
 
-#: lxc/image.go:419
+#: lxc/image.go:424
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the image properties.\n"
@@ -665,7 +665,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1168
+#: lxc/image.go:1174
 #, c-format
 msgid "%s (%d more)"
 msgstr "%s (altri %d)"
@@ -776,7 +776,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr "Creazione del container in corso"
 
-#: lxc/image.go:695
+#: lxc/image.go:700
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -789,15 +789,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1138 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr "ALIAS"
 
-#: lxc/image.go:1133
+#: lxc/image.go:1139
 msgid "ALIASES"
 msgstr "ALIAS"
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1144 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr "ARCHITETTURA"
 
@@ -983,7 +983,7 @@ msgstr "Nome dell'alias mancante"
 msgid "Aliases already exists: %s"
 msgstr "il remote %s esiste già"
 
-#: lxc/image.go:1045
+#: lxc/image.go:1051
 msgid "Aliases:"
 msgstr "Alias:"
 
@@ -1000,7 +1000,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr "Accetta certificato"
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1022 lxc/info.go:486
 #, c-format
 msgid "Architecture: %s"
 msgstr "Architettura: %s"
@@ -1019,11 +1019,11 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:342 lxc/rebuild.go:131
+#: lxc/init.go:347 lxc/rebuild.go:136
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/init.go:346
+#: lxc/init.go:351
 msgid "Asked for a container but image is of type VM"
 msgstr ""
 
@@ -1082,7 +1082,7 @@ msgstr ""
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1061
 #, c-format
 msgid "Auto update: %s"
 msgstr "Aggiornamento automatico: %s"
@@ -1139,7 +1139,7 @@ msgstr "Proprietà errata: %s"
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:816
+#: lxc/image.go:821
 #, c-format
 msgid "Bad property: %s"
 msgstr "Proprietà errata: %s"
@@ -1221,7 +1221,7 @@ msgstr "CREATO IL"
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1060
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -1242,7 +1242,7 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr "Impossibile effettuare il pull di una directory senza --recursive"
 
-#: lxc/utils.go:239 lxc/utils.go:259
+#: lxc/utils.go:227 lxc/utils.go:247
 #, fuzzy, c-format
 msgid "Can't read from stdin: %w"
 msgstr "Impossible leggere da stdin: %s"
@@ -1276,7 +1276,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:166
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1430,7 +1430,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1589
+#: lxc/image.go:1121 lxc/list.go:132 lxc/storage_volume.go:1589
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr "Colonne"
@@ -1469,7 +1469,7 @@ msgstr ""
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1327 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/config_trust.go:314 lxc/image.go:496 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
@@ -1563,7 +1563,7 @@ msgstr ""
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1752,7 +1752,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1475
+#: lxc/image.go:1029 lxc/info.go:497 lxc/storage_volume.go:1475
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1777,7 +1777,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1143 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -1836,7 +1836,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:341 lxc/image.go:342
 msgid "Delete images"
 msgstr ""
 
@@ -1943,9 +1943,9 @@ msgstr ""
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
 #: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
-#: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
-#: lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090 lxc/image.go:1417
-#: lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638 lxc/image.go:1701
+#: lxc/image.go:159 lxc/image.go:342 lxc/image.go:401 lxc/image.go:530
+#: lxc/image.go:702 lxc/image.go:954 lxc/image.go:1096 lxc/image.go:1423
+#: lxc/image.go:1514 lxc/image.go:1580 lxc/image.go:1644 lxc/image.go:1707
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
@@ -2092,11 +2092,11 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:406
+#: lxc/init.go:411
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:726
+#: lxc/image.go:731
 msgid "Directory import is not available on this platform"
 msgstr "Import da directory non disponibile su questa piattaforma"
 
@@ -2205,7 +2205,7 @@ msgstr ""
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:400 lxc/image.go:401
 msgid "Edit image properties"
 msgstr ""
 
@@ -2286,7 +2286,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1766
+#: lxc/image.go:1155 lxc/list.go:622 lxc/storage_volume.go:1766
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2406,20 +2406,20 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:1029
+#: lxc/image.go:1035
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1037
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:524
+#: lxc/image.go:529
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:530
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2449,7 +2449,7 @@ msgstr ""
 msgid "Exporting the backup: %s"
 msgstr "Creazione del container in corso"
 
-#: lxc/image.go:604
+#: lxc/image.go:609
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2462,7 +2462,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
+#: lxc/config_trust.go:411 lxc/image.go:1140 lxc/image.go:1141
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2481,12 +2481,12 @@ msgstr ""
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/utils.go:296
+#: lxc/utils.go:284
 #, fuzzy, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr "Il nome del container è: %s"
 
-#: lxc/utils.go:288
+#: lxc/utils.go:276
 #, fuzzy, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "Il nome del container è: %s"
@@ -2580,7 +2580,7 @@ msgstr "Il nome del container è: %s"
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: lxc/utils.go:214
+#: lxc/utils.go:202
 #, fuzzy, c-format
 msgid "Failed to create alias %s: %w"
 msgstr "Accetta certificato"
@@ -2605,11 +2605,6 @@ msgstr "Accetta certificato"
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
 
-#: lxc/utils.go:203
-#, fuzzy, c-format
-msgid "Failed to remove alias %s: %w"
-msgstr "Accetta certificato"
-
 #: lxc/file.go:821
 #, c-format
 msgid "Failed to walk path for %s: %s"
@@ -2630,7 +2625,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr "'%s' non è un tipo di file supportato."
 
-#: lxc/image.go:1014
+#: lxc/image.go:1020
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2695,7 +2690,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:770 lxc/auth.go:1697
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1122 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:57
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2771,7 +2766,7 @@ msgstr "Creazione del container in corso"
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1573 lxc/image.go:1574
+#: lxc/image.go:1579 lxc/image.go:1580
 msgid "Get image properties"
 msgstr ""
 
@@ -3057,11 +3052,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr "Creazione del container in corso"
 
-#: lxc/image.go:1489
+#: lxc/image.go:1495
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -3069,25 +3064,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:680
+#: lxc/image.go:685
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1444
+#: lxc/image.go:369 lxc/image.go:1450
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1670
+#: lxc/image.go:449 lxc/image.go:1676
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:918
+#: lxc/image.go:923
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1493
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3107,7 +3102,7 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:697
+#: lxc/image.go:702
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -3117,7 +3112,7 @@ msgid ""
 "os=Ubuntu release=noble variant=cloud."
 msgstr ""
 
-#: lxc/image.go:696
+#: lxc/image.go:701
 msgid "Import images into the image store"
 msgstr ""
 
@@ -3170,7 +3165,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:417
+#: lxc/init.go:422
 #, fuzzy, c-format
 msgid "Instance name is: %s"
 msgstr "Il nome del container è: %s"
@@ -3237,7 +3232,7 @@ msgstr "Il nome del container è: %s"
 msgid "Invalid instance path: %q"
 msgstr "Il nome del container è: %s"
 
-#: lxc/utils.go:253
+#: lxc/utils.go:241
 #, fuzzy, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr "Proprietà errata: %s"
@@ -3352,12 +3347,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr "Aggiornamento automatico: %s"
 
-#: lxc/image.go:1035
+#: lxc/image.go:1041
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:1037
+#: lxc/image.go:1043
 msgid "Last used: never"
 msgstr ""
 
@@ -3484,11 +3479,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1089
+#: lxc/image.go:1095
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1096
 msgid ""
 "List images\n"
 "\n"
@@ -3790,7 +3785,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:165 lxc/image.go:709
 msgid "Make image public"
 msgstr ""
 
@@ -4342,7 +4337,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:728
+#: lxc/image.go:733
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4535,7 +4530,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:168 lxc/image.go:710
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4616,7 +4611,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:805
+#: lxc/image.go:810
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4687,7 +4682,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:752
+#: lxc/image.go:1142 lxc/remote.go:752
 msgid "PUBLIC"
 msgstr ""
 
@@ -4750,7 +4745,7 @@ msgstr ""
 #: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/config_trust.go:315 lxc/image.go:497 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
@@ -4840,11 +4835,11 @@ msgstr "non tutti i profili dell'origine esistono nella destinazione"
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1067
+#: lxc/image.go:1073
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1065
+#: lxc/image.go:1071
 msgid "Profiles: "
 msgstr ""
 
@@ -4867,11 +4862,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1046
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1621
+#: lxc/image.go:1627
 msgid "Property not found"
 msgstr ""
 
@@ -4965,7 +4960,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1024
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -5002,7 +4997,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
+#: lxc/image.go:535 lxc/image.go:957 lxc/image.go:1517
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -5041,7 +5036,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1416 lxc/image.go:1417
+#: lxc/image.go:1422 lxc/image.go:1423
 msgid "Refresh images"
 msgstr ""
 
@@ -5050,7 +5045,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr "Creazione del container in corso"
 
-#: lxc/image.go:1453
+#: lxc/image.go:1459
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5325,7 +5320,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:365
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5361,7 +5356,7 @@ msgstr "Creazione del container in corso"
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1139
+#: lxc/image.go:1145
 msgid "SIZE"
 msgstr ""
 
@@ -5486,7 +5481,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1637 lxc/image.go:1638
+#: lxc/image.go:1643 lxc/image.go:1644
 msgid "Set image properties"
 msgstr ""
 
@@ -5789,7 +5784,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1507 lxc/image.go:1508
+#: lxc/image.go:1513 lxc/image.go:1514
 msgid "Show image properties"
 msgstr ""
 
@@ -5933,7 +5928,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr "Il nome del container è: %s"
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:953 lxc/image.go:954
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5945,7 +5940,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1021
 #, fuzzy, c-format
 msgid "Size: %.2fMiB"
 msgstr "Aggiornamento automatico: %s"
@@ -5977,7 +5972,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr "errore di processamento degli alias %s\n"
 
-#: lxc/image.go:1058
+#: lxc/image.go:1064
 msgid "Source:"
 msgstr ""
 
@@ -6128,7 +6123,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
 #: lxc/storage_volume.go:1730 lxc/warning.go:216
@@ -6194,7 +6189,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:438
+#: lxc/init.go:443
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -6203,12 +6198,12 @@ msgstr ""
 msgid "The key %q does not exist on cluster member %q"
 msgstr "Il nome del container è: %s"
 
-#: lxc/utils.go:376
+#: lxc/utils.go:364
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:%q' instead."
 msgstr ""
 
-#: lxc/utils.go:372
+#: lxc/utils.go:360
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
@@ -6354,15 +6349,15 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1025
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:440
+#: lxc/init.go:445
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:439
+#: lxc/init.go:444
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6416,7 +6411,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:827
+#: lxc/image.go:832
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
@@ -6455,7 +6450,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1023 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1455
 #, c-format
 msgid "Type: %s"
@@ -6470,7 +6465,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1140
+#: lxc/image.go:1146
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6517,7 +6512,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:631 lxc/storage_volume.go:1772
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6562,7 +6557,7 @@ msgstr "non tutti i profili dell'origine esistono nella destinazione"
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1700 lxc/image.go:1701
+#: lxc/image.go:1706 lxc/image.go:1707
 msgid "Unset image properties"
 msgstr ""
 
@@ -6724,7 +6719,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1032
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6908,7 +6903,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:] [<cert>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/image.go:1087 lxc/list.go:46
+#: lxc/image.go:1093 lxc/list.go:46
 #, fuzzy
 msgid "[<remote>:] [<filter>...]"
 msgstr "Creazione del container in corso"
@@ -7045,17 +7040,17 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr "Creazione del container in corso"
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
+#: lxc/image.go:399 lxc/image.go:952 lxc/image.go:1512
 #, fuzzy
 msgid "[<remote>:]<image>"
 msgstr "Creazione del container in corso"
 
-#: lxc/image.go:1572 lxc/image.go:1699
+#: lxc/image.go:1578 lxc/image.go:1705
 #, fuzzy
 msgid "[<remote>:]<image> <key>"
 msgstr "Creazione del container in corso"
 
-#: lxc/image.go:1636
+#: lxc/image.go:1642
 #, fuzzy
 msgid "[<remote>:]<image> <key> <value>"
 msgstr "Creazione del container in corso"
@@ -7075,12 +7070,12 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/image.go:523
+#: lxc/image.go:528
 #, fuzzy
 msgid "[<remote>:]<image> [<target>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/image.go:334 lxc/image.go:1415
+#: lxc/image.go:339 lxc/image.go:1421
 #, fuzzy
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr "Creazione del container in corso"
@@ -7648,7 +7643,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1010
 msgid "disabled"
 msgstr ""
 
@@ -7656,7 +7651,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1012
 msgid "enabled"
 msgstr ""
 
@@ -7797,7 +7792,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:398
+#: lxc/image.go:403
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -8125,7 +8120,7 @@ msgstr "no"
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
+#: lxc/image.go:1000 lxc/image.go:1005 lxc/image.go:1203
 msgid "no"
 msgstr "no"
 
@@ -8170,10 +8165,14 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1194
+#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:1002 lxc/image.go:1007
+#: lxc/image.go:1200
 msgid "yes"
 msgstr "si"
+
+#, fuzzy, c-format
+#~ msgid "Failed to remove alias %s: %w"
+#~ msgstr "Accetta certificato"
 
 #, fuzzy
 #~ msgid "[<remote>:]<cluster member>"

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-19 13:11-0600\n"
+"POT-Creation-Date: 2024-09-25 18:38-0600\n"
 "PO-Revision-Date: 2023-03-10 15:14+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/linux-"
@@ -255,7 +255,7 @@ msgstr ""
 "###\n"
 "### Note that the fingerprint is shown but cannot be changed"
 
-#: lxc/image.go:419
+#: lxc/image.go:424
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -657,7 +657,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr "%d (id: %d, オンライン: %v, NUMA ノード: %v)"
 
-#: lxc/image.go:1168
+#: lxc/image.go:1174
 #, c-format
 msgid "%s (%d more)"
 msgstr "%s (他%d個)"
@@ -765,7 +765,7 @@ msgstr "<remote> <new-name>"
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr "<source path>... [<remote>:]<instance>/<path>"
 
-#: lxc/image.go:695
+#: lxc/image.go:700
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -780,15 +780,15 @@ msgstr "<target>"
 msgid "ADDRESS"
 msgstr "IP ADDRESS"
 
-#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1138 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr "ALIAS"
 
-#: lxc/image.go:1133
+#: lxc/image.go:1139
 msgid "ALIASES"
 msgstr "ALIASES"
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1144 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr "ARCHITECTURE"
 
@@ -991,7 +991,7 @@ msgstr "エイリアスを指定してください"
 msgid "Aliases already exists: %s"
 msgstr "エイリアス %s は既に存在します"
 
-#: lxc/image.go:1045
+#: lxc/image.go:1051
 msgid "Aliases:"
 msgstr "エイリアス:"
 
@@ -1007,7 +1007,7 @@ msgstr "すべてのサーバーアドレスが利用できません"
 msgid "Alternative certificate name"
 msgstr "別の証明署名"
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1022 lxc/info.go:486
 #, c-format
 msgid "Architecture: %s"
 msgstr "アーキテクチャ: %s"
@@ -1027,11 +1027,11 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr "どちらもみつかりませんでした。raw SPICE ソケットはこちらにあります:"
 
-#: lxc/init.go:342 lxc/rebuild.go:131
+#: lxc/init.go:347 lxc/rebuild.go:136
 msgid "Asked for a VM but image is of type container"
 msgstr "VMを要求しましたが、イメージタイプがコンテナです"
 
-#: lxc/init.go:346
+#: lxc/init.go:351
 #, fuzzy
 msgid "Asked for a container but image is of type VM"
 msgstr "VMを要求しましたが、イメージタイプがコンテナです"
@@ -1094,7 +1094,7 @@ msgstr "オートネゴシエーション: %v"
 msgid "Auto update is only available in pull mode"
 msgstr "自動更新は pull モードのときのみ有効です"
 
-#: lxc/image.go:1055
+#: lxc/image.go:1061
 #, c-format
 msgid "Auto update: %s"
 msgstr "自動更新: %s"
@@ -1153,7 +1153,7 @@ msgstr "不適切な キー=値 のペア: %s"
 msgid "Bad key=value pair: %s"
 msgstr "不適切な キー=値 のペア: %s"
 
-#: lxc/image.go:816
+#: lxc/image.go:821
 #, c-format
 msgid "Bad property: %s"
 msgstr "不正なイメージプロパティ形式: %s"
@@ -1234,7 +1234,7 @@ msgstr "CREATED AT"
 msgid "CUDA Version: %v"
 msgstr "CUDA バージョン: %v"
 
-#: lxc/image.go:1054
+#: lxc/image.go:1060
 #, c-format
 msgid "Cached: %s"
 msgstr "キャッシュ済: %s"
@@ -1256,7 +1256,7 @@ msgid "Can't pull a directory without --recursive"
 msgstr ""
 "ディレクトリを pull する場合は --recursive オプションを使用してください"
 
-#: lxc/utils.go:239 lxc/utils.go:259
+#: lxc/utils.go:227 lxc/utils.go:247
 #, c-format
 msgid "Can't read from stdin: %w"
 msgstr "標準入力から読み込めません: %w"
@@ -1290,7 +1290,7 @@ msgstr "再帰 (recursive) モードでは uid/gid/mode を指定できません
 msgid "Can't unset key '%s', it's not currently set"
 msgstr "キー '%s' が設定されていないので削除できません"
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:166
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1447,7 +1447,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr "クラスタリングが有効になりました"
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1589
+#: lxc/image.go:1121 lxc/list.go:132 lxc/storage_volume.go:1589
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr "カラムレイアウト"
@@ -1490,7 +1490,7 @@ msgstr "移動先のインスタンスに適用するキー/値の設定"
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1327 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/config_trust.go:314 lxc/image.go:496 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
@@ -1599,7 +1599,7 @@ msgstr "コピー／移動元とは異なるプロジェクトにコピーしま
 msgid "Copy virtual machine images"
 msgstr "仮想マシンイメージをコピーします"
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr "イメージのコピー中: %s"
@@ -1785,7 +1785,7 @@ msgstr "ストレージプールを作成します"
 msgid "Create the instance with no profiles applied"
 msgstr "プロファイルを適用しないインスタンスを作成します"
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1475
+#: lxc/image.go:1029 lxc/info.go:497 lxc/storage_volume.go:1475
 #, c-format
 msgid "Created: %s"
 msgstr "作成日時: %s"
@@ -1809,7 +1809,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr "DEFAULT TARGET ADDRESS"
 
 #: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1143 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -1869,7 +1869,7 @@ msgstr "クラスタグループを削除します"
 msgid "Delete image aliases"
 msgstr "イメージのエイリアスを削除します"
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:341 lxc/image.go:342
 msgid "Delete images"
 msgstr "イメージを削除します"
 
@@ -1972,9 +1972,9 @@ msgstr "警告を削除します"
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
 #: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
-#: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
-#: lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090 lxc/image.go:1417
-#: lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638 lxc/image.go:1701
+#: lxc/image.go:159 lxc/image.go:342 lxc/image.go:401 lxc/image.go:530
+#: lxc/image.go:702 lxc/image.go:954 lxc/image.go:1096 lxc/image.go:1423
+#: lxc/image.go:1514 lxc/image.go:1580 lxc/image.go:1644 lxc/image.go:1707
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
@@ -2123,13 +2123,13 @@ msgstr "プロファイルのデバイスは個々のインスタンスでは取
 msgid "Device: %s"
 msgstr "デバイス: %s"
 
-#: lxc/init.go:406
+#: lxc/init.go:411
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 "サーバから変更されたイメージ、インスタンス、スナップショットを取得できません"
 "でした"
 
-#: lxc/image.go:726
+#: lxc/image.go:731
 msgid "Directory import is not available on this platform"
 msgstr "このプラットフォーム上ではディレクトリのインポートは利用できません"
 
@@ -2238,7 +2238,7 @@ msgstr "信頼済みクライアント設定をYAMLで編集します"
 msgid "Edit identity provider groups as YAML"
 msgstr "プロファイル設定をYAMLで編集します"
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:400 lxc/image.go:401
 msgid "Edit image properties"
 msgstr "イメージのプロパティを編集します"
 
@@ -2315,7 +2315,7 @@ msgstr "ストレージボリュームの設定をYAMLで編集します"
 msgid "Edit trust configurations as YAML"
 msgstr "信頼済みクライアント設定をYAMLで編集します"
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1766
+#: lxc/image.go:1155 lxc/list.go:622 lxc/storage_volume.go:1766
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2456,20 +2456,20 @@ msgstr ""
 msgid "Expires at"
 msgstr "失効日時"
 
-#: lxc/image.go:1029
+#: lxc/image.go:1035
 #, c-format
 msgid "Expires: %s"
 msgstr "失効日時: %s"
 
-#: lxc/image.go:1031
+#: lxc/image.go:1037
 msgid "Expires: never"
 msgstr "失効日時: 失効しない"
 
-#: lxc/image.go:524
+#: lxc/image.go:529
 msgid "Export and download images"
 msgstr "イメージをエクスポートしてダウンロードします"
 
-#: lxc/image.go:525
+#: lxc/image.go:530
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2501,7 +2501,7 @@ msgstr ""
 msgid "Exporting the backup: %s"
 msgstr "バックアップのエクスポート中: %s"
 
-#: lxc/image.go:604
+#: lxc/image.go:609
 #, c-format
 msgid "Exporting the image: %s"
 msgstr "イメージのエクスポート中: %s"
@@ -2514,7 +2514,7 @@ msgstr "FAILURE DOMAIN"
 msgid "FILENAME"
 msgstr "FILENAME"
 
-#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
+#: lxc/config_trust.go:411 lxc/image.go:1140 lxc/image.go:1141
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr "FINGERPRINT"
@@ -2533,12 +2533,12 @@ msgstr "クライアント %q との SSH ハンドシェイクに失敗しまし
 msgid "Failed accepting channel client %q: %v"
 msgstr "クライアント %q のチャンネルの受け入れに失敗しました: %v"
 
-#: lxc/utils.go:296
+#: lxc/utils.go:284
 #, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr "インスタンスの存在確認に失敗しました \"%s:%s\": %w"
 
-#: lxc/utils.go:288
+#: lxc/utils.go:276
 #, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "インスタンスのスナップショットの存在確認に失敗しました \"%s:%s\": %w"
@@ -2632,7 +2632,7 @@ msgstr "クラスタメンバへの接続に失敗しました: %w"
 msgid "Failed to create %q: %w"
 msgstr "%q の作成に失敗しました: %w"
 
-#: lxc/utils.go:214
+#: lxc/utils.go:202
 #, c-format
 msgid "Failed to create alias %s: %w"
 msgstr "エイリアス %s の作成に失敗しました: %w"
@@ -2657,11 +2657,6 @@ msgstr "コネクションのリッスンに失敗しました: %w"
 msgid "Failed to refresh target instance '%s': %v"
 msgstr "コピー先のインスタンス '%s' のリフレッシュに失敗しました: %v"
 
-#: lxc/utils.go:203
-#, c-format
-msgid "Failed to remove alias %s: %w"
-msgstr "エイリアス %s の削除に失敗しました: %w"
-
 #: lxc/file.go:821
 #, c-format
 msgid "Failed to walk path for %s: %s"
@@ -2681,7 +2676,7 @@ msgstr "Fast モード (--columns=nsacPt と同じ)"
 msgid "Filtering isn't supported yet"
 msgstr "情報表示のフィルタリングはまだサポートされていません"
 
-#: lxc/image.go:1014
+#: lxc/image.go:1020
 #, c-format
 msgid "Fingerprint: %s"
 msgstr "証明書のフィンガープリント: %s"
@@ -2761,7 +2756,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:770 lxc/auth.go:1697
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1122 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:57
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2837,7 +2832,7 @@ msgstr "インスタンスからファイルをマウントします"
 msgid "Get a summary of resource allocations"
 msgstr "リソース割当の状況を表示します"
 
-#: lxc/image.go:1573 lxc/image.go:1574
+#: lxc/image.go:1579 lxc/image.go:1580
 msgid "Get image properties"
 msgstr "イメージのプロパティを取得します"
 
@@ -3126,11 +3121,11 @@ msgstr "コピー中にファイルが更新された場合のエラーを無視
 msgid "Ignore the instance state"
 msgstr "インスタンスの状態を無視します"
 
-#: lxc/image.go:1489
+#: lxc/image.go:1495
 msgid "Image already up to date."
 msgstr "イメージは更新済みです。"
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr "イメージのコピーが成功しました!"
 
@@ -3138,25 +3133,25 @@ msgstr "イメージのコピーが成功しました!"
 msgid "Image expiration date (format: rfc3339)"
 msgstr "イメージの失効日（フォーマット: rfc3339）"
 
-#: lxc/image.go:680
+#: lxc/image.go:685
 msgid "Image exported successfully!"
 msgstr "イメージのエクスポートが成功しました!"
 
-#: lxc/image.go:364 lxc/image.go:1444
+#: lxc/image.go:369 lxc/image.go:1450
 msgid "Image identifier missing"
 msgstr "イメージ名を指定してください"
 
-#: lxc/image.go:444 lxc/image.go:1670
+#: lxc/image.go:449 lxc/image.go:1676
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr "イメージ名を指定してください: %s"
 
-#: lxc/image.go:918
+#: lxc/image.go:923
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr "イメージは以下のフィンガープリントでインポートされました: %s"
 
-#: lxc/image.go:1487
+#: lxc/image.go:1493
 msgid "Image refreshed successfully!"
 msgstr "イメージの更新が成功しました!"
 
@@ -3179,7 +3174,7 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr "新たにカスタムストレージボリュームをインポートします"
 
-#: lxc/image.go:697
+#: lxc/image.go:702
 #, fuzzy
 msgid ""
 "Import image into the image store\n"
@@ -3194,7 +3189,7 @@ msgstr ""
 "ディレクトリのインポートは Linux 上でのみ可能で、root で実行する必要がありま"
 "す。"
 
-#: lxc/image.go:696
+#: lxc/image.go:701
 msgid "Import images into the image store"
 msgstr "イメージをイメージストアにインポートします"
 
@@ -3245,7 +3240,7 @@ msgstr "クライアント %q に対するインスタンスが切断されま�
 msgid "Instance name is mandatory"
 msgstr "インスタンス名を指定する必要があります"
 
-#: lxc/init.go:417
+#: lxc/init.go:422
 #, c-format
 msgid "Instance name is: %s"
 msgstr "インスタンス名: %s"
@@ -3313,7 +3308,7 @@ msgstr "不正なインスタンス名: %s"
 msgid "Invalid instance path: %q"
 msgstr "不正なインスタンスのパス: %q"
 
-#: lxc/utils.go:253
+#: lxc/utils.go:241
 #, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr "不適切な キー=値 の設定: %s"
@@ -3434,12 +3429,12 @@ msgstr "LXD サーバはクラスタの一部ではありません"
 msgid "Last Used: %s"
 msgstr "最終使用: %s"
 
-#: lxc/image.go:1035
+#: lxc/image.go:1041
 #, c-format
 msgid "Last used: %s"
 msgstr "最終使用: %s"
 
-#: lxc/image.go:1037
+#: lxc/image.go:1043
 msgid "Last used: never"
 msgstr "最終使用: 未使用"
 
@@ -3564,11 +3559,11 @@ msgstr ""
 "指定するフィルタはイメージのハッシュ値の一部でもイメージのエイリアスの一部で"
 "も構いません。\n"
 
-#: lxc/image.go:1089
+#: lxc/image.go:1095
 msgid "List images"
 msgstr "イメージを一覧表示します"
 
-#: lxc/image.go:1090
+#: lxc/image.go:1096
 msgid ""
 "List images\n"
 "\n"
@@ -3999,7 +3994,7 @@ msgstr "MTU"
 msgid "MTU: %d"
 msgstr "MTU: %d"
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:165 lxc/image.go:709
 msgid "Make image public"
 msgstr "イメージを public にする"
 
@@ -4558,7 +4553,7 @@ msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 "複数のルールにマッチしました。すべて削除するには --force を指定してください"
 
-#: lxc/image.go:728
+#: lxc/image.go:733
 msgid "Must run as root to import from directory"
 msgstr "ディレクトリからのインポートは root で実行する必要があります"
 
@@ -4753,7 +4748,7 @@ msgstr "ネットワークゾーンレコード %s を削除しました"
 msgid "New alias to define at target"
 msgstr "新しいエイリアスを定義する"
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:168 lxc/image.go:710
 msgid "New aliases to add to the image"
 msgstr "イメージに新しいエイリアスを追加します"
 
@@ -4834,7 +4829,7 @@ msgstr "\"カスタム\" のボリュームのみがスナップショットを�
 msgid "Only https URLs are supported for simplestreams"
 msgstr "simplestreams は https の URL のみサポートします"
 
-#: lxc/image.go:805
+#: lxc/image.go:810
 msgid "Only https:// is supported for remote image import"
 msgstr "リモートイメージのインポートは https:// のみをサポートします"
 
@@ -4905,7 +4900,7 @@ msgstr "PROJECT"
 msgid "PROTOCOL"
 msgstr "PROTOCOL"
 
-#: lxc/image.go:1136 lxc/remote.go:752
+#: lxc/image.go:1142 lxc/remote.go:752
 msgid "PUBLIC"
 msgstr "PUBLIC"
 
@@ -4966,7 +4961,7 @@ msgstr "終了するには ctrl+c を押してください"
 #: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/config_trust.go:315 lxc/image.go:497 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
@@ -5056,11 +5051,11 @@ msgstr "移動先のインスタンスに適用するプロファイル"
 msgid "Profiles %s applied to %s"
 msgstr "プロファイル %s が %s に追加されました"
 
-#: lxc/image.go:1067
+#: lxc/image.go:1073
 msgid "Profiles:"
 msgstr "プロファイル:"
 
-#: lxc/image.go:1065
+#: lxc/image.go:1071
 msgid "Profiles: "
 msgstr "プロファイル: "
 
@@ -5083,11 +5078,11 @@ msgstr "プロジェクト名 %s を %s に変更しました"
 msgid "Project to use for the remote"
 msgstr "リモートで使用するプロジェクト"
 
-#: lxc/image.go:1040
+#: lxc/image.go:1046
 msgid "Properties:"
 msgstr "プロパティ:"
 
-#: lxc/image.go:1621
+#: lxc/image.go:1627
 msgid "Property not found"
 msgstr "プロパティが見つかりません"
 
@@ -5184,7 +5179,7 @@ msgstr ""
 msgid "Public image server"
 msgstr "Public なイメージサーバとして設定します"
 
-#: lxc/image.go:1018
+#: lxc/image.go:1024
 #, c-format
 msgid "Public: %s"
 msgstr "パブリック: %s"
@@ -5220,7 +5215,7 @@ msgstr "ファイル %s をコンテナ %s 内にコピーします: %%s"
 msgid "Query path must start with /"
 msgstr "query のパスは / で始める必要があります"
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
+#: lxc/image.go:535 lxc/image.go:957 lxc/image.go:1517
 msgid "Query virtual machine images"
 msgstr "仮想マシンイメージを対象にします"
 
@@ -5259,7 +5254,7 @@ msgstr "再帰的にファイルを転送します"
 msgid "Refresh and update the existing storage volume copies"
 msgstr "既存のストレージボリュームのコピーの再読込と更新"
 
-#: lxc/image.go:1416 lxc/image.go:1417
+#: lxc/image.go:1422 lxc/image.go:1423
 msgid "Refresh images"
 msgstr "イメージを更新します"
 
@@ -5268,7 +5263,7 @@ msgstr "イメージを更新します"
 msgid "Refreshing instance: %s"
 msgstr "インスタンスの更新中: %s"
 
-#: lxc/image.go:1453
+#: lxc/image.go:1459
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr "イメージの更新中: %s"
@@ -5545,7 +5540,7 @@ msgstr "証明書の使用を1つ以上のプロジェクトに制限します"
 msgid "Retrieve the container's console log"
 msgstr "インスタンスのコンソールログを取得します"
 
-#: lxc/init.go:360
+#: lxc/init.go:365
 #, c-format
 msgid "Retrieving image: %s"
 msgstr "イメージの取得中: %s"
@@ -5579,7 +5574,7 @@ msgstr "すべてのインスタンスに対してコマンドを実行します
 msgid "SEVERITY"
 msgstr "SEVERITY"
 
-#: lxc/image.go:1139
+#: lxc/image.go:1145
 msgid "SIZE"
 msgstr "SIZE"
 
@@ -5712,7 +5707,7 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 
-#: lxc/image.go:1637 lxc/image.go:1638
+#: lxc/image.go:1643 lxc/image.go:1644
 msgid "Set image properties"
 msgstr "イメージのプロパティを設定します"
 
@@ -6065,7 +6060,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1507 lxc/image.go:1508
+#: lxc/image.go:1513 lxc/image.go:1514
 msgid "Show image properties"
 msgstr "イメージのプロパティを表示します"
 
@@ -6200,7 +6195,7 @@ msgstr "信頼済みクライアントの設定を表示します"
 msgid "Show useful information about a cluster member"
 msgstr "クラスターメンバーについての情報を表示します"
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:953 lxc/image.go:954
 msgid "Show useful information about images"
 msgstr "イメージについての情報を表示します"
 
@@ -6212,7 +6207,7 @@ msgstr "ストレージプールの情報を表示します"
 msgid "Show warning"
 msgstr "警告を表示します"
 
-#: lxc/image.go:1015
+#: lxc/image.go:1021
 #, fuzzy, c-format
 msgid "Size: %.2fMiB"
 msgstr "サイズ: %.2fMB"
@@ -6244,7 +6239,7 @@ msgstr "ソケット %d:"
 msgid "Some instances failed to %s"
 msgstr "一部のインスタンスで %s が失敗しました"
 
-#: lxc/image.go:1058
+#: lxc/image.go:1064
 msgid "Source:"
 msgstr "取得元:"
 
@@ -6392,7 +6387,7 @@ msgstr "TARGET"
 msgid "TOKEN"
 msgstr "TOKEN"
 
-#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
 #: lxc/storage_volume.go:1730 lxc/warning.go:216
@@ -6460,7 +6455,7 @@ msgstr ""
 "インスタンスは現在実行中です。停止して、再起動するために --force を使用してく"
 "ださい"
 
-#: lxc/init.go:438
+#: lxc/init.go:443
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr "起動しようとしたインスタンスに接続されているネットワークがありません。"
 
@@ -6469,14 +6464,14 @@ msgstr "起動しようとしたインスタンスに接続されているネッ
 msgid "The key %q does not exist on cluster member %q"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
 
-#: lxc/utils.go:376
+#: lxc/utils.go:364
 #, fuzzy, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:%q' instead."
 msgstr ""
 "ローカルイメージ '%s' が見つかりません。代わりに '%s:%s' を試してみてくださ"
 "い。"
 
-#: lxc/utils.go:372
+#: lxc/utils.go:360
 #, fuzzy, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
@@ -6632,17 +6627,17 @@ msgstr "スレッド:"
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr "インスタンスがクリーンにシャットダウンするまで待つ時間"
 
-#: lxc/image.go:1019
+#: lxc/image.go:1025
 msgid "Timestamps:"
 msgstr "タイムスタンプ:"
 
-#: lxc/init.go:440
+#: lxc/init.go:445
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 "インスタンスにネットワークを接続するには、lxc network attach を使用してくださ"
 "い"
 
-#: lxc/init.go:439
+#: lxc/init.go:444
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 "新しいネットワークを作成するには、lxc network create を使用してください"
@@ -6703,7 +6698,7 @@ msgstr "転送モード。pull, push, relay のいずれか"
 msgid "Transfer mode. One of pull, push or relay."
 msgstr "転送モード。pull, push, relay のいずれか。"
 
-#: lxc/image.go:827
+#: lxc/image.go:832
 #, c-format
 msgid "Transferring image: %s"
 msgstr "イメージを転送中: %s"
@@ -6743,7 +6738,7 @@ msgstr ""
 "確立する接続のタイプ: シリアルコンソールの場合は 'console'、SPICE でのグラ"
 "フィカル出力の場合は 'vga'"
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1023 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1455
 #, c-format
 msgid "Type: %s"
@@ -6758,7 +6753,7 @@ msgstr "タイプ: %s (ephemeral)"
 msgid "UNLIMITED"
 msgstr "UNLIMITED"
 
-#: lxc/image.go:1140
+#: lxc/image.go:1146
 msgid "UPLOAD DATE"
 msgstr "UPLOAD DATE"
 
@@ -6804,7 +6799,7 @@ msgstr "未知の証明書タイプ %q"
 msgid "Unknown channel type for client %q: %s"
 msgstr "クライアント %q の未知のチャンネルタイプ: %s"
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:631 lxc/storage_volume.go:1772
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6847,7 +6842,7 @@ msgstr "移動先のインスタンスのすべてのプロファイルを削除
 msgid "Unset device configuration keys"
 msgstr "デバイスの設定を削除します"
 
-#: lxc/image.go:1700 lxc/image.go:1701
+#: lxc/image.go:1706 lxc/image.go:1707
 msgid "Unset image properties"
 msgstr "イメージのプロパティを削除します"
 
@@ -7009,7 +7004,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr "コピー元の全てのプロファイルがターゲットに存在しません"
 
-#: lxc/image.go:1026
+#: lxc/image.go:1032
 #, c-format
 msgid "Uploaded: %s"
 msgstr "アップロード日時: %s"
@@ -7192,7 +7187,7 @@ msgstr "[<remote>:] <name>"
 msgid "[<remote>:] [<cert>]"
 msgstr "[<remote>:] [<cert>]"
 
-#: lxc/image.go:1087 lxc/list.go:46
+#: lxc/image.go:1093 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr "[<remote>:] [<filter>...]"
 
@@ -7310,15 +7305,15 @@ msgstr "[<remote>:]<member> <group>"
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr "[<remote>:]<group> <new-name>"
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
+#: lxc/image.go:399 lxc/image.go:952 lxc/image.go:1512
 msgid "[<remote>:]<image>"
 msgstr "[<remote>:]<image>"
 
-#: lxc/image.go:1572 lxc/image.go:1699
+#: lxc/image.go:1578 lxc/image.go:1705
 msgid "[<remote>:]<image> <key>"
 msgstr "[<remote>:]<image> <key>"
 
-#: lxc/image.go:1636
+#: lxc/image.go:1642
 msgid "[<remote>:]<image> <key> <value>"
 msgstr "[<remote>:]<image> <key> <value>"
 
@@ -7335,11 +7330,11 @@ msgstr "[<remote>:]<image> [<remote>:][<name>]"
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr "[<remote>:]<image> [<remote>:][<name>]"
 
-#: lxc/image.go:523
+#: lxc/image.go:528
 msgid "[<remote>:]<image> [<target>]"
 msgstr "[<remote>:]<image> [<target>]"
 
-#: lxc/image.go:334 lxc/image.go:1415
+#: lxc/image.go:339 lxc/image.go:1421
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr "[<remote>:]<image> [[<remote>:]<image>...]"
 
@@ -7825,7 +7820,7 @@ msgstr "現在値"
 msgid "description"
 msgstr "説明"
 
-#: lxc/image.go:1004
+#: lxc/image.go:1010
 msgid "disabled"
 msgstr "無効"
 
@@ -7833,7 +7828,7 @@ msgstr "無効"
 msgid "driver"
 msgstr "ドライバ"
 
-#: lxc/image.go:1006
+#: lxc/image.go:1012
 msgid "enabled"
 msgstr "有効"
 
@@ -8034,7 +8029,7 @@ msgstr ""
 "   /etc/hosts ファイルを、インスタンス \"foo\" 内 (の /etc/hosts) にコピーし"
 "ます。"
 
-#: lxc/image.go:398
+#: lxc/image.go:403
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -8511,7 +8506,7 @@ msgstr "n"
 msgid "name"
 msgstr "名前"
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
+#: lxc/image.go:1000 lxc/image.go:1005 lxc/image.go:1203
 msgid "no"
 msgstr "no"
 
@@ -8558,10 +8553,14 @@ msgstr "ストレージを使用中の"
 msgid "y"
 msgstr "y"
 
-#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1194
+#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:1002 lxc/image.go:1007
+#: lxc/image.go:1200
 msgid "yes"
 msgstr "yes"
+
+#, c-format
+#~ msgid "Failed to remove alias %s: %w"
+#~ msgstr "エイリアス %s の削除に失敗しました: %w"
 
 #~ msgid "Make the image public"
 #~ msgstr "イメージを public にする"

--- a/po/ka.po
+++ b/po/ka.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-19 13:11-0600\n"
+"POT-Creation-Date: 2024-09-25 18:38-0600\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -192,7 +192,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:419
+#: lxc/image.go:424
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -420,7 +420,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1168
+#: lxc/image.go:1174
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -528,7 +528,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:695
+#: lxc/image.go:700
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -541,15 +541,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1138 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1133
+#: lxc/image.go:1139
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1144 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -731,7 +731,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1045
+#: lxc/image.go:1051
 msgid "Aliases:"
 msgstr ""
 
@@ -747,7 +747,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1022 lxc/info.go:486
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -766,11 +766,11 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:342 lxc/rebuild.go:131
+#: lxc/init.go:347 lxc/rebuild.go:136
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/init.go:346
+#: lxc/init.go:351
 msgid "Asked for a container but image is of type VM"
 msgstr ""
 
@@ -828,7 +828,7 @@ msgstr ""
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1061
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -885,7 +885,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:816
+#: lxc/image.go:821
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -966,7 +966,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1060
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -987,7 +987,7 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:239 lxc/utils.go:259
+#: lxc/utils.go:227 lxc/utils.go:247
 #, c-format
 msgid "Can't read from stdin: %w"
 msgstr ""
@@ -1021,7 +1021,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:166
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1173,7 +1173,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1589
+#: lxc/image.go:1121 lxc/list.go:132 lxc/storage_volume.go:1589
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1212,7 +1212,7 @@ msgstr ""
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1327 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/config_trust.go:314 lxc/image.go:496 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
@@ -1306,7 +1306,7 @@ msgstr ""
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1486,7 +1486,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1475
+#: lxc/image.go:1029 lxc/info.go:497 lxc/storage_volume.go:1475
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1510,7 +1510,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1143 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -1568,7 +1568,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:341 lxc/image.go:342
 msgid "Delete images"
 msgstr ""
 
@@ -1671,9 +1671,9 @@ msgstr ""
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
 #: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
-#: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
-#: lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090 lxc/image.go:1417
-#: lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638 lxc/image.go:1701
+#: lxc/image.go:159 lxc/image.go:342 lxc/image.go:401 lxc/image.go:530
+#: lxc/image.go:702 lxc/image.go:954 lxc/image.go:1096 lxc/image.go:1423
+#: lxc/image.go:1514 lxc/image.go:1580 lxc/image.go:1644 lxc/image.go:1707
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
@@ -1818,11 +1818,11 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:406
+#: lxc/init.go:411
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:726
+#: lxc/image.go:731
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1926,7 +1926,7 @@ msgstr ""
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:400 lxc/image.go:401
 msgid "Edit image properties"
 msgstr ""
 
@@ -2002,7 +2002,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1766
+#: lxc/image.go:1155 lxc/list.go:622 lxc/storage_volume.go:1766
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2121,20 +2121,20 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:1029
+#: lxc/image.go:1035
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1037
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:524
+#: lxc/image.go:529
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:530
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2162,7 +2162,7 @@ msgstr ""
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:604
+#: lxc/image.go:609
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2175,7 +2175,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
+#: lxc/config_trust.go:411 lxc/image.go:1140 lxc/image.go:1141
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2194,12 +2194,12 @@ msgstr ""
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/utils.go:296
+#: lxc/utils.go:284
 #, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/utils.go:288
+#: lxc/utils.go:276
 #, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
@@ -2293,7 +2293,7 @@ msgstr ""
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: lxc/utils.go:214
+#: lxc/utils.go:202
 #, c-format
 msgid "Failed to create alias %s: %w"
 msgstr ""
@@ -2318,11 +2318,6 @@ msgstr ""
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
 
-#: lxc/utils.go:203
-#, c-format
-msgid "Failed to remove alias %s: %w"
-msgstr ""
-
 #: lxc/file.go:821
 #, c-format
 msgid "Failed to walk path for %s: %s"
@@ -2342,7 +2337,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:1014
+#: lxc/image.go:1020
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2406,7 +2401,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:770 lxc/auth.go:1697
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1122 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:57
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2481,7 +2476,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1573 lxc/image.go:1574
+#: lxc/image.go:1579 lxc/image.go:1580
 msgid "Get image properties"
 msgstr ""
 
@@ -2755,11 +2750,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1489
+#: lxc/image.go:1495
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2767,25 +2762,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:680
+#: lxc/image.go:685
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1444
+#: lxc/image.go:369 lxc/image.go:1450
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1670
+#: lxc/image.go:449 lxc/image.go:1676
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:918
+#: lxc/image.go:923
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1493
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2805,7 +2800,7 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:697
+#: lxc/image.go:702
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -2815,7 +2810,7 @@ msgid ""
 "os=Ubuntu release=noble variant=cloud."
 msgstr ""
 
-#: lxc/image.go:696
+#: lxc/image.go:701
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2866,7 +2861,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:417
+#: lxc/init.go:422
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2932,7 +2927,7 @@ msgstr ""
 msgid "Invalid instance path: %q"
 msgstr ""
 
-#: lxc/utils.go:253
+#: lxc/utils.go:241
 #, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr ""
@@ -3044,12 +3039,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:1035
+#: lxc/image.go:1041
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:1037
+#: lxc/image.go:1043
 msgid "Last used: never"
 msgstr ""
 
@@ -3167,11 +3162,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1089
+#: lxc/image.go:1095
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1096
 msgid ""
 "List images\n"
 "\n"
@@ -3465,7 +3460,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:165 lxc/image.go:709
 msgid "Make image public"
 msgstr ""
 
@@ -3979,7 +3974,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:728
+#: lxc/image.go:733
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4172,7 +4167,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:168 lxc/image.go:710
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4252,7 +4247,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:805
+#: lxc/image.go:810
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4323,7 +4318,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:752
+#: lxc/image.go:1142 lxc/remote.go:752
 msgid "PUBLIC"
 msgstr ""
 
@@ -4384,7 +4379,7 @@ msgstr ""
 #: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/config_trust.go:315 lxc/image.go:497 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
@@ -4472,11 +4467,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1067
+#: lxc/image.go:1073
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1065
+#: lxc/image.go:1071
 msgid "Profiles: "
 msgstr ""
 
@@ -4499,11 +4494,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1046
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1621
+#: lxc/image.go:1627
 msgid "Property not found"
 msgstr ""
 
@@ -4597,7 +4592,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1024
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4633,7 +4628,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
+#: lxc/image.go:535 lxc/image.go:957 lxc/image.go:1517
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4670,7 +4665,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1416 lxc/image.go:1417
+#: lxc/image.go:1422 lxc/image.go:1423
 msgid "Refresh images"
 msgstr ""
 
@@ -4679,7 +4674,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1453
+#: lxc/image.go:1459
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4942,7 +4937,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:365
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -4975,7 +4970,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1139
+#: lxc/image.go:1145
 msgid "SIZE"
 msgstr ""
 
@@ -5098,7 +5093,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1637 lxc/image.go:1638
+#: lxc/image.go:1643 lxc/image.go:1644
 msgid "Set image properties"
 msgstr ""
 
@@ -5391,7 +5386,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1507 lxc/image.go:1508
+#: lxc/image.go:1513 lxc/image.go:1514
 msgid "Show image properties"
 msgstr ""
 
@@ -5525,7 +5520,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:953 lxc/image.go:954
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5537,7 +5532,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1021
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5569,7 +5564,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:1058
+#: lxc/image.go:1064
 msgid "Source:"
 msgstr ""
 
@@ -5717,7 +5712,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
 #: lxc/storage_volume.go:1730 lxc/warning.go:216
@@ -5782,7 +5777,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:438
+#: lxc/init.go:443
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5791,12 +5786,12 @@ msgstr ""
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
 
-#: lxc/utils.go:376
+#: lxc/utils.go:364
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:%q' instead."
 msgstr ""
 
-#: lxc/utils.go:372
+#: lxc/utils.go:360
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
@@ -5939,15 +5934,15 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1025
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:440
+#: lxc/init.go:445
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:439
+#: lxc/init.go:444
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6001,7 +5996,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:827
+#: lxc/image.go:832
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
@@ -6039,7 +6034,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1023 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1455
 #, c-format
 msgid "Type: %s"
@@ -6054,7 +6049,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1140
+#: lxc/image.go:1146
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6100,7 +6095,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:631 lxc/storage_volume.go:1772
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6142,7 +6137,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1700 lxc/image.go:1701
+#: lxc/image.go:1706 lxc/image.go:1707
 msgid "Unset image properties"
 msgstr ""
 
@@ -6293,7 +6288,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1032
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6466,7 +6461,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1087 lxc/list.go:46
+#: lxc/image.go:1093 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6579,15 +6574,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
+#: lxc/image.go:399 lxc/image.go:952 lxc/image.go:1512
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1572 lxc/image.go:1699
+#: lxc/image.go:1578 lxc/image.go:1705
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1636
+#: lxc/image.go:1642
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6603,11 +6598,11 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:523
+#: lxc/image.go:528
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1415
+#: lxc/image.go:339 lxc/image.go:1421
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -7070,7 +7065,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1010
 msgid "disabled"
 msgstr ""
 
@@ -7078,7 +7073,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1012
 msgid "enabled"
 msgstr ""
 
@@ -7219,7 +7214,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:398
+#: lxc/image.go:403
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7546,7 +7541,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
+#: lxc/image.go:1000 lxc/image.go:1005 lxc/image.go:1203
 msgid "no"
 msgstr ""
 
@@ -7591,7 +7586,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1194
+#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:1002 lxc/image.go:1007
+#: lxc/image.go:1200
 msgid "yes"
 msgstr ""

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-19 13:11-0600\n"
+"POT-Creation-Date: 2024-09-25 18:38-0600\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Korean <https://hosted.weblate.org/projects/linux-containers/"
@@ -195,7 +195,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:419
+#: lxc/image.go:424
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -423,7 +423,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1168
+#: lxc/image.go:1174
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -531,7 +531,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:695
+#: lxc/image.go:700
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -544,15 +544,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1138 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1133
+#: lxc/image.go:1139
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1144 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -734,7 +734,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1045
+#: lxc/image.go:1051
 msgid "Aliases:"
 msgstr ""
 
@@ -750,7 +750,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1022 lxc/info.go:486
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -769,11 +769,11 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:342 lxc/rebuild.go:131
+#: lxc/init.go:347 lxc/rebuild.go:136
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/init.go:346
+#: lxc/init.go:351
 msgid "Asked for a container but image is of type VM"
 msgstr ""
 
@@ -831,7 +831,7 @@ msgstr ""
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1061
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -888,7 +888,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:816
+#: lxc/image.go:821
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -969,7 +969,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1060
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -990,7 +990,7 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:239 lxc/utils.go:259
+#: lxc/utils.go:227 lxc/utils.go:247
 #, c-format
 msgid "Can't read from stdin: %w"
 msgstr ""
@@ -1024,7 +1024,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:166
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1176,7 +1176,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1589
+#: lxc/image.go:1121 lxc/list.go:132 lxc/storage_volume.go:1589
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1215,7 +1215,7 @@ msgstr ""
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1327 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/config_trust.go:314 lxc/image.go:496 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
@@ -1309,7 +1309,7 @@ msgstr ""
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1489,7 +1489,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1475
+#: lxc/image.go:1029 lxc/info.go:497 lxc/storage_volume.go:1475
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1513,7 +1513,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1143 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -1571,7 +1571,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:341 lxc/image.go:342
 msgid "Delete images"
 msgstr ""
 
@@ -1674,9 +1674,9 @@ msgstr ""
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
 #: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
-#: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
-#: lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090 lxc/image.go:1417
-#: lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638 lxc/image.go:1701
+#: lxc/image.go:159 lxc/image.go:342 lxc/image.go:401 lxc/image.go:530
+#: lxc/image.go:702 lxc/image.go:954 lxc/image.go:1096 lxc/image.go:1423
+#: lxc/image.go:1514 lxc/image.go:1580 lxc/image.go:1644 lxc/image.go:1707
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
@@ -1821,11 +1821,11 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:406
+#: lxc/init.go:411
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:726
+#: lxc/image.go:731
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1929,7 +1929,7 @@ msgstr ""
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:400 lxc/image.go:401
 msgid "Edit image properties"
 msgstr ""
 
@@ -2005,7 +2005,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1766
+#: lxc/image.go:1155 lxc/list.go:622 lxc/storage_volume.go:1766
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2124,20 +2124,20 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:1029
+#: lxc/image.go:1035
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1037
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:524
+#: lxc/image.go:529
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:530
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2165,7 +2165,7 @@ msgstr ""
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:604
+#: lxc/image.go:609
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2178,7 +2178,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
+#: lxc/config_trust.go:411 lxc/image.go:1140 lxc/image.go:1141
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2197,12 +2197,12 @@ msgstr ""
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/utils.go:296
+#: lxc/utils.go:284
 #, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/utils.go:288
+#: lxc/utils.go:276
 #, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
@@ -2296,7 +2296,7 @@ msgstr ""
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: lxc/utils.go:214
+#: lxc/utils.go:202
 #, c-format
 msgid "Failed to create alias %s: %w"
 msgstr ""
@@ -2321,11 +2321,6 @@ msgstr ""
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
 
-#: lxc/utils.go:203
-#, c-format
-msgid "Failed to remove alias %s: %w"
-msgstr ""
-
 #: lxc/file.go:821
 #, c-format
 msgid "Failed to walk path for %s: %s"
@@ -2345,7 +2340,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:1014
+#: lxc/image.go:1020
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2409,7 +2404,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:770 lxc/auth.go:1697
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1122 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:57
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2484,7 +2479,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1573 lxc/image.go:1574
+#: lxc/image.go:1579 lxc/image.go:1580
 msgid "Get image properties"
 msgstr ""
 
@@ -2758,11 +2753,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1489
+#: lxc/image.go:1495
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2770,25 +2765,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:680
+#: lxc/image.go:685
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1444
+#: lxc/image.go:369 lxc/image.go:1450
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1670
+#: lxc/image.go:449 lxc/image.go:1676
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:918
+#: lxc/image.go:923
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1493
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2808,7 +2803,7 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:697
+#: lxc/image.go:702
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -2818,7 +2813,7 @@ msgid ""
 "os=Ubuntu release=noble variant=cloud."
 msgstr ""
 
-#: lxc/image.go:696
+#: lxc/image.go:701
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2869,7 +2864,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:417
+#: lxc/init.go:422
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2935,7 +2930,7 @@ msgstr ""
 msgid "Invalid instance path: %q"
 msgstr ""
 
-#: lxc/utils.go:253
+#: lxc/utils.go:241
 #, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr ""
@@ -3047,12 +3042,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:1035
+#: lxc/image.go:1041
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:1037
+#: lxc/image.go:1043
 msgid "Last used: never"
 msgstr ""
 
@@ -3170,11 +3165,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1089
+#: lxc/image.go:1095
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1096
 msgid ""
 "List images\n"
 "\n"
@@ -3468,7 +3463,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:165 lxc/image.go:709
 msgid "Make image public"
 msgstr ""
 
@@ -3982,7 +3977,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:728
+#: lxc/image.go:733
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4175,7 +4170,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:168 lxc/image.go:710
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4255,7 +4250,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:805
+#: lxc/image.go:810
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4326,7 +4321,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:752
+#: lxc/image.go:1142 lxc/remote.go:752
 msgid "PUBLIC"
 msgstr ""
 
@@ -4387,7 +4382,7 @@ msgstr ""
 #: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/config_trust.go:315 lxc/image.go:497 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
@@ -4475,11 +4470,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1067
+#: lxc/image.go:1073
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1065
+#: lxc/image.go:1071
 msgid "Profiles: "
 msgstr ""
 
@@ -4502,11 +4497,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1046
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1621
+#: lxc/image.go:1627
 msgid "Property not found"
 msgstr ""
 
@@ -4600,7 +4595,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1024
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4636,7 +4631,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
+#: lxc/image.go:535 lxc/image.go:957 lxc/image.go:1517
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4673,7 +4668,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1416 lxc/image.go:1417
+#: lxc/image.go:1422 lxc/image.go:1423
 msgid "Refresh images"
 msgstr ""
 
@@ -4682,7 +4677,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1453
+#: lxc/image.go:1459
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4945,7 +4940,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:365
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -4978,7 +4973,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1139
+#: lxc/image.go:1145
 msgid "SIZE"
 msgstr ""
 
@@ -5101,7 +5096,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1637 lxc/image.go:1638
+#: lxc/image.go:1643 lxc/image.go:1644
 msgid "Set image properties"
 msgstr ""
 
@@ -5394,7 +5389,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1507 lxc/image.go:1508
+#: lxc/image.go:1513 lxc/image.go:1514
 msgid "Show image properties"
 msgstr ""
 
@@ -5528,7 +5523,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:953 lxc/image.go:954
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5540,7 +5535,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1021
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5572,7 +5567,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:1058
+#: lxc/image.go:1064
 msgid "Source:"
 msgstr ""
 
@@ -5720,7 +5715,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
 #: lxc/storage_volume.go:1730 lxc/warning.go:216
@@ -5785,7 +5780,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:438
+#: lxc/init.go:443
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5794,12 +5789,12 @@ msgstr ""
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
 
-#: lxc/utils.go:376
+#: lxc/utils.go:364
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:%q' instead."
 msgstr ""
 
-#: lxc/utils.go:372
+#: lxc/utils.go:360
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
@@ -5942,15 +5937,15 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1025
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:440
+#: lxc/init.go:445
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:439
+#: lxc/init.go:444
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6004,7 +5999,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:827
+#: lxc/image.go:832
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
@@ -6042,7 +6037,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1023 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1455
 #, c-format
 msgid "Type: %s"
@@ -6057,7 +6052,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1140
+#: lxc/image.go:1146
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6103,7 +6098,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:631 lxc/storage_volume.go:1772
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6145,7 +6140,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1700 lxc/image.go:1701
+#: lxc/image.go:1706 lxc/image.go:1707
 msgid "Unset image properties"
 msgstr ""
 
@@ -6296,7 +6291,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1032
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6469,7 +6464,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1087 lxc/list.go:46
+#: lxc/image.go:1093 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6582,15 +6577,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
+#: lxc/image.go:399 lxc/image.go:952 lxc/image.go:1512
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1572 lxc/image.go:1699
+#: lxc/image.go:1578 lxc/image.go:1705
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1636
+#: lxc/image.go:1642
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6606,11 +6601,11 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:523
+#: lxc/image.go:528
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1415
+#: lxc/image.go:339 lxc/image.go:1421
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -7073,7 +7068,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1010
 msgid "disabled"
 msgstr ""
 
@@ -7081,7 +7076,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1012
 msgid "enabled"
 msgstr ""
 
@@ -7222,7 +7217,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:398
+#: lxc/image.go:403
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7549,7 +7544,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
+#: lxc/image.go:1000 lxc/image.go:1005 lxc/image.go:1203
 msgid "no"
 msgstr ""
 
@@ -7594,7 +7589,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1194
+#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:1002 lxc/image.go:1007
+#: lxc/image.go:1200
 msgid "yes"
 msgstr ""

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-        "POT-Creation-Date: 2024-09-19 13:11-0600\n"
+        "POT-Creation-Date: 2024-09-25 18:38-0600\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -179,7 +179,7 @@ msgid   "### This is a YAML representation of the identity provider group.\n"
         "### Note that the name is shown but cannot be modified"
 msgstr  ""
 
-#: lxc/image.go:419
+#: lxc/image.go:424
 msgid   "### This is a YAML representation of the image properties.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -391,7 +391,7 @@ msgstr  ""
 msgid   "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr  ""
 
-#: lxc/image.go:1168
+#: lxc/image.go:1174
 #, c-format
 msgid   "%s (%d more)"
 msgstr  ""
@@ -498,7 +498,7 @@ msgstr  ""
 msgid   "<source path>... [<remote>:]<instance>/<path>"
 msgstr  ""
 
-#: lxc/image.go:695
+#: lxc/image.go:700
 msgid   "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr  ""
 
@@ -510,15 +510,15 @@ msgstr  ""
 msgid   "ADDRESS"
 msgstr  ""
 
-#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1138 lxc/image_alias.go:234
 msgid   "ALIAS"
 msgstr  ""
 
-#: lxc/image.go:1133
+#: lxc/image.go:1139
 msgid   "ALIASES"
 msgstr  ""
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1144 lxc/list.go:562
 msgid   "ARCHITECTURE"
 msgstr  ""
 
@@ -693,7 +693,7 @@ msgstr  ""
 msgid   "Aliases already exists: %s"
 msgstr  ""
 
-#: lxc/image.go:1045
+#: lxc/image.go:1051
 msgid   "Aliases:"
 msgstr  ""
 
@@ -709,7 +709,7 @@ msgstr  ""
 msgid   "Alternative certificate name"
 msgstr  ""
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1022 lxc/info.go:486
 #, c-format
 msgid   "Architecture: %s"
 msgstr  ""
@@ -728,11 +728,11 @@ msgstr  ""
 msgid   "As neither could be found, the raw SPICE socket can be found at:"
 msgstr  ""
 
-#: lxc/init.go:342 lxc/rebuild.go:131
+#: lxc/init.go:347 lxc/rebuild.go:136
 msgid   "Asked for a VM but image is of type container"
 msgstr  ""
 
-#: lxc/init.go:346
+#: lxc/init.go:351
 msgid   "Asked for a container but image is of type VM"
 msgstr  ""
 
@@ -789,7 +789,7 @@ msgstr  ""
 msgid   "Auto update is only available in pull mode"
 msgstr  ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1061
 #, c-format
 msgid   "Auto update: %s"
 msgstr  ""
@@ -844,7 +844,7 @@ msgstr  ""
 msgid   "Bad key=value pair: %s"
 msgstr  ""
 
-#: lxc/image.go:816
+#: lxc/image.go:821
 #, c-format
 msgid   "Bad property: %s"
 msgstr  ""
@@ -925,7 +925,7 @@ msgstr  ""
 msgid   "CUDA Version: %v"
 msgstr  ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1060
 #, c-format
 msgid   "Cached: %s"
 msgstr  ""
@@ -946,7 +946,7 @@ msgstr  ""
 msgid   "Can't pull a directory without --recursive"
 msgstr  ""
 
-#: lxc/utils.go:239 lxc/utils.go:259
+#: lxc/utils.go:227 lxc/utils.go:247
 #, c-format
 msgid   "Can't read from stdin: %w"
 msgstr  ""
@@ -980,7 +980,7 @@ msgstr  ""
 msgid   "Can't unset key '%s', it's not currently set"
 msgstr  ""
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:166
 msgid   "Can't use an image with --empty"
 msgstr  ""
 
@@ -1104,7 +1104,7 @@ msgstr  ""
 msgid   "Clustering enabled"
 msgstr  ""
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1589 lxc/warning.go:93
+#: lxc/image.go:1121 lxc/list.go:132 lxc/storage_volume.go:1589 lxc/warning.go:93
 msgid   "Columns"
 msgstr  ""
 
@@ -1139,7 +1139,7 @@ msgstr  ""
 msgid   "Config key/value to apply to the target instance"
 msgstr  ""
 
-#: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281 lxc/config.go:356 lxc/config.go:1327 lxc/config_metadata.go:156 lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759 lxc/network_acl.go:698 lxc/network_forward.go:767 lxc/network_load_balancer.go:738 lxc/network_peer.go:698 lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595 lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349 lxc/storage_bucket.go:1126 lxc/storage_volume.go:1150 lxc/storage_volume.go:1182
+#: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281 lxc/config.go:356 lxc/config.go:1327 lxc/config_metadata.go:156 lxc/config_trust.go:314 lxc/image.go:496 lxc/network.go:759 lxc/network_acl.go:698 lxc/network_forward.go:767 lxc/network_load_balancer.go:738 lxc/network_peer.go:698 lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595 lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349 lxc/storage_bucket.go:1126 lxc/storage_volume.go:1150 lxc/storage_volume.go:1182
 #, c-format
 msgid   "Config parsing error: %s"
 msgstr  ""
@@ -1220,7 +1220,7 @@ msgstr  ""
 msgid   "Copy virtual machine images"
 msgstr  ""
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid   "Copying the image: %s"
 msgstr  ""
@@ -1399,7 +1399,7 @@ msgstr  ""
 msgid   "Create the instance with no profiles applied"
 msgstr  ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1475
+#: lxc/image.go:1029 lxc/info.go:497 lxc/storage_volume.go:1475
 #, c-format
 msgid   "Created: %s"
 msgstr  ""
@@ -1422,7 +1422,7 @@ msgstr  ""
 msgid   "DEFAULT TARGET ADDRESS"
 msgstr  ""
 
-#: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504 lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086 lxc/network_acl.go:157 lxc/network_forward.go:157 lxc/network_load_balancer.go:160 lxc/network_peer.go:149 lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173 lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723 lxc/storage_bucket.go:513 lxc/storage_bucket.go:833 lxc/storage_volume.go:1732
+#: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504 lxc/image.go:1143 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086 lxc/network_acl.go:157 lxc/network_forward.go:157 lxc/network_load_balancer.go:160 lxc/network_peer.go:149 lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173 lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723 lxc/storage_bucket.go:513 lxc/storage_bucket.go:833 lxc/storage_volume.go:1732
 msgid   "DESCRIPTION"
 msgstr  ""
 
@@ -1474,7 +1474,7 @@ msgstr  ""
 msgid   "Delete image aliases"
 msgstr  ""
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:341 lxc/image.go:342
 msgid   "Delete images"
 msgstr  ""
 
@@ -1542,7 +1542,7 @@ msgstr  ""
 msgid   "Delete warning"
 msgstr  ""
 
-#: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159 lxc/alias.go:214 lxc/auth.go:31 lxc/auth.go:60 lxc/auth.go:99 lxc/auth.go:153 lxc/auth.go:202 lxc/auth.go:333 lxc/auth.go:393 lxc/auth.go:442 lxc/auth.go:494 lxc/auth.go:517 lxc/auth.go:576 lxc/auth.go:732 lxc/auth.go:766 lxc/auth.go:833 lxc/auth.go:896 lxc/auth.go:957 lxc/auth.go:1085 lxc/auth.go:1108 lxc/auth.go:1166 lxc/auth.go:1235 lxc/auth.go:1257 lxc/auth.go:1435 lxc/auth.go:1473 lxc/auth.go:1525 lxc/auth.go:1574 lxc/auth.go:1693 lxc/auth.go:1753 lxc/auth.go:1802 lxc/auth.go:1853 lxc/auth.go:1876 lxc/auth.go:1929 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677 lxc/cluster.go:770 lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087 lxc/cluster.go:1175 lxc/cluster.go:1299 lxc/cluster.go:1329 lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170 lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440 lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663 lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51 lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:538 lxc/config.go:764 lxc/config.go:896 lxc/config.go:943 lxc/config.go:983 lxc/config.go:1038 lxc/config.go:1129 lxc/config.go:1160 lxc/config.go:1214 lxc/config_device.go:25 lxc/config_device.go:79 lxc/config_device.go:221 lxc/config_device.go:318 lxc/config_device.go:401 lxc/config_device.go:503 lxc/config_device.go:619 lxc/config_device.go:626 lxc/config_device.go:759 lxc/config_device.go:844 lxc/config_metadata.go:28 lxc/config_metadata.go:56 lxc/config_metadata.go:189 lxc/config_template.go:28 lxc/config_template.go:68 lxc/config_template.go:119 lxc/config_template.go:173 lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34 lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651 lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41 lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173 lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090 lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638 lxc/image.go:1701 lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1005 lxc/network.go:1106 lxc/network.go:1185 lxc/network.go:1245 lxc/network.go:1341 lxc/network.go:1413 lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731 lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:51 lxc/network_forward.go:33 lxc/network_forward.go:90 lxc/network_forward.go:179 lxc/network_forward.go:256 lxc/network_forward.go:404 lxc/network_forward.go:489 lxc/network_forward.go:599 lxc/network_forward.go:646 lxc/network_forward.go:800 lxc/network_forward.go:874 lxc/network_forward.go:889 lxc/network_forward.go:970 lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476 lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935 lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1121 lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236 lxc/network_peer.go:360 lxc/network_peer.go:445 lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:165 lxc/network_zone.go:228 lxc/network_zone.go:301 lxc/network_zone.go:396 lxc/network_zone.go:484 lxc/network_zone.go:527 lxc/network_zone.go:654 lxc/network_zone.go:710 lxc/network_zone.go:767 lxc/network_zone.go:845 lxc/network_zone.go:909 lxc/network_zone.go:985 lxc/network_zone.go:1083 lxc/network_zone.go:1172 lxc/network_zone.go:1219 lxc/network_zone.go:1349 lxc/network_zone.go:1410 lxc/network_zone.go:1425 lxc/network_zone.go:1483 lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180 lxc/profile.go:271 lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493 lxc/profile.go:629 lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860 lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31 lxc/project.go:95 lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472 lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789 lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853 lxc/remote.go:917 lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250 lxc/storage_bucket.go:383 lxc/storage_bucket.go:459 lxc/storage_bucket.go:536 lxc/storage_bucket.go:630 lxc/storage_bucket.go:699 lxc/storage_bucket.go:733 lxc/storage_bucket.go:774 lxc/storage_bucket.go:853 lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158 lxc/storage_volume.go:58 lxc/storage_volume.go:169 lxc/storage_volume.go:283 lxc/storage_volume.go:390 lxc/storage_volume.go:605 lxc/storage_volume.go:714 lxc/storage_volume.go:801 lxc/storage_volume.go:899 lxc/storage_volume.go:996 lxc/storage_volume.go:1217 lxc/storage_volume.go:1348 lxc/storage_volume.go:1507 lxc/storage_volume.go:1591 lxc/storage_volume.go:1844 lxc/storage_volume.go:1937 lxc/storage_volume.go:2064 lxc/storage_volume.go:2222 lxc/storage_volume.go:2343 lxc/storage_volume.go:2405 lxc/storage_volume.go:2541 lxc/storage_volume.go:2624 lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
+#: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159 lxc/alias.go:214 lxc/auth.go:31 lxc/auth.go:60 lxc/auth.go:99 lxc/auth.go:153 lxc/auth.go:202 lxc/auth.go:333 lxc/auth.go:393 lxc/auth.go:442 lxc/auth.go:494 lxc/auth.go:517 lxc/auth.go:576 lxc/auth.go:732 lxc/auth.go:766 lxc/auth.go:833 lxc/auth.go:896 lxc/auth.go:957 lxc/auth.go:1085 lxc/auth.go:1108 lxc/auth.go:1166 lxc/auth.go:1235 lxc/auth.go:1257 lxc/auth.go:1435 lxc/auth.go:1473 lxc/auth.go:1525 lxc/auth.go:1574 lxc/auth.go:1693 lxc/auth.go:1753 lxc/auth.go:1802 lxc/auth.go:1853 lxc/auth.go:1876 lxc/auth.go:1929 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677 lxc/cluster.go:770 lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087 lxc/cluster.go:1175 lxc/cluster.go:1299 lxc/cluster.go:1329 lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170 lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440 lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663 lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51 lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:538 lxc/config.go:764 lxc/config.go:896 lxc/config.go:943 lxc/config.go:983 lxc/config.go:1038 lxc/config.go:1129 lxc/config.go:1160 lxc/config.go:1214 lxc/config_device.go:25 lxc/config_device.go:79 lxc/config_device.go:221 lxc/config_device.go:318 lxc/config_device.go:401 lxc/config_device.go:503 lxc/config_device.go:619 lxc/config_device.go:626 lxc/config_device.go:759 lxc/config_device.go:844 lxc/config_metadata.go:28 lxc/config_metadata.go:56 lxc/config_metadata.go:189 lxc/config_template.go:28 lxc/config_template.go:68 lxc/config_template.go:119 lxc/config_template.go:173 lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34 lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651 lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41 lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173 lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38 lxc/image.go:159 lxc/image.go:342 lxc/image.go:401 lxc/image.go:530 lxc/image.go:702 lxc/image.go:954 lxc/image.go:1096 lxc/image.go:1423 lxc/image.go:1514 lxc/image.go:1580 lxc/image.go:1644 lxc/image.go:1707 lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1005 lxc/network.go:1106 lxc/network.go:1185 lxc/network.go:1245 lxc/network.go:1341 lxc/network.go:1413 lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731 lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:51 lxc/network_forward.go:33 lxc/network_forward.go:90 lxc/network_forward.go:179 lxc/network_forward.go:256 lxc/network_forward.go:404 lxc/network_forward.go:489 lxc/network_forward.go:599 lxc/network_forward.go:646 lxc/network_forward.go:800 lxc/network_forward.go:874 lxc/network_forward.go:889 lxc/network_forward.go:970 lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476 lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935 lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1121 lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236 lxc/network_peer.go:360 lxc/network_peer.go:445 lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:165 lxc/network_zone.go:228 lxc/network_zone.go:301 lxc/network_zone.go:396 lxc/network_zone.go:484 lxc/network_zone.go:527 lxc/network_zone.go:654 lxc/network_zone.go:710 lxc/network_zone.go:767 lxc/network_zone.go:845 lxc/network_zone.go:909 lxc/network_zone.go:985 lxc/network_zone.go:1083 lxc/network_zone.go:1172 lxc/network_zone.go:1219 lxc/network_zone.go:1349 lxc/network_zone.go:1410 lxc/network_zone.go:1425 lxc/network_zone.go:1483 lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180 lxc/profile.go:271 lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493 lxc/profile.go:629 lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860 lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31 lxc/project.go:95 lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472 lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789 lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853 lxc/remote.go:917 lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250 lxc/storage_bucket.go:383 lxc/storage_bucket.go:459 lxc/storage_bucket.go:536 lxc/storage_bucket.go:630 lxc/storage_bucket.go:699 lxc/storage_bucket.go:733 lxc/storage_bucket.go:774 lxc/storage_bucket.go:853 lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158 lxc/storage_volume.go:58 lxc/storage_volume.go:169 lxc/storage_volume.go:283 lxc/storage_volume.go:390 lxc/storage_volume.go:605 lxc/storage_volume.go:714 lxc/storage_volume.go:801 lxc/storage_volume.go:899 lxc/storage_volume.go:996 lxc/storage_volume.go:1217 lxc/storage_volume.go:1348 lxc/storage_volume.go:1507 lxc/storage_volume.go:1591 lxc/storage_volume.go:1844 lxc/storage_volume.go:1937 lxc/storage_volume.go:2064 lxc/storage_volume.go:2222 lxc/storage_volume.go:2343 lxc/storage_volume.go:2405 lxc/storage_volume.go:2541 lxc/storage_volume.go:2624 lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid   "Description"
 msgstr  ""
 
@@ -1612,11 +1612,11 @@ msgstr  ""
 msgid   "Device: %s"
 msgstr  ""
 
-#: lxc/init.go:406
+#: lxc/init.go:411
 msgid   "Didn't get any affected image, instance or snapshot from server"
 msgstr  ""
 
-#: lxc/image.go:726
+#: lxc/image.go:731
 msgid   "Directory import is not available on this platform"
 msgstr  ""
 
@@ -1718,7 +1718,7 @@ msgstr  ""
 msgid   "Edit identity provider groups as YAML"
 msgstr  ""
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:400 lxc/image.go:401
 msgid   "Edit image properties"
 msgstr  ""
 
@@ -1794,7 +1794,7 @@ msgstr  ""
 msgid   "Edit trust configurations as YAML"
 msgstr  ""
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1766 lxc/warning.go:236
+#: lxc/image.go:1155 lxc/list.go:622 lxc/storage_volume.go:1766 lxc/warning.go:236
 #, c-format
 msgid   "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr  ""
@@ -1895,20 +1895,20 @@ msgstr  ""
 msgid   "Expires at"
 msgstr  ""
 
-#: lxc/image.go:1029
+#: lxc/image.go:1035
 #, c-format
 msgid   "Expires: %s"
 msgstr  ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1037
 msgid   "Expires: never"
 msgstr  ""
 
-#: lxc/image.go:524
+#: lxc/image.go:529
 msgid   "Export and download images"
 msgstr  ""
 
-#: lxc/image.go:525
+#: lxc/image.go:530
 msgid   "Export and download images\n"
         "\n"
         "The output target is optional and defaults to the working directory."
@@ -1935,7 +1935,7 @@ msgstr  ""
 msgid   "Exporting the backup: %s"
 msgstr  ""
 
-#: lxc/image.go:604
+#: lxc/image.go:609
 #, c-format
 msgid   "Exporting the image: %s"
 msgstr  ""
@@ -1948,7 +1948,7 @@ msgstr  ""
 msgid   "FILENAME"
 msgstr  ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135 lxc/image_alias.go:235
+#: lxc/config_trust.go:411 lxc/image.go:1140 lxc/image.go:1141 lxc/image_alias.go:235
 msgid   "FINGERPRINT"
 msgstr  ""
 
@@ -1966,12 +1966,12 @@ msgstr  ""
 msgid   "Failed accepting channel client %q: %v"
 msgstr  ""
 
-#: lxc/utils.go:296
+#: lxc/utils.go:284
 #, c-format
 msgid   "Failed checking instance exists \"%s:%s\": %w"
 msgstr  ""
 
-#: lxc/utils.go:288
+#: lxc/utils.go:276
 #, c-format
 msgid   "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr  ""
@@ -2065,7 +2065,7 @@ msgstr  ""
 msgid   "Failed to create %q: %w"
 msgstr  ""
 
-#: lxc/utils.go:214
+#: lxc/utils.go:202
 #, c-format
 msgid   "Failed to create alias %s: %w"
 msgstr  ""
@@ -2090,11 +2090,6 @@ msgstr  ""
 msgid   "Failed to refresh target instance '%s': %v"
 msgstr  ""
 
-#: lxc/utils.go:203
-#, c-format
-msgid   "Failed to remove alias %s: %w"
-msgstr  ""
-
 #: lxc/file.go:821
 #, c-format
 msgid   "Failed to walk path for %s: %s"
@@ -2113,7 +2108,7 @@ msgstr  ""
 msgid   "Filtering isn't supported yet"
 msgstr  ""
 
-#: lxc/image.go:1014
+#: lxc/image.go:1020
 #, c-format
 msgid   "Fingerprint: %s"
 msgstr  ""
@@ -2169,7 +2164,7 @@ msgid   "Forcefully removing a server from the cluster should only be done as a 
         "Are you really sure you want to force removing %s? (yes/no): "
 msgstr  ""
 
-#: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:770 lxc/auth.go:1697 lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442 lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434 lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009 lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:57 lxc/network_forward.go:93 lxc/network_load_balancer.go:97 lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770 lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474 lxc/project.go:919 lxc/remote.go:690 lxc/storage.go:657 lxc/storage_bucket.go:460 lxc/storage_bucket.go:775 lxc/storage_volume.go:1608 lxc/warning.go:94
+#: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:770 lxc/auth.go:1697 lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442 lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434 lxc/image.go:1122 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009 lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:57 lxc/network_forward.go:93 lxc/network_load_balancer.go:97 lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770 lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474 lxc/project.go:919 lxc/remote.go:690 lxc/storage.go:657 lxc/storage_bucket.go:460 lxc/storage_bucket.go:775 lxc/storage_volume.go:1608 lxc/warning.go:94
 msgid   "Format (csv|json|table|yaml|compact)"
 msgstr  ""
 
@@ -2237,7 +2232,7 @@ msgstr  ""
 msgid   "Get a summary of resource allocations"
 msgstr  ""
 
-#: lxc/image.go:1573 lxc/image.go:1574
+#: lxc/image.go:1579 lxc/image.go:1580
 msgid   "Get image properties"
 msgstr  ""
 
@@ -2509,11 +2504,11 @@ msgstr  ""
 msgid   "Ignore the instance state"
 msgstr  ""
 
-#: lxc/image.go:1489
+#: lxc/image.go:1495
 msgid   "Image already up to date."
 msgstr  ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid   "Image copied successfully!"
 msgstr  ""
 
@@ -2521,25 +2516,25 @@ msgstr  ""
 msgid   "Image expiration date (format: rfc3339)"
 msgstr  ""
 
-#: lxc/image.go:680
+#: lxc/image.go:685
 msgid   "Image exported successfully!"
 msgstr  ""
 
-#: lxc/image.go:364 lxc/image.go:1444
+#: lxc/image.go:369 lxc/image.go:1450
 msgid   "Image identifier missing"
 msgstr  ""
 
-#: lxc/image.go:444 lxc/image.go:1670
+#: lxc/image.go:449 lxc/image.go:1676
 #, c-format
 msgid   "Image identifier missing: %s"
 msgstr  ""
 
-#: lxc/image.go:918
+#: lxc/image.go:923
 #, c-format
 msgid   "Image imported with fingerprint: %s"
 msgstr  ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1493
 msgid   "Image refreshed successfully!"
 msgstr  ""
 
@@ -2559,7 +2554,7 @@ msgstr  ""
 msgid   "Import custom storage volumes"
 msgstr  ""
 
-#: lxc/image.go:697
+#: lxc/image.go:702
 msgid   "Import image into the image store\n"
         "\n"
         "Directory import is only available on Linux and must be performed as root.\n"
@@ -2567,7 +2562,7 @@ msgid   "Import image into the image store\n"
         "Descriptive properties can be set by providing key=value pairs. Example: os=Ubuntu release=noble variant=cloud."
 msgstr  ""
 
-#: lxc/image.go:696
+#: lxc/image.go:701
 msgid   "Import images into the image store"
 msgstr  ""
 
@@ -2618,7 +2613,7 @@ msgstr  ""
 msgid   "Instance name is mandatory"
 msgstr  ""
 
-#: lxc/init.go:417
+#: lxc/init.go:422
 #, c-format
 msgid   "Instance name is: %s"
 msgstr  ""
@@ -2684,7 +2679,7 @@ msgstr  ""
 msgid   "Invalid instance path: %q"
 msgstr  ""
 
-#: lxc/utils.go:253
+#: lxc/utils.go:241
 #, c-format
 msgid   "Invalid key=value configuration: %s"
 msgstr  ""
@@ -2790,12 +2785,12 @@ msgstr  ""
 msgid   "Last Used: %s"
 msgstr  ""
 
-#: lxc/image.go:1035
+#: lxc/image.go:1041
 #, c-format
 msgid   "Last used: %s"
 msgstr  ""
 
-#: lxc/image.go:1037
+#: lxc/image.go:1043
 msgid   "Last used: never"
 msgstr  ""
 
@@ -2912,11 +2907,11 @@ msgid   "List image aliases\n"
         "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr  ""
 
-#: lxc/image.go:1089
+#: lxc/image.go:1095
 msgid   "List images"
 msgstr  ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1096
 msgid   "List images\n"
         "\n"
         "Filters may be of the <key>=<value> form for property based filtering,\n"
@@ -3199,7 +3194,7 @@ msgstr  ""
 msgid   "MTU: %d"
 msgstr  ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:165 lxc/image.go:709
 msgid   "Make image public"
 msgstr  ""
 
@@ -3640,7 +3635,7 @@ msgstr  ""
 msgid   "Multiple rules match. Use --force to remove them all"
 msgstr  ""
 
-#: lxc/image.go:728
+#: lxc/image.go:733
 msgid   "Must run as root to import from directory"
 msgstr  ""
 
@@ -3823,7 +3818,7 @@ msgstr  ""
 msgid   "New alias to define at target"
 msgstr  ""
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:168 lxc/image.go:710
 msgid   "New aliases to add to the image"
 msgstr  ""
 
@@ -3903,7 +3898,7 @@ msgstr  ""
 msgid   "Only https URLs are supported for simplestreams"
 msgstr  ""
 
-#: lxc/image.go:805
+#: lxc/image.go:810
 msgid   "Only https:// is supported for remote image import"
 msgstr  ""
 
@@ -3974,7 +3969,7 @@ msgstr  ""
 msgid   "PROTOCOL"
 msgstr  ""
 
-#: lxc/image.go:1136 lxc/remote.go:752
+#: lxc/image.go:1142 lxc/remote.go:752
 msgid   "PUBLIC"
 msgstr  ""
 
@@ -4032,7 +4027,7 @@ msgstr  ""
 msgid   "Press ctrl+c to finish"
 msgstr  ""
 
-#: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860 lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357 lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239 lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760 lxc/network_acl.go:699 lxc/network_forward.go:768 lxc/network_load_balancer.go:739 lxc/network_peer.go:699 lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596 lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350 lxc/storage_bucket.go:1127 lxc/storage_volume.go:1151 lxc/storage_volume.go:1183
+#: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860 lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357 lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239 lxc/config_trust.go:315 lxc/image.go:497 lxc/network.go:760 lxc/network_acl.go:699 lxc/network_forward.go:768 lxc/network_load_balancer.go:739 lxc/network_peer.go:699 lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596 lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350 lxc/storage_bucket.go:1127 lxc/storage_volume.go:1151 lxc/storage_volume.go:1183
 msgid   "Press enter to open the editor again or ctrl+c to abort change"
 msgstr  ""
 
@@ -4114,11 +4109,11 @@ msgstr  ""
 msgid   "Profiles %s applied to %s"
 msgstr  ""
 
-#: lxc/image.go:1067
+#: lxc/image.go:1073
 msgid   "Profiles:"
 msgstr  ""
 
-#: lxc/image.go:1065
+#: lxc/image.go:1071
 msgid   "Profiles: "
 msgstr  ""
 
@@ -4141,11 +4136,11 @@ msgstr  ""
 msgid   "Project to use for the remote"
 msgstr  ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1046
 msgid   "Properties:"
 msgstr  ""
 
-#: lxc/image.go:1621
+#: lxc/image.go:1627
 msgid   "Property not found"
 msgstr  ""
 
@@ -4223,7 +4218,7 @@ msgstr  ""
 msgid   "Public image server"
 msgstr  ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1024
 #, c-format
 msgid   "Public: %s"
 msgstr  ""
@@ -4259,7 +4254,7 @@ msgstr  ""
 msgid   "Query path must start with /"
 msgstr  ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
+#: lxc/image.go:535 lxc/image.go:957 lxc/image.go:1517
 msgid   "Query virtual machine images"
 msgstr  ""
 
@@ -4296,7 +4291,7 @@ msgstr  ""
 msgid   "Refresh and update the existing storage volume copies"
 msgstr  ""
 
-#: lxc/image.go:1416 lxc/image.go:1417
+#: lxc/image.go:1422 lxc/image.go:1423
 msgid   "Refresh images"
 msgstr  ""
 
@@ -4305,7 +4300,7 @@ msgstr  ""
 msgid   "Refreshing instance: %s"
 msgstr  ""
 
-#: lxc/image.go:1453
+#: lxc/image.go:1459
 #, c-format
 msgid   "Refreshing the image: %s"
 msgstr  ""
@@ -4564,7 +4559,7 @@ msgstr  ""
 msgid   "Retrieve the container's console log"
 msgstr  ""
 
-#: lxc/init.go:360
+#: lxc/init.go:365
 #, c-format
 msgid   "Retrieving image: %s"
 msgstr  ""
@@ -4597,7 +4592,7 @@ msgstr  ""
 msgid   "SEVERITY"
 msgstr  ""
 
-#: lxc/image.go:1139
+#: lxc/image.go:1145
 msgid   "SIZE"
 msgstr  ""
 
@@ -4715,7 +4710,7 @@ msgid   "Set device configuration keys\n"
         "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr  ""
 
-#: lxc/image.go:1637 lxc/image.go:1638
+#: lxc/image.go:1643 lxc/image.go:1644
 msgid   "Set image properties"
 msgstr  ""
 
@@ -4980,7 +4975,7 @@ msgid   "Show identity configurations\n"
         "method. Use the identifier instead if this occurs.\n"
 msgstr  ""
 
-#: lxc/image.go:1507 lxc/image.go:1508
+#: lxc/image.go:1513 lxc/image.go:1514
 msgid   "Show image properties"
 msgstr  ""
 
@@ -5112,7 +5107,7 @@ msgstr  ""
 msgid   "Show useful information about a cluster member"
 msgstr  ""
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:953 lxc/image.go:954
 msgid   "Show useful information about images"
 msgstr  ""
 
@@ -5124,7 +5119,7 @@ msgstr  ""
 msgid   "Show warning"
 msgstr  ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1021
 #, c-format
 msgid   "Size: %.2fMiB"
 msgstr  ""
@@ -5156,7 +5151,7 @@ msgstr  ""
 msgid   "Some instances failed to %s"
 msgstr  ""
 
-#: lxc/image.go:1058
+#: lxc/image.go:1064
 msgid   "Source:"
 msgstr  ""
 
@@ -5304,7 +5299,7 @@ msgstr  ""
 msgid   "TOKEN"
 msgstr  ""
 
-#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1141 lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082 lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172 lxc/storage_volume.go:1730 lxc/warning.go:216
+#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1147 lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082 lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172 lxc/storage_volume.go:1730 lxc/warning.go:216
 msgid   "TYPE"
 msgstr  ""
 
@@ -5364,7 +5359,7 @@ msgstr  ""
 msgid   "The instance is currently running. Use --force to have it stopped and restarted"
 msgstr  ""
 
-#: lxc/init.go:438
+#: lxc/init.go:443
 msgid   "The instance you are starting doesn't have any network attached to it."
 msgstr  ""
 
@@ -5373,12 +5368,12 @@ msgstr  ""
 msgid   "The key %q does not exist on cluster member %q"
 msgstr  ""
 
-#: lxc/utils.go:376
+#: lxc/utils.go:364
 #, c-format
 msgid   "The local image '%q' couldn't be found, trying '%q:%q' instead."
 msgstr  ""
 
-#: lxc/utils.go:372
+#: lxc/utils.go:360
 #, c-format
 msgid   "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr  ""
@@ -5515,15 +5510,15 @@ msgstr  ""
 msgid   "Time to wait for the instance to shutdown cleanly"
 msgstr  ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1025
 msgid   "Timestamps:"
 msgstr  ""
 
-#: lxc/init.go:440
+#: lxc/init.go:445
 msgid   "To attach a network to an instance, use: lxc network attach"
 msgstr  ""
 
-#: lxc/init.go:439
+#: lxc/init.go:444
 msgid   "To create a new network, use: lxc network create"
 msgstr  ""
 
@@ -5575,7 +5570,7 @@ msgstr  ""
 msgid   "Transfer mode. One of pull, push or relay."
 msgstr  ""
 
-#: lxc/image.go:827
+#: lxc/image.go:832
 #, c-format
 msgid   "Transferring image: %s"
 msgstr  ""
@@ -5611,7 +5606,7 @@ msgstr  ""
 msgid   "Type of connection to establish: 'console' for serial console, 'vga' for SPICE graphical output"
 msgstr  ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930 lxc/storage_volume.go:1455
+#: lxc/image.go:1023 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930 lxc/storage_volume.go:1455
 #, c-format
 msgid   "Type: %s"
 msgstr  ""
@@ -5625,7 +5620,7 @@ msgstr  ""
 msgid   "UNLIMITED"
 msgstr  ""
 
-#: lxc/image.go:1140
+#: lxc/image.go:1146
 msgid   "UPLOAD DATE"
 msgstr  ""
 
@@ -5669,7 +5664,7 @@ msgstr  ""
 msgid   "Unknown channel type for client %q: %s"
 msgstr  ""
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1772 lxc/warning.go:242
+#: lxc/image.go:1161 lxc/list.go:631 lxc/storage_volume.go:1772 lxc/warning.go:242
 #, c-format
 msgid   "Unknown column shorthand char '%c' in '%s'"
 msgstr  ""
@@ -5710,7 +5705,7 @@ msgstr  ""
 msgid   "Unset device configuration keys"
 msgstr  ""
 
-#: lxc/image.go:1700 lxc/image.go:1701
+#: lxc/image.go:1706 lxc/image.go:1707
 msgid   "Unset image properties"
 msgstr  ""
 
@@ -5859,7 +5854,7 @@ msgstr  ""
 msgid   "Update the target profile from the source if it already exists"
 msgstr  ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1032
 #, c-format
 msgid   "Uploaded: %s"
 msgstr  ""
@@ -6019,7 +6014,7 @@ msgstr  ""
 msgid   "[<remote>:] [<cert>]"
 msgstr  ""
 
-#: lxc/image.go:1087 lxc/list.go:46
+#: lxc/image.go:1093 lxc/list.go:46
 msgid   "[<remote>:] [<filter>...]"
 msgstr  ""
 
@@ -6127,15 +6122,15 @@ msgstr  ""
 msgid   "[<remote>:]<identity_provider_group> <new_name>"
 msgstr  ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
+#: lxc/image.go:399 lxc/image.go:952 lxc/image.go:1512
 msgid   "[<remote>:]<image>"
 msgstr  ""
 
-#: lxc/image.go:1572 lxc/image.go:1699
+#: lxc/image.go:1578 lxc/image.go:1705
 msgid   "[<remote>:]<image> <key>"
 msgstr  ""
 
-#: lxc/image.go:1636
+#: lxc/image.go:1642
 msgid   "[<remote>:]<image> <key> <value>"
 msgstr  ""
 
@@ -6151,11 +6146,11 @@ msgstr  ""
 msgid   "[<remote>:]<image> [<remote>:][<name>]"
 msgstr  ""
 
-#: lxc/image.go:523
+#: lxc/image.go:528
 msgid   "[<remote>:]<image> [<target>]"
 msgstr  ""
 
-#: lxc/image.go:334 lxc/image.go:1415
+#: lxc/image.go:339 lxc/image.go:1421
 msgid   "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr  ""
 
@@ -6591,7 +6586,7 @@ msgstr  ""
 msgid   "description"
 msgstr  ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1010
 msgid   "disabled"
 msgstr  ""
 
@@ -6599,7 +6594,7 @@ msgstr  ""
 msgid   "driver"
 msgstr  ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1012
 msgid   "enabled"
 msgstr  ""
 
@@ -6713,7 +6708,7 @@ msgid   "lxc file push /etc/hosts foo/etc/hosts\n"
         "   To push /etc/hosts into the instance \"foo\"."
 msgstr  ""
 
-#: lxc/image.go:398
+#: lxc/image.go:403
 msgid   "lxc image edit <image>\n"
         "    Launch a text editor to edit the properties\n"
         "\n"
@@ -6986,7 +6981,7 @@ msgstr  ""
 msgid   "name"
 msgstr  ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
+#: lxc/image.go:1000 lxc/image.go:1005 lxc/image.go:1203
 msgid   "no"
 msgstr  ""
 
@@ -7031,7 +7026,7 @@ msgstr  ""
 msgid   "y"
 msgstr  ""
 
-#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001 lxc/image.go:1194
+#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:1002 lxc/image.go:1007 lxc/image.go:1200
 msgid   "yes"
 msgstr  ""
 

--- a/po/mr.po
+++ b/po/mr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-19 13:11-0600\n"
+"POT-Creation-Date: 2024-09-25 18:38-0600\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Marathi <https://hosted.weblate.org/projects/linux-containers/"
@@ -195,7 +195,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:419
+#: lxc/image.go:424
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -423,7 +423,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1168
+#: lxc/image.go:1174
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -531,7 +531,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:695
+#: lxc/image.go:700
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -544,15 +544,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1138 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1133
+#: lxc/image.go:1139
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1144 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -734,7 +734,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1045
+#: lxc/image.go:1051
 msgid "Aliases:"
 msgstr ""
 
@@ -750,7 +750,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1022 lxc/info.go:486
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -769,11 +769,11 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:342 lxc/rebuild.go:131
+#: lxc/init.go:347 lxc/rebuild.go:136
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/init.go:346
+#: lxc/init.go:351
 msgid "Asked for a container but image is of type VM"
 msgstr ""
 
@@ -831,7 +831,7 @@ msgstr ""
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1061
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -888,7 +888,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:816
+#: lxc/image.go:821
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -969,7 +969,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1060
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -990,7 +990,7 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:239 lxc/utils.go:259
+#: lxc/utils.go:227 lxc/utils.go:247
 #, c-format
 msgid "Can't read from stdin: %w"
 msgstr ""
@@ -1024,7 +1024,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:166
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1176,7 +1176,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1589
+#: lxc/image.go:1121 lxc/list.go:132 lxc/storage_volume.go:1589
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1215,7 +1215,7 @@ msgstr ""
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1327 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/config_trust.go:314 lxc/image.go:496 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
@@ -1309,7 +1309,7 @@ msgstr ""
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1489,7 +1489,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1475
+#: lxc/image.go:1029 lxc/info.go:497 lxc/storage_volume.go:1475
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1513,7 +1513,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1143 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -1571,7 +1571,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:341 lxc/image.go:342
 msgid "Delete images"
 msgstr ""
 
@@ -1674,9 +1674,9 @@ msgstr ""
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
 #: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
-#: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
-#: lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090 lxc/image.go:1417
-#: lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638 lxc/image.go:1701
+#: lxc/image.go:159 lxc/image.go:342 lxc/image.go:401 lxc/image.go:530
+#: lxc/image.go:702 lxc/image.go:954 lxc/image.go:1096 lxc/image.go:1423
+#: lxc/image.go:1514 lxc/image.go:1580 lxc/image.go:1644 lxc/image.go:1707
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
@@ -1821,11 +1821,11 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:406
+#: lxc/init.go:411
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:726
+#: lxc/image.go:731
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1929,7 +1929,7 @@ msgstr ""
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:400 lxc/image.go:401
 msgid "Edit image properties"
 msgstr ""
 
@@ -2005,7 +2005,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1766
+#: lxc/image.go:1155 lxc/list.go:622 lxc/storage_volume.go:1766
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2124,20 +2124,20 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:1029
+#: lxc/image.go:1035
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1037
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:524
+#: lxc/image.go:529
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:530
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2165,7 +2165,7 @@ msgstr ""
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:604
+#: lxc/image.go:609
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2178,7 +2178,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
+#: lxc/config_trust.go:411 lxc/image.go:1140 lxc/image.go:1141
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2197,12 +2197,12 @@ msgstr ""
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/utils.go:296
+#: lxc/utils.go:284
 #, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/utils.go:288
+#: lxc/utils.go:276
 #, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
@@ -2296,7 +2296,7 @@ msgstr ""
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: lxc/utils.go:214
+#: lxc/utils.go:202
 #, c-format
 msgid "Failed to create alias %s: %w"
 msgstr ""
@@ -2321,11 +2321,6 @@ msgstr ""
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
 
-#: lxc/utils.go:203
-#, c-format
-msgid "Failed to remove alias %s: %w"
-msgstr ""
-
 #: lxc/file.go:821
 #, c-format
 msgid "Failed to walk path for %s: %s"
@@ -2345,7 +2340,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:1014
+#: lxc/image.go:1020
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2409,7 +2404,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:770 lxc/auth.go:1697
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1122 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:57
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2484,7 +2479,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1573 lxc/image.go:1574
+#: lxc/image.go:1579 lxc/image.go:1580
 msgid "Get image properties"
 msgstr ""
 
@@ -2758,11 +2753,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1489
+#: lxc/image.go:1495
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2770,25 +2765,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:680
+#: lxc/image.go:685
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1444
+#: lxc/image.go:369 lxc/image.go:1450
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1670
+#: lxc/image.go:449 lxc/image.go:1676
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:918
+#: lxc/image.go:923
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1493
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2808,7 +2803,7 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:697
+#: lxc/image.go:702
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -2818,7 +2813,7 @@ msgid ""
 "os=Ubuntu release=noble variant=cloud."
 msgstr ""
 
-#: lxc/image.go:696
+#: lxc/image.go:701
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2869,7 +2864,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:417
+#: lxc/init.go:422
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2935,7 +2930,7 @@ msgstr ""
 msgid "Invalid instance path: %q"
 msgstr ""
 
-#: lxc/utils.go:253
+#: lxc/utils.go:241
 #, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr ""
@@ -3047,12 +3042,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:1035
+#: lxc/image.go:1041
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:1037
+#: lxc/image.go:1043
 msgid "Last used: never"
 msgstr ""
 
@@ -3170,11 +3165,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1089
+#: lxc/image.go:1095
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1096
 msgid ""
 "List images\n"
 "\n"
@@ -3468,7 +3463,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:165 lxc/image.go:709
 msgid "Make image public"
 msgstr ""
 
@@ -3982,7 +3977,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:728
+#: lxc/image.go:733
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4175,7 +4170,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:168 lxc/image.go:710
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4255,7 +4250,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:805
+#: lxc/image.go:810
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4326,7 +4321,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:752
+#: lxc/image.go:1142 lxc/remote.go:752
 msgid "PUBLIC"
 msgstr ""
 
@@ -4387,7 +4382,7 @@ msgstr ""
 #: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/config_trust.go:315 lxc/image.go:497 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
@@ -4475,11 +4470,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1067
+#: lxc/image.go:1073
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1065
+#: lxc/image.go:1071
 msgid "Profiles: "
 msgstr ""
 
@@ -4502,11 +4497,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1046
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1621
+#: lxc/image.go:1627
 msgid "Property not found"
 msgstr ""
 
@@ -4600,7 +4595,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1024
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4636,7 +4631,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
+#: lxc/image.go:535 lxc/image.go:957 lxc/image.go:1517
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4673,7 +4668,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1416 lxc/image.go:1417
+#: lxc/image.go:1422 lxc/image.go:1423
 msgid "Refresh images"
 msgstr ""
 
@@ -4682,7 +4677,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1453
+#: lxc/image.go:1459
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4945,7 +4940,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:365
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -4978,7 +4973,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1139
+#: lxc/image.go:1145
 msgid "SIZE"
 msgstr ""
 
@@ -5101,7 +5096,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1637 lxc/image.go:1638
+#: lxc/image.go:1643 lxc/image.go:1644
 msgid "Set image properties"
 msgstr ""
 
@@ -5394,7 +5389,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1507 lxc/image.go:1508
+#: lxc/image.go:1513 lxc/image.go:1514
 msgid "Show image properties"
 msgstr ""
 
@@ -5528,7 +5523,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:953 lxc/image.go:954
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5540,7 +5535,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1021
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5572,7 +5567,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:1058
+#: lxc/image.go:1064
 msgid "Source:"
 msgstr ""
 
@@ -5720,7 +5715,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
 #: lxc/storage_volume.go:1730 lxc/warning.go:216
@@ -5785,7 +5780,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:438
+#: lxc/init.go:443
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5794,12 +5789,12 @@ msgstr ""
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
 
-#: lxc/utils.go:376
+#: lxc/utils.go:364
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:%q' instead."
 msgstr ""
 
-#: lxc/utils.go:372
+#: lxc/utils.go:360
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
@@ -5942,15 +5937,15 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1025
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:440
+#: lxc/init.go:445
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:439
+#: lxc/init.go:444
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6004,7 +5999,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:827
+#: lxc/image.go:832
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
@@ -6042,7 +6037,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1023 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1455
 #, c-format
 msgid "Type: %s"
@@ -6057,7 +6052,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1140
+#: lxc/image.go:1146
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6103,7 +6098,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:631 lxc/storage_volume.go:1772
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6145,7 +6140,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1700 lxc/image.go:1701
+#: lxc/image.go:1706 lxc/image.go:1707
 msgid "Unset image properties"
 msgstr ""
 
@@ -6296,7 +6291,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1032
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6469,7 +6464,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1087 lxc/list.go:46
+#: lxc/image.go:1093 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6582,15 +6577,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
+#: lxc/image.go:399 lxc/image.go:952 lxc/image.go:1512
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1572 lxc/image.go:1699
+#: lxc/image.go:1578 lxc/image.go:1705
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1636
+#: lxc/image.go:1642
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6606,11 +6601,11 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:523
+#: lxc/image.go:528
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1415
+#: lxc/image.go:339 lxc/image.go:1421
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -7073,7 +7068,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1010
 msgid "disabled"
 msgstr ""
 
@@ -7081,7 +7076,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1012
 msgid "enabled"
 msgstr ""
 
@@ -7222,7 +7217,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:398
+#: lxc/image.go:403
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7549,7 +7544,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
+#: lxc/image.go:1000 lxc/image.go:1005 lxc/image.go:1203
 msgid "no"
 msgstr ""
 
@@ -7594,7 +7589,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1194
+#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:1002 lxc/image.go:1007
+#: lxc/image.go:1200
 msgid "yes"
 msgstr ""

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-19 13:11-0600\n"
+"POT-Creation-Date: 2024-09-25 18:38-0600\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Norwegian Bokmål <https://hosted.weblate.org/projects/linux-"
@@ -195,7 +195,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:419
+#: lxc/image.go:424
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -423,7 +423,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1168
+#: lxc/image.go:1174
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -531,7 +531,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:695
+#: lxc/image.go:700
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -544,15 +544,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1138 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1133
+#: lxc/image.go:1139
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1144 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -734,7 +734,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1045
+#: lxc/image.go:1051
 msgid "Aliases:"
 msgstr ""
 
@@ -750,7 +750,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1022 lxc/info.go:486
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -769,11 +769,11 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:342 lxc/rebuild.go:131
+#: lxc/init.go:347 lxc/rebuild.go:136
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/init.go:346
+#: lxc/init.go:351
 msgid "Asked for a container but image is of type VM"
 msgstr ""
 
@@ -831,7 +831,7 @@ msgstr ""
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1061
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -888,7 +888,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:816
+#: lxc/image.go:821
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -969,7 +969,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1060
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -990,7 +990,7 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:239 lxc/utils.go:259
+#: lxc/utils.go:227 lxc/utils.go:247
 #, c-format
 msgid "Can't read from stdin: %w"
 msgstr ""
@@ -1024,7 +1024,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:166
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1176,7 +1176,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1589
+#: lxc/image.go:1121 lxc/list.go:132 lxc/storage_volume.go:1589
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1215,7 +1215,7 @@ msgstr ""
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1327 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/config_trust.go:314 lxc/image.go:496 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
@@ -1309,7 +1309,7 @@ msgstr ""
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1489,7 +1489,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1475
+#: lxc/image.go:1029 lxc/info.go:497 lxc/storage_volume.go:1475
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1513,7 +1513,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1143 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -1571,7 +1571,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:341 lxc/image.go:342
 msgid "Delete images"
 msgstr ""
 
@@ -1674,9 +1674,9 @@ msgstr ""
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
 #: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
-#: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
-#: lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090 lxc/image.go:1417
-#: lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638 lxc/image.go:1701
+#: lxc/image.go:159 lxc/image.go:342 lxc/image.go:401 lxc/image.go:530
+#: lxc/image.go:702 lxc/image.go:954 lxc/image.go:1096 lxc/image.go:1423
+#: lxc/image.go:1514 lxc/image.go:1580 lxc/image.go:1644 lxc/image.go:1707
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
@@ -1821,11 +1821,11 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:406
+#: lxc/init.go:411
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:726
+#: lxc/image.go:731
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1929,7 +1929,7 @@ msgstr ""
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:400 lxc/image.go:401
 msgid "Edit image properties"
 msgstr ""
 
@@ -2005,7 +2005,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1766
+#: lxc/image.go:1155 lxc/list.go:622 lxc/storage_volume.go:1766
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2124,20 +2124,20 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:1029
+#: lxc/image.go:1035
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1037
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:524
+#: lxc/image.go:529
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:530
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2165,7 +2165,7 @@ msgstr ""
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:604
+#: lxc/image.go:609
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2178,7 +2178,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
+#: lxc/config_trust.go:411 lxc/image.go:1140 lxc/image.go:1141
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2197,12 +2197,12 @@ msgstr ""
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/utils.go:296
+#: lxc/utils.go:284
 #, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/utils.go:288
+#: lxc/utils.go:276
 #, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
@@ -2296,7 +2296,7 @@ msgstr ""
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: lxc/utils.go:214
+#: lxc/utils.go:202
 #, c-format
 msgid "Failed to create alias %s: %w"
 msgstr ""
@@ -2321,11 +2321,6 @@ msgstr ""
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
 
-#: lxc/utils.go:203
-#, c-format
-msgid "Failed to remove alias %s: %w"
-msgstr ""
-
 #: lxc/file.go:821
 #, c-format
 msgid "Failed to walk path for %s: %s"
@@ -2345,7 +2340,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:1014
+#: lxc/image.go:1020
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2409,7 +2404,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:770 lxc/auth.go:1697
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1122 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:57
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2484,7 +2479,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1573 lxc/image.go:1574
+#: lxc/image.go:1579 lxc/image.go:1580
 msgid "Get image properties"
 msgstr ""
 
@@ -2758,11 +2753,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1489
+#: lxc/image.go:1495
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2770,25 +2765,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:680
+#: lxc/image.go:685
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1444
+#: lxc/image.go:369 lxc/image.go:1450
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1670
+#: lxc/image.go:449 lxc/image.go:1676
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:918
+#: lxc/image.go:923
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1493
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2808,7 +2803,7 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:697
+#: lxc/image.go:702
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -2818,7 +2813,7 @@ msgid ""
 "os=Ubuntu release=noble variant=cloud."
 msgstr ""
 
-#: lxc/image.go:696
+#: lxc/image.go:701
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2869,7 +2864,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:417
+#: lxc/init.go:422
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2935,7 +2930,7 @@ msgstr ""
 msgid "Invalid instance path: %q"
 msgstr ""
 
-#: lxc/utils.go:253
+#: lxc/utils.go:241
 #, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr ""
@@ -3047,12 +3042,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:1035
+#: lxc/image.go:1041
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:1037
+#: lxc/image.go:1043
 msgid "Last used: never"
 msgstr ""
 
@@ -3170,11 +3165,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1089
+#: lxc/image.go:1095
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1096
 msgid ""
 "List images\n"
 "\n"
@@ -3468,7 +3463,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:165 lxc/image.go:709
 msgid "Make image public"
 msgstr ""
 
@@ -3982,7 +3977,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:728
+#: lxc/image.go:733
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4175,7 +4170,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:168 lxc/image.go:710
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4255,7 +4250,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:805
+#: lxc/image.go:810
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4326,7 +4321,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:752
+#: lxc/image.go:1142 lxc/remote.go:752
 msgid "PUBLIC"
 msgstr ""
 
@@ -4387,7 +4382,7 @@ msgstr ""
 #: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/config_trust.go:315 lxc/image.go:497 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
@@ -4475,11 +4470,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1067
+#: lxc/image.go:1073
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1065
+#: lxc/image.go:1071
 msgid "Profiles: "
 msgstr ""
 
@@ -4502,11 +4497,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1046
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1621
+#: lxc/image.go:1627
 msgid "Property not found"
 msgstr ""
 
@@ -4600,7 +4595,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1024
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4636,7 +4631,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
+#: lxc/image.go:535 lxc/image.go:957 lxc/image.go:1517
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4673,7 +4668,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1416 lxc/image.go:1417
+#: lxc/image.go:1422 lxc/image.go:1423
 msgid "Refresh images"
 msgstr ""
 
@@ -4682,7 +4677,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1453
+#: lxc/image.go:1459
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4945,7 +4940,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:365
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -4978,7 +4973,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1139
+#: lxc/image.go:1145
 msgid "SIZE"
 msgstr ""
 
@@ -5101,7 +5096,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1637 lxc/image.go:1638
+#: lxc/image.go:1643 lxc/image.go:1644
 msgid "Set image properties"
 msgstr ""
 
@@ -5394,7 +5389,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1507 lxc/image.go:1508
+#: lxc/image.go:1513 lxc/image.go:1514
 msgid "Show image properties"
 msgstr ""
 
@@ -5528,7 +5523,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:953 lxc/image.go:954
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5540,7 +5535,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1021
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5572,7 +5567,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:1058
+#: lxc/image.go:1064
 msgid "Source:"
 msgstr ""
 
@@ -5720,7 +5715,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
 #: lxc/storage_volume.go:1730 lxc/warning.go:216
@@ -5785,7 +5780,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:438
+#: lxc/init.go:443
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5794,12 +5789,12 @@ msgstr ""
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
 
-#: lxc/utils.go:376
+#: lxc/utils.go:364
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:%q' instead."
 msgstr ""
 
-#: lxc/utils.go:372
+#: lxc/utils.go:360
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
@@ -5942,15 +5937,15 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1025
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:440
+#: lxc/init.go:445
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:439
+#: lxc/init.go:444
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6004,7 +5999,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:827
+#: lxc/image.go:832
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
@@ -6042,7 +6037,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1023 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1455
 #, c-format
 msgid "Type: %s"
@@ -6057,7 +6052,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1140
+#: lxc/image.go:1146
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6103,7 +6098,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:631 lxc/storage_volume.go:1772
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6145,7 +6140,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1700 lxc/image.go:1701
+#: lxc/image.go:1706 lxc/image.go:1707
 msgid "Unset image properties"
 msgstr ""
 
@@ -6296,7 +6291,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1032
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6469,7 +6464,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1087 lxc/list.go:46
+#: lxc/image.go:1093 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6582,15 +6577,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
+#: lxc/image.go:399 lxc/image.go:952 lxc/image.go:1512
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1572 lxc/image.go:1699
+#: lxc/image.go:1578 lxc/image.go:1705
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1636
+#: lxc/image.go:1642
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6606,11 +6601,11 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:523
+#: lxc/image.go:528
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1415
+#: lxc/image.go:339 lxc/image.go:1421
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -7073,7 +7068,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1010
 msgid "disabled"
 msgstr ""
 
@@ -7081,7 +7076,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1012
 msgid "enabled"
 msgstr ""
 
@@ -7222,7 +7217,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:398
+#: lxc/image.go:403
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7549,7 +7544,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
+#: lxc/image.go:1000 lxc/image.go:1005 lxc/image.go:1203
 msgid "no"
 msgstr ""
 
@@ -7594,7 +7589,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1194
+#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:1002 lxc/image.go:1007
+#: lxc/image.go:1200
 msgid "yes"
 msgstr ""

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-19 13:11-0600\n"
+"POT-Creation-Date: 2024-09-25 18:38-0600\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Heimen Stoffels <vistausss@fastmail.com>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/linux-containers/"
@@ -270,7 +270,7 @@ msgstr ""
 "### Bijvoorbeeld:\n"
 "###  description: Mijn eigen image"
 
-#: lxc/image.go:419
+#: lxc/image.go:424
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the image properties.\n"
@@ -647,7 +647,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1168
+#: lxc/image.go:1174
 #, c-format
 msgid "%s (%d more)"
 msgstr "%s (en nog %d)"
@@ -755,7 +755,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:695
+#: lxc/image.go:700
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -768,15 +768,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1138 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr "ALIAS"
 
-#: lxc/image.go:1133
+#: lxc/image.go:1139
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1144 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr "ARCHITECTUUR"
 
@@ -958,7 +958,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1045
+#: lxc/image.go:1051
 msgid "Aliases:"
 msgstr ""
 
@@ -974,7 +974,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1022 lxc/info.go:486
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -993,11 +993,11 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:342 lxc/rebuild.go:131
+#: lxc/init.go:347 lxc/rebuild.go:136
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/init.go:346
+#: lxc/init.go:351
 msgid "Asked for a container but image is of type VM"
 msgstr ""
 
@@ -1055,7 +1055,7 @@ msgstr ""
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1061
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -1112,7 +1112,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:816
+#: lxc/image.go:821
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -1193,7 +1193,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1060
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -1214,7 +1214,7 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:239 lxc/utils.go:259
+#: lxc/utils.go:227 lxc/utils.go:247
 #, c-format
 msgid "Can't read from stdin: %w"
 msgstr ""
@@ -1248,7 +1248,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:166
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1400,7 +1400,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1589
+#: lxc/image.go:1121 lxc/list.go:132 lxc/storage_volume.go:1589
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1439,7 +1439,7 @@ msgstr ""
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1327 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/config_trust.go:314 lxc/image.go:496 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
@@ -1533,7 +1533,7 @@ msgstr ""
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1713,7 +1713,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1475
+#: lxc/image.go:1029 lxc/info.go:497 lxc/storage_volume.go:1475
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1737,7 +1737,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1143 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -1795,7 +1795,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:341 lxc/image.go:342
 msgid "Delete images"
 msgstr ""
 
@@ -1898,9 +1898,9 @@ msgstr ""
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
 #: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
-#: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
-#: lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090 lxc/image.go:1417
-#: lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638 lxc/image.go:1701
+#: lxc/image.go:159 lxc/image.go:342 lxc/image.go:401 lxc/image.go:530
+#: lxc/image.go:702 lxc/image.go:954 lxc/image.go:1096 lxc/image.go:1423
+#: lxc/image.go:1514 lxc/image.go:1580 lxc/image.go:1644 lxc/image.go:1707
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
@@ -2045,11 +2045,11 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:406
+#: lxc/init.go:411
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:726
+#: lxc/image.go:731
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -2153,7 +2153,7 @@ msgstr ""
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:400 lxc/image.go:401
 msgid "Edit image properties"
 msgstr ""
 
@@ -2229,7 +2229,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1766
+#: lxc/image.go:1155 lxc/list.go:622 lxc/storage_volume.go:1766
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2348,20 +2348,20 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:1029
+#: lxc/image.go:1035
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1037
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:524
+#: lxc/image.go:529
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:530
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2389,7 +2389,7 @@ msgstr ""
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:604
+#: lxc/image.go:609
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2402,7 +2402,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
+#: lxc/config_trust.go:411 lxc/image.go:1140 lxc/image.go:1141
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2421,12 +2421,12 @@ msgstr ""
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/utils.go:296
+#: lxc/utils.go:284
 #, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/utils.go:288
+#: lxc/utils.go:276
 #, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
@@ -2520,7 +2520,7 @@ msgstr ""
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: lxc/utils.go:214
+#: lxc/utils.go:202
 #, c-format
 msgid "Failed to create alias %s: %w"
 msgstr ""
@@ -2545,11 +2545,6 @@ msgstr ""
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
 
-#: lxc/utils.go:203
-#, c-format
-msgid "Failed to remove alias %s: %w"
-msgstr ""
-
 #: lxc/file.go:821
 #, c-format
 msgid "Failed to walk path for %s: %s"
@@ -2569,7 +2564,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:1014
+#: lxc/image.go:1020
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2633,7 +2628,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:770 lxc/auth.go:1697
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1122 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:57
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2708,7 +2703,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1573 lxc/image.go:1574
+#: lxc/image.go:1579 lxc/image.go:1580
 msgid "Get image properties"
 msgstr ""
 
@@ -2982,11 +2977,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1489
+#: lxc/image.go:1495
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2994,25 +2989,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:680
+#: lxc/image.go:685
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1444
+#: lxc/image.go:369 lxc/image.go:1450
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1670
+#: lxc/image.go:449 lxc/image.go:1676
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:918
+#: lxc/image.go:923
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1493
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3032,7 +3027,7 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:697
+#: lxc/image.go:702
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -3042,7 +3037,7 @@ msgid ""
 "os=Ubuntu release=noble variant=cloud."
 msgstr ""
 
-#: lxc/image.go:696
+#: lxc/image.go:701
 msgid "Import images into the image store"
 msgstr ""
 
@@ -3093,7 +3088,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:417
+#: lxc/init.go:422
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -3159,7 +3154,7 @@ msgstr ""
 msgid "Invalid instance path: %q"
 msgstr ""
 
-#: lxc/utils.go:253
+#: lxc/utils.go:241
 #, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr ""
@@ -3271,12 +3266,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:1035
+#: lxc/image.go:1041
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:1037
+#: lxc/image.go:1043
 msgid "Last used: never"
 msgstr ""
 
@@ -3394,11 +3389,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1089
+#: lxc/image.go:1095
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1096
 msgid ""
 "List images\n"
 "\n"
@@ -3692,7 +3687,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:165 lxc/image.go:709
 msgid "Make image public"
 msgstr ""
 
@@ -4206,7 +4201,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:728
+#: lxc/image.go:733
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4399,7 +4394,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:168 lxc/image.go:710
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4479,7 +4474,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:805
+#: lxc/image.go:810
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4550,7 +4545,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:752
+#: lxc/image.go:1142 lxc/remote.go:752
 msgid "PUBLIC"
 msgstr ""
 
@@ -4611,7 +4606,7 @@ msgstr ""
 #: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/config_trust.go:315 lxc/image.go:497 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
@@ -4699,11 +4694,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1067
+#: lxc/image.go:1073
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1065
+#: lxc/image.go:1071
 msgid "Profiles: "
 msgstr ""
 
@@ -4726,11 +4721,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1046
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1621
+#: lxc/image.go:1627
 msgid "Property not found"
 msgstr ""
 
@@ -4824,7 +4819,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1024
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4860,7 +4855,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
+#: lxc/image.go:535 lxc/image.go:957 lxc/image.go:1517
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4897,7 +4892,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1416 lxc/image.go:1417
+#: lxc/image.go:1422 lxc/image.go:1423
 msgid "Refresh images"
 msgstr ""
 
@@ -4906,7 +4901,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1453
+#: lxc/image.go:1459
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5169,7 +5164,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:365
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5202,7 +5197,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1139
+#: lxc/image.go:1145
 msgid "SIZE"
 msgstr ""
 
@@ -5325,7 +5320,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1637 lxc/image.go:1638
+#: lxc/image.go:1643 lxc/image.go:1644
 msgid "Set image properties"
 msgstr ""
 
@@ -5618,7 +5613,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1507 lxc/image.go:1508
+#: lxc/image.go:1513 lxc/image.go:1514
 msgid "Show image properties"
 msgstr ""
 
@@ -5752,7 +5747,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:953 lxc/image.go:954
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5764,7 +5759,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1021
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5796,7 +5791,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:1058
+#: lxc/image.go:1064
 msgid "Source:"
 msgstr ""
 
@@ -5944,7 +5939,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
 #: lxc/storage_volume.go:1730 lxc/warning.go:216
@@ -6009,7 +6004,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:438
+#: lxc/init.go:443
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -6018,12 +6013,12 @@ msgstr ""
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
 
-#: lxc/utils.go:376
+#: lxc/utils.go:364
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:%q' instead."
 msgstr ""
 
-#: lxc/utils.go:372
+#: lxc/utils.go:360
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
@@ -6166,15 +6161,15 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1025
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:440
+#: lxc/init.go:445
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:439
+#: lxc/init.go:444
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6228,7 +6223,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:827
+#: lxc/image.go:832
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
@@ -6266,7 +6261,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1023 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1455
 #, c-format
 msgid "Type: %s"
@@ -6281,7 +6276,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1140
+#: lxc/image.go:1146
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6327,7 +6322,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:631 lxc/storage_volume.go:1772
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6369,7 +6364,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1700 lxc/image.go:1701
+#: lxc/image.go:1706 lxc/image.go:1707
 msgid "Unset image properties"
 msgstr ""
 
@@ -6520,7 +6515,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1032
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6693,7 +6688,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1087 lxc/list.go:46
+#: lxc/image.go:1093 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6806,15 +6801,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
+#: lxc/image.go:399 lxc/image.go:952 lxc/image.go:1512
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1572 lxc/image.go:1699
+#: lxc/image.go:1578 lxc/image.go:1705
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1636
+#: lxc/image.go:1642
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6830,11 +6825,11 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:523
+#: lxc/image.go:528
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1415
+#: lxc/image.go:339 lxc/image.go:1421
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -7297,7 +7292,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1010
 msgid "disabled"
 msgstr ""
 
@@ -7305,7 +7300,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1012
 msgid "enabled"
 msgstr ""
 
@@ -7446,7 +7441,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:398
+#: lxc/image.go:403
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7773,7 +7768,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
+#: lxc/image.go:1000 lxc/image.go:1005 lxc/image.go:1203
 msgid "no"
 msgstr ""
 
@@ -7818,8 +7813,8 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1194
+#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:1002 lxc/image.go:1007
+#: lxc/image.go:1200
 msgid "yes"
 msgstr ""
 

--- a/po/pa.po
+++ b/po/pa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-19 13:11-0600\n"
+"POT-Creation-Date: 2024-09-25 18:38-0600\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Punjabi <https://hosted.weblate.org/projects/linux-containers/"
@@ -195,7 +195,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:419
+#: lxc/image.go:424
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -423,7 +423,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1168
+#: lxc/image.go:1174
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -531,7 +531,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:695
+#: lxc/image.go:700
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -544,15 +544,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1138 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1133
+#: lxc/image.go:1139
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1144 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -734,7 +734,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1045
+#: lxc/image.go:1051
 msgid "Aliases:"
 msgstr ""
 
@@ -750,7 +750,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1022 lxc/info.go:486
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -769,11 +769,11 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:342 lxc/rebuild.go:131
+#: lxc/init.go:347 lxc/rebuild.go:136
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/init.go:346
+#: lxc/init.go:351
 msgid "Asked for a container but image is of type VM"
 msgstr ""
 
@@ -831,7 +831,7 @@ msgstr ""
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1061
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -888,7 +888,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:816
+#: lxc/image.go:821
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -969,7 +969,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1060
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -990,7 +990,7 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:239 lxc/utils.go:259
+#: lxc/utils.go:227 lxc/utils.go:247
 #, c-format
 msgid "Can't read from stdin: %w"
 msgstr ""
@@ -1024,7 +1024,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:166
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1176,7 +1176,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1589
+#: lxc/image.go:1121 lxc/list.go:132 lxc/storage_volume.go:1589
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1215,7 +1215,7 @@ msgstr ""
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1327 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/config_trust.go:314 lxc/image.go:496 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
@@ -1309,7 +1309,7 @@ msgstr ""
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1489,7 +1489,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1475
+#: lxc/image.go:1029 lxc/info.go:497 lxc/storage_volume.go:1475
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1513,7 +1513,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1143 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -1571,7 +1571,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:341 lxc/image.go:342
 msgid "Delete images"
 msgstr ""
 
@@ -1674,9 +1674,9 @@ msgstr ""
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
 #: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
-#: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
-#: lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090 lxc/image.go:1417
-#: lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638 lxc/image.go:1701
+#: lxc/image.go:159 lxc/image.go:342 lxc/image.go:401 lxc/image.go:530
+#: lxc/image.go:702 lxc/image.go:954 lxc/image.go:1096 lxc/image.go:1423
+#: lxc/image.go:1514 lxc/image.go:1580 lxc/image.go:1644 lxc/image.go:1707
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
@@ -1821,11 +1821,11 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:406
+#: lxc/init.go:411
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:726
+#: lxc/image.go:731
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1929,7 +1929,7 @@ msgstr ""
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:400 lxc/image.go:401
 msgid "Edit image properties"
 msgstr ""
 
@@ -2005,7 +2005,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1766
+#: lxc/image.go:1155 lxc/list.go:622 lxc/storage_volume.go:1766
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2124,20 +2124,20 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:1029
+#: lxc/image.go:1035
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1037
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:524
+#: lxc/image.go:529
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:530
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2165,7 +2165,7 @@ msgstr ""
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:604
+#: lxc/image.go:609
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2178,7 +2178,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
+#: lxc/config_trust.go:411 lxc/image.go:1140 lxc/image.go:1141
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2197,12 +2197,12 @@ msgstr ""
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/utils.go:296
+#: lxc/utils.go:284
 #, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/utils.go:288
+#: lxc/utils.go:276
 #, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
@@ -2296,7 +2296,7 @@ msgstr ""
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: lxc/utils.go:214
+#: lxc/utils.go:202
 #, c-format
 msgid "Failed to create alias %s: %w"
 msgstr ""
@@ -2321,11 +2321,6 @@ msgstr ""
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
 
-#: lxc/utils.go:203
-#, c-format
-msgid "Failed to remove alias %s: %w"
-msgstr ""
-
 #: lxc/file.go:821
 #, c-format
 msgid "Failed to walk path for %s: %s"
@@ -2345,7 +2340,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:1014
+#: lxc/image.go:1020
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2409,7 +2404,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:770 lxc/auth.go:1697
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1122 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:57
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2484,7 +2479,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1573 lxc/image.go:1574
+#: lxc/image.go:1579 lxc/image.go:1580
 msgid "Get image properties"
 msgstr ""
 
@@ -2758,11 +2753,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1489
+#: lxc/image.go:1495
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2770,25 +2765,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:680
+#: lxc/image.go:685
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1444
+#: lxc/image.go:369 lxc/image.go:1450
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1670
+#: lxc/image.go:449 lxc/image.go:1676
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:918
+#: lxc/image.go:923
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1493
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2808,7 +2803,7 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:697
+#: lxc/image.go:702
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -2818,7 +2813,7 @@ msgid ""
 "os=Ubuntu release=noble variant=cloud."
 msgstr ""
 
-#: lxc/image.go:696
+#: lxc/image.go:701
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2869,7 +2864,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:417
+#: lxc/init.go:422
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2935,7 +2930,7 @@ msgstr ""
 msgid "Invalid instance path: %q"
 msgstr ""
 
-#: lxc/utils.go:253
+#: lxc/utils.go:241
 #, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr ""
@@ -3047,12 +3042,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:1035
+#: lxc/image.go:1041
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:1037
+#: lxc/image.go:1043
 msgid "Last used: never"
 msgstr ""
 
@@ -3170,11 +3165,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1089
+#: lxc/image.go:1095
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1096
 msgid ""
 "List images\n"
 "\n"
@@ -3468,7 +3463,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:165 lxc/image.go:709
 msgid "Make image public"
 msgstr ""
 
@@ -3982,7 +3977,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:728
+#: lxc/image.go:733
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4175,7 +4170,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:168 lxc/image.go:710
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4255,7 +4250,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:805
+#: lxc/image.go:810
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4326,7 +4321,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:752
+#: lxc/image.go:1142 lxc/remote.go:752
 msgid "PUBLIC"
 msgstr ""
 
@@ -4387,7 +4382,7 @@ msgstr ""
 #: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/config_trust.go:315 lxc/image.go:497 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
@@ -4475,11 +4470,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1067
+#: lxc/image.go:1073
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1065
+#: lxc/image.go:1071
 msgid "Profiles: "
 msgstr ""
 
@@ -4502,11 +4497,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1046
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1621
+#: lxc/image.go:1627
 msgid "Property not found"
 msgstr ""
 
@@ -4600,7 +4595,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1024
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4636,7 +4631,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
+#: lxc/image.go:535 lxc/image.go:957 lxc/image.go:1517
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4673,7 +4668,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1416 lxc/image.go:1417
+#: lxc/image.go:1422 lxc/image.go:1423
 msgid "Refresh images"
 msgstr ""
 
@@ -4682,7 +4677,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1453
+#: lxc/image.go:1459
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4945,7 +4940,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:365
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -4978,7 +4973,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1139
+#: lxc/image.go:1145
 msgid "SIZE"
 msgstr ""
 
@@ -5101,7 +5096,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1637 lxc/image.go:1638
+#: lxc/image.go:1643 lxc/image.go:1644
 msgid "Set image properties"
 msgstr ""
 
@@ -5394,7 +5389,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1507 lxc/image.go:1508
+#: lxc/image.go:1513 lxc/image.go:1514
 msgid "Show image properties"
 msgstr ""
 
@@ -5528,7 +5523,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:953 lxc/image.go:954
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5540,7 +5535,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1021
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5572,7 +5567,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:1058
+#: lxc/image.go:1064
 msgid "Source:"
 msgstr ""
 
@@ -5720,7 +5715,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
 #: lxc/storage_volume.go:1730 lxc/warning.go:216
@@ -5785,7 +5780,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:438
+#: lxc/init.go:443
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5794,12 +5789,12 @@ msgstr ""
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
 
-#: lxc/utils.go:376
+#: lxc/utils.go:364
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:%q' instead."
 msgstr ""
 
-#: lxc/utils.go:372
+#: lxc/utils.go:360
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
@@ -5942,15 +5937,15 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1025
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:440
+#: lxc/init.go:445
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:439
+#: lxc/init.go:444
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6004,7 +5999,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:827
+#: lxc/image.go:832
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
@@ -6042,7 +6037,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1023 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1455
 #, c-format
 msgid "Type: %s"
@@ -6057,7 +6052,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1140
+#: lxc/image.go:1146
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6103,7 +6098,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:631 lxc/storage_volume.go:1772
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6145,7 +6140,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1700 lxc/image.go:1701
+#: lxc/image.go:1706 lxc/image.go:1707
 msgid "Unset image properties"
 msgstr ""
 
@@ -6296,7 +6291,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1032
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6469,7 +6464,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1087 lxc/list.go:46
+#: lxc/image.go:1093 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6582,15 +6577,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
+#: lxc/image.go:399 lxc/image.go:952 lxc/image.go:1512
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1572 lxc/image.go:1699
+#: lxc/image.go:1578 lxc/image.go:1705
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1636
+#: lxc/image.go:1642
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6606,11 +6601,11 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:523
+#: lxc/image.go:528
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1415
+#: lxc/image.go:339 lxc/image.go:1421
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -7073,7 +7068,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1010
 msgid "disabled"
 msgstr ""
 
@@ -7081,7 +7076,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1012
 msgid "enabled"
 msgstr ""
 
@@ -7222,7 +7217,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:398
+#: lxc/image.go:403
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7549,7 +7544,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
+#: lxc/image.go:1000 lxc/image.go:1005 lxc/image.go:1203
 msgid "no"
 msgstr ""
 
@@ -7594,7 +7589,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1194
+#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:1002 lxc/image.go:1007
+#: lxc/image.go:1200
 msgid "yes"
 msgstr ""

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-19 13:11-0600\n"
+"POT-Creation-Date: 2024-09-25 18:38-0600\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/linux-containers/"
@@ -280,7 +280,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/image.go:419
+#: lxc/image.go:424
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the image properties.\n"
@@ -685,7 +685,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1168
+#: lxc/image.go:1174
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -793,7 +793,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:695
+#: lxc/image.go:700
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -806,15 +806,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1138 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1133
+#: lxc/image.go:1139
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1144 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -996,7 +996,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1045
+#: lxc/image.go:1051
 msgid "Aliases:"
 msgstr ""
 
@@ -1012,7 +1012,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1022 lxc/info.go:486
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -1031,11 +1031,11 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:342 lxc/rebuild.go:131
+#: lxc/init.go:347 lxc/rebuild.go:136
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/init.go:346
+#: lxc/init.go:351
 msgid "Asked for a container but image is of type VM"
 msgstr ""
 
@@ -1093,7 +1093,7 @@ msgstr ""
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1061
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -1150,7 +1150,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:816
+#: lxc/image.go:821
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -1231,7 +1231,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1060
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -1252,7 +1252,7 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:239 lxc/utils.go:259
+#: lxc/utils.go:227 lxc/utils.go:247
 #, c-format
 msgid "Can't read from stdin: %w"
 msgstr ""
@@ -1286,7 +1286,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:166
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1438,7 +1438,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1589
+#: lxc/image.go:1121 lxc/list.go:132 lxc/storage_volume.go:1589
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1477,7 +1477,7 @@ msgstr ""
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1327 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/config_trust.go:314 lxc/image.go:496 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
@@ -1571,7 +1571,7 @@ msgstr ""
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1751,7 +1751,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1475
+#: lxc/image.go:1029 lxc/info.go:497 lxc/storage_volume.go:1475
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1775,7 +1775,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1143 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -1833,7 +1833,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:341 lxc/image.go:342
 msgid "Delete images"
 msgstr ""
 
@@ -1936,9 +1936,9 @@ msgstr ""
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
 #: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
-#: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
-#: lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090 lxc/image.go:1417
-#: lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638 lxc/image.go:1701
+#: lxc/image.go:159 lxc/image.go:342 lxc/image.go:401 lxc/image.go:530
+#: lxc/image.go:702 lxc/image.go:954 lxc/image.go:1096 lxc/image.go:1423
+#: lxc/image.go:1514 lxc/image.go:1580 lxc/image.go:1644 lxc/image.go:1707
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
@@ -2083,11 +2083,11 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:406
+#: lxc/init.go:411
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:726
+#: lxc/image.go:731
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -2191,7 +2191,7 @@ msgstr ""
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:400 lxc/image.go:401
 msgid "Edit image properties"
 msgstr ""
 
@@ -2267,7 +2267,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1766
+#: lxc/image.go:1155 lxc/list.go:622 lxc/storage_volume.go:1766
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2386,20 +2386,20 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:1029
+#: lxc/image.go:1035
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1037
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:524
+#: lxc/image.go:529
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:530
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2427,7 +2427,7 @@ msgstr ""
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:604
+#: lxc/image.go:609
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2440,7 +2440,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
+#: lxc/config_trust.go:411 lxc/image.go:1140 lxc/image.go:1141
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2459,12 +2459,12 @@ msgstr ""
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/utils.go:296
+#: lxc/utils.go:284
 #, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/utils.go:288
+#: lxc/utils.go:276
 #, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
@@ -2558,7 +2558,7 @@ msgstr ""
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: lxc/utils.go:214
+#: lxc/utils.go:202
 #, c-format
 msgid "Failed to create alias %s: %w"
 msgstr ""
@@ -2583,11 +2583,6 @@ msgstr ""
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
 
-#: lxc/utils.go:203
-#, c-format
-msgid "Failed to remove alias %s: %w"
-msgstr ""
-
 #: lxc/file.go:821
 #, c-format
 msgid "Failed to walk path for %s: %s"
@@ -2607,7 +2602,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:1014
+#: lxc/image.go:1020
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2671,7 +2666,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:770 lxc/auth.go:1697
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1122 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:57
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2746,7 +2741,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1573 lxc/image.go:1574
+#: lxc/image.go:1579 lxc/image.go:1580
 msgid "Get image properties"
 msgstr ""
 
@@ -3020,11 +3015,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1489
+#: lxc/image.go:1495
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -3032,25 +3027,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:680
+#: lxc/image.go:685
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1444
+#: lxc/image.go:369 lxc/image.go:1450
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1670
+#: lxc/image.go:449 lxc/image.go:1676
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:918
+#: lxc/image.go:923
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1493
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3070,7 +3065,7 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:697
+#: lxc/image.go:702
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -3080,7 +3075,7 @@ msgid ""
 "os=Ubuntu release=noble variant=cloud."
 msgstr ""
 
-#: lxc/image.go:696
+#: lxc/image.go:701
 msgid "Import images into the image store"
 msgstr ""
 
@@ -3131,7 +3126,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:417
+#: lxc/init.go:422
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -3197,7 +3192,7 @@ msgstr ""
 msgid "Invalid instance path: %q"
 msgstr ""
 
-#: lxc/utils.go:253
+#: lxc/utils.go:241
 #, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr ""
@@ -3309,12 +3304,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:1035
+#: lxc/image.go:1041
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:1037
+#: lxc/image.go:1043
 msgid "Last used: never"
 msgstr ""
 
@@ -3432,11 +3427,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1089
+#: lxc/image.go:1095
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1096
 msgid ""
 "List images\n"
 "\n"
@@ -3730,7 +3725,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:165 lxc/image.go:709
 msgid "Make image public"
 msgstr ""
 
@@ -4244,7 +4239,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:728
+#: lxc/image.go:733
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4437,7 +4432,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:168 lxc/image.go:710
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4517,7 +4512,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:805
+#: lxc/image.go:810
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4588,7 +4583,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:752
+#: lxc/image.go:1142 lxc/remote.go:752
 msgid "PUBLIC"
 msgstr ""
 
@@ -4649,7 +4644,7 @@ msgstr ""
 #: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/config_trust.go:315 lxc/image.go:497 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
@@ -4737,11 +4732,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1067
+#: lxc/image.go:1073
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1065
+#: lxc/image.go:1071
 msgid "Profiles: "
 msgstr ""
 
@@ -4764,11 +4759,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1046
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1621
+#: lxc/image.go:1627
 msgid "Property not found"
 msgstr ""
 
@@ -4862,7 +4857,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1024
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4898,7 +4893,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
+#: lxc/image.go:535 lxc/image.go:957 lxc/image.go:1517
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4935,7 +4930,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1416 lxc/image.go:1417
+#: lxc/image.go:1422 lxc/image.go:1423
 msgid "Refresh images"
 msgstr ""
 
@@ -4944,7 +4939,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1453
+#: lxc/image.go:1459
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5207,7 +5202,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:365
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5240,7 +5235,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1139
+#: lxc/image.go:1145
 msgid "SIZE"
 msgstr ""
 
@@ -5363,7 +5358,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1637 lxc/image.go:1638
+#: lxc/image.go:1643 lxc/image.go:1644
 msgid "Set image properties"
 msgstr ""
 
@@ -5656,7 +5651,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1507 lxc/image.go:1508
+#: lxc/image.go:1513 lxc/image.go:1514
 msgid "Show image properties"
 msgstr ""
 
@@ -5790,7 +5785,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:953 lxc/image.go:954
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5802,7 +5797,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1021
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5834,7 +5829,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:1058
+#: lxc/image.go:1064
 msgid "Source:"
 msgstr ""
 
@@ -5982,7 +5977,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
 #: lxc/storage_volume.go:1730 lxc/warning.go:216
@@ -6047,7 +6042,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:438
+#: lxc/init.go:443
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -6056,12 +6051,12 @@ msgstr ""
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
 
-#: lxc/utils.go:376
+#: lxc/utils.go:364
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:%q' instead."
 msgstr ""
 
-#: lxc/utils.go:372
+#: lxc/utils.go:360
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
@@ -6204,15 +6199,15 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1025
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:440
+#: lxc/init.go:445
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:439
+#: lxc/init.go:444
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6266,7 +6261,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:827
+#: lxc/image.go:832
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
@@ -6304,7 +6299,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1023 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1455
 #, c-format
 msgid "Type: %s"
@@ -6319,7 +6314,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1140
+#: lxc/image.go:1146
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6365,7 +6360,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:631 lxc/storage_volume.go:1772
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6407,7 +6402,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1700 lxc/image.go:1701
+#: lxc/image.go:1706 lxc/image.go:1707
 msgid "Unset image properties"
 msgstr ""
 
@@ -6558,7 +6553,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1032
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6731,7 +6726,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1087 lxc/list.go:46
+#: lxc/image.go:1093 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6844,15 +6839,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
+#: lxc/image.go:399 lxc/image.go:952 lxc/image.go:1512
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1572 lxc/image.go:1699
+#: lxc/image.go:1578 lxc/image.go:1705
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1636
+#: lxc/image.go:1642
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6868,11 +6863,11 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:523
+#: lxc/image.go:528
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1415
+#: lxc/image.go:339 lxc/image.go:1421
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -7335,7 +7330,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1010
 msgid "disabled"
 msgstr ""
 
@@ -7343,7 +7338,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1012
 msgid "enabled"
 msgstr ""
 
@@ -7484,7 +7479,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:398
+#: lxc/image.go:403
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7811,7 +7806,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
+#: lxc/image.go:1000 lxc/image.go:1005 lxc/image.go:1203
 msgid "no"
 msgstr ""
 
@@ -7856,8 +7851,8 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1194
+#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:1002 lxc/image.go:1007
+#: lxc/image.go:1200
 msgid "yes"
 msgstr ""
 

--- a/po/pt.po
+++ b/po/pt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-19 13:11-0600\n"
+"POT-Creation-Date: 2024-09-25 18:38-0600\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -192,7 +192,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:419
+#: lxc/image.go:424
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -420,7 +420,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1168
+#: lxc/image.go:1174
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -528,7 +528,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:695
+#: lxc/image.go:700
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -541,15 +541,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1138 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1133
+#: lxc/image.go:1139
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1144 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -731,7 +731,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1045
+#: lxc/image.go:1051
 msgid "Aliases:"
 msgstr ""
 
@@ -747,7 +747,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1022 lxc/info.go:486
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -766,11 +766,11 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:342 lxc/rebuild.go:131
+#: lxc/init.go:347 lxc/rebuild.go:136
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/init.go:346
+#: lxc/init.go:351
 msgid "Asked for a container but image is of type VM"
 msgstr ""
 
@@ -828,7 +828,7 @@ msgstr ""
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1061
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -885,7 +885,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:816
+#: lxc/image.go:821
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -966,7 +966,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1060
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -987,7 +987,7 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:239 lxc/utils.go:259
+#: lxc/utils.go:227 lxc/utils.go:247
 #, c-format
 msgid "Can't read from stdin: %w"
 msgstr ""
@@ -1021,7 +1021,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:166
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1173,7 +1173,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1589
+#: lxc/image.go:1121 lxc/list.go:132 lxc/storage_volume.go:1589
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1212,7 +1212,7 @@ msgstr ""
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1327 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/config_trust.go:314 lxc/image.go:496 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
@@ -1306,7 +1306,7 @@ msgstr ""
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1486,7 +1486,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1475
+#: lxc/image.go:1029 lxc/info.go:497 lxc/storage_volume.go:1475
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1510,7 +1510,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1143 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -1568,7 +1568,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:341 lxc/image.go:342
 msgid "Delete images"
 msgstr ""
 
@@ -1671,9 +1671,9 @@ msgstr ""
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
 #: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
-#: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
-#: lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090 lxc/image.go:1417
-#: lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638 lxc/image.go:1701
+#: lxc/image.go:159 lxc/image.go:342 lxc/image.go:401 lxc/image.go:530
+#: lxc/image.go:702 lxc/image.go:954 lxc/image.go:1096 lxc/image.go:1423
+#: lxc/image.go:1514 lxc/image.go:1580 lxc/image.go:1644 lxc/image.go:1707
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
@@ -1818,11 +1818,11 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:406
+#: lxc/init.go:411
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:726
+#: lxc/image.go:731
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1926,7 +1926,7 @@ msgstr ""
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:400 lxc/image.go:401
 msgid "Edit image properties"
 msgstr ""
 
@@ -2002,7 +2002,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1766
+#: lxc/image.go:1155 lxc/list.go:622 lxc/storage_volume.go:1766
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2121,20 +2121,20 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:1029
+#: lxc/image.go:1035
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1037
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:524
+#: lxc/image.go:529
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:530
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2162,7 +2162,7 @@ msgstr ""
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:604
+#: lxc/image.go:609
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2175,7 +2175,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
+#: lxc/config_trust.go:411 lxc/image.go:1140 lxc/image.go:1141
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2194,12 +2194,12 @@ msgstr ""
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/utils.go:296
+#: lxc/utils.go:284
 #, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/utils.go:288
+#: lxc/utils.go:276
 #, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
@@ -2293,7 +2293,7 @@ msgstr ""
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: lxc/utils.go:214
+#: lxc/utils.go:202
 #, c-format
 msgid "Failed to create alias %s: %w"
 msgstr ""
@@ -2318,11 +2318,6 @@ msgstr ""
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
 
-#: lxc/utils.go:203
-#, c-format
-msgid "Failed to remove alias %s: %w"
-msgstr ""
-
 #: lxc/file.go:821
 #, c-format
 msgid "Failed to walk path for %s: %s"
@@ -2342,7 +2337,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:1014
+#: lxc/image.go:1020
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2406,7 +2401,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:770 lxc/auth.go:1697
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1122 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:57
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2481,7 +2476,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1573 lxc/image.go:1574
+#: lxc/image.go:1579 lxc/image.go:1580
 msgid "Get image properties"
 msgstr ""
 
@@ -2755,11 +2750,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1489
+#: lxc/image.go:1495
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2767,25 +2762,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:680
+#: lxc/image.go:685
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1444
+#: lxc/image.go:369 lxc/image.go:1450
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1670
+#: lxc/image.go:449 lxc/image.go:1676
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:918
+#: lxc/image.go:923
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1493
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2805,7 +2800,7 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:697
+#: lxc/image.go:702
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -2815,7 +2810,7 @@ msgid ""
 "os=Ubuntu release=noble variant=cloud."
 msgstr ""
 
-#: lxc/image.go:696
+#: lxc/image.go:701
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2866,7 +2861,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:417
+#: lxc/init.go:422
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2932,7 +2927,7 @@ msgstr ""
 msgid "Invalid instance path: %q"
 msgstr ""
 
-#: lxc/utils.go:253
+#: lxc/utils.go:241
 #, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr ""
@@ -3044,12 +3039,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:1035
+#: lxc/image.go:1041
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:1037
+#: lxc/image.go:1043
 msgid "Last used: never"
 msgstr ""
 
@@ -3167,11 +3162,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1089
+#: lxc/image.go:1095
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1096
 msgid ""
 "List images\n"
 "\n"
@@ -3465,7 +3460,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:165 lxc/image.go:709
 msgid "Make image public"
 msgstr ""
 
@@ -3979,7 +3974,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:728
+#: lxc/image.go:733
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4172,7 +4167,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:168 lxc/image.go:710
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4252,7 +4247,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:805
+#: lxc/image.go:810
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4323,7 +4318,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:752
+#: lxc/image.go:1142 lxc/remote.go:752
 msgid "PUBLIC"
 msgstr ""
 
@@ -4384,7 +4379,7 @@ msgstr ""
 #: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/config_trust.go:315 lxc/image.go:497 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
@@ -4472,11 +4467,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1067
+#: lxc/image.go:1073
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1065
+#: lxc/image.go:1071
 msgid "Profiles: "
 msgstr ""
 
@@ -4499,11 +4494,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1046
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1621
+#: lxc/image.go:1627
 msgid "Property not found"
 msgstr ""
 
@@ -4597,7 +4592,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1024
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4633,7 +4628,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
+#: lxc/image.go:535 lxc/image.go:957 lxc/image.go:1517
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4670,7 +4665,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1416 lxc/image.go:1417
+#: lxc/image.go:1422 lxc/image.go:1423
 msgid "Refresh images"
 msgstr ""
 
@@ -4679,7 +4674,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1453
+#: lxc/image.go:1459
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4942,7 +4937,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:365
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -4975,7 +4970,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1139
+#: lxc/image.go:1145
 msgid "SIZE"
 msgstr ""
 
@@ -5098,7 +5093,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1637 lxc/image.go:1638
+#: lxc/image.go:1643 lxc/image.go:1644
 msgid "Set image properties"
 msgstr ""
 
@@ -5391,7 +5386,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1507 lxc/image.go:1508
+#: lxc/image.go:1513 lxc/image.go:1514
 msgid "Show image properties"
 msgstr ""
 
@@ -5525,7 +5520,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:953 lxc/image.go:954
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5537,7 +5532,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1021
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5569,7 +5564,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:1058
+#: lxc/image.go:1064
 msgid "Source:"
 msgstr ""
 
@@ -5717,7 +5712,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
 #: lxc/storage_volume.go:1730 lxc/warning.go:216
@@ -5782,7 +5777,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:438
+#: lxc/init.go:443
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5791,12 +5786,12 @@ msgstr ""
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
 
-#: lxc/utils.go:376
+#: lxc/utils.go:364
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:%q' instead."
 msgstr ""
 
-#: lxc/utils.go:372
+#: lxc/utils.go:360
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
@@ -5939,15 +5934,15 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1025
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:440
+#: lxc/init.go:445
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:439
+#: lxc/init.go:444
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6001,7 +5996,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:827
+#: lxc/image.go:832
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
@@ -6039,7 +6034,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1023 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1455
 #, c-format
 msgid "Type: %s"
@@ -6054,7 +6049,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1140
+#: lxc/image.go:1146
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6100,7 +6095,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:631 lxc/storage_volume.go:1772
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6142,7 +6137,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1700 lxc/image.go:1701
+#: lxc/image.go:1706 lxc/image.go:1707
 msgid "Unset image properties"
 msgstr ""
 
@@ -6293,7 +6288,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1032
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6466,7 +6461,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1087 lxc/list.go:46
+#: lxc/image.go:1093 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6579,15 +6574,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
+#: lxc/image.go:399 lxc/image.go:952 lxc/image.go:1512
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1572 lxc/image.go:1699
+#: lxc/image.go:1578 lxc/image.go:1705
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1636
+#: lxc/image.go:1642
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6603,11 +6598,11 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:523
+#: lxc/image.go:528
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1415
+#: lxc/image.go:339 lxc/image.go:1421
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -7070,7 +7065,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1010
 msgid "disabled"
 msgstr ""
 
@@ -7078,7 +7073,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1012
 msgid "enabled"
 msgstr ""
 
@@ -7219,7 +7214,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:398
+#: lxc/image.go:403
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7546,7 +7541,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
+#: lxc/image.go:1000 lxc/image.go:1005 lxc/image.go:1203
 msgid "no"
 msgstr ""
 
@@ -7591,7 +7586,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1194
+#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:1002 lxc/image.go:1007
+#: lxc/image.go:1200
 msgid "yes"
 msgstr ""

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-19 13:11-0600\n"
+"POT-Creation-Date: 2024-09-25 18:38-0600\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Renato dos Santos <renato.santos@wplex.com.br>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -273,7 +273,7 @@ msgstr ""
 "# # # um exemplo seria:\n"
 "# # # Descrição: Minha imagem personalizada"
 
-#: lxc/image.go:419
+#: lxc/image.go:424
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the image properties.\n"
@@ -671,7 +671,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr "%d (id: %d, online: %v, NUMA nó: %v)"
 
-#: lxc/image.go:1168
+#: lxc/image.go:1174
 #, c-format
 msgid "%s (%d more)"
 msgstr "%s (%d mais)"
@@ -790,7 +790,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/image.go:695
+#: lxc/image.go:700
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -803,15 +803,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1138 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr "ALIAS"
 
-#: lxc/image.go:1133
+#: lxc/image.go:1139
 msgid "ALIASES"
 msgstr "ALIASES"
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1144 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr "ARQUITETURA"
 
@@ -1001,7 +1001,7 @@ msgstr "Nome do alias ausente"
 msgid "Aliases already exists: %s"
 msgstr "Alias %s já existe"
 
-#: lxc/image.go:1045
+#: lxc/image.go:1051
 msgid "Aliases:"
 msgstr "Aliases:"
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr "Aceitar certificado"
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1022 lxc/info.go:486
 #, c-format
 msgid "Architecture: %s"
 msgstr "Arquitetura: %s"
@@ -1038,11 +1038,11 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:342 lxc/rebuild.go:131
+#: lxc/init.go:347 lxc/rebuild.go:136
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/init.go:346
+#: lxc/init.go:351
 msgid "Asked for a container but image is of type VM"
 msgstr ""
 
@@ -1106,7 +1106,7 @@ msgstr ""
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1061
 #, c-format
 msgid "Auto update: %s"
 msgstr "Atualização automática: %s"
@@ -1164,7 +1164,7 @@ msgstr "par de chave=valor inválido %s"
 msgid "Bad key=value pair: %s"
 msgstr "par de chave=valor inválido %s"
 
-#: lxc/image.go:816
+#: lxc/image.go:821
 #, c-format
 msgid "Bad property: %s"
 msgstr "Propriedade ruim: %s"
@@ -1245,7 +1245,7 @@ msgstr "CRIADO EM"
 msgid "CUDA Version: %v"
 msgstr "Versão CUDA: %v"
 
-#: lxc/image.go:1054
+#: lxc/image.go:1060
 #, c-format
 msgid "Cached: %s"
 msgstr "Em cache: %s"
@@ -1267,7 +1267,7 @@ msgstr "Não pode fornecer um nome para a imagem de destino"
 msgid "Can't pull a directory without --recursive"
 msgstr "Não pode pegar um diretório sem --recursive"
 
-#: lxc/utils.go:239 lxc/utils.go:259
+#: lxc/utils.go:227 lxc/utils.go:247
 #, fuzzy, c-format
 msgid "Can't read from stdin: %w"
 msgstr "Não é possível ler stdin: %s"
@@ -1302,7 +1302,7 @@ msgstr "Não é possível fornecer o uid/gid/modo no modo recursivo"
 msgid "Can't unset key '%s', it's not currently set"
 msgstr "Não é possível remover chave '%s', não está atualmente definido"
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:166
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1456,7 +1456,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr "Clustering ativado"
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1589
+#: lxc/image.go:1121 lxc/list.go:132 lxc/storage_volume.go:1589
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr "Colunas"
@@ -1504,7 +1504,7 @@ msgstr "Configuração chave/valor para aplicar ao novo contêiner"
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1327 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/config_trust.go:314 lxc/image.go:496 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
@@ -1600,7 +1600,7 @@ msgstr ""
 msgid "Copy virtual machine images"
 msgstr "Copiar a imagem: %s"
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr "Copiar a imagem: %s"
@@ -1796,7 +1796,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1475
+#: lxc/image.go:1029 lxc/info.go:497 lxc/storage_volume.go:1475
 #, c-format
 msgid "Created: %s"
 msgstr "Criado: %s"
@@ -1821,7 +1821,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1143 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -1883,7 +1883,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr "Apagar nomes alternativos da imagem"
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:341 lxc/image.go:342
 msgid "Delete images"
 msgstr ""
 
@@ -1995,9 +1995,9 @@ msgstr ""
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
 #: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
-#: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
-#: lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090 lxc/image.go:1417
-#: lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638 lxc/image.go:1701
+#: lxc/image.go:159 lxc/image.go:342 lxc/image.go:401 lxc/image.go:530
+#: lxc/image.go:702 lxc/image.go:954 lxc/image.go:1096 lxc/image.go:1423
+#: lxc/image.go:1514 lxc/image.go:1580 lxc/image.go:1644 lxc/image.go:1707
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
@@ -2146,11 +2146,11 @@ msgstr ""
 msgid "Device: %s"
 msgstr "Em cache: %s"
 
-#: lxc/init.go:406
+#: lxc/init.go:411
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:726
+#: lxc/image.go:731
 msgid "Directory import is not available on this platform"
 msgstr "A importação de diretório não está disponível nessa plataforma"
 
@@ -2262,7 +2262,7 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Edit identity provider groups as YAML"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:400 lxc/image.go:401
 msgid "Edit image properties"
 msgstr "Editar propriedades da imagem"
 
@@ -2351,7 +2351,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1766
+#: lxc/image.go:1155 lxc/list.go:622 lxc/storage_volume.go:1766
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2471,20 +2471,20 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:1029
+#: lxc/image.go:1035
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1037
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:524
+#: lxc/image.go:529
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:530
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2512,7 +2512,7 @@ msgstr ""
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:604
+#: lxc/image.go:609
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2525,7 +2525,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
+#: lxc/config_trust.go:411 lxc/image.go:1140 lxc/image.go:1141
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2544,12 +2544,12 @@ msgstr ""
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/utils.go:296
+#: lxc/utils.go:284
 #, fuzzy, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr "Nome de membro do cluster"
 
-#: lxc/utils.go:288
+#: lxc/utils.go:276
 #, fuzzy, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "Nome de membro do cluster"
@@ -2643,7 +2643,7 @@ msgstr "Nome de membro do cluster"
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: lxc/utils.go:214
+#: lxc/utils.go:202
 #, fuzzy, c-format
 msgid "Failed to create alias %s: %w"
 msgstr "Aceitar certificado"
@@ -2668,11 +2668,6 @@ msgstr "Aceitar certificado"
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
 
-#: lxc/utils.go:203
-#, fuzzy, c-format
-msgid "Failed to remove alias %s: %w"
-msgstr "Aceitar certificado"
-
 #: lxc/file.go:821
 #, c-format
 msgid "Failed to walk path for %s: %s"
@@ -2692,7 +2687,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:1014
+#: lxc/image.go:1020
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2757,7 +2752,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:770 lxc/auth.go:1697
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1122 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:57
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2833,7 +2828,7 @@ msgstr "Adicionar perfis aos containers"
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1573 lxc/image.go:1574
+#: lxc/image.go:1579 lxc/image.go:1580
 #, fuzzy
 msgid "Get image properties"
 msgstr "Editar propriedades da imagem"
@@ -3127,11 +3122,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr "Ignorar o estado do container"
 
-#: lxc/image.go:1489
+#: lxc/image.go:1495
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -3139,25 +3134,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:680
+#: lxc/image.go:685
 msgid "Image exported successfully!"
 msgstr "Imagem exportada com sucesso!"
 
-#: lxc/image.go:364 lxc/image.go:1444
+#: lxc/image.go:369 lxc/image.go:1450
 msgid "Image identifier missing"
 msgstr "Falta o identificador da imagem"
 
-#: lxc/image.go:444 lxc/image.go:1670
+#: lxc/image.go:449 lxc/image.go:1676
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr "Falta o identificador da imagem: %s"
 
-#: lxc/image.go:918
+#: lxc/image.go:923
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1493
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3178,7 +3173,7 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:697
+#: lxc/image.go:702
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -3188,7 +3183,7 @@ msgid ""
 "os=Ubuntu release=noble variant=cloud."
 msgstr ""
 
-#: lxc/image.go:696
+#: lxc/image.go:701
 msgid "Import images into the image store"
 msgstr ""
 
@@ -3239,7 +3234,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:417
+#: lxc/init.go:422
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -3305,7 +3300,7 @@ msgstr "Editar arquivos no container"
 msgid "Invalid instance path: %q"
 msgstr "Editar arquivos no container"
 
-#: lxc/utils.go:253
+#: lxc/utils.go:241
 #, fuzzy, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr "par de chave=valor inválido %s"
@@ -3419,12 +3414,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr "Criado: %s"
 
-#: lxc/image.go:1035
+#: lxc/image.go:1041
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:1037
+#: lxc/image.go:1043
 msgid "Last used: never"
 msgstr ""
 
@@ -3548,11 +3543,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1089
+#: lxc/image.go:1095
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1096
 msgid ""
 "List images\n"
 "\n"
@@ -3851,7 +3846,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:165 lxc/image.go:709
 msgid "Make image public"
 msgstr ""
 
@@ -4408,7 +4403,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:728
+#: lxc/image.go:733
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4601,7 +4596,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:168 lxc/image.go:710
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4681,7 +4676,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:805
+#: lxc/image.go:810
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4752,7 +4747,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:752
+#: lxc/image.go:1142 lxc/remote.go:752
 msgid "PUBLIC"
 msgstr ""
 
@@ -4814,7 +4809,7 @@ msgstr ""
 #: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/config_trust.go:315 lxc/image.go:497 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
@@ -4905,12 +4900,12 @@ msgstr "Configuração chave/valor para aplicar ao novo contêiner"
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1067
+#: lxc/image.go:1073
 #, fuzzy
 msgid "Profiles:"
 msgstr "Copiar perfis"
 
-#: lxc/image.go:1065
+#: lxc/image.go:1071
 #, fuzzy
 msgid "Profiles: "
 msgstr "Copiar perfis"
@@ -4934,11 +4929,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1046
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1621
+#: lxc/image.go:1627
 msgid "Property not found"
 msgstr ""
 
@@ -5032,7 +5027,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1024
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -5069,7 +5064,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
+#: lxc/image.go:535 lxc/image.go:957 lxc/image.go:1517
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -5108,7 +5103,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1416 lxc/image.go:1417
+#: lxc/image.go:1422 lxc/image.go:1423
 msgid "Refresh images"
 msgstr ""
 
@@ -5117,7 +5112,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr "Editar arquivos no container"
 
-#: lxc/image.go:1453
+#: lxc/image.go:1459
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5404,7 +5399,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:365
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5440,7 +5435,7 @@ msgstr "Criar projetos"
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1139
+#: lxc/image.go:1145
 msgid "SIZE"
 msgstr ""
 
@@ -5566,7 +5561,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1637 lxc/image.go:1638
+#: lxc/image.go:1643 lxc/image.go:1644
 #, fuzzy
 msgid "Set image properties"
 msgstr "Editar propriedades da imagem"
@@ -5880,7 +5875,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1507 lxc/image.go:1508
+#: lxc/image.go:1513 lxc/image.go:1514
 msgid "Show image properties"
 msgstr ""
 
@@ -6031,7 +6026,7 @@ msgstr "Editar configurações do container ou do servidor como YAML"
 msgid "Show useful information about a cluster member"
 msgstr "Nome de membro do cluster"
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:953 lxc/image.go:954
 msgid "Show useful information about images"
 msgstr ""
 
@@ -6043,7 +6038,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1021
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -6075,7 +6070,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr "Dispositivo %s adicionado a %s"
 
-#: lxc/image.go:1058
+#: lxc/image.go:1064
 msgid "Source:"
 msgstr ""
 
@@ -6224,7 +6219,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
 #: lxc/storage_volume.go:1730 lxc/warning.go:216
@@ -6293,7 +6288,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:438
+#: lxc/init.go:443
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -6302,12 +6297,12 @@ msgstr ""
 msgid "The key %q does not exist on cluster member %q"
 msgstr "Nome de membro do cluster"
 
-#: lxc/utils.go:376
+#: lxc/utils.go:364
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:%q' instead."
 msgstr ""
 
-#: lxc/utils.go:372
+#: lxc/utils.go:360
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
@@ -6452,15 +6447,15 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1025
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:440
+#: lxc/init.go:445
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:439
+#: lxc/init.go:444
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6514,7 +6509,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:827
+#: lxc/image.go:832
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
@@ -6553,7 +6548,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1023 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1455
 #, c-format
 msgid "Type: %s"
@@ -6568,7 +6563,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1140
+#: lxc/image.go:1146
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6615,7 +6610,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:631 lxc/storage_volume.go:1772
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6661,7 +6656,7 @@ msgstr "Não pode fornecer um nome para a imagem de destino"
 msgid "Unset device configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/image.go:1700 lxc/image.go:1701
+#: lxc/image.go:1706 lxc/image.go:1707
 #, fuzzy
 msgid "Unset image properties"
 msgstr "Editar propriedades da imagem"
@@ -6833,7 +6828,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1032
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -7011,7 +7006,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr "Criar perfis"
 
-#: lxc/image.go:1087 lxc/list.go:46
+#: lxc/image.go:1093 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -7142,16 +7137,16 @@ msgstr "Editar templates de arquivo do container"
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr "Criar perfis"
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
+#: lxc/image.go:399 lxc/image.go:952 lxc/image.go:1512
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1572 lxc/image.go:1699
+#: lxc/image.go:1578 lxc/image.go:1705
 #, fuzzy
 msgid "[<remote>:]<image> <key>"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/image.go:1636
+#: lxc/image.go:1642
 #, fuzzy
 msgid "[<remote>:]<image> <key> <value>"
 msgstr "Editar templates de arquivo do container"
@@ -7169,11 +7164,11 @@ msgstr "Editar templates de arquivo do container"
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:523
+#: lxc/image.go:528
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1415
+#: lxc/image.go:339 lxc/image.go:1421
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -7684,7 +7679,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1010
 msgid "disabled"
 msgstr ""
 
@@ -7692,7 +7687,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1012
 msgid "enabled"
 msgstr ""
 
@@ -7833,7 +7828,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:398
+#: lxc/image.go:403
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -8160,7 +8155,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
+#: lxc/image.go:1000 lxc/image.go:1005 lxc/image.go:1203
 msgid "no"
 msgstr ""
 
@@ -8205,10 +8200,14 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1194
+#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:1002 lxc/image.go:1007
+#: lxc/image.go:1200
 msgid "yes"
 msgstr "sim"
+
+#, fuzzy, c-format
+#~ msgid "Failed to remove alias %s: %w"
+#~ msgstr "Aceitar certificado"
 
 #~ msgid "Console log:"
 #~ msgstr "Log de Console:"

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-19 13:11-0600\n"
+"POT-Creation-Date: 2024-09-25 18:38-0600\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Александр Киль <shorrey@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -277,7 +277,7 @@ msgstr ""
 "### Например:\n"
 "###  description: My custom image"
 
-#: lxc/image.go:419
+#: lxc/image.go:424
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the image properties.\n"
@@ -680,7 +680,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1168
+#: lxc/image.go:1174
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -793,7 +793,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/image.go:695
+#: lxc/image.go:700
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -806,16 +806,16 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1138 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr "ПСЕВДОНИМ"
 
-#: lxc/image.go:1133
+#: lxc/image.go:1139
 #, fuzzy
 msgid "ALIASES"
 msgstr "ПСЕВДОНИМ"
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1144 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr "АРХИТЕКТУРА"
 
@@ -1002,7 +1002,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1045
+#: lxc/image.go:1051
 msgid "Aliases:"
 msgstr "Псевдонимы:"
 
@@ -1020,7 +1020,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr "Принять сертификат"
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1022 lxc/info.go:486
 #, c-format
 msgid "Architecture: %s"
 msgstr "Архитектура: %s"
@@ -1039,11 +1039,11 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:342 lxc/rebuild.go:131
+#: lxc/init.go:347 lxc/rebuild.go:136
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/init.go:346
+#: lxc/init.go:351
 msgid "Asked for a container but image is of type VM"
 msgstr ""
 
@@ -1103,7 +1103,7 @@ msgstr ""
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1061
 #, c-format
 msgid "Auto update: %s"
 msgstr "Авто-обновление: %s"
@@ -1161,7 +1161,7 @@ msgstr "Имя контейнера: %s"
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:816
+#: lxc/image.go:821
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -1244,7 +1244,7 @@ msgstr "СОЗДАН"
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1060
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -1265,7 +1265,7 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:239 lxc/utils.go:259
+#: lxc/utils.go:227 lxc/utils.go:247
 #, fuzzy, c-format
 msgid "Can't read from stdin: %w"
 msgstr "Невозможно прочитать из стандартного ввода: %s"
@@ -1299,7 +1299,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:166
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1456,7 +1456,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1589
+#: lxc/image.go:1121 lxc/list.go:132 lxc/storage_volume.go:1589
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr "Столбцы"
@@ -1495,7 +1495,7 @@ msgstr ""
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1327 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/config_trust.go:314 lxc/image.go:496 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
@@ -1591,7 +1591,7 @@ msgstr ""
 msgid "Copy virtual machine images"
 msgstr "Копирование образа: %s"
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr "Копирование образа: %s"
@@ -1788,7 +1788,7 @@ msgstr "Копирование образа: %s"
 msgid "Create the instance with no profiles applied"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1475
+#: lxc/image.go:1029 lxc/info.go:497 lxc/storage_volume.go:1475
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1813,7 +1813,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1143 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -1873,7 +1873,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:341 lxc/image.go:342
 msgid "Delete images"
 msgstr ""
 
@@ -1984,9 +1984,9 @@ msgstr ""
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
 #: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
-#: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
-#: lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090 lxc/image.go:1417
-#: lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638 lxc/image.go:1701
+#: lxc/image.go:159 lxc/image.go:342 lxc/image.go:401 lxc/image.go:530
+#: lxc/image.go:702 lxc/image.go:954 lxc/image.go:1096 lxc/image.go:1423
+#: lxc/image.go:1514 lxc/image.go:1580 lxc/image.go:1644 lxc/image.go:1707
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
@@ -2133,11 +2133,11 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:406
+#: lxc/init.go:411
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:726
+#: lxc/image.go:731
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -2246,7 +2246,7 @@ msgstr ""
 msgid "Edit identity provider groups as YAML"
 msgstr "Копирование образа: %s"
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:400 lxc/image.go:401
 msgid "Edit image properties"
 msgstr ""
 
@@ -2330,7 +2330,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1766
+#: lxc/image.go:1155 lxc/list.go:622 lxc/storage_volume.go:1766
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2453,21 +2453,21 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:1029
+#: lxc/image.go:1035
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1037
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:524
+#: lxc/image.go:529
 #, fuzzy
 msgid "Export and download images"
 msgstr "Копирование образа: %s"
 
-#: lxc/image.go:525
+#: lxc/image.go:530
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2499,7 +2499,7 @@ msgstr "Копирование образа: %s"
 msgid "Exporting the backup: %s"
 msgstr "Копирование образа: %s"
 
-#: lxc/image.go:604
+#: lxc/image.go:609
 #, fuzzy, c-format
 msgid "Exporting the image: %s"
 msgstr "Копирование образа: %s"
@@ -2512,7 +2512,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
+#: lxc/config_trust.go:411 lxc/image.go:1140 lxc/image.go:1141
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2531,12 +2531,12 @@ msgstr ""
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/utils.go:296
+#: lxc/utils.go:284
 #, fuzzy, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr "Копирование образа: %s"
 
-#: lxc/utils.go:288
+#: lxc/utils.go:276
 #, fuzzy, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "Копирование образа: %s"
@@ -2630,7 +2630,7 @@ msgstr "Копирование образа: %s"
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: lxc/utils.go:214
+#: lxc/utils.go:202
 #, fuzzy, c-format
 msgid "Failed to create alias %s: %w"
 msgstr "Принять сертификат"
@@ -2655,11 +2655,6 @@ msgstr "Принять сертификат"
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
 
-#: lxc/utils.go:203
-#, fuzzy, c-format
-msgid "Failed to remove alias %s: %w"
-msgstr "Принять сертификат"
-
 #: lxc/file.go:821
 #, c-format
 msgid "Failed to walk path for %s: %s"
@@ -2679,7 +2674,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:1014
+#: lxc/image.go:1020
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2744,7 +2739,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:770 lxc/auth.go:1697
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1122 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:57
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2820,7 +2815,7 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1573 lxc/image.go:1574
+#: lxc/image.go:1579 lxc/image.go:1580
 msgid "Get image properties"
 msgstr ""
 
@@ -3111,11 +3106,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/image.go:1489
+#: lxc/image.go:1495
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -3123,25 +3118,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:680
+#: lxc/image.go:685
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1444
+#: lxc/image.go:369 lxc/image.go:1450
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1670
+#: lxc/image.go:449 lxc/image.go:1676
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:918
+#: lxc/image.go:923
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1493
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3162,7 +3157,7 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr "Копирование образа: %s"
 
-#: lxc/image.go:697
+#: lxc/image.go:702
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -3172,7 +3167,7 @@ msgid ""
 "os=Ubuntu release=noble variant=cloud."
 msgstr ""
 
-#: lxc/image.go:696
+#: lxc/image.go:701
 #, fuzzy
 msgid "Import images into the image store"
 msgstr "Копирование образа: %s"
@@ -3227,7 +3222,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr "Имя контейнера является обязательным"
 
-#: lxc/init.go:417
+#: lxc/init.go:422
 #, fuzzy, c-format
 msgid "Instance name is: %s"
 msgstr "Имя контейнера: %s"
@@ -3294,7 +3289,7 @@ msgstr "Имя контейнера: %s"
 msgid "Invalid instance path: %q"
 msgstr "Имя контейнера: %s"
 
-#: lxc/utils.go:253
+#: lxc/utils.go:241
 #, fuzzy, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr "Имя контейнера: %s"
@@ -3408,12 +3403,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr "Авто-обновление: %s"
 
-#: lxc/image.go:1035
+#: lxc/image.go:1041
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:1037
+#: lxc/image.go:1043
 msgid "Last used: never"
 msgstr ""
 
@@ -3540,11 +3535,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1089
+#: lxc/image.go:1095
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1096
 msgid ""
 "List images\n"
 "\n"
@@ -3849,7 +3844,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:165 lxc/image.go:709
 msgid "Make image public"
 msgstr ""
 
@@ -4412,7 +4407,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:728
+#: lxc/image.go:733
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4607,7 +4602,7 @@ msgstr " Использование сети:"
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:168 lxc/image.go:710
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4689,7 +4684,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:805
+#: lxc/image.go:810
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4760,7 +4755,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:752
+#: lxc/image.go:1142 lxc/remote.go:752
 msgid "PUBLIC"
 msgstr ""
 
@@ -4822,7 +4817,7 @@ msgstr ""
 #: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/config_trust.go:315 lxc/image.go:497 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
@@ -4910,11 +4905,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1067
+#: lxc/image.go:1073
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1065
+#: lxc/image.go:1071
 msgid "Profiles: "
 msgstr ""
 
@@ -4937,11 +4932,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1046
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1621
+#: lxc/image.go:1627
 msgid "Property not found"
 msgstr ""
 
@@ -5035,7 +5030,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1024
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -5071,7 +5066,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
+#: lxc/image.go:535 lxc/image.go:957 lxc/image.go:1517
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -5111,7 +5106,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr "Копирование образа: %s"
 
-#: lxc/image.go:1416 lxc/image.go:1417
+#: lxc/image.go:1422 lxc/image.go:1423
 #, fuzzy
 msgid "Refresh images"
 msgstr "Копирование образа: %s"
@@ -5121,7 +5116,7 @@ msgstr "Копирование образа: %s"
 msgid "Refreshing instance: %s"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/image.go:1453
+#: lxc/image.go:1459
 #, fuzzy, c-format
 msgid "Refreshing the image: %s"
 msgstr "Копирование образа: %s"
@@ -5401,7 +5396,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:365
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5437,7 +5432,7 @@ msgstr "Доступные команды:"
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1139
+#: lxc/image.go:1145
 msgid "SIZE"
 msgstr ""
 
@@ -5562,7 +5557,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1637 lxc/image.go:1638
+#: lxc/image.go:1643 lxc/image.go:1644
 msgid "Set image properties"
 msgstr ""
 
@@ -5872,7 +5867,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1507 lxc/image.go:1508
+#: lxc/image.go:1513 lxc/image.go:1514
 msgid "Show image properties"
 msgstr ""
 
@@ -6020,7 +6015,7 @@ msgstr "Копирование образа: %s"
 msgid "Show useful information about a cluster member"
 msgstr "Копирование образа: %s"
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:953 lxc/image.go:954
 msgid "Show useful information about images"
 msgstr ""
 
@@ -6032,7 +6027,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1021
 #, fuzzy, c-format
 msgid "Size: %.2fMiB"
 msgstr "Авто-обновление: %s"
@@ -6065,7 +6060,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/image.go:1058
+#: lxc/image.go:1064
 msgid "Source:"
 msgstr ""
 
@@ -6217,7 +6212,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
 #: lxc/storage_volume.go:1730 lxc/warning.go:216
@@ -6282,7 +6277,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:438
+#: lxc/init.go:443
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -6291,12 +6286,12 @@ msgstr ""
 msgid "The key %q does not exist on cluster member %q"
 msgstr "Копирование образа: %s"
 
-#: lxc/utils.go:376
+#: lxc/utils.go:364
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:%q' instead."
 msgstr ""
 
-#: lxc/utils.go:372
+#: lxc/utils.go:360
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
@@ -6440,15 +6435,15 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1025
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:440
+#: lxc/init.go:445
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:439
+#: lxc/init.go:444
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6502,7 +6497,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:827
+#: lxc/image.go:832
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
@@ -6541,7 +6536,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1023 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1455
 #, c-format
 msgid "Type: %s"
@@ -6556,7 +6551,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1140
+#: lxc/image.go:1146
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6602,7 +6597,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:631 lxc/storage_volume.go:1772
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6646,7 +6641,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1700 lxc/image.go:1701
+#: lxc/image.go:1706 lxc/image.go:1707
 msgid "Unset image properties"
 msgstr ""
 
@@ -6816,7 +6811,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1032
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -7018,7 +7013,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/image.go:1087 lxc/list.go:46
+#: lxc/image.go:1093 lxc/list.go:46
 #, fuzzy
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
@@ -7227,7 +7222,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
+#: lxc/image.go:399 lxc/image.go:952 lxc/image.go:1512
 #, fuzzy
 msgid "[<remote>:]<image>"
 msgstr ""
@@ -7235,7 +7230,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/image.go:1572 lxc/image.go:1699
+#: lxc/image.go:1578 lxc/image.go:1705
 #, fuzzy
 msgid "[<remote>:]<image> <key>"
 msgstr ""
@@ -7243,7 +7238,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/image.go:1636
+#: lxc/image.go:1642
 #, fuzzy
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
@@ -7275,7 +7270,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/image.go:523
+#: lxc/image.go:528
 #, fuzzy
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
@@ -7283,7 +7278,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/image.go:334 lxc/image.go:1415
+#: lxc/image.go:339 lxc/image.go:1421
 #, fuzzy
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
@@ -8170,7 +8165,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1010
 msgid "disabled"
 msgstr ""
 
@@ -8178,7 +8173,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1012
 msgid "enabled"
 msgstr ""
 
@@ -8319,7 +8314,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:398
+#: lxc/image.go:403
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -8646,7 +8641,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
+#: lxc/image.go:1000 lxc/image.go:1005 lxc/image.go:1203
 msgid "no"
 msgstr ""
 
@@ -8691,10 +8686,14 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1194
+#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:1002 lxc/image.go:1007
+#: lxc/image.go:1200
 msgid "yes"
 msgstr "да"
+
+#, fuzzy, c-format
+#~ msgid "Failed to remove alias %s: %w"
+#~ msgstr "Принять сертификат"
 
 #, fuzzy
 #~ msgid "[<remote>:]<cluster member>"

--- a/po/si.po
+++ b/po/si.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-19 13:11-0600\n"
+"POT-Creation-Date: 2024-09-25 18:38-0600\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Sinhala <https://hosted.weblate.org/projects/linux-containers/"
@@ -195,7 +195,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:419
+#: lxc/image.go:424
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -423,7 +423,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1168
+#: lxc/image.go:1174
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -531,7 +531,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:695
+#: lxc/image.go:700
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -544,15 +544,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1138 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1133
+#: lxc/image.go:1139
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1144 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -734,7 +734,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1045
+#: lxc/image.go:1051
 msgid "Aliases:"
 msgstr ""
 
@@ -750,7 +750,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1022 lxc/info.go:486
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -769,11 +769,11 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:342 lxc/rebuild.go:131
+#: lxc/init.go:347 lxc/rebuild.go:136
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/init.go:346
+#: lxc/init.go:351
 msgid "Asked for a container but image is of type VM"
 msgstr ""
 
@@ -831,7 +831,7 @@ msgstr ""
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1061
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -888,7 +888,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:816
+#: lxc/image.go:821
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -969,7 +969,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1060
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -990,7 +990,7 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:239 lxc/utils.go:259
+#: lxc/utils.go:227 lxc/utils.go:247
 #, c-format
 msgid "Can't read from stdin: %w"
 msgstr ""
@@ -1024,7 +1024,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:166
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1176,7 +1176,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1589
+#: lxc/image.go:1121 lxc/list.go:132 lxc/storage_volume.go:1589
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1215,7 +1215,7 @@ msgstr ""
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1327 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/config_trust.go:314 lxc/image.go:496 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
@@ -1309,7 +1309,7 @@ msgstr ""
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1489,7 +1489,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1475
+#: lxc/image.go:1029 lxc/info.go:497 lxc/storage_volume.go:1475
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1513,7 +1513,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1143 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -1571,7 +1571,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:341 lxc/image.go:342
 msgid "Delete images"
 msgstr ""
 
@@ -1674,9 +1674,9 @@ msgstr ""
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
 #: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
-#: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
-#: lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090 lxc/image.go:1417
-#: lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638 lxc/image.go:1701
+#: lxc/image.go:159 lxc/image.go:342 lxc/image.go:401 lxc/image.go:530
+#: lxc/image.go:702 lxc/image.go:954 lxc/image.go:1096 lxc/image.go:1423
+#: lxc/image.go:1514 lxc/image.go:1580 lxc/image.go:1644 lxc/image.go:1707
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
@@ -1821,11 +1821,11 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:406
+#: lxc/init.go:411
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:726
+#: lxc/image.go:731
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1929,7 +1929,7 @@ msgstr ""
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:400 lxc/image.go:401
 msgid "Edit image properties"
 msgstr ""
 
@@ -2005,7 +2005,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1766
+#: lxc/image.go:1155 lxc/list.go:622 lxc/storage_volume.go:1766
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2124,20 +2124,20 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:1029
+#: lxc/image.go:1035
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1037
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:524
+#: lxc/image.go:529
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:530
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2165,7 +2165,7 @@ msgstr ""
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:604
+#: lxc/image.go:609
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2178,7 +2178,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
+#: lxc/config_trust.go:411 lxc/image.go:1140 lxc/image.go:1141
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2197,12 +2197,12 @@ msgstr ""
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/utils.go:296
+#: lxc/utils.go:284
 #, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/utils.go:288
+#: lxc/utils.go:276
 #, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
@@ -2296,7 +2296,7 @@ msgstr ""
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: lxc/utils.go:214
+#: lxc/utils.go:202
 #, c-format
 msgid "Failed to create alias %s: %w"
 msgstr ""
@@ -2321,11 +2321,6 @@ msgstr ""
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
 
-#: lxc/utils.go:203
-#, c-format
-msgid "Failed to remove alias %s: %w"
-msgstr ""
-
 #: lxc/file.go:821
 #, c-format
 msgid "Failed to walk path for %s: %s"
@@ -2345,7 +2340,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:1014
+#: lxc/image.go:1020
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2409,7 +2404,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:770 lxc/auth.go:1697
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1122 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:57
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2484,7 +2479,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1573 lxc/image.go:1574
+#: lxc/image.go:1579 lxc/image.go:1580
 msgid "Get image properties"
 msgstr ""
 
@@ -2758,11 +2753,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1489
+#: lxc/image.go:1495
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2770,25 +2765,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:680
+#: lxc/image.go:685
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1444
+#: lxc/image.go:369 lxc/image.go:1450
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1670
+#: lxc/image.go:449 lxc/image.go:1676
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:918
+#: lxc/image.go:923
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1493
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2808,7 +2803,7 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:697
+#: lxc/image.go:702
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -2818,7 +2813,7 @@ msgid ""
 "os=Ubuntu release=noble variant=cloud."
 msgstr ""
 
-#: lxc/image.go:696
+#: lxc/image.go:701
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2869,7 +2864,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:417
+#: lxc/init.go:422
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2935,7 +2930,7 @@ msgstr ""
 msgid "Invalid instance path: %q"
 msgstr ""
 
-#: lxc/utils.go:253
+#: lxc/utils.go:241
 #, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr ""
@@ -3047,12 +3042,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:1035
+#: lxc/image.go:1041
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:1037
+#: lxc/image.go:1043
 msgid "Last used: never"
 msgstr ""
 
@@ -3170,11 +3165,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1089
+#: lxc/image.go:1095
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1096
 msgid ""
 "List images\n"
 "\n"
@@ -3468,7 +3463,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:165 lxc/image.go:709
 msgid "Make image public"
 msgstr ""
 
@@ -3982,7 +3977,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:728
+#: lxc/image.go:733
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4175,7 +4170,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:168 lxc/image.go:710
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4255,7 +4250,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:805
+#: lxc/image.go:810
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4326,7 +4321,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:752
+#: lxc/image.go:1142 lxc/remote.go:752
 msgid "PUBLIC"
 msgstr ""
 
@@ -4387,7 +4382,7 @@ msgstr ""
 #: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/config_trust.go:315 lxc/image.go:497 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
@@ -4475,11 +4470,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1067
+#: lxc/image.go:1073
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1065
+#: lxc/image.go:1071
 msgid "Profiles: "
 msgstr ""
 
@@ -4502,11 +4497,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1046
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1621
+#: lxc/image.go:1627
 msgid "Property not found"
 msgstr ""
 
@@ -4600,7 +4595,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1024
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4636,7 +4631,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
+#: lxc/image.go:535 lxc/image.go:957 lxc/image.go:1517
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4673,7 +4668,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1416 lxc/image.go:1417
+#: lxc/image.go:1422 lxc/image.go:1423
 msgid "Refresh images"
 msgstr ""
 
@@ -4682,7 +4677,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1453
+#: lxc/image.go:1459
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4945,7 +4940,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:365
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -4978,7 +4973,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1139
+#: lxc/image.go:1145
 msgid "SIZE"
 msgstr ""
 
@@ -5101,7 +5096,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1637 lxc/image.go:1638
+#: lxc/image.go:1643 lxc/image.go:1644
 msgid "Set image properties"
 msgstr ""
 
@@ -5394,7 +5389,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1507 lxc/image.go:1508
+#: lxc/image.go:1513 lxc/image.go:1514
 msgid "Show image properties"
 msgstr ""
 
@@ -5528,7 +5523,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:953 lxc/image.go:954
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5540,7 +5535,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1021
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5572,7 +5567,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:1058
+#: lxc/image.go:1064
 msgid "Source:"
 msgstr ""
 
@@ -5720,7 +5715,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
 #: lxc/storage_volume.go:1730 lxc/warning.go:216
@@ -5785,7 +5780,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:438
+#: lxc/init.go:443
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5794,12 +5789,12 @@ msgstr ""
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
 
-#: lxc/utils.go:376
+#: lxc/utils.go:364
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:%q' instead."
 msgstr ""
 
-#: lxc/utils.go:372
+#: lxc/utils.go:360
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
@@ -5942,15 +5937,15 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1025
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:440
+#: lxc/init.go:445
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:439
+#: lxc/init.go:444
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6004,7 +5999,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:827
+#: lxc/image.go:832
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
@@ -6042,7 +6037,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1023 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1455
 #, c-format
 msgid "Type: %s"
@@ -6057,7 +6052,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1140
+#: lxc/image.go:1146
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6103,7 +6098,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:631 lxc/storage_volume.go:1772
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6145,7 +6140,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1700 lxc/image.go:1701
+#: lxc/image.go:1706 lxc/image.go:1707
 msgid "Unset image properties"
 msgstr ""
 
@@ -6296,7 +6291,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1032
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6469,7 +6464,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1087 lxc/list.go:46
+#: lxc/image.go:1093 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6582,15 +6577,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
+#: lxc/image.go:399 lxc/image.go:952 lxc/image.go:1512
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1572 lxc/image.go:1699
+#: lxc/image.go:1578 lxc/image.go:1705
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1636
+#: lxc/image.go:1642
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6606,11 +6601,11 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:523
+#: lxc/image.go:528
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1415
+#: lxc/image.go:339 lxc/image.go:1421
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -7073,7 +7068,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1010
 msgid "disabled"
 msgstr ""
 
@@ -7081,7 +7076,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1012
 msgid "enabled"
 msgstr ""
 
@@ -7222,7 +7217,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:398
+#: lxc/image.go:403
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7549,7 +7544,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
+#: lxc/image.go:1000 lxc/image.go:1005 lxc/image.go:1203
 msgid "no"
 msgstr ""
 
@@ -7594,7 +7589,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1194
+#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:1002 lxc/image.go:1007
+#: lxc/image.go:1200
 msgid "yes"
 msgstr ""

--- a/po/sl.po
+++ b/po/sl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-19 13:11-0600\n"
+"POT-Creation-Date: 2024-09-25 18:38-0600\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Slovenian <https://hosted.weblate.org/projects/linux-"
@@ -196,7 +196,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:419
+#: lxc/image.go:424
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -424,7 +424,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1168
+#: lxc/image.go:1174
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -532,7 +532,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:695
+#: lxc/image.go:700
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -545,15 +545,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1138 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1133
+#: lxc/image.go:1139
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1144 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -735,7 +735,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1045
+#: lxc/image.go:1051
 msgid "Aliases:"
 msgstr ""
 
@@ -751,7 +751,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1022 lxc/info.go:486
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -770,11 +770,11 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:342 lxc/rebuild.go:131
+#: lxc/init.go:347 lxc/rebuild.go:136
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/init.go:346
+#: lxc/init.go:351
 msgid "Asked for a container but image is of type VM"
 msgstr ""
 
@@ -832,7 +832,7 @@ msgstr ""
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1061
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -889,7 +889,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:816
+#: lxc/image.go:821
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -970,7 +970,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1060
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -991,7 +991,7 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:239 lxc/utils.go:259
+#: lxc/utils.go:227 lxc/utils.go:247
 #, c-format
 msgid "Can't read from stdin: %w"
 msgstr ""
@@ -1025,7 +1025,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:166
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1177,7 +1177,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1589
+#: lxc/image.go:1121 lxc/list.go:132 lxc/storage_volume.go:1589
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1216,7 +1216,7 @@ msgstr ""
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1327 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/config_trust.go:314 lxc/image.go:496 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
@@ -1310,7 +1310,7 @@ msgstr ""
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1490,7 +1490,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1475
+#: lxc/image.go:1029 lxc/info.go:497 lxc/storage_volume.go:1475
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1514,7 +1514,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1143 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -1572,7 +1572,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:341 lxc/image.go:342
 msgid "Delete images"
 msgstr ""
 
@@ -1675,9 +1675,9 @@ msgstr ""
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
 #: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
-#: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
-#: lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090 lxc/image.go:1417
-#: lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638 lxc/image.go:1701
+#: lxc/image.go:159 lxc/image.go:342 lxc/image.go:401 lxc/image.go:530
+#: lxc/image.go:702 lxc/image.go:954 lxc/image.go:1096 lxc/image.go:1423
+#: lxc/image.go:1514 lxc/image.go:1580 lxc/image.go:1644 lxc/image.go:1707
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
@@ -1822,11 +1822,11 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:406
+#: lxc/init.go:411
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:726
+#: lxc/image.go:731
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1930,7 +1930,7 @@ msgstr ""
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:400 lxc/image.go:401
 msgid "Edit image properties"
 msgstr ""
 
@@ -2006,7 +2006,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1766
+#: lxc/image.go:1155 lxc/list.go:622 lxc/storage_volume.go:1766
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2125,20 +2125,20 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:1029
+#: lxc/image.go:1035
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1037
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:524
+#: lxc/image.go:529
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:530
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2166,7 +2166,7 @@ msgstr ""
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:604
+#: lxc/image.go:609
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2179,7 +2179,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
+#: lxc/config_trust.go:411 lxc/image.go:1140 lxc/image.go:1141
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2198,12 +2198,12 @@ msgstr ""
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/utils.go:296
+#: lxc/utils.go:284
 #, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/utils.go:288
+#: lxc/utils.go:276
 #, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
@@ -2297,7 +2297,7 @@ msgstr ""
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: lxc/utils.go:214
+#: lxc/utils.go:202
 #, c-format
 msgid "Failed to create alias %s: %w"
 msgstr ""
@@ -2322,11 +2322,6 @@ msgstr ""
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
 
-#: lxc/utils.go:203
-#, c-format
-msgid "Failed to remove alias %s: %w"
-msgstr ""
-
 #: lxc/file.go:821
 #, c-format
 msgid "Failed to walk path for %s: %s"
@@ -2346,7 +2341,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:1014
+#: lxc/image.go:1020
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2410,7 +2405,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:770 lxc/auth.go:1697
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1122 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:57
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2485,7 +2480,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1573 lxc/image.go:1574
+#: lxc/image.go:1579 lxc/image.go:1580
 msgid "Get image properties"
 msgstr ""
 
@@ -2759,11 +2754,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1489
+#: lxc/image.go:1495
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2771,25 +2766,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:680
+#: lxc/image.go:685
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1444
+#: lxc/image.go:369 lxc/image.go:1450
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1670
+#: lxc/image.go:449 lxc/image.go:1676
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:918
+#: lxc/image.go:923
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1493
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2809,7 +2804,7 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:697
+#: lxc/image.go:702
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -2819,7 +2814,7 @@ msgid ""
 "os=Ubuntu release=noble variant=cloud."
 msgstr ""
 
-#: lxc/image.go:696
+#: lxc/image.go:701
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2870,7 +2865,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:417
+#: lxc/init.go:422
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2936,7 +2931,7 @@ msgstr ""
 msgid "Invalid instance path: %q"
 msgstr ""
 
-#: lxc/utils.go:253
+#: lxc/utils.go:241
 #, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr ""
@@ -3048,12 +3043,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:1035
+#: lxc/image.go:1041
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:1037
+#: lxc/image.go:1043
 msgid "Last used: never"
 msgstr ""
 
@@ -3171,11 +3166,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1089
+#: lxc/image.go:1095
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1096
 msgid ""
 "List images\n"
 "\n"
@@ -3469,7 +3464,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:165 lxc/image.go:709
 msgid "Make image public"
 msgstr ""
 
@@ -3983,7 +3978,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:728
+#: lxc/image.go:733
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4176,7 +4171,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:168 lxc/image.go:710
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4256,7 +4251,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:805
+#: lxc/image.go:810
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4327,7 +4322,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:752
+#: lxc/image.go:1142 lxc/remote.go:752
 msgid "PUBLIC"
 msgstr ""
 
@@ -4388,7 +4383,7 @@ msgstr ""
 #: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/config_trust.go:315 lxc/image.go:497 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
@@ -4476,11 +4471,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1067
+#: lxc/image.go:1073
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1065
+#: lxc/image.go:1071
 msgid "Profiles: "
 msgstr ""
 
@@ -4503,11 +4498,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1046
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1621
+#: lxc/image.go:1627
 msgid "Property not found"
 msgstr ""
 
@@ -4601,7 +4596,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1024
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4637,7 +4632,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
+#: lxc/image.go:535 lxc/image.go:957 lxc/image.go:1517
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4674,7 +4669,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1416 lxc/image.go:1417
+#: lxc/image.go:1422 lxc/image.go:1423
 msgid "Refresh images"
 msgstr ""
 
@@ -4683,7 +4678,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1453
+#: lxc/image.go:1459
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4946,7 +4941,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:365
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -4979,7 +4974,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1139
+#: lxc/image.go:1145
 msgid "SIZE"
 msgstr ""
 
@@ -5102,7 +5097,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1637 lxc/image.go:1638
+#: lxc/image.go:1643 lxc/image.go:1644
 msgid "Set image properties"
 msgstr ""
 
@@ -5395,7 +5390,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1507 lxc/image.go:1508
+#: lxc/image.go:1513 lxc/image.go:1514
 msgid "Show image properties"
 msgstr ""
 
@@ -5529,7 +5524,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:953 lxc/image.go:954
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5541,7 +5536,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1021
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5573,7 +5568,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:1058
+#: lxc/image.go:1064
 msgid "Source:"
 msgstr ""
 
@@ -5721,7 +5716,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
 #: lxc/storage_volume.go:1730 lxc/warning.go:216
@@ -5786,7 +5781,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:438
+#: lxc/init.go:443
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5795,12 +5790,12 @@ msgstr ""
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
 
-#: lxc/utils.go:376
+#: lxc/utils.go:364
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:%q' instead."
 msgstr ""
 
-#: lxc/utils.go:372
+#: lxc/utils.go:360
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
@@ -5943,15 +5938,15 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1025
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:440
+#: lxc/init.go:445
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:439
+#: lxc/init.go:444
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6005,7 +6000,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:827
+#: lxc/image.go:832
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
@@ -6043,7 +6038,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1023 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1455
 #, c-format
 msgid "Type: %s"
@@ -6058,7 +6053,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1140
+#: lxc/image.go:1146
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6104,7 +6099,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:631 lxc/storage_volume.go:1772
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6146,7 +6141,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1700 lxc/image.go:1701
+#: lxc/image.go:1706 lxc/image.go:1707
 msgid "Unset image properties"
 msgstr ""
 
@@ -6297,7 +6292,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1032
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6470,7 +6465,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1087 lxc/list.go:46
+#: lxc/image.go:1093 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6583,15 +6578,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
+#: lxc/image.go:399 lxc/image.go:952 lxc/image.go:1512
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1572 lxc/image.go:1699
+#: lxc/image.go:1578 lxc/image.go:1705
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1636
+#: lxc/image.go:1642
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6607,11 +6602,11 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:523
+#: lxc/image.go:528
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1415
+#: lxc/image.go:339 lxc/image.go:1421
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -7074,7 +7069,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1010
 msgid "disabled"
 msgstr ""
 
@@ -7082,7 +7077,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1012
 msgid "enabled"
 msgstr ""
 
@@ -7223,7 +7218,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:398
+#: lxc/image.go:403
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7550,7 +7545,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
+#: lxc/image.go:1000 lxc/image.go:1005 lxc/image.go:1203
 msgid "no"
 msgstr ""
 
@@ -7595,7 +7590,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1194
+#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:1002 lxc/image.go:1007
+#: lxc/image.go:1200
 msgid "yes"
 msgstr ""

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-19 13:11-0600\n"
+"POT-Creation-Date: 2024-09-25 18:38-0600\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Serbian <https://hosted.weblate.org/projects/linux-containers/"
@@ -196,7 +196,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:419
+#: lxc/image.go:424
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -424,7 +424,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1168
+#: lxc/image.go:1174
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -532,7 +532,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:695
+#: lxc/image.go:700
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -545,15 +545,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1138 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1133
+#: lxc/image.go:1139
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1144 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -735,7 +735,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1045
+#: lxc/image.go:1051
 msgid "Aliases:"
 msgstr ""
 
@@ -751,7 +751,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1022 lxc/info.go:486
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -770,11 +770,11 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:342 lxc/rebuild.go:131
+#: lxc/init.go:347 lxc/rebuild.go:136
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/init.go:346
+#: lxc/init.go:351
 msgid "Asked for a container but image is of type VM"
 msgstr ""
 
@@ -832,7 +832,7 @@ msgstr ""
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1061
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -889,7 +889,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:816
+#: lxc/image.go:821
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -970,7 +970,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1060
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -991,7 +991,7 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:239 lxc/utils.go:259
+#: lxc/utils.go:227 lxc/utils.go:247
 #, c-format
 msgid "Can't read from stdin: %w"
 msgstr ""
@@ -1025,7 +1025,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:166
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1177,7 +1177,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1589
+#: lxc/image.go:1121 lxc/list.go:132 lxc/storage_volume.go:1589
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1216,7 +1216,7 @@ msgstr ""
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1327 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/config_trust.go:314 lxc/image.go:496 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
@@ -1310,7 +1310,7 @@ msgstr ""
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1490,7 +1490,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1475
+#: lxc/image.go:1029 lxc/info.go:497 lxc/storage_volume.go:1475
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1514,7 +1514,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1143 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -1572,7 +1572,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:341 lxc/image.go:342
 msgid "Delete images"
 msgstr ""
 
@@ -1675,9 +1675,9 @@ msgstr ""
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
 #: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
-#: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
-#: lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090 lxc/image.go:1417
-#: lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638 lxc/image.go:1701
+#: lxc/image.go:159 lxc/image.go:342 lxc/image.go:401 lxc/image.go:530
+#: lxc/image.go:702 lxc/image.go:954 lxc/image.go:1096 lxc/image.go:1423
+#: lxc/image.go:1514 lxc/image.go:1580 lxc/image.go:1644 lxc/image.go:1707
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
@@ -1822,11 +1822,11 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:406
+#: lxc/init.go:411
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:726
+#: lxc/image.go:731
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1930,7 +1930,7 @@ msgstr ""
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:400 lxc/image.go:401
 msgid "Edit image properties"
 msgstr ""
 
@@ -2006,7 +2006,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1766
+#: lxc/image.go:1155 lxc/list.go:622 lxc/storage_volume.go:1766
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2125,20 +2125,20 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:1029
+#: lxc/image.go:1035
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1037
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:524
+#: lxc/image.go:529
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:530
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2166,7 +2166,7 @@ msgstr ""
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:604
+#: lxc/image.go:609
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2179,7 +2179,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
+#: lxc/config_trust.go:411 lxc/image.go:1140 lxc/image.go:1141
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2198,12 +2198,12 @@ msgstr ""
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/utils.go:296
+#: lxc/utils.go:284
 #, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/utils.go:288
+#: lxc/utils.go:276
 #, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
@@ -2297,7 +2297,7 @@ msgstr ""
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: lxc/utils.go:214
+#: lxc/utils.go:202
 #, c-format
 msgid "Failed to create alias %s: %w"
 msgstr ""
@@ -2322,11 +2322,6 @@ msgstr ""
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
 
-#: lxc/utils.go:203
-#, c-format
-msgid "Failed to remove alias %s: %w"
-msgstr ""
-
 #: lxc/file.go:821
 #, c-format
 msgid "Failed to walk path for %s: %s"
@@ -2346,7 +2341,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:1014
+#: lxc/image.go:1020
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2410,7 +2405,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:770 lxc/auth.go:1697
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1122 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:57
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2485,7 +2480,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1573 lxc/image.go:1574
+#: lxc/image.go:1579 lxc/image.go:1580
 msgid "Get image properties"
 msgstr ""
 
@@ -2759,11 +2754,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1489
+#: lxc/image.go:1495
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2771,25 +2766,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:680
+#: lxc/image.go:685
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1444
+#: lxc/image.go:369 lxc/image.go:1450
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1670
+#: lxc/image.go:449 lxc/image.go:1676
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:918
+#: lxc/image.go:923
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1493
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2809,7 +2804,7 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:697
+#: lxc/image.go:702
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -2819,7 +2814,7 @@ msgid ""
 "os=Ubuntu release=noble variant=cloud."
 msgstr ""
 
-#: lxc/image.go:696
+#: lxc/image.go:701
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2870,7 +2865,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:417
+#: lxc/init.go:422
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2936,7 +2931,7 @@ msgstr ""
 msgid "Invalid instance path: %q"
 msgstr ""
 
-#: lxc/utils.go:253
+#: lxc/utils.go:241
 #, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr ""
@@ -3048,12 +3043,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:1035
+#: lxc/image.go:1041
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:1037
+#: lxc/image.go:1043
 msgid "Last used: never"
 msgstr ""
 
@@ -3171,11 +3166,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1089
+#: lxc/image.go:1095
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1096
 msgid ""
 "List images\n"
 "\n"
@@ -3469,7 +3464,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:165 lxc/image.go:709
 msgid "Make image public"
 msgstr ""
 
@@ -3983,7 +3978,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:728
+#: lxc/image.go:733
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4176,7 +4171,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:168 lxc/image.go:710
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4256,7 +4251,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:805
+#: lxc/image.go:810
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4327,7 +4322,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:752
+#: lxc/image.go:1142 lxc/remote.go:752
 msgid "PUBLIC"
 msgstr ""
 
@@ -4388,7 +4383,7 @@ msgstr ""
 #: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/config_trust.go:315 lxc/image.go:497 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
@@ -4476,11 +4471,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1067
+#: lxc/image.go:1073
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1065
+#: lxc/image.go:1071
 msgid "Profiles: "
 msgstr ""
 
@@ -4503,11 +4498,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1046
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1621
+#: lxc/image.go:1627
 msgid "Property not found"
 msgstr ""
 
@@ -4601,7 +4596,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1024
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4637,7 +4632,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
+#: lxc/image.go:535 lxc/image.go:957 lxc/image.go:1517
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4674,7 +4669,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1416 lxc/image.go:1417
+#: lxc/image.go:1422 lxc/image.go:1423
 msgid "Refresh images"
 msgstr ""
 
@@ -4683,7 +4678,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1453
+#: lxc/image.go:1459
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4946,7 +4941,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:365
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -4979,7 +4974,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1139
+#: lxc/image.go:1145
 msgid "SIZE"
 msgstr ""
 
@@ -5102,7 +5097,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1637 lxc/image.go:1638
+#: lxc/image.go:1643 lxc/image.go:1644
 msgid "Set image properties"
 msgstr ""
 
@@ -5395,7 +5390,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1507 lxc/image.go:1508
+#: lxc/image.go:1513 lxc/image.go:1514
 msgid "Show image properties"
 msgstr ""
 
@@ -5529,7 +5524,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:953 lxc/image.go:954
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5541,7 +5536,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1021
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5573,7 +5568,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:1058
+#: lxc/image.go:1064
 msgid "Source:"
 msgstr ""
 
@@ -5721,7 +5716,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
 #: lxc/storage_volume.go:1730 lxc/warning.go:216
@@ -5786,7 +5781,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:438
+#: lxc/init.go:443
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5795,12 +5790,12 @@ msgstr ""
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
 
-#: lxc/utils.go:376
+#: lxc/utils.go:364
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:%q' instead."
 msgstr ""
 
-#: lxc/utils.go:372
+#: lxc/utils.go:360
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
@@ -5943,15 +5938,15 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1025
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:440
+#: lxc/init.go:445
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:439
+#: lxc/init.go:444
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6005,7 +6000,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:827
+#: lxc/image.go:832
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
@@ -6043,7 +6038,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1023 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1455
 #, c-format
 msgid "Type: %s"
@@ -6058,7 +6053,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1140
+#: lxc/image.go:1146
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6104,7 +6099,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:631 lxc/storage_volume.go:1772
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6146,7 +6141,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1700 lxc/image.go:1701
+#: lxc/image.go:1706 lxc/image.go:1707
 msgid "Unset image properties"
 msgstr ""
 
@@ -6297,7 +6292,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1032
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6470,7 +6465,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1087 lxc/list.go:46
+#: lxc/image.go:1093 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6583,15 +6578,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
+#: lxc/image.go:399 lxc/image.go:952 lxc/image.go:1512
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1572 lxc/image.go:1699
+#: lxc/image.go:1578 lxc/image.go:1705
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1636
+#: lxc/image.go:1642
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6607,11 +6602,11 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:523
+#: lxc/image.go:528
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1415
+#: lxc/image.go:339 lxc/image.go:1421
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -7074,7 +7069,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1010
 msgid "disabled"
 msgstr ""
 
@@ -7082,7 +7077,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1012
 msgid "enabled"
 msgstr ""
 
@@ -7223,7 +7218,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:398
+#: lxc/image.go:403
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7550,7 +7545,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
+#: lxc/image.go:1000 lxc/image.go:1005 lxc/image.go:1203
 msgid "no"
 msgstr ""
 
@@ -7595,7 +7590,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1194
+#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:1002 lxc/image.go:1007
+#: lxc/image.go:1200
 msgid "yes"
 msgstr ""

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-19 13:11-0600\n"
+"POT-Creation-Date: 2024-09-25 18:38-0600\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Swedish <https://hosted.weblate.org/projects/linux-containers/"
@@ -195,7 +195,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:419
+#: lxc/image.go:424
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -423,7 +423,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1168
+#: lxc/image.go:1174
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -531,7 +531,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:695
+#: lxc/image.go:700
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -544,15 +544,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1138 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1133
+#: lxc/image.go:1139
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1144 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -734,7 +734,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1045
+#: lxc/image.go:1051
 msgid "Aliases:"
 msgstr ""
 
@@ -750,7 +750,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1022 lxc/info.go:486
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -769,11 +769,11 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:342 lxc/rebuild.go:131
+#: lxc/init.go:347 lxc/rebuild.go:136
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/init.go:346
+#: lxc/init.go:351
 msgid "Asked for a container but image is of type VM"
 msgstr ""
 
@@ -831,7 +831,7 @@ msgstr ""
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1061
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -888,7 +888,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:816
+#: lxc/image.go:821
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -969,7 +969,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1060
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -990,7 +990,7 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:239 lxc/utils.go:259
+#: lxc/utils.go:227 lxc/utils.go:247
 #, c-format
 msgid "Can't read from stdin: %w"
 msgstr ""
@@ -1024,7 +1024,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:166
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1176,7 +1176,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1589
+#: lxc/image.go:1121 lxc/list.go:132 lxc/storage_volume.go:1589
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1215,7 +1215,7 @@ msgstr ""
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1327 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/config_trust.go:314 lxc/image.go:496 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
@@ -1309,7 +1309,7 @@ msgstr ""
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1489,7 +1489,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1475
+#: lxc/image.go:1029 lxc/info.go:497 lxc/storage_volume.go:1475
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1513,7 +1513,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1143 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -1571,7 +1571,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:341 lxc/image.go:342
 msgid "Delete images"
 msgstr ""
 
@@ -1674,9 +1674,9 @@ msgstr ""
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
 #: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
-#: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
-#: lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090 lxc/image.go:1417
-#: lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638 lxc/image.go:1701
+#: lxc/image.go:159 lxc/image.go:342 lxc/image.go:401 lxc/image.go:530
+#: lxc/image.go:702 lxc/image.go:954 lxc/image.go:1096 lxc/image.go:1423
+#: lxc/image.go:1514 lxc/image.go:1580 lxc/image.go:1644 lxc/image.go:1707
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
@@ -1821,11 +1821,11 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:406
+#: lxc/init.go:411
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:726
+#: lxc/image.go:731
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1929,7 +1929,7 @@ msgstr ""
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:400 lxc/image.go:401
 msgid "Edit image properties"
 msgstr ""
 
@@ -2005,7 +2005,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1766
+#: lxc/image.go:1155 lxc/list.go:622 lxc/storage_volume.go:1766
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2124,20 +2124,20 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:1029
+#: lxc/image.go:1035
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1037
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:524
+#: lxc/image.go:529
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:530
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2165,7 +2165,7 @@ msgstr ""
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:604
+#: lxc/image.go:609
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2178,7 +2178,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
+#: lxc/config_trust.go:411 lxc/image.go:1140 lxc/image.go:1141
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2197,12 +2197,12 @@ msgstr ""
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/utils.go:296
+#: lxc/utils.go:284
 #, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/utils.go:288
+#: lxc/utils.go:276
 #, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
@@ -2296,7 +2296,7 @@ msgstr ""
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: lxc/utils.go:214
+#: lxc/utils.go:202
 #, c-format
 msgid "Failed to create alias %s: %w"
 msgstr ""
@@ -2321,11 +2321,6 @@ msgstr ""
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
 
-#: lxc/utils.go:203
-#, c-format
-msgid "Failed to remove alias %s: %w"
-msgstr ""
-
 #: lxc/file.go:821
 #, c-format
 msgid "Failed to walk path for %s: %s"
@@ -2345,7 +2340,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:1014
+#: lxc/image.go:1020
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2409,7 +2404,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:770 lxc/auth.go:1697
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1122 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:57
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2484,7 +2479,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1573 lxc/image.go:1574
+#: lxc/image.go:1579 lxc/image.go:1580
 msgid "Get image properties"
 msgstr ""
 
@@ -2758,11 +2753,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1489
+#: lxc/image.go:1495
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2770,25 +2765,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:680
+#: lxc/image.go:685
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1444
+#: lxc/image.go:369 lxc/image.go:1450
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1670
+#: lxc/image.go:449 lxc/image.go:1676
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:918
+#: lxc/image.go:923
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1493
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2808,7 +2803,7 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:697
+#: lxc/image.go:702
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -2818,7 +2813,7 @@ msgid ""
 "os=Ubuntu release=noble variant=cloud."
 msgstr ""
 
-#: lxc/image.go:696
+#: lxc/image.go:701
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2869,7 +2864,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:417
+#: lxc/init.go:422
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2935,7 +2930,7 @@ msgstr ""
 msgid "Invalid instance path: %q"
 msgstr ""
 
-#: lxc/utils.go:253
+#: lxc/utils.go:241
 #, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr ""
@@ -3047,12 +3042,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:1035
+#: lxc/image.go:1041
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:1037
+#: lxc/image.go:1043
 msgid "Last used: never"
 msgstr ""
 
@@ -3170,11 +3165,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1089
+#: lxc/image.go:1095
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1096
 msgid ""
 "List images\n"
 "\n"
@@ -3468,7 +3463,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:165 lxc/image.go:709
 msgid "Make image public"
 msgstr ""
 
@@ -3982,7 +3977,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:728
+#: lxc/image.go:733
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4175,7 +4170,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:168 lxc/image.go:710
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4255,7 +4250,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:805
+#: lxc/image.go:810
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4326,7 +4321,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:752
+#: lxc/image.go:1142 lxc/remote.go:752
 msgid "PUBLIC"
 msgstr ""
 
@@ -4387,7 +4382,7 @@ msgstr ""
 #: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/config_trust.go:315 lxc/image.go:497 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
@@ -4475,11 +4470,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1067
+#: lxc/image.go:1073
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1065
+#: lxc/image.go:1071
 msgid "Profiles: "
 msgstr ""
 
@@ -4502,11 +4497,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1046
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1621
+#: lxc/image.go:1627
 msgid "Property not found"
 msgstr ""
 
@@ -4600,7 +4595,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1024
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4636,7 +4631,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
+#: lxc/image.go:535 lxc/image.go:957 lxc/image.go:1517
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4673,7 +4668,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1416 lxc/image.go:1417
+#: lxc/image.go:1422 lxc/image.go:1423
 msgid "Refresh images"
 msgstr ""
 
@@ -4682,7 +4677,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1453
+#: lxc/image.go:1459
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4945,7 +4940,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:365
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -4978,7 +4973,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1139
+#: lxc/image.go:1145
 msgid "SIZE"
 msgstr ""
 
@@ -5101,7 +5096,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1637 lxc/image.go:1638
+#: lxc/image.go:1643 lxc/image.go:1644
 msgid "Set image properties"
 msgstr ""
 
@@ -5394,7 +5389,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1507 lxc/image.go:1508
+#: lxc/image.go:1513 lxc/image.go:1514
 msgid "Show image properties"
 msgstr ""
 
@@ -5528,7 +5523,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:953 lxc/image.go:954
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5540,7 +5535,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1021
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5572,7 +5567,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:1058
+#: lxc/image.go:1064
 msgid "Source:"
 msgstr ""
 
@@ -5720,7 +5715,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
 #: lxc/storage_volume.go:1730 lxc/warning.go:216
@@ -5785,7 +5780,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:438
+#: lxc/init.go:443
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5794,12 +5789,12 @@ msgstr ""
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
 
-#: lxc/utils.go:376
+#: lxc/utils.go:364
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:%q' instead."
 msgstr ""
 
-#: lxc/utils.go:372
+#: lxc/utils.go:360
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
@@ -5942,15 +5937,15 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1025
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:440
+#: lxc/init.go:445
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:439
+#: lxc/init.go:444
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6004,7 +5999,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:827
+#: lxc/image.go:832
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
@@ -6042,7 +6037,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1023 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1455
 #, c-format
 msgid "Type: %s"
@@ -6057,7 +6052,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1140
+#: lxc/image.go:1146
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6103,7 +6098,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:631 lxc/storage_volume.go:1772
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6145,7 +6140,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1700 lxc/image.go:1701
+#: lxc/image.go:1706 lxc/image.go:1707
 msgid "Unset image properties"
 msgstr ""
 
@@ -6296,7 +6291,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1032
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6469,7 +6464,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1087 lxc/list.go:46
+#: lxc/image.go:1093 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6582,15 +6577,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
+#: lxc/image.go:399 lxc/image.go:952 lxc/image.go:1512
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1572 lxc/image.go:1699
+#: lxc/image.go:1578 lxc/image.go:1705
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1636
+#: lxc/image.go:1642
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6606,11 +6601,11 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:523
+#: lxc/image.go:528
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1415
+#: lxc/image.go:339 lxc/image.go:1421
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -7073,7 +7068,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1010
 msgid "disabled"
 msgstr ""
 
@@ -7081,7 +7076,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1012
 msgid "enabled"
 msgstr ""
 
@@ -7222,7 +7217,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:398
+#: lxc/image.go:403
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7549,7 +7544,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
+#: lxc/image.go:1000 lxc/image.go:1005 lxc/image.go:1203
 msgid "no"
 msgstr ""
 
@@ -7594,7 +7589,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1194
+#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:1002 lxc/image.go:1007
+#: lxc/image.go:1200
 msgid "yes"
 msgstr ""

--- a/po/te.po
+++ b/po/te.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-19 13:11-0600\n"
+"POT-Creation-Date: 2024-09-25 18:38-0600\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Telugu <https://hosted.weblate.org/projects/linux-containers/"
@@ -195,7 +195,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:419
+#: lxc/image.go:424
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -423,7 +423,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1168
+#: lxc/image.go:1174
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -531,7 +531,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:695
+#: lxc/image.go:700
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -544,15 +544,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1138 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1133
+#: lxc/image.go:1139
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1144 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -734,7 +734,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1045
+#: lxc/image.go:1051
 msgid "Aliases:"
 msgstr ""
 
@@ -750,7 +750,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1022 lxc/info.go:486
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -769,11 +769,11 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:342 lxc/rebuild.go:131
+#: lxc/init.go:347 lxc/rebuild.go:136
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/init.go:346
+#: lxc/init.go:351
 msgid "Asked for a container but image is of type VM"
 msgstr ""
 
@@ -831,7 +831,7 @@ msgstr ""
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1061
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -888,7 +888,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:816
+#: lxc/image.go:821
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -969,7 +969,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1060
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -990,7 +990,7 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:239 lxc/utils.go:259
+#: lxc/utils.go:227 lxc/utils.go:247
 #, c-format
 msgid "Can't read from stdin: %w"
 msgstr ""
@@ -1024,7 +1024,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:166
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1176,7 +1176,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1589
+#: lxc/image.go:1121 lxc/list.go:132 lxc/storage_volume.go:1589
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1215,7 +1215,7 @@ msgstr ""
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1327 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/config_trust.go:314 lxc/image.go:496 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
@@ -1309,7 +1309,7 @@ msgstr ""
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1489,7 +1489,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1475
+#: lxc/image.go:1029 lxc/info.go:497 lxc/storage_volume.go:1475
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1513,7 +1513,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1143 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -1571,7 +1571,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:341 lxc/image.go:342
 msgid "Delete images"
 msgstr ""
 
@@ -1674,9 +1674,9 @@ msgstr ""
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
 #: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
-#: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
-#: lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090 lxc/image.go:1417
-#: lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638 lxc/image.go:1701
+#: lxc/image.go:159 lxc/image.go:342 lxc/image.go:401 lxc/image.go:530
+#: lxc/image.go:702 lxc/image.go:954 lxc/image.go:1096 lxc/image.go:1423
+#: lxc/image.go:1514 lxc/image.go:1580 lxc/image.go:1644 lxc/image.go:1707
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
@@ -1821,11 +1821,11 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:406
+#: lxc/init.go:411
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:726
+#: lxc/image.go:731
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1929,7 +1929,7 @@ msgstr ""
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:400 lxc/image.go:401
 msgid "Edit image properties"
 msgstr ""
 
@@ -2005,7 +2005,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1766
+#: lxc/image.go:1155 lxc/list.go:622 lxc/storage_volume.go:1766
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2124,20 +2124,20 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:1029
+#: lxc/image.go:1035
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1037
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:524
+#: lxc/image.go:529
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:530
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2165,7 +2165,7 @@ msgstr ""
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:604
+#: lxc/image.go:609
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2178,7 +2178,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
+#: lxc/config_trust.go:411 lxc/image.go:1140 lxc/image.go:1141
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2197,12 +2197,12 @@ msgstr ""
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/utils.go:296
+#: lxc/utils.go:284
 #, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/utils.go:288
+#: lxc/utils.go:276
 #, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
@@ -2296,7 +2296,7 @@ msgstr ""
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: lxc/utils.go:214
+#: lxc/utils.go:202
 #, c-format
 msgid "Failed to create alias %s: %w"
 msgstr ""
@@ -2321,11 +2321,6 @@ msgstr ""
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
 
-#: lxc/utils.go:203
-#, c-format
-msgid "Failed to remove alias %s: %w"
-msgstr ""
-
 #: lxc/file.go:821
 #, c-format
 msgid "Failed to walk path for %s: %s"
@@ -2345,7 +2340,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:1014
+#: lxc/image.go:1020
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2409,7 +2404,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:770 lxc/auth.go:1697
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1122 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:57
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2484,7 +2479,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1573 lxc/image.go:1574
+#: lxc/image.go:1579 lxc/image.go:1580
 msgid "Get image properties"
 msgstr ""
 
@@ -2758,11 +2753,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1489
+#: lxc/image.go:1495
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2770,25 +2765,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:680
+#: lxc/image.go:685
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1444
+#: lxc/image.go:369 lxc/image.go:1450
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1670
+#: lxc/image.go:449 lxc/image.go:1676
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:918
+#: lxc/image.go:923
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1493
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2808,7 +2803,7 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:697
+#: lxc/image.go:702
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -2818,7 +2813,7 @@ msgid ""
 "os=Ubuntu release=noble variant=cloud."
 msgstr ""
 
-#: lxc/image.go:696
+#: lxc/image.go:701
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2869,7 +2864,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:417
+#: lxc/init.go:422
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2935,7 +2930,7 @@ msgstr ""
 msgid "Invalid instance path: %q"
 msgstr ""
 
-#: lxc/utils.go:253
+#: lxc/utils.go:241
 #, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr ""
@@ -3047,12 +3042,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:1035
+#: lxc/image.go:1041
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:1037
+#: lxc/image.go:1043
 msgid "Last used: never"
 msgstr ""
 
@@ -3170,11 +3165,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1089
+#: lxc/image.go:1095
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1096
 msgid ""
 "List images\n"
 "\n"
@@ -3468,7 +3463,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:165 lxc/image.go:709
 msgid "Make image public"
 msgstr ""
 
@@ -3982,7 +3977,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:728
+#: lxc/image.go:733
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4175,7 +4170,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:168 lxc/image.go:710
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4255,7 +4250,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:805
+#: lxc/image.go:810
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4326,7 +4321,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:752
+#: lxc/image.go:1142 lxc/remote.go:752
 msgid "PUBLIC"
 msgstr ""
 
@@ -4387,7 +4382,7 @@ msgstr ""
 #: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/config_trust.go:315 lxc/image.go:497 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
@@ -4475,11 +4470,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1067
+#: lxc/image.go:1073
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1065
+#: lxc/image.go:1071
 msgid "Profiles: "
 msgstr ""
 
@@ -4502,11 +4497,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1046
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1621
+#: lxc/image.go:1627
 msgid "Property not found"
 msgstr ""
 
@@ -4600,7 +4595,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1024
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4636,7 +4631,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
+#: lxc/image.go:535 lxc/image.go:957 lxc/image.go:1517
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4673,7 +4668,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1416 lxc/image.go:1417
+#: lxc/image.go:1422 lxc/image.go:1423
 msgid "Refresh images"
 msgstr ""
 
@@ -4682,7 +4677,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1453
+#: lxc/image.go:1459
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4945,7 +4940,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:365
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -4978,7 +4973,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1139
+#: lxc/image.go:1145
 msgid "SIZE"
 msgstr ""
 
@@ -5101,7 +5096,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1637 lxc/image.go:1638
+#: lxc/image.go:1643 lxc/image.go:1644
 msgid "Set image properties"
 msgstr ""
 
@@ -5394,7 +5389,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1507 lxc/image.go:1508
+#: lxc/image.go:1513 lxc/image.go:1514
 msgid "Show image properties"
 msgstr ""
 
@@ -5528,7 +5523,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:953 lxc/image.go:954
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5540,7 +5535,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1021
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5572,7 +5567,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:1058
+#: lxc/image.go:1064
 msgid "Source:"
 msgstr ""
 
@@ -5720,7 +5715,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
 #: lxc/storage_volume.go:1730 lxc/warning.go:216
@@ -5785,7 +5780,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:438
+#: lxc/init.go:443
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5794,12 +5789,12 @@ msgstr ""
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
 
-#: lxc/utils.go:376
+#: lxc/utils.go:364
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:%q' instead."
 msgstr ""
 
-#: lxc/utils.go:372
+#: lxc/utils.go:360
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
@@ -5942,15 +5937,15 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1025
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:440
+#: lxc/init.go:445
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:439
+#: lxc/init.go:444
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6004,7 +5999,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:827
+#: lxc/image.go:832
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
@@ -6042,7 +6037,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1023 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1455
 #, c-format
 msgid "Type: %s"
@@ -6057,7 +6052,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1140
+#: lxc/image.go:1146
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6103,7 +6098,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:631 lxc/storage_volume.go:1772
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6145,7 +6140,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1700 lxc/image.go:1701
+#: lxc/image.go:1706 lxc/image.go:1707
 msgid "Unset image properties"
 msgstr ""
 
@@ -6296,7 +6291,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1032
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6469,7 +6464,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1087 lxc/list.go:46
+#: lxc/image.go:1093 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6582,15 +6577,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
+#: lxc/image.go:399 lxc/image.go:952 lxc/image.go:1512
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1572 lxc/image.go:1699
+#: lxc/image.go:1578 lxc/image.go:1705
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1636
+#: lxc/image.go:1642
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6606,11 +6601,11 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:523
+#: lxc/image.go:528
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1415
+#: lxc/image.go:339 lxc/image.go:1421
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -7073,7 +7068,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1010
 msgid "disabled"
 msgstr ""
 
@@ -7081,7 +7076,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1012
 msgid "enabled"
 msgstr ""
 
@@ -7222,7 +7217,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:398
+#: lxc/image.go:403
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7549,7 +7544,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
+#: lxc/image.go:1000 lxc/image.go:1005 lxc/image.go:1203
 msgid "no"
 msgstr ""
 
@@ -7594,7 +7589,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1194
+#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:1002 lxc/image.go:1007
+#: lxc/image.go:1200
 msgid "yes"
 msgstr ""

--- a/po/th.po
+++ b/po/th.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-19 13:11-0600\n"
+"POT-Creation-Date: 2024-09-25 18:38-0600\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -192,7 +192,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:419
+#: lxc/image.go:424
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -420,7 +420,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1168
+#: lxc/image.go:1174
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -528,7 +528,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:695
+#: lxc/image.go:700
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -541,15 +541,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1138 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1133
+#: lxc/image.go:1139
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1144 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -731,7 +731,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1045
+#: lxc/image.go:1051
 msgid "Aliases:"
 msgstr ""
 
@@ -747,7 +747,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1022 lxc/info.go:486
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -766,11 +766,11 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:342 lxc/rebuild.go:131
+#: lxc/init.go:347 lxc/rebuild.go:136
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/init.go:346
+#: lxc/init.go:351
 msgid "Asked for a container but image is of type VM"
 msgstr ""
 
@@ -828,7 +828,7 @@ msgstr ""
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1061
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -885,7 +885,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:816
+#: lxc/image.go:821
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -966,7 +966,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1060
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -987,7 +987,7 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:239 lxc/utils.go:259
+#: lxc/utils.go:227 lxc/utils.go:247
 #, c-format
 msgid "Can't read from stdin: %w"
 msgstr ""
@@ -1021,7 +1021,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:166
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1173,7 +1173,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1589
+#: lxc/image.go:1121 lxc/list.go:132 lxc/storage_volume.go:1589
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1212,7 +1212,7 @@ msgstr ""
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1327 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/config_trust.go:314 lxc/image.go:496 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
@@ -1306,7 +1306,7 @@ msgstr ""
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1486,7 +1486,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1475
+#: lxc/image.go:1029 lxc/info.go:497 lxc/storage_volume.go:1475
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1510,7 +1510,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1143 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -1568,7 +1568,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:341 lxc/image.go:342
 msgid "Delete images"
 msgstr ""
 
@@ -1671,9 +1671,9 @@ msgstr ""
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
 #: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
-#: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
-#: lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090 lxc/image.go:1417
-#: lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638 lxc/image.go:1701
+#: lxc/image.go:159 lxc/image.go:342 lxc/image.go:401 lxc/image.go:530
+#: lxc/image.go:702 lxc/image.go:954 lxc/image.go:1096 lxc/image.go:1423
+#: lxc/image.go:1514 lxc/image.go:1580 lxc/image.go:1644 lxc/image.go:1707
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
@@ -1818,11 +1818,11 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:406
+#: lxc/init.go:411
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:726
+#: lxc/image.go:731
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1926,7 +1926,7 @@ msgstr ""
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:400 lxc/image.go:401
 msgid "Edit image properties"
 msgstr ""
 
@@ -2002,7 +2002,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1766
+#: lxc/image.go:1155 lxc/list.go:622 lxc/storage_volume.go:1766
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2121,20 +2121,20 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:1029
+#: lxc/image.go:1035
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1037
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:524
+#: lxc/image.go:529
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:530
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2162,7 +2162,7 @@ msgstr ""
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:604
+#: lxc/image.go:609
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2175,7 +2175,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
+#: lxc/config_trust.go:411 lxc/image.go:1140 lxc/image.go:1141
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2194,12 +2194,12 @@ msgstr ""
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/utils.go:296
+#: lxc/utils.go:284
 #, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/utils.go:288
+#: lxc/utils.go:276
 #, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
@@ -2293,7 +2293,7 @@ msgstr ""
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: lxc/utils.go:214
+#: lxc/utils.go:202
 #, c-format
 msgid "Failed to create alias %s: %w"
 msgstr ""
@@ -2318,11 +2318,6 @@ msgstr ""
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
 
-#: lxc/utils.go:203
-#, c-format
-msgid "Failed to remove alias %s: %w"
-msgstr ""
-
 #: lxc/file.go:821
 #, c-format
 msgid "Failed to walk path for %s: %s"
@@ -2342,7 +2337,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:1014
+#: lxc/image.go:1020
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2406,7 +2401,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:770 lxc/auth.go:1697
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1122 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:57
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2481,7 +2476,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1573 lxc/image.go:1574
+#: lxc/image.go:1579 lxc/image.go:1580
 msgid "Get image properties"
 msgstr ""
 
@@ -2755,11 +2750,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1489
+#: lxc/image.go:1495
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2767,25 +2762,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:680
+#: lxc/image.go:685
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1444
+#: lxc/image.go:369 lxc/image.go:1450
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1670
+#: lxc/image.go:449 lxc/image.go:1676
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:918
+#: lxc/image.go:923
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1493
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2805,7 +2800,7 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:697
+#: lxc/image.go:702
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -2815,7 +2810,7 @@ msgid ""
 "os=Ubuntu release=noble variant=cloud."
 msgstr ""
 
-#: lxc/image.go:696
+#: lxc/image.go:701
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2866,7 +2861,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:417
+#: lxc/init.go:422
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2932,7 +2927,7 @@ msgstr ""
 msgid "Invalid instance path: %q"
 msgstr ""
 
-#: lxc/utils.go:253
+#: lxc/utils.go:241
 #, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr ""
@@ -3044,12 +3039,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:1035
+#: lxc/image.go:1041
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:1037
+#: lxc/image.go:1043
 msgid "Last used: never"
 msgstr ""
 
@@ -3167,11 +3162,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1089
+#: lxc/image.go:1095
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1096
 msgid ""
 "List images\n"
 "\n"
@@ -3465,7 +3460,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:165 lxc/image.go:709
 msgid "Make image public"
 msgstr ""
 
@@ -3979,7 +3974,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:728
+#: lxc/image.go:733
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4172,7 +4167,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:168 lxc/image.go:710
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4252,7 +4247,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:805
+#: lxc/image.go:810
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4323,7 +4318,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:752
+#: lxc/image.go:1142 lxc/remote.go:752
 msgid "PUBLIC"
 msgstr ""
 
@@ -4384,7 +4379,7 @@ msgstr ""
 #: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/config_trust.go:315 lxc/image.go:497 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
@@ -4472,11 +4467,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1067
+#: lxc/image.go:1073
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1065
+#: lxc/image.go:1071
 msgid "Profiles: "
 msgstr ""
 
@@ -4499,11 +4494,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1046
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1621
+#: lxc/image.go:1627
 msgid "Property not found"
 msgstr ""
 
@@ -4597,7 +4592,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1024
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4633,7 +4628,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
+#: lxc/image.go:535 lxc/image.go:957 lxc/image.go:1517
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4670,7 +4665,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1416 lxc/image.go:1417
+#: lxc/image.go:1422 lxc/image.go:1423
 msgid "Refresh images"
 msgstr ""
 
@@ -4679,7 +4674,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1453
+#: lxc/image.go:1459
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4942,7 +4937,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:365
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -4975,7 +4970,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1139
+#: lxc/image.go:1145
 msgid "SIZE"
 msgstr ""
 
@@ -5098,7 +5093,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1637 lxc/image.go:1638
+#: lxc/image.go:1643 lxc/image.go:1644
 msgid "Set image properties"
 msgstr ""
 
@@ -5391,7 +5386,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1507 lxc/image.go:1508
+#: lxc/image.go:1513 lxc/image.go:1514
 msgid "Show image properties"
 msgstr ""
 
@@ -5525,7 +5520,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:953 lxc/image.go:954
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5537,7 +5532,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1021
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5569,7 +5564,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:1058
+#: lxc/image.go:1064
 msgid "Source:"
 msgstr ""
 
@@ -5717,7 +5712,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
 #: lxc/storage_volume.go:1730 lxc/warning.go:216
@@ -5782,7 +5777,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:438
+#: lxc/init.go:443
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5791,12 +5786,12 @@ msgstr ""
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
 
-#: lxc/utils.go:376
+#: lxc/utils.go:364
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:%q' instead."
 msgstr ""
 
-#: lxc/utils.go:372
+#: lxc/utils.go:360
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
@@ -5939,15 +5934,15 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1025
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:440
+#: lxc/init.go:445
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:439
+#: lxc/init.go:444
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6001,7 +5996,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:827
+#: lxc/image.go:832
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
@@ -6039,7 +6034,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1023 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1455
 #, c-format
 msgid "Type: %s"
@@ -6054,7 +6049,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1140
+#: lxc/image.go:1146
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6100,7 +6095,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:631 lxc/storage_volume.go:1772
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6142,7 +6137,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1700 lxc/image.go:1701
+#: lxc/image.go:1706 lxc/image.go:1707
 msgid "Unset image properties"
 msgstr ""
 
@@ -6293,7 +6288,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1032
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6466,7 +6461,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1087 lxc/list.go:46
+#: lxc/image.go:1093 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6579,15 +6574,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
+#: lxc/image.go:399 lxc/image.go:952 lxc/image.go:1512
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1572 lxc/image.go:1699
+#: lxc/image.go:1578 lxc/image.go:1705
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1636
+#: lxc/image.go:1642
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6603,11 +6598,11 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:523
+#: lxc/image.go:528
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1415
+#: lxc/image.go:339 lxc/image.go:1421
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -7070,7 +7065,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1010
 msgid "disabled"
 msgstr ""
 
@@ -7078,7 +7073,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1012
 msgid "enabled"
 msgstr ""
 
@@ -7219,7 +7214,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:398
+#: lxc/image.go:403
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7546,7 +7541,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
+#: lxc/image.go:1000 lxc/image.go:1005 lxc/image.go:1203
 msgid "no"
 msgstr ""
 
@@ -7591,7 +7586,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1194
+#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:1002 lxc/image.go:1007
+#: lxc/image.go:1200
 msgid "yes"
 msgstr ""

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-19 13:11-0600\n"
+"POT-Creation-Date: 2024-09-25 18:38-0600\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Turkish <https://hosted.weblate.org/projects/linux-containers/"
@@ -195,7 +195,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:419
+#: lxc/image.go:424
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -423,7 +423,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1168
+#: lxc/image.go:1174
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -531,7 +531,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:695
+#: lxc/image.go:700
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -544,15 +544,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1138 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1133
+#: lxc/image.go:1139
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1144 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -734,7 +734,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1045
+#: lxc/image.go:1051
 msgid "Aliases:"
 msgstr ""
 
@@ -750,7 +750,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1022 lxc/info.go:486
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -769,11 +769,11 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:342 lxc/rebuild.go:131
+#: lxc/init.go:347 lxc/rebuild.go:136
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/init.go:346
+#: lxc/init.go:351
 msgid "Asked for a container but image is of type VM"
 msgstr ""
 
@@ -831,7 +831,7 @@ msgstr ""
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1061
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -888,7 +888,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:816
+#: lxc/image.go:821
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -969,7 +969,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1060
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -990,7 +990,7 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:239 lxc/utils.go:259
+#: lxc/utils.go:227 lxc/utils.go:247
 #, c-format
 msgid "Can't read from stdin: %w"
 msgstr ""
@@ -1024,7 +1024,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:166
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1176,7 +1176,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1589
+#: lxc/image.go:1121 lxc/list.go:132 lxc/storage_volume.go:1589
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1215,7 +1215,7 @@ msgstr ""
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1327 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/config_trust.go:314 lxc/image.go:496 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
@@ -1309,7 +1309,7 @@ msgstr ""
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1489,7 +1489,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1475
+#: lxc/image.go:1029 lxc/info.go:497 lxc/storage_volume.go:1475
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1513,7 +1513,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1143 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -1571,7 +1571,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:341 lxc/image.go:342
 msgid "Delete images"
 msgstr ""
 
@@ -1674,9 +1674,9 @@ msgstr ""
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
 #: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
-#: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
-#: lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090 lxc/image.go:1417
-#: lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638 lxc/image.go:1701
+#: lxc/image.go:159 lxc/image.go:342 lxc/image.go:401 lxc/image.go:530
+#: lxc/image.go:702 lxc/image.go:954 lxc/image.go:1096 lxc/image.go:1423
+#: lxc/image.go:1514 lxc/image.go:1580 lxc/image.go:1644 lxc/image.go:1707
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
@@ -1821,11 +1821,11 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:406
+#: lxc/init.go:411
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:726
+#: lxc/image.go:731
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1929,7 +1929,7 @@ msgstr ""
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:400 lxc/image.go:401
 msgid "Edit image properties"
 msgstr ""
 
@@ -2005,7 +2005,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1766
+#: lxc/image.go:1155 lxc/list.go:622 lxc/storage_volume.go:1766
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2124,20 +2124,20 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:1029
+#: lxc/image.go:1035
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1037
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:524
+#: lxc/image.go:529
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:530
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2165,7 +2165,7 @@ msgstr ""
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:604
+#: lxc/image.go:609
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2178,7 +2178,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
+#: lxc/config_trust.go:411 lxc/image.go:1140 lxc/image.go:1141
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2197,12 +2197,12 @@ msgstr ""
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/utils.go:296
+#: lxc/utils.go:284
 #, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/utils.go:288
+#: lxc/utils.go:276
 #, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
@@ -2296,7 +2296,7 @@ msgstr ""
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: lxc/utils.go:214
+#: lxc/utils.go:202
 #, c-format
 msgid "Failed to create alias %s: %w"
 msgstr ""
@@ -2321,11 +2321,6 @@ msgstr ""
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
 
-#: lxc/utils.go:203
-#, c-format
-msgid "Failed to remove alias %s: %w"
-msgstr ""
-
 #: lxc/file.go:821
 #, c-format
 msgid "Failed to walk path for %s: %s"
@@ -2345,7 +2340,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:1014
+#: lxc/image.go:1020
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2409,7 +2404,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:770 lxc/auth.go:1697
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1122 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:57
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2484,7 +2479,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1573 lxc/image.go:1574
+#: lxc/image.go:1579 lxc/image.go:1580
 msgid "Get image properties"
 msgstr ""
 
@@ -2758,11 +2753,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1489
+#: lxc/image.go:1495
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2770,25 +2765,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:680
+#: lxc/image.go:685
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1444
+#: lxc/image.go:369 lxc/image.go:1450
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1670
+#: lxc/image.go:449 lxc/image.go:1676
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:918
+#: lxc/image.go:923
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1493
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2808,7 +2803,7 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:697
+#: lxc/image.go:702
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -2818,7 +2813,7 @@ msgid ""
 "os=Ubuntu release=noble variant=cloud."
 msgstr ""
 
-#: lxc/image.go:696
+#: lxc/image.go:701
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2869,7 +2864,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:417
+#: lxc/init.go:422
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2935,7 +2930,7 @@ msgstr ""
 msgid "Invalid instance path: %q"
 msgstr ""
 
-#: lxc/utils.go:253
+#: lxc/utils.go:241
 #, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr ""
@@ -3047,12 +3042,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:1035
+#: lxc/image.go:1041
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:1037
+#: lxc/image.go:1043
 msgid "Last used: never"
 msgstr ""
 
@@ -3170,11 +3165,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1089
+#: lxc/image.go:1095
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1096
 msgid ""
 "List images\n"
 "\n"
@@ -3468,7 +3463,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:165 lxc/image.go:709
 msgid "Make image public"
 msgstr ""
 
@@ -3982,7 +3977,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:728
+#: lxc/image.go:733
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4175,7 +4170,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:168 lxc/image.go:710
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4255,7 +4250,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:805
+#: lxc/image.go:810
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4326,7 +4321,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:752
+#: lxc/image.go:1142 lxc/remote.go:752
 msgid "PUBLIC"
 msgstr ""
 
@@ -4387,7 +4382,7 @@ msgstr ""
 #: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/config_trust.go:315 lxc/image.go:497 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
@@ -4475,11 +4470,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1067
+#: lxc/image.go:1073
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1065
+#: lxc/image.go:1071
 msgid "Profiles: "
 msgstr ""
 
@@ -4502,11 +4497,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1046
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1621
+#: lxc/image.go:1627
 msgid "Property not found"
 msgstr ""
 
@@ -4600,7 +4595,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1024
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4636,7 +4631,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
+#: lxc/image.go:535 lxc/image.go:957 lxc/image.go:1517
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4673,7 +4668,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1416 lxc/image.go:1417
+#: lxc/image.go:1422 lxc/image.go:1423
 msgid "Refresh images"
 msgstr ""
 
@@ -4682,7 +4677,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1453
+#: lxc/image.go:1459
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4945,7 +4940,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:365
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -4978,7 +4973,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1139
+#: lxc/image.go:1145
 msgid "SIZE"
 msgstr ""
 
@@ -5101,7 +5096,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1637 lxc/image.go:1638
+#: lxc/image.go:1643 lxc/image.go:1644
 msgid "Set image properties"
 msgstr ""
 
@@ -5394,7 +5389,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1507 lxc/image.go:1508
+#: lxc/image.go:1513 lxc/image.go:1514
 msgid "Show image properties"
 msgstr ""
 
@@ -5528,7 +5523,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:953 lxc/image.go:954
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5540,7 +5535,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1021
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5572,7 +5567,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:1058
+#: lxc/image.go:1064
 msgid "Source:"
 msgstr ""
 
@@ -5720,7 +5715,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
 #: lxc/storage_volume.go:1730 lxc/warning.go:216
@@ -5785,7 +5780,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:438
+#: lxc/init.go:443
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5794,12 +5789,12 @@ msgstr ""
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
 
-#: lxc/utils.go:376
+#: lxc/utils.go:364
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:%q' instead."
 msgstr ""
 
-#: lxc/utils.go:372
+#: lxc/utils.go:360
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
@@ -5942,15 +5937,15 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1025
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:440
+#: lxc/init.go:445
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:439
+#: lxc/init.go:444
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6004,7 +5999,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:827
+#: lxc/image.go:832
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
@@ -6042,7 +6037,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1023 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1455
 #, c-format
 msgid "Type: %s"
@@ -6057,7 +6052,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1140
+#: lxc/image.go:1146
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6103,7 +6098,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:631 lxc/storage_volume.go:1772
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6145,7 +6140,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1700 lxc/image.go:1701
+#: lxc/image.go:1706 lxc/image.go:1707
 msgid "Unset image properties"
 msgstr ""
 
@@ -6296,7 +6291,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1032
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6469,7 +6464,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1087 lxc/list.go:46
+#: lxc/image.go:1093 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6582,15 +6577,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
+#: lxc/image.go:399 lxc/image.go:952 lxc/image.go:1512
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1572 lxc/image.go:1699
+#: lxc/image.go:1578 lxc/image.go:1705
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1636
+#: lxc/image.go:1642
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6606,11 +6601,11 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:523
+#: lxc/image.go:528
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1415
+#: lxc/image.go:339 lxc/image.go:1421
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -7073,7 +7068,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1010
 msgid "disabled"
 msgstr ""
 
@@ -7081,7 +7076,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1012
 msgid "enabled"
 msgstr ""
 
@@ -7222,7 +7217,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:398
+#: lxc/image.go:403
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7549,7 +7544,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
+#: lxc/image.go:1000 lxc/image.go:1005 lxc/image.go:1203
 msgid "no"
 msgstr ""
 
@@ -7594,7 +7589,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1194
+#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:1002 lxc/image.go:1007
+#: lxc/image.go:1200
 msgid "yes"
 msgstr ""

--- a/po/tzm.po
+++ b/po/tzm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-19 13:11-0600\n"
+"POT-Creation-Date: 2024-09-25 18:38-0600\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Tamazight (Central Atlas) <https://hosted.weblate.org/"
@@ -195,7 +195,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:419
+#: lxc/image.go:424
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -423,7 +423,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1168
+#: lxc/image.go:1174
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -531,7 +531,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:695
+#: lxc/image.go:700
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -544,15 +544,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1138 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1133
+#: lxc/image.go:1139
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1144 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -734,7 +734,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1045
+#: lxc/image.go:1051
 msgid "Aliases:"
 msgstr ""
 
@@ -750,7 +750,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1022 lxc/info.go:486
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -769,11 +769,11 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:342 lxc/rebuild.go:131
+#: lxc/init.go:347 lxc/rebuild.go:136
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/init.go:346
+#: lxc/init.go:351
 msgid "Asked for a container but image is of type VM"
 msgstr ""
 
@@ -831,7 +831,7 @@ msgstr ""
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1061
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -888,7 +888,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:816
+#: lxc/image.go:821
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -969,7 +969,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1060
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -990,7 +990,7 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:239 lxc/utils.go:259
+#: lxc/utils.go:227 lxc/utils.go:247
 #, c-format
 msgid "Can't read from stdin: %w"
 msgstr ""
@@ -1024,7 +1024,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:166
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1176,7 +1176,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1589
+#: lxc/image.go:1121 lxc/list.go:132 lxc/storage_volume.go:1589
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1215,7 +1215,7 @@ msgstr ""
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1327 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/config_trust.go:314 lxc/image.go:496 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
@@ -1309,7 +1309,7 @@ msgstr ""
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1489,7 +1489,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1475
+#: lxc/image.go:1029 lxc/info.go:497 lxc/storage_volume.go:1475
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1513,7 +1513,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1143 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -1571,7 +1571,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:341 lxc/image.go:342
 msgid "Delete images"
 msgstr ""
 
@@ -1674,9 +1674,9 @@ msgstr ""
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
 #: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
-#: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
-#: lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090 lxc/image.go:1417
-#: lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638 lxc/image.go:1701
+#: lxc/image.go:159 lxc/image.go:342 lxc/image.go:401 lxc/image.go:530
+#: lxc/image.go:702 lxc/image.go:954 lxc/image.go:1096 lxc/image.go:1423
+#: lxc/image.go:1514 lxc/image.go:1580 lxc/image.go:1644 lxc/image.go:1707
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
@@ -1821,11 +1821,11 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:406
+#: lxc/init.go:411
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:726
+#: lxc/image.go:731
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1929,7 +1929,7 @@ msgstr ""
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:400 lxc/image.go:401
 msgid "Edit image properties"
 msgstr ""
 
@@ -2005,7 +2005,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1766
+#: lxc/image.go:1155 lxc/list.go:622 lxc/storage_volume.go:1766
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2124,20 +2124,20 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:1029
+#: lxc/image.go:1035
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1037
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:524
+#: lxc/image.go:529
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:530
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2165,7 +2165,7 @@ msgstr ""
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:604
+#: lxc/image.go:609
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2178,7 +2178,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
+#: lxc/config_trust.go:411 lxc/image.go:1140 lxc/image.go:1141
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2197,12 +2197,12 @@ msgstr ""
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/utils.go:296
+#: lxc/utils.go:284
 #, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/utils.go:288
+#: lxc/utils.go:276
 #, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
@@ -2296,7 +2296,7 @@ msgstr ""
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: lxc/utils.go:214
+#: lxc/utils.go:202
 #, c-format
 msgid "Failed to create alias %s: %w"
 msgstr ""
@@ -2321,11 +2321,6 @@ msgstr ""
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
 
-#: lxc/utils.go:203
-#, c-format
-msgid "Failed to remove alias %s: %w"
-msgstr ""
-
 #: lxc/file.go:821
 #, c-format
 msgid "Failed to walk path for %s: %s"
@@ -2345,7 +2340,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:1014
+#: lxc/image.go:1020
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2409,7 +2404,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:770 lxc/auth.go:1697
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1122 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:57
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2484,7 +2479,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1573 lxc/image.go:1574
+#: lxc/image.go:1579 lxc/image.go:1580
 msgid "Get image properties"
 msgstr ""
 
@@ -2758,11 +2753,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1489
+#: lxc/image.go:1495
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2770,25 +2765,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:680
+#: lxc/image.go:685
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1444
+#: lxc/image.go:369 lxc/image.go:1450
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1670
+#: lxc/image.go:449 lxc/image.go:1676
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:918
+#: lxc/image.go:923
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1493
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2808,7 +2803,7 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:697
+#: lxc/image.go:702
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -2818,7 +2813,7 @@ msgid ""
 "os=Ubuntu release=noble variant=cloud."
 msgstr ""
 
-#: lxc/image.go:696
+#: lxc/image.go:701
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2869,7 +2864,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:417
+#: lxc/init.go:422
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2935,7 +2930,7 @@ msgstr ""
 msgid "Invalid instance path: %q"
 msgstr ""
 
-#: lxc/utils.go:253
+#: lxc/utils.go:241
 #, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr ""
@@ -3047,12 +3042,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:1035
+#: lxc/image.go:1041
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:1037
+#: lxc/image.go:1043
 msgid "Last used: never"
 msgstr ""
 
@@ -3170,11 +3165,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1089
+#: lxc/image.go:1095
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1096
 msgid ""
 "List images\n"
 "\n"
@@ -3468,7 +3463,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:165 lxc/image.go:709
 msgid "Make image public"
 msgstr ""
 
@@ -3982,7 +3977,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:728
+#: lxc/image.go:733
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4175,7 +4170,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:168 lxc/image.go:710
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4255,7 +4250,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:805
+#: lxc/image.go:810
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4326,7 +4321,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:752
+#: lxc/image.go:1142 lxc/remote.go:752
 msgid "PUBLIC"
 msgstr ""
 
@@ -4387,7 +4382,7 @@ msgstr ""
 #: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/config_trust.go:315 lxc/image.go:497 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
@@ -4475,11 +4470,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1067
+#: lxc/image.go:1073
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1065
+#: lxc/image.go:1071
 msgid "Profiles: "
 msgstr ""
 
@@ -4502,11 +4497,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1046
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1621
+#: lxc/image.go:1627
 msgid "Property not found"
 msgstr ""
 
@@ -4600,7 +4595,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1024
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4636,7 +4631,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
+#: lxc/image.go:535 lxc/image.go:957 lxc/image.go:1517
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4673,7 +4668,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1416 lxc/image.go:1417
+#: lxc/image.go:1422 lxc/image.go:1423
 msgid "Refresh images"
 msgstr ""
 
@@ -4682,7 +4677,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1453
+#: lxc/image.go:1459
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4945,7 +4940,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:365
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -4978,7 +4973,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1139
+#: lxc/image.go:1145
 msgid "SIZE"
 msgstr ""
 
@@ -5101,7 +5096,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1637 lxc/image.go:1638
+#: lxc/image.go:1643 lxc/image.go:1644
 msgid "Set image properties"
 msgstr ""
 
@@ -5394,7 +5389,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1507 lxc/image.go:1508
+#: lxc/image.go:1513 lxc/image.go:1514
 msgid "Show image properties"
 msgstr ""
 
@@ -5528,7 +5523,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:953 lxc/image.go:954
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5540,7 +5535,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1021
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5572,7 +5567,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:1058
+#: lxc/image.go:1064
 msgid "Source:"
 msgstr ""
 
@@ -5720,7 +5715,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
 #: lxc/storage_volume.go:1730 lxc/warning.go:216
@@ -5785,7 +5780,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:438
+#: lxc/init.go:443
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5794,12 +5789,12 @@ msgstr ""
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
 
-#: lxc/utils.go:376
+#: lxc/utils.go:364
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:%q' instead."
 msgstr ""
 
-#: lxc/utils.go:372
+#: lxc/utils.go:360
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
@@ -5942,15 +5937,15 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1025
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:440
+#: lxc/init.go:445
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:439
+#: lxc/init.go:444
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6004,7 +5999,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:827
+#: lxc/image.go:832
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
@@ -6042,7 +6037,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1023 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1455
 #, c-format
 msgid "Type: %s"
@@ -6057,7 +6052,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1140
+#: lxc/image.go:1146
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6103,7 +6098,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:631 lxc/storage_volume.go:1772
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6145,7 +6140,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1700 lxc/image.go:1701
+#: lxc/image.go:1706 lxc/image.go:1707
 msgid "Unset image properties"
 msgstr ""
 
@@ -6296,7 +6291,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1032
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6469,7 +6464,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1087 lxc/list.go:46
+#: lxc/image.go:1093 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6582,15 +6577,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
+#: lxc/image.go:399 lxc/image.go:952 lxc/image.go:1512
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1572 lxc/image.go:1699
+#: lxc/image.go:1578 lxc/image.go:1705
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1636
+#: lxc/image.go:1642
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6606,11 +6601,11 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:523
+#: lxc/image.go:528
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1415
+#: lxc/image.go:339 lxc/image.go:1421
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -7073,7 +7068,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1010
 msgid "disabled"
 msgstr ""
 
@@ -7081,7 +7076,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1012
 msgid "enabled"
 msgstr ""
 
@@ -7222,7 +7217,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:398
+#: lxc/image.go:403
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7549,7 +7544,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
+#: lxc/image.go:1000 lxc/image.go:1005 lxc/image.go:1203
 msgid "no"
 msgstr ""
 
@@ -7594,7 +7589,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1194
+#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:1002 lxc/image.go:1007
+#: lxc/image.go:1200
 msgid "yes"
 msgstr ""

--- a/po/ug.po
+++ b/po/ug.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-19 13:11-0600\n"
+"POT-Creation-Date: 2024-09-25 18:38-0600\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Uyghur <https://hosted.weblate.org/projects/linux-containers/"
@@ -195,7 +195,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:419
+#: lxc/image.go:424
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -423,7 +423,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1168
+#: lxc/image.go:1174
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -531,7 +531,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:695
+#: lxc/image.go:700
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -544,15 +544,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1138 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1133
+#: lxc/image.go:1139
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1144 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -734,7 +734,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1045
+#: lxc/image.go:1051
 msgid "Aliases:"
 msgstr ""
 
@@ -750,7 +750,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1022 lxc/info.go:486
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -769,11 +769,11 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:342 lxc/rebuild.go:131
+#: lxc/init.go:347 lxc/rebuild.go:136
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/init.go:346
+#: lxc/init.go:351
 msgid "Asked for a container but image is of type VM"
 msgstr ""
 
@@ -831,7 +831,7 @@ msgstr ""
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1061
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -888,7 +888,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:816
+#: lxc/image.go:821
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -969,7 +969,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1060
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -990,7 +990,7 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:239 lxc/utils.go:259
+#: lxc/utils.go:227 lxc/utils.go:247
 #, c-format
 msgid "Can't read from stdin: %w"
 msgstr ""
@@ -1024,7 +1024,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:166
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1176,7 +1176,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1589
+#: lxc/image.go:1121 lxc/list.go:132 lxc/storage_volume.go:1589
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1215,7 +1215,7 @@ msgstr ""
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1327 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/config_trust.go:314 lxc/image.go:496 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
@@ -1309,7 +1309,7 @@ msgstr ""
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1489,7 +1489,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1475
+#: lxc/image.go:1029 lxc/info.go:497 lxc/storage_volume.go:1475
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1513,7 +1513,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1143 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -1571,7 +1571,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:341 lxc/image.go:342
 msgid "Delete images"
 msgstr ""
 
@@ -1674,9 +1674,9 @@ msgstr ""
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
 #: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
-#: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
-#: lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090 lxc/image.go:1417
-#: lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638 lxc/image.go:1701
+#: lxc/image.go:159 lxc/image.go:342 lxc/image.go:401 lxc/image.go:530
+#: lxc/image.go:702 lxc/image.go:954 lxc/image.go:1096 lxc/image.go:1423
+#: lxc/image.go:1514 lxc/image.go:1580 lxc/image.go:1644 lxc/image.go:1707
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
@@ -1821,11 +1821,11 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:406
+#: lxc/init.go:411
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:726
+#: lxc/image.go:731
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1929,7 +1929,7 @@ msgstr ""
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:400 lxc/image.go:401
 msgid "Edit image properties"
 msgstr ""
 
@@ -2005,7 +2005,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1766
+#: lxc/image.go:1155 lxc/list.go:622 lxc/storage_volume.go:1766
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2124,20 +2124,20 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:1029
+#: lxc/image.go:1035
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1037
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:524
+#: lxc/image.go:529
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:530
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2165,7 +2165,7 @@ msgstr ""
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:604
+#: lxc/image.go:609
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2178,7 +2178,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
+#: lxc/config_trust.go:411 lxc/image.go:1140 lxc/image.go:1141
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2197,12 +2197,12 @@ msgstr ""
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/utils.go:296
+#: lxc/utils.go:284
 #, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/utils.go:288
+#: lxc/utils.go:276
 #, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
@@ -2296,7 +2296,7 @@ msgstr ""
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: lxc/utils.go:214
+#: lxc/utils.go:202
 #, c-format
 msgid "Failed to create alias %s: %w"
 msgstr ""
@@ -2321,11 +2321,6 @@ msgstr ""
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
 
-#: lxc/utils.go:203
-#, c-format
-msgid "Failed to remove alias %s: %w"
-msgstr ""
-
 #: lxc/file.go:821
 #, c-format
 msgid "Failed to walk path for %s: %s"
@@ -2345,7 +2340,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:1014
+#: lxc/image.go:1020
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2409,7 +2404,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:770 lxc/auth.go:1697
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1122 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:57
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2484,7 +2479,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1573 lxc/image.go:1574
+#: lxc/image.go:1579 lxc/image.go:1580
 msgid "Get image properties"
 msgstr ""
 
@@ -2758,11 +2753,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1489
+#: lxc/image.go:1495
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2770,25 +2765,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:680
+#: lxc/image.go:685
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1444
+#: lxc/image.go:369 lxc/image.go:1450
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1670
+#: lxc/image.go:449 lxc/image.go:1676
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:918
+#: lxc/image.go:923
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1493
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2808,7 +2803,7 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:697
+#: lxc/image.go:702
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -2818,7 +2813,7 @@ msgid ""
 "os=Ubuntu release=noble variant=cloud."
 msgstr ""
 
-#: lxc/image.go:696
+#: lxc/image.go:701
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2869,7 +2864,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:417
+#: lxc/init.go:422
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2935,7 +2930,7 @@ msgstr ""
 msgid "Invalid instance path: %q"
 msgstr ""
 
-#: lxc/utils.go:253
+#: lxc/utils.go:241
 #, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr ""
@@ -3047,12 +3042,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:1035
+#: lxc/image.go:1041
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:1037
+#: lxc/image.go:1043
 msgid "Last used: never"
 msgstr ""
 
@@ -3170,11 +3165,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1089
+#: lxc/image.go:1095
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1096
 msgid ""
 "List images\n"
 "\n"
@@ -3468,7 +3463,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:165 lxc/image.go:709
 msgid "Make image public"
 msgstr ""
 
@@ -3982,7 +3977,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:728
+#: lxc/image.go:733
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4175,7 +4170,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:168 lxc/image.go:710
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4255,7 +4250,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:805
+#: lxc/image.go:810
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4326,7 +4321,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:752
+#: lxc/image.go:1142 lxc/remote.go:752
 msgid "PUBLIC"
 msgstr ""
 
@@ -4387,7 +4382,7 @@ msgstr ""
 #: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/config_trust.go:315 lxc/image.go:497 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
@@ -4475,11 +4470,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1067
+#: lxc/image.go:1073
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1065
+#: lxc/image.go:1071
 msgid "Profiles: "
 msgstr ""
 
@@ -4502,11 +4497,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1046
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1621
+#: lxc/image.go:1627
 msgid "Property not found"
 msgstr ""
 
@@ -4600,7 +4595,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1024
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4636,7 +4631,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
+#: lxc/image.go:535 lxc/image.go:957 lxc/image.go:1517
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4673,7 +4668,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1416 lxc/image.go:1417
+#: lxc/image.go:1422 lxc/image.go:1423
 msgid "Refresh images"
 msgstr ""
 
@@ -4682,7 +4677,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1453
+#: lxc/image.go:1459
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4945,7 +4940,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:365
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -4978,7 +4973,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1139
+#: lxc/image.go:1145
 msgid "SIZE"
 msgstr ""
 
@@ -5101,7 +5096,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1637 lxc/image.go:1638
+#: lxc/image.go:1643 lxc/image.go:1644
 msgid "Set image properties"
 msgstr ""
 
@@ -5394,7 +5389,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1507 lxc/image.go:1508
+#: lxc/image.go:1513 lxc/image.go:1514
 msgid "Show image properties"
 msgstr ""
 
@@ -5528,7 +5523,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:953 lxc/image.go:954
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5540,7 +5535,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1021
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5572,7 +5567,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:1058
+#: lxc/image.go:1064
 msgid "Source:"
 msgstr ""
 
@@ -5720,7 +5715,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
 #: lxc/storage_volume.go:1730 lxc/warning.go:216
@@ -5785,7 +5780,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:438
+#: lxc/init.go:443
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5794,12 +5789,12 @@ msgstr ""
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
 
-#: lxc/utils.go:376
+#: lxc/utils.go:364
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:%q' instead."
 msgstr ""
 
-#: lxc/utils.go:372
+#: lxc/utils.go:360
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
@@ -5942,15 +5937,15 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1025
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:440
+#: lxc/init.go:445
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:439
+#: lxc/init.go:444
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6004,7 +5999,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:827
+#: lxc/image.go:832
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
@@ -6042,7 +6037,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1023 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1455
 #, c-format
 msgid "Type: %s"
@@ -6057,7 +6052,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1140
+#: lxc/image.go:1146
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6103,7 +6098,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:631 lxc/storage_volume.go:1772
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6145,7 +6140,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1700 lxc/image.go:1701
+#: lxc/image.go:1706 lxc/image.go:1707
 msgid "Unset image properties"
 msgstr ""
 
@@ -6296,7 +6291,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1032
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6469,7 +6464,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1087 lxc/list.go:46
+#: lxc/image.go:1093 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6582,15 +6577,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
+#: lxc/image.go:399 lxc/image.go:952 lxc/image.go:1512
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1572 lxc/image.go:1699
+#: lxc/image.go:1578 lxc/image.go:1705
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1636
+#: lxc/image.go:1642
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6606,11 +6601,11 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:523
+#: lxc/image.go:528
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1415
+#: lxc/image.go:339 lxc/image.go:1421
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -7073,7 +7068,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1010
 msgid "disabled"
 msgstr ""
 
@@ -7081,7 +7076,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1012
 msgid "enabled"
 msgstr ""
 
@@ -7222,7 +7217,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:398
+#: lxc/image.go:403
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7549,7 +7544,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
+#: lxc/image.go:1000 lxc/image.go:1005 lxc/image.go:1203
 msgid "no"
 msgstr ""
 
@@ -7594,7 +7589,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1194
+#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:1002 lxc/image.go:1007
+#: lxc/image.go:1200
 msgid "yes"
 msgstr ""

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-19 13:11-0600\n"
+"POT-Creation-Date: 2024-09-25 18:38-0600\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Ukrainian <https://hosted.weblate.org/projects/linux-"
@@ -196,7 +196,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:419
+#: lxc/image.go:424
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -424,7 +424,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1168
+#: lxc/image.go:1174
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -532,7 +532,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:695
+#: lxc/image.go:700
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -545,15 +545,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1138 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1133
+#: lxc/image.go:1139
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1144 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -735,7 +735,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1045
+#: lxc/image.go:1051
 msgid "Aliases:"
 msgstr ""
 
@@ -751,7 +751,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1022 lxc/info.go:486
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -770,11 +770,11 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:342 lxc/rebuild.go:131
+#: lxc/init.go:347 lxc/rebuild.go:136
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/init.go:346
+#: lxc/init.go:351
 msgid "Asked for a container but image is of type VM"
 msgstr ""
 
@@ -832,7 +832,7 @@ msgstr ""
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1061
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -889,7 +889,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:816
+#: lxc/image.go:821
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -970,7 +970,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1060
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -991,7 +991,7 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:239 lxc/utils.go:259
+#: lxc/utils.go:227 lxc/utils.go:247
 #, c-format
 msgid "Can't read from stdin: %w"
 msgstr ""
@@ -1025,7 +1025,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:166
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1177,7 +1177,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1589
+#: lxc/image.go:1121 lxc/list.go:132 lxc/storage_volume.go:1589
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1216,7 +1216,7 @@ msgstr ""
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1327 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/config_trust.go:314 lxc/image.go:496 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
@@ -1310,7 +1310,7 @@ msgstr ""
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1490,7 +1490,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1475
+#: lxc/image.go:1029 lxc/info.go:497 lxc/storage_volume.go:1475
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1514,7 +1514,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1143 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -1572,7 +1572,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:341 lxc/image.go:342
 msgid "Delete images"
 msgstr ""
 
@@ -1675,9 +1675,9 @@ msgstr ""
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
 #: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
-#: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
-#: lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090 lxc/image.go:1417
-#: lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638 lxc/image.go:1701
+#: lxc/image.go:159 lxc/image.go:342 lxc/image.go:401 lxc/image.go:530
+#: lxc/image.go:702 lxc/image.go:954 lxc/image.go:1096 lxc/image.go:1423
+#: lxc/image.go:1514 lxc/image.go:1580 lxc/image.go:1644 lxc/image.go:1707
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
@@ -1822,11 +1822,11 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:406
+#: lxc/init.go:411
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:726
+#: lxc/image.go:731
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1930,7 +1930,7 @@ msgstr ""
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:400 lxc/image.go:401
 msgid "Edit image properties"
 msgstr ""
 
@@ -2006,7 +2006,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1766
+#: lxc/image.go:1155 lxc/list.go:622 lxc/storage_volume.go:1766
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2125,20 +2125,20 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:1029
+#: lxc/image.go:1035
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1037
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:524
+#: lxc/image.go:529
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:530
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2166,7 +2166,7 @@ msgstr ""
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:604
+#: lxc/image.go:609
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2179,7 +2179,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
+#: lxc/config_trust.go:411 lxc/image.go:1140 lxc/image.go:1141
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2198,12 +2198,12 @@ msgstr ""
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/utils.go:296
+#: lxc/utils.go:284
 #, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/utils.go:288
+#: lxc/utils.go:276
 #, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
@@ -2297,7 +2297,7 @@ msgstr ""
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: lxc/utils.go:214
+#: lxc/utils.go:202
 #, c-format
 msgid "Failed to create alias %s: %w"
 msgstr ""
@@ -2322,11 +2322,6 @@ msgstr ""
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
 
-#: lxc/utils.go:203
-#, c-format
-msgid "Failed to remove alias %s: %w"
-msgstr ""
-
 #: lxc/file.go:821
 #, c-format
 msgid "Failed to walk path for %s: %s"
@@ -2346,7 +2341,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:1014
+#: lxc/image.go:1020
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2410,7 +2405,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:770 lxc/auth.go:1697
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1122 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:57
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2485,7 +2480,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1573 lxc/image.go:1574
+#: lxc/image.go:1579 lxc/image.go:1580
 msgid "Get image properties"
 msgstr ""
 
@@ -2759,11 +2754,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1489
+#: lxc/image.go:1495
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2771,25 +2766,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:680
+#: lxc/image.go:685
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1444
+#: lxc/image.go:369 lxc/image.go:1450
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1670
+#: lxc/image.go:449 lxc/image.go:1676
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:918
+#: lxc/image.go:923
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1493
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2809,7 +2804,7 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:697
+#: lxc/image.go:702
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -2819,7 +2814,7 @@ msgid ""
 "os=Ubuntu release=noble variant=cloud."
 msgstr ""
 
-#: lxc/image.go:696
+#: lxc/image.go:701
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2870,7 +2865,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:417
+#: lxc/init.go:422
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2936,7 +2931,7 @@ msgstr ""
 msgid "Invalid instance path: %q"
 msgstr ""
 
-#: lxc/utils.go:253
+#: lxc/utils.go:241
 #, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr ""
@@ -3048,12 +3043,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:1035
+#: lxc/image.go:1041
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:1037
+#: lxc/image.go:1043
 msgid "Last used: never"
 msgstr ""
 
@@ -3171,11 +3166,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1089
+#: lxc/image.go:1095
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1096
 msgid ""
 "List images\n"
 "\n"
@@ -3469,7 +3464,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:165 lxc/image.go:709
 msgid "Make image public"
 msgstr ""
 
@@ -3983,7 +3978,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:728
+#: lxc/image.go:733
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4176,7 +4171,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:168 lxc/image.go:710
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4256,7 +4251,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:805
+#: lxc/image.go:810
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4327,7 +4322,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:752
+#: lxc/image.go:1142 lxc/remote.go:752
 msgid "PUBLIC"
 msgstr ""
 
@@ -4388,7 +4383,7 @@ msgstr ""
 #: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/config_trust.go:315 lxc/image.go:497 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
@@ -4476,11 +4471,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1067
+#: lxc/image.go:1073
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1065
+#: lxc/image.go:1071
 msgid "Profiles: "
 msgstr ""
 
@@ -4503,11 +4498,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1046
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1621
+#: lxc/image.go:1627
 msgid "Property not found"
 msgstr ""
 
@@ -4601,7 +4596,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1024
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4637,7 +4632,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
+#: lxc/image.go:535 lxc/image.go:957 lxc/image.go:1517
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4674,7 +4669,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1416 lxc/image.go:1417
+#: lxc/image.go:1422 lxc/image.go:1423
 msgid "Refresh images"
 msgstr ""
 
@@ -4683,7 +4678,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1453
+#: lxc/image.go:1459
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4946,7 +4941,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:365
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -4979,7 +4974,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1139
+#: lxc/image.go:1145
 msgid "SIZE"
 msgstr ""
 
@@ -5102,7 +5097,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1637 lxc/image.go:1638
+#: lxc/image.go:1643 lxc/image.go:1644
 msgid "Set image properties"
 msgstr ""
 
@@ -5395,7 +5390,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1507 lxc/image.go:1508
+#: lxc/image.go:1513 lxc/image.go:1514
 msgid "Show image properties"
 msgstr ""
 
@@ -5529,7 +5524,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:953 lxc/image.go:954
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5541,7 +5536,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1021
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5573,7 +5568,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:1058
+#: lxc/image.go:1064
 msgid "Source:"
 msgstr ""
 
@@ -5721,7 +5716,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
 #: lxc/storage_volume.go:1730 lxc/warning.go:216
@@ -5786,7 +5781,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:438
+#: lxc/init.go:443
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5795,12 +5790,12 @@ msgstr ""
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
 
-#: lxc/utils.go:376
+#: lxc/utils.go:364
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:%q' instead."
 msgstr ""
 
-#: lxc/utils.go:372
+#: lxc/utils.go:360
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
@@ -5943,15 +5938,15 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1025
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:440
+#: lxc/init.go:445
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:439
+#: lxc/init.go:444
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6005,7 +6000,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:827
+#: lxc/image.go:832
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
@@ -6043,7 +6038,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1023 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1455
 #, c-format
 msgid "Type: %s"
@@ -6058,7 +6053,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1140
+#: lxc/image.go:1146
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6104,7 +6099,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:631 lxc/storage_volume.go:1772
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6146,7 +6141,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1700 lxc/image.go:1701
+#: lxc/image.go:1706 lxc/image.go:1707
 msgid "Unset image properties"
 msgstr ""
 
@@ -6297,7 +6292,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1032
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6470,7 +6465,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1087 lxc/list.go:46
+#: lxc/image.go:1093 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6583,15 +6578,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
+#: lxc/image.go:399 lxc/image.go:952 lxc/image.go:1512
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1572 lxc/image.go:1699
+#: lxc/image.go:1578 lxc/image.go:1705
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1636
+#: lxc/image.go:1642
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6607,11 +6602,11 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:523
+#: lxc/image.go:528
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1415
+#: lxc/image.go:339 lxc/image.go:1421
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -7074,7 +7069,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1010
 msgid "disabled"
 msgstr ""
 
@@ -7082,7 +7077,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1012
 msgid "enabled"
 msgstr ""
 
@@ -7223,7 +7218,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:398
+#: lxc/image.go:403
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7550,7 +7545,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
+#: lxc/image.go:1000 lxc/image.go:1005 lxc/image.go:1203
 msgid "no"
 msgstr ""
 
@@ -7595,7 +7590,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1194
+#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:1002 lxc/image.go:1007
+#: lxc/image.go:1200
 msgid "yes"
 msgstr ""

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-19 13:11-0600\n"
+"POT-Creation-Date: 2024-09-25 18:38-0600\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: 0x0916 <w@laoqinren.net>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -280,7 +280,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/image.go:419
+#: lxc/image.go:424
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -584,7 +584,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1168
+#: lxc/image.go:1174
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -692,7 +692,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:695
+#: lxc/image.go:700
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -705,15 +705,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1138 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1133
+#: lxc/image.go:1139
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1144 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1045
+#: lxc/image.go:1051
 msgid "Aliases:"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1022 lxc/info.go:486
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -930,11 +930,11 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:342 lxc/rebuild.go:131
+#: lxc/init.go:347 lxc/rebuild.go:136
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/init.go:346
+#: lxc/init.go:351
 msgid "Asked for a container but image is of type VM"
 msgstr ""
 
@@ -992,7 +992,7 @@ msgstr ""
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1061
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -1049,7 +1049,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:816
+#: lxc/image.go:821
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -1130,7 +1130,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1060
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:239 lxc/utils.go:259
+#: lxc/utils.go:227 lxc/utils.go:247
 #, c-format
 msgid "Can't read from stdin: %w"
 msgstr ""
@@ -1185,7 +1185,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:166
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1337,7 +1337,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1589
+#: lxc/image.go:1121 lxc/list.go:132 lxc/storage_volume.go:1589
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1376,7 +1376,7 @@ msgstr ""
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1327 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/config_trust.go:314 lxc/image.go:496 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
@@ -1470,7 +1470,7 @@ msgstr ""
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1650,7 +1650,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1475
+#: lxc/image.go:1029 lxc/info.go:497 lxc/storage_volume.go:1475
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1674,7 +1674,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1143 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -1732,7 +1732,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:341 lxc/image.go:342
 msgid "Delete images"
 msgstr ""
 
@@ -1835,9 +1835,9 @@ msgstr ""
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
 #: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
-#: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
-#: lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090 lxc/image.go:1417
-#: lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638 lxc/image.go:1701
+#: lxc/image.go:159 lxc/image.go:342 lxc/image.go:401 lxc/image.go:530
+#: lxc/image.go:702 lxc/image.go:954 lxc/image.go:1096 lxc/image.go:1423
+#: lxc/image.go:1514 lxc/image.go:1580 lxc/image.go:1644 lxc/image.go:1707
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
@@ -1982,11 +1982,11 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:406
+#: lxc/init.go:411
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:726
+#: lxc/image.go:731
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -2090,7 +2090,7 @@ msgstr ""
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:400 lxc/image.go:401
 msgid "Edit image properties"
 msgstr ""
 
@@ -2166,7 +2166,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1766
+#: lxc/image.go:1155 lxc/list.go:622 lxc/storage_volume.go:1766
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2285,20 +2285,20 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:1029
+#: lxc/image.go:1035
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1037
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:524
+#: lxc/image.go:529
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:530
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2326,7 +2326,7 @@ msgstr ""
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:604
+#: lxc/image.go:609
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2339,7 +2339,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
+#: lxc/config_trust.go:411 lxc/image.go:1140 lxc/image.go:1141
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2358,12 +2358,12 @@ msgstr ""
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/utils.go:296
+#: lxc/utils.go:284
 #, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/utils.go:288
+#: lxc/utils.go:276
 #, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
@@ -2457,7 +2457,7 @@ msgstr ""
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: lxc/utils.go:214
+#: lxc/utils.go:202
 #, c-format
 msgid "Failed to create alias %s: %w"
 msgstr ""
@@ -2482,11 +2482,6 @@ msgstr ""
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
 
-#: lxc/utils.go:203
-#, c-format
-msgid "Failed to remove alias %s: %w"
-msgstr ""
-
 #: lxc/file.go:821
 #, c-format
 msgid "Failed to walk path for %s: %s"
@@ -2506,7 +2501,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:1014
+#: lxc/image.go:1020
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2570,7 +2565,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:770 lxc/auth.go:1697
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1122 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:57
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2645,7 +2640,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1573 lxc/image.go:1574
+#: lxc/image.go:1579 lxc/image.go:1580
 msgid "Get image properties"
 msgstr ""
 
@@ -2919,11 +2914,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1489
+#: lxc/image.go:1495
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2931,25 +2926,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:680
+#: lxc/image.go:685
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1444
+#: lxc/image.go:369 lxc/image.go:1450
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1670
+#: lxc/image.go:449 lxc/image.go:1676
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:918
+#: lxc/image.go:923
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1493
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2969,7 +2964,7 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:697
+#: lxc/image.go:702
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -2979,7 +2974,7 @@ msgid ""
 "os=Ubuntu release=noble variant=cloud."
 msgstr ""
 
-#: lxc/image.go:696
+#: lxc/image.go:701
 msgid "Import images into the image store"
 msgstr ""
 
@@ -3030,7 +3025,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:417
+#: lxc/init.go:422
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -3096,7 +3091,7 @@ msgstr ""
 msgid "Invalid instance path: %q"
 msgstr ""
 
-#: lxc/utils.go:253
+#: lxc/utils.go:241
 #, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr ""
@@ -3208,12 +3203,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:1035
+#: lxc/image.go:1041
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:1037
+#: lxc/image.go:1043
 msgid "Last used: never"
 msgstr ""
 
@@ -3331,11 +3326,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1089
+#: lxc/image.go:1095
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1096
 msgid ""
 "List images\n"
 "\n"
@@ -3629,7 +3624,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:165 lxc/image.go:709
 msgid "Make image public"
 msgstr ""
 
@@ -4143,7 +4138,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:728
+#: lxc/image.go:733
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4336,7 +4331,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:168 lxc/image.go:710
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4416,7 +4411,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:805
+#: lxc/image.go:810
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4487,7 +4482,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:752
+#: lxc/image.go:1142 lxc/remote.go:752
 msgid "PUBLIC"
 msgstr ""
 
@@ -4548,7 +4543,7 @@ msgstr ""
 #: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/config_trust.go:315 lxc/image.go:497 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
@@ -4636,11 +4631,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1067
+#: lxc/image.go:1073
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1065
+#: lxc/image.go:1071
 msgid "Profiles: "
 msgstr ""
 
@@ -4663,11 +4658,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1046
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1621
+#: lxc/image.go:1627
 msgid "Property not found"
 msgstr ""
 
@@ -4761,7 +4756,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1024
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4797,7 +4792,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
+#: lxc/image.go:535 lxc/image.go:957 lxc/image.go:1517
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4834,7 +4829,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1416 lxc/image.go:1417
+#: lxc/image.go:1422 lxc/image.go:1423
 msgid "Refresh images"
 msgstr ""
 
@@ -4843,7 +4838,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1453
+#: lxc/image.go:1459
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5106,7 +5101,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:365
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5139,7 +5134,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1139
+#: lxc/image.go:1145
 msgid "SIZE"
 msgstr ""
 
@@ -5262,7 +5257,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1637 lxc/image.go:1638
+#: lxc/image.go:1643 lxc/image.go:1644
 msgid "Set image properties"
 msgstr ""
 
@@ -5555,7 +5550,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1507 lxc/image.go:1508
+#: lxc/image.go:1513 lxc/image.go:1514
 msgid "Show image properties"
 msgstr ""
 
@@ -5689,7 +5684,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:953 lxc/image.go:954
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5701,7 +5696,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1021
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5733,7 +5728,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:1058
+#: lxc/image.go:1064
 msgid "Source:"
 msgstr ""
 
@@ -5881,7 +5876,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
 #: lxc/storage_volume.go:1730 lxc/warning.go:216
@@ -5946,7 +5941,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:438
+#: lxc/init.go:443
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5955,12 +5950,12 @@ msgstr ""
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
 
-#: lxc/utils.go:376
+#: lxc/utils.go:364
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:%q' instead."
 msgstr ""
 
-#: lxc/utils.go:372
+#: lxc/utils.go:360
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
@@ -6103,15 +6098,15 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1025
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:440
+#: lxc/init.go:445
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:439
+#: lxc/init.go:444
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6165,7 +6160,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:827
+#: lxc/image.go:832
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
@@ -6203,7 +6198,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1023 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1455
 #, c-format
 msgid "Type: %s"
@@ -6218,7 +6213,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1140
+#: lxc/image.go:1146
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6264,7 +6259,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:631 lxc/storage_volume.go:1772
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6306,7 +6301,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1700 lxc/image.go:1701
+#: lxc/image.go:1706 lxc/image.go:1707
 msgid "Unset image properties"
 msgstr ""
 
@@ -6457,7 +6452,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1032
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6630,7 +6625,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1087 lxc/list.go:46
+#: lxc/image.go:1093 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6743,15 +6738,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
+#: lxc/image.go:399 lxc/image.go:952 lxc/image.go:1512
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1572 lxc/image.go:1699
+#: lxc/image.go:1578 lxc/image.go:1705
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1636
+#: lxc/image.go:1642
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6767,11 +6762,11 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:523
+#: lxc/image.go:528
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1415
+#: lxc/image.go:339 lxc/image.go:1421
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -7234,7 +7229,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1010
 msgid "disabled"
 msgstr ""
 
@@ -7242,7 +7237,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1012
 msgid "enabled"
 msgstr ""
 
@@ -7383,7 +7378,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:398
+#: lxc/image.go:403
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7710,7 +7705,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
+#: lxc/image.go:1000 lxc/image.go:1005 lxc/image.go:1203
 msgid "no"
 msgstr ""
 
@@ -7755,8 +7750,8 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1194
+#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:1002 lxc/image.go:1007
+#: lxc/image.go:1200
 msgid "yes"
 msgstr ""
 

--- a/po/zh_Hant.po
+++ b/po/zh_Hant.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-19 13:11-0600\n"
+"POT-Creation-Date: 2024-09-25 18:38-0600\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Chinese (Traditional) <https://hosted.weblate.org/projects/"
@@ -195,7 +195,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:419
+#: lxc/image.go:424
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -423,7 +423,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1168
+#: lxc/image.go:1174
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -531,7 +531,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:695
+#: lxc/image.go:700
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -544,15 +544,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1138 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1133
+#: lxc/image.go:1139
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1144 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -734,7 +734,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1045
+#: lxc/image.go:1051
 msgid "Aliases:"
 msgstr ""
 
@@ -750,7 +750,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1022 lxc/info.go:486
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -769,11 +769,11 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:342 lxc/rebuild.go:131
+#: lxc/init.go:347 lxc/rebuild.go:136
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
-#: lxc/init.go:346
+#: lxc/init.go:351
 msgid "Asked for a container but image is of type VM"
 msgstr ""
 
@@ -831,7 +831,7 @@ msgstr ""
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1061
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -888,7 +888,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:816
+#: lxc/image.go:821
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -969,7 +969,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1060
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -990,7 +990,7 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:239 lxc/utils.go:259
+#: lxc/utils.go:227 lxc/utils.go:247
 #, c-format
 msgid "Can't read from stdin: %w"
 msgstr ""
@@ -1024,7 +1024,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/rebuild.go:161
+#: lxc/rebuild.go:166
 msgid "Can't use an image with --empty"
 msgstr ""
 
@@ -1176,7 +1176,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1589
+#: lxc/image.go:1121 lxc/list.go:132 lxc/storage_volume.go:1589
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1215,7 +1215,7 @@ msgstr ""
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1327 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/config_trust.go:314 lxc/image.go:496 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
@@ -1309,7 +1309,7 @@ msgstr ""
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1489,7 +1489,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1475
+#: lxc/image.go:1029 lxc/info.go:497 lxc/storage_volume.go:1475
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1513,7 +1513,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1143 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -1571,7 +1571,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:341 lxc/image.go:342
 msgid "Delete images"
 msgstr ""
 
@@ -1674,9 +1674,9 @@ msgstr ""
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
 #: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
 #: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
-#: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
-#: lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090 lxc/image.go:1417
-#: lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638 lxc/image.go:1701
+#: lxc/image.go:159 lxc/image.go:342 lxc/image.go:401 lxc/image.go:530
+#: lxc/image.go:702 lxc/image.go:954 lxc/image.go:1096 lxc/image.go:1423
+#: lxc/image.go:1514 lxc/image.go:1580 lxc/image.go:1644 lxc/image.go:1707
 #: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
 #: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
 #: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
@@ -1821,11 +1821,11 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:406
+#: lxc/init.go:411
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:726
+#: lxc/image.go:731
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1929,7 +1929,7 @@ msgstr ""
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:400 lxc/image.go:401
 msgid "Edit image properties"
 msgstr ""
 
@@ -2005,7 +2005,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1766
+#: lxc/image.go:1155 lxc/list.go:622 lxc/storage_volume.go:1766
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2124,20 +2124,20 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:1029
+#: lxc/image.go:1035
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1037
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:524
+#: lxc/image.go:529
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:530
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2165,7 +2165,7 @@ msgstr ""
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:604
+#: lxc/image.go:609
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2178,7 +2178,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
+#: lxc/config_trust.go:411 lxc/image.go:1140 lxc/image.go:1141
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2197,12 +2197,12 @@ msgstr ""
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/utils.go:296
+#: lxc/utils.go:284
 #, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/utils.go:288
+#: lxc/utils.go:276
 #, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
@@ -2296,7 +2296,7 @@ msgstr ""
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: lxc/utils.go:214
+#: lxc/utils.go:202
 #, c-format
 msgid "Failed to create alias %s: %w"
 msgstr ""
@@ -2321,11 +2321,6 @@ msgstr ""
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
 
-#: lxc/utils.go:203
-#, c-format
-msgid "Failed to remove alias %s: %w"
-msgstr ""
-
 #: lxc/file.go:821
 #, c-format
 msgid "Failed to walk path for %s: %s"
@@ -2345,7 +2340,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:1014
+#: lxc/image.go:1020
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2409,7 +2404,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:770 lxc/auth.go:1697
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1122 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:57
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2484,7 +2479,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1573 lxc/image.go:1574
+#: lxc/image.go:1579 lxc/image.go:1580
 msgid "Get image properties"
 msgstr ""
 
@@ -2758,11 +2753,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1489
+#: lxc/image.go:1495
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2770,25 +2765,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:680
+#: lxc/image.go:685
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1444
+#: lxc/image.go:369 lxc/image.go:1450
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1670
+#: lxc/image.go:449 lxc/image.go:1676
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:918
+#: lxc/image.go:923
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1493
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2808,7 +2803,7 @@ msgstr ""
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:697
+#: lxc/image.go:702
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -2818,7 +2813,7 @@ msgid ""
 "os=Ubuntu release=noble variant=cloud."
 msgstr ""
 
-#: lxc/image.go:696
+#: lxc/image.go:701
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2869,7 +2864,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:417
+#: lxc/init.go:422
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2935,7 +2930,7 @@ msgstr ""
 msgid "Invalid instance path: %q"
 msgstr ""
 
-#: lxc/utils.go:253
+#: lxc/utils.go:241
 #, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr ""
@@ -3047,12 +3042,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:1035
+#: lxc/image.go:1041
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:1037
+#: lxc/image.go:1043
 msgid "Last used: never"
 msgstr ""
 
@@ -3170,11 +3165,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1089
+#: lxc/image.go:1095
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1096
 msgid ""
 "List images\n"
 "\n"
@@ -3468,7 +3463,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:165 lxc/image.go:709
 msgid "Make image public"
 msgstr ""
 
@@ -3982,7 +3977,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:728
+#: lxc/image.go:733
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4175,7 +4170,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:168 lxc/image.go:710
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4255,7 +4250,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:805
+#: lxc/image.go:810
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4326,7 +4321,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:752
+#: lxc/image.go:1142 lxc/remote.go:752
 msgid "PUBLIC"
 msgstr ""
 
@@ -4387,7 +4382,7 @@ msgstr ""
 #: lxc/auth.go:302 lxc/auth.go:1056 lxc/auth.go:1662 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1328 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/config_trust.go:315 lxc/image.go:497 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
@@ -4475,11 +4470,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1067
+#: lxc/image.go:1073
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1065
+#: lxc/image.go:1071
 msgid "Profiles: "
 msgstr ""
 
@@ -4502,11 +4497,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1046
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1621
+#: lxc/image.go:1627
 msgid "Property not found"
 msgstr ""
 
@@ -4600,7 +4595,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1024
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4636,7 +4631,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
+#: lxc/image.go:535 lxc/image.go:957 lxc/image.go:1517
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4673,7 +4668,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1416 lxc/image.go:1417
+#: lxc/image.go:1422 lxc/image.go:1423
 msgid "Refresh images"
 msgstr ""
 
@@ -4682,7 +4677,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1453
+#: lxc/image.go:1459
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4945,7 +4940,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:365
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -4978,7 +4973,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1139
+#: lxc/image.go:1145
 msgid "SIZE"
 msgstr ""
 
@@ -5101,7 +5096,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1637 lxc/image.go:1638
+#: lxc/image.go:1643 lxc/image.go:1644
 msgid "Set image properties"
 msgstr ""
 
@@ -5394,7 +5389,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1507 lxc/image.go:1508
+#: lxc/image.go:1513 lxc/image.go:1514
 msgid "Show image properties"
 msgstr ""
 
@@ -5528,7 +5523,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:953 lxc/image.go:954
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5540,7 +5535,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1021
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5572,7 +5567,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:1058
+#: lxc/image.go:1064
 msgid "Source:"
 msgstr ""
 
@@ -5720,7 +5715,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:815 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
 #: lxc/storage_volume.go:1730 lxc/warning.go:216
@@ -5785,7 +5780,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:438
+#: lxc/init.go:443
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5794,12 +5789,12 @@ msgstr ""
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
 
-#: lxc/utils.go:376
+#: lxc/utils.go:364
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:%q' instead."
 msgstr ""
 
-#: lxc/utils.go:372
+#: lxc/utils.go:360
 #, c-format
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
@@ -5942,15 +5937,15 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1025
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:440
+#: lxc/init.go:445
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:439
+#: lxc/init.go:444
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6004,7 +5999,7 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:827
+#: lxc/image.go:832
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
@@ -6042,7 +6037,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1023 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1455
 #, c-format
 msgid "Type: %s"
@@ -6057,7 +6052,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1140
+#: lxc/image.go:1146
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6103,7 +6098,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:631 lxc/storage_volume.go:1772
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6145,7 +6140,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1700 lxc/image.go:1701
+#: lxc/image.go:1706 lxc/image.go:1707
 msgid "Unset image properties"
 msgstr ""
 
@@ -6296,7 +6291,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1032
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6469,7 +6464,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1087 lxc/list.go:46
+#: lxc/image.go:1093 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6582,15 +6577,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
+#: lxc/image.go:399 lxc/image.go:952 lxc/image.go:1512
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1572 lxc/image.go:1699
+#: lxc/image.go:1578 lxc/image.go:1705
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1636
+#: lxc/image.go:1642
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6606,11 +6601,11 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:523
+#: lxc/image.go:528
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1415
+#: lxc/image.go:339 lxc/image.go:1421
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -7073,7 +7068,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1010
 msgid "disabled"
 msgstr ""
 
@@ -7081,7 +7076,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1012
 msgid "enabled"
 msgstr ""
 
@@ -7222,7 +7217,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:398
+#: lxc/image.go:403
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7549,7 +7544,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
+#: lxc/image.go:1000 lxc/image.go:1005 lxc/image.go:1203
 msgid "no"
 msgstr ""
 
@@ -7594,7 +7589,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1194
+#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:1002 lxc/image.go:1007
+#: lxc/image.go:1200
 msgid "yes"
 msgstr ""

--- a/shared/api/image.go
+++ b/shared/api/image.go
@@ -239,6 +239,10 @@ type ImageAlias struct {
 	// Description of the alias
 	// Example: Our preferred Ubuntu image
 	Description string `json:"description" yaml:"description"`
+
+	// Alias type (container or virtual-machine)
+	// Example: container
+	Type string `json:"type" yaml:"type"`
 }
 
 // ImageSource represents the source of a LXD image
@@ -282,6 +286,10 @@ type ImageAliasesEntryPost struct {
 	// Alias name
 	// Example: ubuntu-24.04
 	Name string `json:"name" yaml:"name"`
+
+	// Alias type (container or virtual-machine)
+	// Example: container
+	Type string `json:"type" yaml:"type"`
 }
 
 // ImageAliasesEntryPut represents the modifiable fields of a LXD image alias
@@ -295,6 +303,10 @@ type ImageAliasesEntryPut struct {
 	// Target fingerprint for the alias
 	// Example: 06b86454720d36b20f94e31c6812e05ec51c1b568cf3a8abd273769d213394bb
 	Target string `json:"target" yaml:"target"`
+
+	// Alias type (container or virtual-machine)
+	// Example: container
+	Type string `json:"type" yaml:"type"`
 }
 
 // ImageAliasesEntry represents a LXD image alias


### PR DESCRIPTION
Fixes https://github.com/canonical/lxd/issues/14047.

This PR includes several changes to image alias functionality, including:

- `images_aliases` schema update which adds an image type column;
- improvements to the `/images/aliases` API including added support for image types;
- instance type checking for improved error handling; and
- client support for aliases with image types.