### PR TITLE
Revert "lxc/init: Add error handling for launching container when image is of type VM"

### DIFF
--- a/lxc/init.go
+++ b/lxc/init.go
@@ -342,10 +342,6 @@ func (c *cmdInit) create(conf *config.Config, args []string, launch bool) (lxd.I
 				return nil, "", errors.New(i18n.G("Asked for a VM but image is of type container"))
 			}
 
-			if imgInfo.Type != "container" && !c.flagVM {
-				return nil, "", errors.New(i18n.G("Asked for a container but image is of type VM"))
-			}
-
 			req.Type = api.InstanceType(imgInfo.Type)
 		}
 

--- a/po/ar.po
+++ b/po/ar.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-19 13:11-0600\n"
+"POT-Creation-Date: 2024-09-26 11:55-0600\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -768,10 +768,6 @@ msgstr ""
 
 #: lxc/init.go:342 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
-msgstr ""
-
-#: lxc/init.go:346
-msgid "Asked for a container but image is of type VM"
 msgstr ""
 
 #: lxc/cluster_group.go:84 lxc/cluster_group.go:85
@@ -1818,7 +1814,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:406
+#: lxc/init.go:402
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -2866,7 +2862,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:417
+#: lxc/init.go:413
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -4942,7 +4938,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:356
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5782,7 +5778,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:438
+#: lxc/init.go:434
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5943,11 +5939,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:440
+#: lxc/init.go:436
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:439
+#: lxc/init.go:435
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 

--- a/po/ber.po
+++ b/po/ber.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-19 13:11-0600\n"
+"POT-Creation-Date: 2024-09-26 11:55-0600\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Berber <https://hosted.weblate.org/projects/linux-containers/"
@@ -771,10 +771,6 @@ msgstr ""
 
 #: lxc/init.go:342 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
-msgstr ""
-
-#: lxc/init.go:346
-msgid "Asked for a container but image is of type VM"
 msgstr ""
 
 #: lxc/cluster_group.go:84 lxc/cluster_group.go:85
@@ -1821,7 +1817,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:406
+#: lxc/init.go:402
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -2869,7 +2865,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:417
+#: lxc/init.go:413
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -4945,7 +4941,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:356
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5785,7 +5781,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:438
+#: lxc/init.go:434
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5946,11 +5942,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:440
+#: lxc/init.go:436
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:439
+#: lxc/init.go:435
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 

--- a/po/bg.po
+++ b/po/bg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-19 13:11-0600\n"
+"POT-Creation-Date: 2024-09-26 11:55-0600\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Bulgarian <https://hosted.weblate.org/projects/linux-"
@@ -771,10 +771,6 @@ msgstr ""
 
 #: lxc/init.go:342 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
-msgstr ""
-
-#: lxc/init.go:346
-msgid "Asked for a container but image is of type VM"
 msgstr ""
 
 #: lxc/cluster_group.go:84 lxc/cluster_group.go:85
@@ -1821,7 +1817,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:406
+#: lxc/init.go:402
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -2869,7 +2865,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:417
+#: lxc/init.go:413
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -4945,7 +4941,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:356
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5785,7 +5781,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:438
+#: lxc/init.go:434
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5946,11 +5942,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:440
+#: lxc/init.go:436
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:439
+#: lxc/init.go:435
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 

--- a/po/ca.po
+++ b/po/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-19 13:11-0600\n"
+"POT-Creation-Date: 2024-09-26 11:55-0600\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Catalan <https://hosted.weblate.org/projects/linux-containers/"
@@ -771,10 +771,6 @@ msgstr ""
 
 #: lxc/init.go:342 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
-msgstr ""
-
-#: lxc/init.go:346
-msgid "Asked for a container but image is of type VM"
 msgstr ""
 
 #: lxc/cluster_group.go:84 lxc/cluster_group.go:85
@@ -1821,7 +1817,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:406
+#: lxc/init.go:402
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -2869,7 +2865,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:417
+#: lxc/init.go:413
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -4945,7 +4941,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:356
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5785,7 +5781,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:438
+#: lxc/init.go:434
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5946,11 +5942,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:440
+#: lxc/init.go:436
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:439
+#: lxc/init.go:435
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 

--- a/po/cs.po
+++ b/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-19 13:11-0600\n"
+"POT-Creation-Date: 2024-09-26 11:55-0600\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Czech <https://hosted.weblate.org/projects/linux-containers/"
@@ -771,10 +771,6 @@ msgstr ""
 
 #: lxc/init.go:342 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
-msgstr ""
-
-#: lxc/init.go:346
-msgid "Asked for a container but image is of type VM"
 msgstr ""
 
 #: lxc/cluster_group.go:84 lxc/cluster_group.go:85
@@ -1821,7 +1817,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:406
+#: lxc/init.go:402
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -2869,7 +2865,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:417
+#: lxc/init.go:413
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -4945,7 +4941,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:356
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5785,7 +5781,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:438
+#: lxc/init.go:434
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5946,11 +5942,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:440
+#: lxc/init.go:436
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:439
+#: lxc/init.go:435
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-19 13:11-0600\n"
+"POT-Creation-Date: 2024-09-26 11:55-0600\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Krombel <krombel@krombel.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/linux-containers/"
@@ -1048,10 +1048,6 @@ msgstr ""
 
 #: lxc/init.go:342 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
-msgstr ""
-
-#: lxc/init.go:346
-msgid "Asked for a container but image is of type VM"
 msgstr ""
 
 #: lxc/cluster_group.go:84 lxc/cluster_group.go:85
@@ -2171,7 +2167,7 @@ msgstr ""
 "Optionen:\n"
 "\n"
 
-#: lxc/init.go:406
+#: lxc/init.go:402
 #, fuzzy
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
@@ -3289,7 +3285,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:417
+#: lxc/init.go:413
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -5522,7 +5518,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/init.go:360
+#: lxc/init.go:356
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -6426,7 +6422,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:438
+#: lxc/init.go:434
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -6593,11 +6589,11 @@ msgstr "Wartezeit bevor der Container gestoppt wird."
 msgid "Timestamps:"
 msgstr "Zeitstempel:\n"
 
-#: lxc/init.go:440
+#: lxc/init.go:436
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:439
+#: lxc/init.go:435
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-19 13:11-0600\n"
+"POT-Creation-Date: 2024-09-26 11:55-0600\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/linux-containers/"
@@ -774,10 +774,6 @@ msgstr ""
 
 #: lxc/init.go:342 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
-msgstr ""
-
-#: lxc/init.go:346
-msgid "Asked for a container but image is of type VM"
 msgstr ""
 
 #: lxc/cluster_group.go:84 lxc/cluster_group.go:85
@@ -1834,7 +1830,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:406
+#: lxc/init.go:402
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -2904,7 +2900,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:417
+#: lxc/init.go:413
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -5015,7 +5011,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:356
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5880,7 +5876,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:438
+#: lxc/init.go:434
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -6042,11 +6038,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:440
+#: lxc/init.go:436
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:439
+#: lxc/init.go:435
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 

--- a/po/eo.po
+++ b/po/eo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-19 13:11-0600\n"
+"POT-Creation-Date: 2024-09-26 11:55-0600\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Esperanto <https://hosted.weblate.org/projects/linux-"
@@ -771,10 +771,6 @@ msgstr ""
 
 #: lxc/init.go:342 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
-msgstr ""
-
-#: lxc/init.go:346
-msgid "Asked for a container but image is of type VM"
 msgstr ""
 
 #: lxc/cluster_group.go:84 lxc/cluster_group.go:85
@@ -1821,7 +1817,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:406
+#: lxc/init.go:402
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -2869,7 +2865,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:417
+#: lxc/init.go:413
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -4945,7 +4941,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:356
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5785,7 +5781,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:438
+#: lxc/init.go:434
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5946,11 +5942,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:440
+#: lxc/init.go:436
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:439
+#: lxc/init.go:435
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-19 13:11-0600\n"
+"POT-Creation-Date: 2024-09-26 11:55-0600\n"
 "PO-Revision-Date: 2023-06-16 20:55+0000\n"
 "Last-Translator: Francisco Serrador <fserrador@gmail.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -1019,10 +1019,6 @@ msgstr ""
 
 #: lxc/init.go:342 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
-msgstr ""
-
-#: lxc/init.go:346
-msgid "Asked for a container but image is of type VM"
 msgstr ""
 
 #: lxc/cluster_group.go:84 lxc/cluster_group.go:85
@@ -2097,7 +2093,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr "Dispositivo: %s"
 
-#: lxc/init.go:406
+#: lxc/init.go:402
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -3178,7 +3174,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr "Nombre del contenedor es obligatorio"
 
-#: lxc/init.go:417
+#: lxc/init.go:413
 #, fuzzy, c-format
 msgid "Instance name is: %s"
 msgstr "Nombre del contenedor es: %s"
@@ -5325,7 +5321,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:356
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -6197,7 +6193,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:438
+#: lxc/init.go:434
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -6360,11 +6356,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:440
+#: lxc/init.go:436
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:439
+#: lxc/init.go:435
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 

--- a/po/fa.po
+++ b/po/fa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-19 13:11-0600\n"
+"POT-Creation-Date: 2024-09-26 11:55-0600\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Persian <https://hosted.weblate.org/projects/linux-containers/"
@@ -771,10 +771,6 @@ msgstr ""
 
 #: lxc/init.go:342 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
-msgstr ""
-
-#: lxc/init.go:346
-msgid "Asked for a container but image is of type VM"
 msgstr ""
 
 #: lxc/cluster_group.go:84 lxc/cluster_group.go:85
@@ -1821,7 +1817,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:406
+#: lxc/init.go:402
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -2869,7 +2865,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:417
+#: lxc/init.go:413
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -4945,7 +4941,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:356
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5785,7 +5781,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:438
+#: lxc/init.go:434
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5946,11 +5942,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:440
+#: lxc/init.go:436
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:439
+#: lxc/init.go:435
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-19 13:11-0600\n"
+"POT-Creation-Date: 2024-09-26 11:55-0600\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/linux-containers/"
@@ -771,10 +771,6 @@ msgstr ""
 
 #: lxc/init.go:342 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
-msgstr ""
-
-#: lxc/init.go:346
-msgid "Asked for a container but image is of type VM"
 msgstr ""
 
 #: lxc/cluster_group.go:84 lxc/cluster_group.go:85
@@ -1821,7 +1817,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:406
+#: lxc/init.go:402
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -2869,7 +2865,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:417
+#: lxc/init.go:413
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -4945,7 +4941,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:356
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5785,7 +5781,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:438
+#: lxc/init.go:434
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5946,11 +5942,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:440
+#: lxc/init.go:436
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:439
+#: lxc/init.go:435
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-19 13:11-0600\n"
+"POT-Creation-Date: 2024-09-26 11:55-0600\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Wivik <seb+weblate@zedas.fr>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/linux-containers/"
@@ -1052,10 +1052,6 @@ msgstr ""
 
 #: lxc/init.go:342 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
-msgstr ""
-
-#: lxc/init.go:346
-msgid "Asked for a container but image is of type VM"
 msgstr ""
 
 #: lxc/cluster_group.go:84 lxc/cluster_group.go:85
@@ -2190,7 +2186,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr "Serveur distant : %s"
 
-#: lxc/init.go:406
+#: lxc/init.go:402
 #, fuzzy
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr "pas d'image, conteneur ou instantané affecté sur ce serveur"
@@ -3333,7 +3329,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr "Le nom du conteneur est obligatoire"
 
-#: lxc/init.go:417
+#: lxc/init.go:413
 #, fuzzy, c-format
 msgid "Instance name is: %s"
 msgstr "Le nom du conteneur est : %s"
@@ -5644,7 +5640,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
 
-#: lxc/init.go:360
+#: lxc/init.go:356
 #, c-format
 msgid "Retrieving image: %s"
 msgstr "Récupération de l'image : %s"
@@ -6564,7 +6560,7 @@ msgstr ""
 "Le conteneur est en cours d'exécution. Utiliser --force pour qu'il soit "
 "arrêté et redémarré."
 
-#: lxc/init.go:438
+#: lxc/init.go:434
 #, fuzzy
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
@@ -6731,12 +6727,12 @@ msgstr "Temps d'attente du conteneur avant de le tuer"
 msgid "Timestamps:"
 msgstr "Horodatage :"
 
-#: lxc/init.go:440
+#: lxc/init.go:436
 #, fuzzy
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr "Pour attacher un réseau à un conteneur, utiliser : lxc network attach"
 
-#: lxc/init.go:439
+#: lxc/init.go:435
 msgid "To create a new network, use: lxc network create"
 msgstr "Pour créer un réseau, utiliser : lxc network create"
 

--- a/po/he.po
+++ b/po/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-19 13:11-0600\n"
+"POT-Creation-Date: 2024-09-26 11:55-0600\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hebrew <https://hosted.weblate.org/projects/linux-containers/"
@@ -772,10 +772,6 @@ msgstr ""
 
 #: lxc/init.go:342 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
-msgstr ""
-
-#: lxc/init.go:346
-msgid "Asked for a container but image is of type VM"
 msgstr ""
 
 #: lxc/cluster_group.go:84 lxc/cluster_group.go:85
@@ -1822,7 +1818,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:406
+#: lxc/init.go:402
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -2870,7 +2866,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:417
+#: lxc/init.go:413
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -4946,7 +4942,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:356
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5786,7 +5782,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:438
+#: lxc/init.go:434
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5947,11 +5943,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:440
+#: lxc/init.go:436
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:439
+#: lxc/init.go:435
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 

--- a/po/hi.po
+++ b/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-19 13:11-0600\n"
+"POT-Creation-Date: 2024-09-26 11:55-0600\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hindi <https://hosted.weblate.org/projects/linux-containers/"
@@ -771,10 +771,6 @@ msgstr ""
 
 #: lxc/init.go:342 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
-msgstr ""
-
-#: lxc/init.go:346
-msgid "Asked for a container but image is of type VM"
 msgstr ""
 
 #: lxc/cluster_group.go:84 lxc/cluster_group.go:85
@@ -1821,7 +1817,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:406
+#: lxc/init.go:402
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -2869,7 +2865,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:417
+#: lxc/init.go:413
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -4945,7 +4941,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:356
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5785,7 +5781,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:438
+#: lxc/init.go:434
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5946,11 +5942,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:440
+#: lxc/init.go:436
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:439
+#: lxc/init.go:435
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-19 13:11-0600\n"
+"POT-Creation-Date: 2024-09-26 11:55-0600\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Indonesian <https://hosted.weblate.org/projects/linux-"
@@ -771,10 +771,6 @@ msgstr ""
 
 #: lxc/init.go:342 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
-msgstr ""
-
-#: lxc/init.go:346
-msgid "Asked for a container but image is of type VM"
 msgstr ""
 
 #: lxc/cluster_group.go:84 lxc/cluster_group.go:85
@@ -1821,7 +1817,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:406
+#: lxc/init.go:402
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -2869,7 +2865,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:417
+#: lxc/init.go:413
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -4945,7 +4941,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:356
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5785,7 +5781,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:438
+#: lxc/init.go:434
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5946,11 +5942,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:440
+#: lxc/init.go:436
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:439
+#: lxc/init.go:435
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-19 13:11-0600\n"
+"POT-Creation-Date: 2024-09-26 11:55-0600\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Luigi Operoso <brokenpip3@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/linux-containers/"
@@ -1021,10 +1021,6 @@ msgstr ""
 
 #: lxc/init.go:342 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
-msgstr ""
-
-#: lxc/init.go:346
-msgid "Asked for a container but image is of type VM"
 msgstr ""
 
 #: lxc/cluster_group.go:84 lxc/cluster_group.go:85
@@ -2092,7 +2088,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:406
+#: lxc/init.go:402
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -3170,7 +3166,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:417
+#: lxc/init.go:413
 #, fuzzy, c-format
 msgid "Instance name is: %s"
 msgstr "Il nome del container è: %s"
@@ -5325,7 +5321,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:356
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -6194,7 +6190,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:438
+#: lxc/init.go:434
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -6358,11 +6354,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:440
+#: lxc/init.go:436
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:439
+#: lxc/init.go:435
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-19 13:11-0600\n"
+"POT-Creation-Date: 2024-09-26 11:55-0600\n"
 "PO-Revision-Date: 2023-03-10 15:14+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/linux-"
@@ -1029,11 +1029,6 @@ msgstr "どちらもみつかりませんでした。raw SPICE ソケットは�
 
 #: lxc/init.go:342 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
-msgstr "VMを要求しましたが、イメージタイプがコンテナです"
-
-#: lxc/init.go:346
-#, fuzzy
-msgid "Asked for a container but image is of type VM"
 msgstr "VMを要求しましたが、イメージタイプがコンテナです"
 
 #: lxc/cluster_group.go:84 lxc/cluster_group.go:85
@@ -2123,7 +2118,7 @@ msgstr "プロファイルのデバイスは個々のインスタンスでは取
 msgid "Device: %s"
 msgstr "デバイス: %s"
 
-#: lxc/init.go:406
+#: lxc/init.go:402
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 "サーバから変更されたイメージ、インスタンス、スナップショットを取得できません"
@@ -3245,7 +3240,7 @@ msgstr "クライアント %q に対するインスタンスが切断されま�
 msgid "Instance name is mandatory"
 msgstr "インスタンス名を指定する必要があります"
 
-#: lxc/init.go:417
+#: lxc/init.go:413
 #, c-format
 msgid "Instance name is: %s"
 msgstr "インスタンス名: %s"
@@ -5545,7 +5540,7 @@ msgstr "証明書の使用を1つ以上のプロジェクトに制限します"
 msgid "Retrieve the container's console log"
 msgstr "インスタンスのコンソールログを取得します"
 
-#: lxc/init.go:360
+#: lxc/init.go:356
 #, c-format
 msgid "Retrieving image: %s"
 msgstr "イメージの取得中: %s"
@@ -6460,7 +6455,7 @@ msgstr ""
 "インスタンスは現在実行中です。停止して、再起動するために --force を使用してく"
 "ださい"
 
-#: lxc/init.go:438
+#: lxc/init.go:434
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr "起動しようとしたインスタンスに接続されているネットワークがありません。"
 
@@ -6636,13 +6631,13 @@ msgstr "インスタンスがクリーンにシャットダウンするまで待
 msgid "Timestamps:"
 msgstr "タイムスタンプ:"
 
-#: lxc/init.go:440
+#: lxc/init.go:436
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 "インスタンスにネットワークを接続するには、lxc network attach を使用してくださ"
 "い"
 
-#: lxc/init.go:439
+#: lxc/init.go:435
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 "新しいネットワークを作成するには、lxc network create を使用してください"
@@ -8562,6 +8557,10 @@ msgstr "y"
 #: lxc/image.go:1194
 msgid "yes"
 msgstr "yes"
+
+#, fuzzy
+#~ msgid "Asked for a container but image is of type VM"
+#~ msgstr "VMを要求しましたが、イメージタイプがコンテナです"
 
 #~ msgid "Make the image public"
 #~ msgstr "イメージを public にする"

--- a/po/ka.po
+++ b/po/ka.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-19 13:11-0600\n"
+"POT-Creation-Date: 2024-09-26 11:55-0600\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -768,10 +768,6 @@ msgstr ""
 
 #: lxc/init.go:342 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
-msgstr ""
-
-#: lxc/init.go:346
-msgid "Asked for a container but image is of type VM"
 msgstr ""
 
 #: lxc/cluster_group.go:84 lxc/cluster_group.go:85
@@ -1818,7 +1814,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:406
+#: lxc/init.go:402
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -2866,7 +2862,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:417
+#: lxc/init.go:413
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -4942,7 +4938,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:356
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5782,7 +5778,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:438
+#: lxc/init.go:434
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5943,11 +5939,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:440
+#: lxc/init.go:436
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:439
+#: lxc/init.go:435
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-19 13:11-0600\n"
+"POT-Creation-Date: 2024-09-26 11:55-0600\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Korean <https://hosted.weblate.org/projects/linux-containers/"
@@ -771,10 +771,6 @@ msgstr ""
 
 #: lxc/init.go:342 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
-msgstr ""
-
-#: lxc/init.go:346
-msgid "Asked for a container but image is of type VM"
 msgstr ""
 
 #: lxc/cluster_group.go:84 lxc/cluster_group.go:85
@@ -1821,7 +1817,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:406
+#: lxc/init.go:402
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -2869,7 +2865,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:417
+#: lxc/init.go:413
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -4945,7 +4941,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:356
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5785,7 +5781,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:438
+#: lxc/init.go:434
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5946,11 +5942,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:440
+#: lxc/init.go:436
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:439
+#: lxc/init.go:435
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-        "POT-Creation-Date: 2024-09-19 13:11-0600\n"
+        "POT-Creation-Date: 2024-09-26 11:55-0600\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -730,10 +730,6 @@ msgstr  ""
 
 #: lxc/init.go:342 lxc/rebuild.go:131
 msgid   "Asked for a VM but image is of type container"
-msgstr  ""
-
-#: lxc/init.go:346
-msgid   "Asked for a container but image is of type VM"
 msgstr  ""
 
 #: lxc/cluster_group.go:84 lxc/cluster_group.go:85
@@ -1612,7 +1608,7 @@ msgstr  ""
 msgid   "Device: %s"
 msgstr  ""
 
-#: lxc/init.go:406
+#: lxc/init.go:402
 msgid   "Didn't get any affected image, instance or snapshot from server"
 msgstr  ""
 
@@ -2618,7 +2614,7 @@ msgstr  ""
 msgid   "Instance name is mandatory"
 msgstr  ""
 
-#: lxc/init.go:417
+#: lxc/init.go:413
 #, c-format
 msgid   "Instance name is: %s"
 msgstr  ""
@@ -4564,7 +4560,7 @@ msgstr  ""
 msgid   "Retrieve the container's console log"
 msgstr  ""
 
-#: lxc/init.go:360
+#: lxc/init.go:356
 #, c-format
 msgid   "Retrieving image: %s"
 msgstr  ""
@@ -5364,7 +5360,7 @@ msgstr  ""
 msgid   "The instance is currently running. Use --force to have it stopped and restarted"
 msgstr  ""
 
-#: lxc/init.go:438
+#: lxc/init.go:434
 msgid   "The instance you are starting doesn't have any network attached to it."
 msgstr  ""
 
@@ -5519,11 +5515,11 @@ msgstr  ""
 msgid   "Timestamps:"
 msgstr  ""
 
-#: lxc/init.go:440
+#: lxc/init.go:436
 msgid   "To attach a network to an instance, use: lxc network attach"
 msgstr  ""
 
-#: lxc/init.go:439
+#: lxc/init.go:435
 msgid   "To create a new network, use: lxc network create"
 msgstr  ""
 

--- a/po/mr.po
+++ b/po/mr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-19 13:11-0600\n"
+"POT-Creation-Date: 2024-09-26 11:55-0600\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Marathi <https://hosted.weblate.org/projects/linux-containers/"
@@ -771,10 +771,6 @@ msgstr ""
 
 #: lxc/init.go:342 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
-msgstr ""
-
-#: lxc/init.go:346
-msgid "Asked for a container but image is of type VM"
 msgstr ""
 
 #: lxc/cluster_group.go:84 lxc/cluster_group.go:85
@@ -1821,7 +1817,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:406
+#: lxc/init.go:402
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -2869,7 +2865,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:417
+#: lxc/init.go:413
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -4945,7 +4941,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:356
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5785,7 +5781,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:438
+#: lxc/init.go:434
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5946,11 +5942,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:440
+#: lxc/init.go:436
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:439
+#: lxc/init.go:435
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-19 13:11-0600\n"
+"POT-Creation-Date: 2024-09-26 11:55-0600\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Norwegian Bokmål <https://hosted.weblate.org/projects/linux-"
@@ -771,10 +771,6 @@ msgstr ""
 
 #: lxc/init.go:342 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
-msgstr ""
-
-#: lxc/init.go:346
-msgid "Asked for a container but image is of type VM"
 msgstr ""
 
 #: lxc/cluster_group.go:84 lxc/cluster_group.go:85
@@ -1821,7 +1817,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:406
+#: lxc/init.go:402
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -2869,7 +2865,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:417
+#: lxc/init.go:413
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -4945,7 +4941,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:356
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5785,7 +5781,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:438
+#: lxc/init.go:434
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5946,11 +5942,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:440
+#: lxc/init.go:436
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:439
+#: lxc/init.go:435
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-19 13:11-0600\n"
+"POT-Creation-Date: 2024-09-26 11:55-0600\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Heimen Stoffels <vistausss@fastmail.com>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/linux-containers/"
@@ -995,10 +995,6 @@ msgstr ""
 
 #: lxc/init.go:342 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
-msgstr ""
-
-#: lxc/init.go:346
-msgid "Asked for a container but image is of type VM"
 msgstr ""
 
 #: lxc/cluster_group.go:84 lxc/cluster_group.go:85
@@ -2045,7 +2041,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:406
+#: lxc/init.go:402
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -3093,7 +3089,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:417
+#: lxc/init.go:413
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -5169,7 +5165,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:356
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -6009,7 +6005,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:438
+#: lxc/init.go:434
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -6170,11 +6166,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:440
+#: lxc/init.go:436
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:439
+#: lxc/init.go:435
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 

--- a/po/pa.po
+++ b/po/pa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-19 13:11-0600\n"
+"POT-Creation-Date: 2024-09-26 11:55-0600\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Punjabi <https://hosted.weblate.org/projects/linux-containers/"
@@ -771,10 +771,6 @@ msgstr ""
 
 #: lxc/init.go:342 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
-msgstr ""
-
-#: lxc/init.go:346
-msgid "Asked for a container but image is of type VM"
 msgstr ""
 
 #: lxc/cluster_group.go:84 lxc/cluster_group.go:85
@@ -1821,7 +1817,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:406
+#: lxc/init.go:402
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -2869,7 +2865,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:417
+#: lxc/init.go:413
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -4945,7 +4941,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:356
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5785,7 +5781,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:438
+#: lxc/init.go:434
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5946,11 +5942,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:440
+#: lxc/init.go:436
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:439
+#: lxc/init.go:435
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-19 13:11-0600\n"
+"POT-Creation-Date: 2024-09-26 11:55-0600\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/linux-containers/"
@@ -1033,10 +1033,6 @@ msgstr ""
 
 #: lxc/init.go:342 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
-msgstr ""
-
-#: lxc/init.go:346
-msgid "Asked for a container but image is of type VM"
 msgstr ""
 
 #: lxc/cluster_group.go:84 lxc/cluster_group.go:85
@@ -2083,7 +2079,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:406
+#: lxc/init.go:402
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -3131,7 +3127,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:417
+#: lxc/init.go:413
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -5207,7 +5203,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:356
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -6047,7 +6043,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:438
+#: lxc/init.go:434
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -6208,11 +6204,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:440
+#: lxc/init.go:436
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:439
+#: lxc/init.go:435
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 

--- a/po/pt.po
+++ b/po/pt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-19 13:11-0600\n"
+"POT-Creation-Date: 2024-09-26 11:55-0600\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -768,10 +768,6 @@ msgstr ""
 
 #: lxc/init.go:342 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
-msgstr ""
-
-#: lxc/init.go:346
-msgid "Asked for a container but image is of type VM"
 msgstr ""
 
 #: lxc/cluster_group.go:84 lxc/cluster_group.go:85
@@ -1818,7 +1814,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:406
+#: lxc/init.go:402
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -2866,7 +2862,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:417
+#: lxc/init.go:413
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -4942,7 +4938,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:356
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5782,7 +5778,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:438
+#: lxc/init.go:434
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5943,11 +5939,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:440
+#: lxc/init.go:436
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:439
+#: lxc/init.go:435
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-19 13:11-0600\n"
+"POT-Creation-Date: 2024-09-26 11:55-0600\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Renato dos Santos <renato.santos@wplex.com.br>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -1040,10 +1040,6 @@ msgstr ""
 
 #: lxc/init.go:342 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
-msgstr ""
-
-#: lxc/init.go:346
-msgid "Asked for a container but image is of type VM"
 msgstr ""
 
 #: lxc/cluster_group.go:84 lxc/cluster_group.go:85
@@ -2146,7 +2142,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr "Em cache: %s"
 
-#: lxc/init.go:406
+#: lxc/init.go:402
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -3239,7 +3235,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:417
+#: lxc/init.go:413
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -5404,7 +5400,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:356
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -6293,7 +6289,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:438
+#: lxc/init.go:434
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -6456,11 +6452,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:440
+#: lxc/init.go:436
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:439
+#: lxc/init.go:435
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-19 13:11-0600\n"
+"POT-Creation-Date: 2024-09-26 11:55-0600\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Александр Киль <shorrey@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -1041,10 +1041,6 @@ msgstr ""
 
 #: lxc/init.go:342 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
-msgstr ""
-
-#: lxc/init.go:346
-msgid "Asked for a container but image is of type VM"
 msgstr ""
 
 #: lxc/cluster_group.go:84 lxc/cluster_group.go:85
@@ -2133,7 +2129,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:406
+#: lxc/init.go:402
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -3227,7 +3223,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr "Имя контейнера является обязательным"
 
-#: lxc/init.go:417
+#: lxc/init.go:413
 #, fuzzy, c-format
 msgid "Instance name is: %s"
 msgstr "Имя контейнера: %s"
@@ -5401,7 +5397,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:356
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -6282,7 +6278,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:438
+#: lxc/init.go:434
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -6444,11 +6440,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:440
+#: lxc/init.go:436
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:439
+#: lxc/init.go:435
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 

--- a/po/si.po
+++ b/po/si.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-19 13:11-0600\n"
+"POT-Creation-Date: 2024-09-26 11:55-0600\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Sinhala <https://hosted.weblate.org/projects/linux-containers/"
@@ -771,10 +771,6 @@ msgstr ""
 
 #: lxc/init.go:342 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
-msgstr ""
-
-#: lxc/init.go:346
-msgid "Asked for a container but image is of type VM"
 msgstr ""
 
 #: lxc/cluster_group.go:84 lxc/cluster_group.go:85
@@ -1821,7 +1817,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:406
+#: lxc/init.go:402
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -2869,7 +2865,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:417
+#: lxc/init.go:413
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -4945,7 +4941,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:356
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5785,7 +5781,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:438
+#: lxc/init.go:434
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5946,11 +5942,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:440
+#: lxc/init.go:436
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:439
+#: lxc/init.go:435
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 

--- a/po/sl.po
+++ b/po/sl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-19 13:11-0600\n"
+"POT-Creation-Date: 2024-09-26 11:55-0600\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Slovenian <https://hosted.weblate.org/projects/linux-"
@@ -772,10 +772,6 @@ msgstr ""
 
 #: lxc/init.go:342 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
-msgstr ""
-
-#: lxc/init.go:346
-msgid "Asked for a container but image is of type VM"
 msgstr ""
 
 #: lxc/cluster_group.go:84 lxc/cluster_group.go:85
@@ -1822,7 +1818,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:406
+#: lxc/init.go:402
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -2870,7 +2866,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:417
+#: lxc/init.go:413
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -4946,7 +4942,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:356
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5786,7 +5782,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:438
+#: lxc/init.go:434
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5947,11 +5943,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:440
+#: lxc/init.go:436
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:439
+#: lxc/init.go:435
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-19 13:11-0600\n"
+"POT-Creation-Date: 2024-09-26 11:55-0600\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Serbian <https://hosted.weblate.org/projects/linux-containers/"
@@ -772,10 +772,6 @@ msgstr ""
 
 #: lxc/init.go:342 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
-msgstr ""
-
-#: lxc/init.go:346
-msgid "Asked for a container but image is of type VM"
 msgstr ""
 
 #: lxc/cluster_group.go:84 lxc/cluster_group.go:85
@@ -1822,7 +1818,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:406
+#: lxc/init.go:402
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -2870,7 +2866,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:417
+#: lxc/init.go:413
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -4946,7 +4942,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:356
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5786,7 +5782,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:438
+#: lxc/init.go:434
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5947,11 +5943,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:440
+#: lxc/init.go:436
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:439
+#: lxc/init.go:435
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-19 13:11-0600\n"
+"POT-Creation-Date: 2024-09-26 11:55-0600\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Swedish <https://hosted.weblate.org/projects/linux-containers/"
@@ -771,10 +771,6 @@ msgstr ""
 
 #: lxc/init.go:342 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
-msgstr ""
-
-#: lxc/init.go:346
-msgid "Asked for a container but image is of type VM"
 msgstr ""
 
 #: lxc/cluster_group.go:84 lxc/cluster_group.go:85
@@ -1821,7 +1817,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:406
+#: lxc/init.go:402
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -2869,7 +2865,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:417
+#: lxc/init.go:413
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -4945,7 +4941,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:356
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5785,7 +5781,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:438
+#: lxc/init.go:434
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5946,11 +5942,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:440
+#: lxc/init.go:436
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:439
+#: lxc/init.go:435
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 

--- a/po/te.po
+++ b/po/te.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-19 13:11-0600\n"
+"POT-Creation-Date: 2024-09-26 11:55-0600\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Telugu <https://hosted.weblate.org/projects/linux-containers/"
@@ -771,10 +771,6 @@ msgstr ""
 
 #: lxc/init.go:342 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
-msgstr ""
-
-#: lxc/init.go:346
-msgid "Asked for a container but image is of type VM"
 msgstr ""
 
 #: lxc/cluster_group.go:84 lxc/cluster_group.go:85
@@ -1821,7 +1817,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:406
+#: lxc/init.go:402
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -2869,7 +2865,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:417
+#: lxc/init.go:413
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -4945,7 +4941,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:356
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5785,7 +5781,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:438
+#: lxc/init.go:434
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5946,11 +5942,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:440
+#: lxc/init.go:436
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:439
+#: lxc/init.go:435
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 

--- a/po/th.po
+++ b/po/th.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-19 13:11-0600\n"
+"POT-Creation-Date: 2024-09-26 11:55-0600\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -768,10 +768,6 @@ msgstr ""
 
 #: lxc/init.go:342 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
-msgstr ""
-
-#: lxc/init.go:346
-msgid "Asked for a container but image is of type VM"
 msgstr ""
 
 #: lxc/cluster_group.go:84 lxc/cluster_group.go:85
@@ -1818,7 +1814,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:406
+#: lxc/init.go:402
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -2866,7 +2862,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:417
+#: lxc/init.go:413
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -4942,7 +4938,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:356
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5782,7 +5778,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:438
+#: lxc/init.go:434
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5943,11 +5939,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:440
+#: lxc/init.go:436
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:439
+#: lxc/init.go:435
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-19 13:11-0600\n"
+"POT-Creation-Date: 2024-09-26 11:55-0600\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Turkish <https://hosted.weblate.org/projects/linux-containers/"
@@ -771,10 +771,6 @@ msgstr ""
 
 #: lxc/init.go:342 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
-msgstr ""
-
-#: lxc/init.go:346
-msgid "Asked for a container but image is of type VM"
 msgstr ""
 
 #: lxc/cluster_group.go:84 lxc/cluster_group.go:85
@@ -1821,7 +1817,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:406
+#: lxc/init.go:402
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -2869,7 +2865,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:417
+#: lxc/init.go:413
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -4945,7 +4941,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:356
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5785,7 +5781,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:438
+#: lxc/init.go:434
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5946,11 +5942,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:440
+#: lxc/init.go:436
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:439
+#: lxc/init.go:435
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 

--- a/po/tzm.po
+++ b/po/tzm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-19 13:11-0600\n"
+"POT-Creation-Date: 2024-09-26 11:55-0600\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Tamazight (Central Atlas) <https://hosted.weblate.org/"
@@ -771,10 +771,6 @@ msgstr ""
 
 #: lxc/init.go:342 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
-msgstr ""
-
-#: lxc/init.go:346
-msgid "Asked for a container but image is of type VM"
 msgstr ""
 
 #: lxc/cluster_group.go:84 lxc/cluster_group.go:85
@@ -1821,7 +1817,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:406
+#: lxc/init.go:402
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -2869,7 +2865,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:417
+#: lxc/init.go:413
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -4945,7 +4941,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:356
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5785,7 +5781,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:438
+#: lxc/init.go:434
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5946,11 +5942,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:440
+#: lxc/init.go:436
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:439
+#: lxc/init.go:435
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 

--- a/po/ug.po
+++ b/po/ug.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-19 13:11-0600\n"
+"POT-Creation-Date: 2024-09-26 11:55-0600\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Uyghur <https://hosted.weblate.org/projects/linux-containers/"
@@ -771,10 +771,6 @@ msgstr ""
 
 #: lxc/init.go:342 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
-msgstr ""
-
-#: lxc/init.go:346
-msgid "Asked for a container but image is of type VM"
 msgstr ""
 
 #: lxc/cluster_group.go:84 lxc/cluster_group.go:85
@@ -1821,7 +1817,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:406
+#: lxc/init.go:402
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -2869,7 +2865,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:417
+#: lxc/init.go:413
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -4945,7 +4941,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:356
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5785,7 +5781,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:438
+#: lxc/init.go:434
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5946,11 +5942,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:440
+#: lxc/init.go:436
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:439
+#: lxc/init.go:435
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-19 13:11-0600\n"
+"POT-Creation-Date: 2024-09-26 11:55-0600\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Ukrainian <https://hosted.weblate.org/projects/linux-"
@@ -772,10 +772,6 @@ msgstr ""
 
 #: lxc/init.go:342 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
-msgstr ""
-
-#: lxc/init.go:346
-msgid "Asked for a container but image is of type VM"
 msgstr ""
 
 #: lxc/cluster_group.go:84 lxc/cluster_group.go:85
@@ -1822,7 +1818,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:406
+#: lxc/init.go:402
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -2870,7 +2866,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:417
+#: lxc/init.go:413
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -4946,7 +4942,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:356
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5786,7 +5782,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:438
+#: lxc/init.go:434
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5947,11 +5943,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:440
+#: lxc/init.go:436
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:439
+#: lxc/init.go:435
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-19 13:11-0600\n"
+"POT-Creation-Date: 2024-09-26 11:55-0600\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: 0x0916 <w@laoqinren.net>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -932,10 +932,6 @@ msgstr ""
 
 #: lxc/init.go:342 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
-msgstr ""
-
-#: lxc/init.go:346
-msgid "Asked for a container but image is of type VM"
 msgstr ""
 
 #: lxc/cluster_group.go:84 lxc/cluster_group.go:85
@@ -1982,7 +1978,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:406
+#: lxc/init.go:402
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -3030,7 +3026,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:417
+#: lxc/init.go:413
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -5106,7 +5102,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:356
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5946,7 +5942,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:438
+#: lxc/init.go:434
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -6107,11 +6103,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:440
+#: lxc/init.go:436
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:439
+#: lxc/init.go:435
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 

--- a/po/zh_Hant.po
+++ b/po/zh_Hant.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-19 13:11-0600\n"
+"POT-Creation-Date: 2024-09-26 11:55-0600\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Chinese (Traditional) <https://hosted.weblate.org/projects/"
@@ -771,10 +771,6 @@ msgstr ""
 
 #: lxc/init.go:342 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
-msgstr ""
-
-#: lxc/init.go:346
-msgid "Asked for a container but image is of type VM"
 msgstr ""
 
 #: lxc/cluster_group.go:84 lxc/cluster_group.go:85
@@ -1821,7 +1817,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:406
+#: lxc/init.go:402
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -2869,7 +2865,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:417
+#: lxc/init.go:413
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -4945,7 +4941,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:356
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5785,7 +5781,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:438
+#: lxc/init.go:434
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5946,11 +5942,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:440
+#: lxc/init.go:436
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:439
+#: lxc/init.go:435
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 


### PR DESCRIPTION
Reverting additional error handling included in https://github.com/canonical/lxd/pull/14137 to avoid introducing regressions to `lxd-ci`. We can keep the test included in https://github.com/canonical/lxd/pull/14137.