### PR TITLE
Fix cloud-init instance key typos

### DIFF
--- a/doc/metadata.txt
+++ b/doc/metadata.txt
@@ -2505,7 +2505,7 @@ The template with the given name is triggered upon next startup.
 The hash of the image that the instance was created from (empty if the instance was not created from an image).
 ```
 
-```{config:option} volatile.cloud_init.instance-id instance-volatile
+```{config:option} volatile.cloud-init.instance-id instance-volatile
 :shortdesc: "`instance-id` (UUID) exposed to `cloud-init`"
 :type: "string"
 

--- a/lxd/instance/instancetype/instance.go
+++ b/lxd/instance/instancetype/instance.go
@@ -435,7 +435,7 @@ var InstanceConfigKeysAny = map[string]func(value string) error{
 	//  shortdesc: Hash of the base image
 	"volatile.base_image": validate.IsAny,
 
-	// lxdmeta:generate(entities=instance; group=volatile; key=volatile.cloud_init.instance-id)
+	// lxdmeta:generate(entities=instance; group=volatile; key=volatile.cloud-init.instance-id)
 	//
 	// ---
 	//  type: string

--- a/lxd/metadata/configuration.json
+++ b/lxd/metadata/configuration.json
@@ -2818,7 +2818,7 @@
 						}
 					},
 					{
-						"volatile.cloud_init.instance-id": {
+						"volatile.cloud-init.instance-id": {
 							"longdesc": "",
 							"shortdesc": "`instance-id` (UUID) exposed to `cloud-init`",
 							"type": "string"


### PR DESCRIPTION
It looks like `volatile.cloud_init.instance-id` should actually be `volatile.cloud-init.instance-id` on [this page](https://documentation.ubuntu.com/lxd/en/latest/reference/instance_options/#instance-volatile:volatile.cloud_init.instance-id). I found a few other references in a grep of the code base.