### PR TITLE
Add trailing `/` to `ubuntu:` and `ubuntu-daily:` remotes to avoid redirects

### DIFF
--- a/client/doc.go
+++ b/client/doc.go
@@ -115,7 +115,7 @@
 //	}
 //
 //	// Connect to the remote SimpleStreams server
-//	d, err = lxd.ConnectSimpleStreams("https://cloud-images.ubuntu.com/releases", nil)
+//	d, err = lxd.ConnectSimpleStreams("https://cloud-images.ubuntu.com/releases/", nil)
 //	if err != nil {
 //	  return err
 //	}

--- a/doc/howto/instances_create.md
+++ b/doc/howto/instances_create.md
@@ -127,7 +127,7 @@ To create a container with an Ubuntu 24.04 LTS image from the `ubuntu` server us
       "source": {
         "alias": "24.04",
         "protocol": "simplestreams",
-        "server": "https://cloud-images.ubuntu.com/releases",
+        "server": "https://cloud-images.ubuntu.com/releases/",
         "type": "image"
       }
     }'
@@ -154,7 +154,7 @@ To create a virtual machine with an Ubuntu 24.04 LTS image from the `ubuntu` ser
       "source": {
         "alias": "24.04",
         "protocol": "simplestreams",
-        "server": "https://cloud-images.ubuntu.com/releases",
+        "server": "https://cloud-images.ubuntu.com/releases/",
         "type": "image"
       },
       "type": "virtual-machine"
@@ -188,7 +188,7 @@ Or with a bigger disk:
       "source": {
         "alias": "24.04",
         "protocol": "simplestreams",
-        "server": "https://cloud-images.ubuntu.com/releases",
+        "server": "https://cloud-images.ubuntu.com/releases/",
         "type": "image"
       },
       "type": "virtual-machine"
@@ -220,7 +220,7 @@ To create a container and limit its resources to one vCPU and 8 GiB of RAM:
       "source": {
         "alias": "24.04",
         "protocol": "simplestreams",
-        "server": "https://cloud-images.ubuntu.com/releases",
+        "server": "https://cloud-images.ubuntu.com/releases/",
         "type": "image"
       }
     }'
@@ -247,7 +247,7 @@ To create a virtual machine on the cluster member `micro2`, enter the following 
       "source": {
         "alias": "24.04",
         "protocol": "simplestreams",
-        "server": "https://cloud-images.ubuntu.com/releases",
+        "server": "https://cloud-images.ubuntu.com/releases/",
         "type": "image"
       },
       "type": "virtual-machine"
@@ -293,7 +293,7 @@ To create a container with this instance type:
       "source": {
         "alias": "24.04",
         "protocol": "simplestreams",
-        "server": "https://cloud-images.ubuntu.com/releases",
+        "server": "https://cloud-images.ubuntu.com/releases/",
         "type": "image"
       }
     }'

--- a/doc/howto/instances_routed_nic_vm.md
+++ b/doc/howto/instances_routed_nic_vm.md
@@ -17,7 +17,7 @@ To configure the gateways with `cloud-init`, firstly initialize an instance:
       "source": {
         "alias": "24.04",
         "protocol": "simplestreams",
-        "server": "https://cloud-images.ubuntu.com/releases",
+        "server": "https://cloud-images.ubuntu.com/releases/",
         "type": "image"
       },
       "type": "virtual-machine"

--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -1221,7 +1221,7 @@ definitions:
                 x-go-name: Protocol
             server:
                 description: URL of the source server
-                example: https://cloud-images.ubuntu.com/releases
+                example: https://cloud-images.ubuntu.com/releases/
                 type: string
                 x-go-name: Server
         type: object
@@ -1336,7 +1336,7 @@ definitions:
                 x-go-name: Secret
             server:
                 description: URL of the source server
-                example: https://cloud-images.ubuntu.com/releases
+                example: https://cloud-images.ubuntu.com/releases/
                 type: string
                 x-go-name: Server
             type:
@@ -2370,7 +2370,7 @@ definitions:
                 x-go-name: Websockets
             server:
                 description: Remote server URL (for remote images)
-                example: https://cloud-images.ubuntu.com/releases
+                example: https://cloud-images.ubuntu.com/releases/
                 type: string
                 x-go-name: Server
             source:

--- a/lxc/config/default.go
+++ b/lxc/config/default.go
@@ -24,7 +24,7 @@ var UbuntuRemote = Remote{
 
 // UbuntuDailyRemote is the Ubuntu daily image server (over simplestreams).
 var UbuntuDailyRemote = Remote{
-	Addr:     "https://cloud-images.ubuntu.com/daily",
+	Addr:     "https://cloud-images.ubuntu.com/daily/",
 	Static:   true,
 	Public:   true,
 	Protocol: "simplestreams",

--- a/lxc/config/default.go
+++ b/lxc/config/default.go
@@ -16,7 +16,7 @@ var ImagesRemote = Remote{
 
 // UbuntuRemote is the Ubuntu image server (over simplestreams).
 var UbuntuRemote = Remote{
-	Addr:     "https://cloud-images.ubuntu.com/releases",
+	Addr:     "https://cloud-images.ubuntu.com/releases/",
 	Static:   true,
 	Public:   true,
 	Protocol: "simplestreams",

--- a/shared/api/image.go
+++ b/shared/api/image.go
@@ -258,7 +258,7 @@ type ImageSource struct {
 	Protocol string `json:"protocol" yaml:"protocol"`
 
 	// URL of the source server
-	// Example: https://cloud-images.ubuntu.com/releases
+	// Example: https://cloud-images.ubuntu.com/releases/
 	Server string `json:"server" yaml:"server"`
 
 	// Type of image (container or virtual-machine)

--- a/shared/api/instance.go
+++ b/shared/api/instance.go
@@ -368,7 +368,7 @@ type InstanceSource struct {
 	Properties map[string]string `json:"properties,omitempty" yaml:"properties,omitempty"`
 
 	// Remote server URL (for remote images)
-	// Example: https://cloud-images.ubuntu.com/releases
+	// Example: https://cloud-images.ubuntu.com/releases/
 	Server string `json:"server,omitempty" yaml:"server,omitempty"`
 
 	// Remote server secret (for remote private images)

--- a/test/suites/remote.sh
+++ b/test/suites/remote.sh
@@ -28,8 +28,8 @@ test_remote_url() {
 
   # Check that we can add simplestream remotes with valid certs without confirmation
   if [ -z "${LXD_OFFLINE:-}" ]; then
-    lxc_remote remote add ubuntu1 https://cloud-images.ubuntu.com/releases --protocol=simplestreams
-    lxc_remote remote add ubuntu2 https://cloud-images.ubuntu.com:443/releases --protocol=simplestreams
+    lxc_remote remote add ubuntu1 https://cloud-images.ubuntu.com/releases/ --protocol=simplestreams
+    lxc_remote remote add ubuntu2 https://cloud-images.ubuntu.com:443/releases/ --protocol=simplestreams
     lxc_remote remote remove ubuntu1
     lxc_remote remote remove ubuntu2
   fi


### PR DESCRIPTION
Of the 4 builtin remotes, 2 don't have a trailing `/`:

```
$ lxc remote list -f csv | awk -F, '/^ubuntu/ {print $2}' | grep -v /$
https://cloud-images.ubuntu.com/releases
https://cloud-images.ubuntu.com/daily
```

They should probably have one to avoid a permanent redirection (301):

```
$ wget -qSO /dev/null https://cloud-images.ubuntu.com/releases 2>&1 | grep -E 'HTTP/|Location'
  HTTP/1.1 301 Moved Permanently
  Location: https://cloud-images.ubuntu.com/releases/
  HTTP/1.1 200 OK

$ wget -qSO /dev/null https://cloud-images.ubuntu.com/daily 2>&1 | grep -E 'HTTP/|Location'
  HTTP/1.1 301 Moved Permanently
  Location: https://cloud-images.ubuntu.com/daily/
  HTTP/1.1 200 OK
```