### PR TITLE
Use `strings.Cut()` where appropriate.

### DIFF
--- a/lxc/completion.go
+++ b/lxc/completion.go
@@ -334,7 +334,7 @@ func (g *cmdGlobal) cmpInstancesAndSnapshots(toComplete string) ([]string, cobra
 		resource := resources[0]
 
 		if strings.Contains(resource.name, shared.SnapshotDelimiter) {
-			instName := strings.SplitN(resource.name, shared.SnapshotDelimiter, 2)[0]
+			instName, _, _ := strings.Cut(resource.name, shared.SnapshotDelimiter)
 			snapshots, _ := resource.server.GetInstanceSnapshotNames(instName)
 			for _, snapshot := range snapshots {
 				results = append(results, fmt.Sprintf("%s/%s", instName, snapshot))

--- a/lxc/config/remote.go
+++ b/lxc/config/remote.go
@@ -32,22 +32,22 @@ type Remote struct {
 
 // ParseRemote splits remote and object.
 func (c *Config) ParseRemote(raw string) (remoteName string, resourceName string, err error) {
-	result := strings.SplitN(raw, ":", 2)
-	if len(result) == 1 {
+	remote, object, found := strings.Cut(raw, ":")
+	if !found {
 		return c.DefaultRemote, raw, nil
 	}
 
-	_, ok := c.Remotes[result[0]]
+	_, ok := c.Remotes[remote]
 	if !ok {
 		// Attempt to play nice with snapshots containing ":"
-		if shared.IsSnapshot(raw) && shared.IsSnapshot(result[0]) {
+		if shared.IsSnapshot(raw) && shared.IsSnapshot(remote) {
 			return c.DefaultRemote, raw, nil
 		}
 
-		return "", "", fmt.Errorf("The remote \"%s\" doesn't exist", result[0])
+		return "", "", fmt.Errorf("The remote \"%s\" doesn't exist", remote)
 	}
 
-	return result[0], result[1], nil
+	return remote, object, nil
 }
 
 // GetInstanceServer returns a lxd.InstanceServer for the remote with the given name.

--- a/lxc/exec.go
+++ b/lxc/exec.go
@@ -124,13 +124,10 @@ func (c *cmdExec) run(cmd *cobra.Command, args []string) error {
 	}
 
 	for _, arg := range c.flagEnvironment {
-		pieces := strings.SplitN(arg, "=", 2)
-		value := ""
-		if len(pieces) > 1 {
-			value = pieces[1]
+		variable, value, found := strings.Cut(arg, "=")
+		if found {
+			env[variable] = value
 		}
-
-		env[pieces[0]] = value
 	}
 
 	// Configure the terminal

--- a/lxc/project.go
+++ b/lxc/project.go
@@ -960,7 +960,7 @@ func (c *cmdProjectInfo) run(cmd *cobra.Command, args []string) error {
 	byteLimits := []string{"disk", "memory"}
 	data := [][]string{}
 	for k, v := range projectState.Resources {
-		shortKey := strings.SplitN(k, ".", 2)[0]
+		shortKey, _, _ := strings.Cut(k, ".")
 
 		limit := i18n.G("UNLIMITED")
 		if v.Limit >= 0 {
@@ -979,9 +979,9 @@ func (c *cmdProjectInfo) run(cmd *cobra.Command, args []string) error {
 		}
 
 		columnName := strings.ToUpper(k)
-		fields := strings.SplitN(columnName, ".", 2)
-		if len(fields) == 2 {
-			columnName = fmt.Sprintf("%s (%s)", fields[0], fields[1])
+		before, after, found := strings.Cut(columnName, ".")
+		if found {
+			columnName = fmt.Sprintf("%s (%s)", before, after)
 		}
 
 		data = append(data, []string{columnName, limit, usage})


### PR DESCRIPTION
`strings.Cut()` is a wrapper around `stringslite.Cut()`: https://cs.opensource.google/go/go/+/refs/tags/go1.23.1:src/internal/stringslite/strings.go;l=108
`strings.SplitN()` is a wrapper around `strings.genSplit()`: https://cs.opensource.google/go/go/+/refs/tags/go1.23.1:src/strings/strings.go;l=236

The former (`strings.Cut()`) seems to be slightly more efficient as it doesn't do any slice allocation.