### PR TITLE
lxd/ubuntupro: Return host guest attachment setting if instance setting is unset

### DIFF
--- a/lxd/ubuntupro/client.go
+++ b/lxd/ubuntupro/client.go
@@ -125,9 +125,9 @@ func (s *Client) getGuestAttachSetting(instanceSetting string) string {
 		return guestAttachSettingOff
 	}
 
-	// The `ubuntu_pro.guest_attach` setting is optional.
+	// The `ubuntu_pro.guest_attach` setting is optional. If it is not set, return the host's guest attach setting.
 	if instanceSetting == "" {
-		return guestAttachSettingOff
+		return s.guestAttachSetting
 	}
 
 	// If the setting is not empty, check it is valid. This should have been validated already when setting the value so

--- a/lxd/ubuntupro/client_test.go
+++ b/lxd/ubuntupro/client_test.go
@@ -91,12 +91,35 @@ func TestClient(t *testing.T) {
 		},
 	}
 
-	assertionsWhenHostHasGuestAttachmentOnOrAvailable := []assertion{
+	assertionsWhenHostHasGuestAttachmentAvailable := []assertion{
 		{
-			instanceSetting:   "",
+			instanceSetting: "",
+			expectedSetting: guestAttachSettingAvailable,
+			expectedToken:   &mockTokenResponse,
+		},
+		{
+			instanceSetting:   guestAttachSettingOff,
 			expectedSetting:   guestAttachSettingOff,
 			expectErr:         true,
 			expectedErrorCode: http.StatusForbidden,
+		},
+		{
+			instanceSetting: guestAttachSettingAvailable,
+			expectedSetting: guestAttachSettingAvailable,
+			expectedToken:   &mockTokenResponse,
+		},
+		{
+			instanceSetting: guestAttachSettingOn,
+			expectedSetting: guestAttachSettingOn,
+			expectedToken:   &mockTokenResponse,
+		},
+	}
+
+	assertionsWhenHostHasGuestAttachmentOn := []assertion{
+		{
+			instanceSetting: "",
+			expectedSetting: guestAttachSettingOn,
+			expectedToken:   &mockTokenResponse,
 		},
 		{
 			instanceSetting:   guestAttachSettingOff,
@@ -169,7 +192,7 @@ func TestClient(t *testing.T) {
 	// Write '{"guest_attach":"available"}' to the settings file.
 	writeSettingsFile(lxdConfigFilepath, "", guestAttachSettingAvailable)
 	assert.Equal(t, guestAttachSettingAvailable, s.guestAttachSetting)
-	runAssertions(assertionsWhenHostHasGuestAttachmentOnOrAvailable)
+	runAssertions(assertionsWhenHostHasGuestAttachmentAvailable)
 
 	// Write '{"guest_attach":"off"}' to the settings file.
 	writeSettingsFile(lxdConfigFilepath, "", guestAttachSettingOff)
@@ -179,7 +202,7 @@ func TestClient(t *testing.T) {
 	// Write '{"guest_attach":"on"}' to the settings file.
 	writeSettingsFile(lxdConfigFilepath, "", guestAttachSettingOn)
 	assert.Equal(t, guestAttachSettingOn, s.guestAttachSetting)
-	runAssertions(assertionsWhenHostHasGuestAttachmentOnOrAvailable)
+	runAssertions(assertionsWhenHostHasGuestAttachmentOn)
 
 	// Write invalid JSON to the settings file.
 	writeSettingsFile(lxdConfigFilepath, "{{}\\foo", "")
@@ -189,7 +212,7 @@ func TestClient(t *testing.T) {
 	// Write '{"guest_attach":"on"}' to the settings file.
 	writeSettingsFile(lxdConfigFilepath, "", guestAttachSettingOn)
 	assert.Equal(t, guestAttachSettingOn, s.guestAttachSetting)
-	runAssertions(assertionsWhenHostHasGuestAttachmentOnOrAvailable)
+	runAssertions(assertionsWhenHostHasGuestAttachmentOn)
 
 	// Write an invalid setting to the settings file.
 	writeSettingsFile(lxdConfigFilepath, "", "foo")
@@ -199,7 +222,7 @@ func TestClient(t *testing.T) {
 	// Write '{"guest_attach":"on"}' to the settings file.
 	writeSettingsFile(lxdConfigFilepath, "", guestAttachSettingOn)
 	assert.Equal(t, guestAttachSettingOn, s.guestAttachSetting)
-	runAssertions(assertionsWhenHostHasGuestAttachmentOnOrAvailable)
+	runAssertions(assertionsWhenHostHasGuestAttachmentOn)
 
 	// Remove the config file.
 	err = os.Remove(lxdConfigFilepath)
@@ -220,7 +243,7 @@ func TestClient(t *testing.T) {
 	require.NoError(t, err)
 	sleep()
 	assert.Equal(t, guestAttachSettingOn, s.guestAttachSetting)
-	runAssertions(assertionsWhenHostHasGuestAttachmentOnOrAvailable)
+	runAssertions(assertionsWhenHostHasGuestAttachmentOn)
 
 	// Cancel the context.
 	cancel()


### PR DESCRIPTION
From the Ubuntu Pro guest attachment specification:

> A user can attempt to run `pro auto-attach` at any time on a LXD guest,
> even if `ubuntu_pro.guest_attach` is not set to on; however, if it is set to off,
> the process will fail when LXD blocks a request (described below).

The initial implementation defaulted to returning "off" when `ubuntu_pro.guest_attach` was unset. This was overriding the host setting. (I was testing manually with the impression that this was expected behaviour).

Instead, we should return the host guest attachment setting when the instance setting is empty.

What this means:
- `pro config set lxd_guest_attach=on` & `ubuntu_pro.guest_attach` is unset: Ubuntu instances will auto-attach at startup.
- `pro config set lxd_guest_attach=available` and `ubuntu_pro.guest_attach` is unset: Ubuntu instance will not auto-attach at startup, but `pro auto-attach` will succeed.
- `pro config set lxd_guest_attach=off` & `ubuntu_pro.guest_attach` is unset: Ubuntu instances will not auto-attach at start up and `pro auto-attach` will fail with 403 Forbidden.