### PR TITLE
Auth: Redefine identity certificate entity types to prevent overlap

### DIFF
--- a/lxd/auth_groups.go
+++ b/lxd/auth_groups.go
@@ -855,7 +855,6 @@ func upsertPermissions(ctx context.Context, tx *sql.Tx, groupID int, permissions
 		}
 
 		authGroupPermissions = append(authGroupPermissions, dbCluster.Permission{
-			GroupID:     groupID,
 			Entitlement: entitlement,
 			EntityType:  entityType,
 			EntityID:    entityRef.EntityID,

--- a/lxd/db/cluster/auth_groups.go
+++ b/lxd/db/cluster/auth_groups.go
@@ -287,7 +287,7 @@ func SetAuthGroupPermissions(ctx context.Context, tx *sql.Tx, groupID int, authG
 	}
 
 	for _, permission := range authGroupPermissions {
-		_, err := tx.ExecContext(ctx, `INSERT INTO auth_groups_permissions (auth_group_id, entity_type, entity_id, entitlement) VALUES (?, ?, ?, ?);`, permission.GroupID, permission.EntityType, permission.EntityID, permission.Entitlement)
+		_, err := tx.ExecContext(ctx, `INSERT INTO auth_groups_permissions (auth_group_id, entity_type, entity_id, entitlement) VALUES (?, ?, ?, ?);`, groupID, permission.EntityType, permission.EntityID, permission.Entitlement)
 		if err != nil {
 			return fmt.Errorf("Failed to write group permissions: %w", err)
 		}

--- a/lxd/db/cluster/entity_type_certificate.go
+++ b/lxd/db/cluster/entity_type_certificate.go
@@ -12,7 +12,16 @@ func (e entityTypeCertificate) code() int64 {
 }
 
 func (e entityTypeCertificate) allURLsQuery() string {
-	return fmt.Sprintf(`SELECT %d, identities.id, '', '', json_array(identities.identifier) FROM identities WHERE auth_method = %d`, e.code(), authMethodTLS)
+	return fmt.Sprintf(
+		`SELECT %d, identities.id, '', '', json_array(identities.identifier) FROM identities WHERE auth_method = %d AND type IN (%d, %d, %d, %d, %d)`,
+		e.code(),
+		authMethodTLS,
+		identityTypeCertificateClientRestricted,
+		identityTypeCertificateClientUnrestricted,
+		identityTypeCertificateServer,
+		identityTypeCertificateMetricsRestricted,
+		identityTypeCertificateMetricsUnrestricted,
+	)
 }
 
 func (e entityTypeCertificate) urlsByProjectQuery() string {
@@ -31,7 +40,14 @@ WHERE '' = ?
 	AND '' = ? 
 	AND identities.identifier = ? 
 	AND identities.auth_method = %d
-`, authMethodTLS)
+	AND identities.type IN (%d, %d, %d, %d, %d)
+`, authMethodTLS,
+		identityTypeCertificateClientRestricted,
+		identityTypeCertificateClientUnrestricted,
+		identityTypeCertificateServer,
+		identityTypeCertificateMetricsRestricted,
+		identityTypeCertificateMetricsUnrestricted,
+	)
 }
 
 func (e entityTypeCertificate) onDeleteTriggerSQL() (name string, sql string) {

--- a/lxd/db/cluster/entity_type_identity.go
+++ b/lxd/db/cluster/entity_type_identity.go
@@ -28,10 +28,12 @@ SELECT
 		identities.identifier
 	) 
 FROM identities
+WHERE type IN (%d)
 `,
 		e.code(),
 		authMethodTLS, api.AuthenticationMethodTLS,
 		authMethodOIDC, api.AuthenticationMethodOIDC,
+		identityTypeOIDCClient,
 	)
 }
 
@@ -40,7 +42,7 @@ func (e entityTypeIdentity) urlsByProjectQuery() string {
 }
 
 func (e entityTypeIdentity) urlByIDQuery() string {
-	return fmt.Sprintf(`%s WHERE identities.id = ?`, e.allURLsQuery())
+	return fmt.Sprintf(`%s AND identities.id = ?`, e.allURLsQuery())
 }
 
 func (e entityTypeIdentity) idFromURLQuery() string {
@@ -54,8 +56,11 @@ WHERE '' = ?
 		WHEN %d THEN '%s' 
 	END = ? 
 	AND identities.identifier = ?
+	AND identities.type IN (%d)
 `, authMethodTLS, api.AuthenticationMethodTLS,
-		authMethodOIDC, api.AuthenticationMethodOIDC)
+		authMethodOIDC, api.AuthenticationMethodOIDC,
+		identityTypeOIDCClient,
+	)
 }
 
 func (e entityTypeIdentity) onDeleteTriggerSQL() (name string, sql string) {

--- a/lxd/identity/util.go
+++ b/lxd/identity/util.go
@@ -8,6 +8,11 @@ import (
 	"github.com/canonical/lxd/shared/api"
 )
 
+// IsFineGrainedIdentityType returns true if permissions of the identity type are managed via group membership.
+func IsFineGrainedIdentityType(identityType string) bool {
+	return shared.ValueInSlice(identityType, []string{api.IdentityTypeOIDCClient})
+}
+
 // IsRestrictedIdentityType returns whether the given identity is restricted or not. Identity types that are not
 // restricted have full access to LXD. An error is returned if the identity type is not recognised.
 func IsRestrictedIdentityType(identityType string) (bool, error) {

--- a/lxd/patches_test.go
+++ b/lxd/patches_test.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/canonical/lxd/lxd/auth"
+	"github.com/canonical/lxd/lxd/certificate"
+	"github.com/canonical/lxd/lxd/db"
+	dbCluster "github.com/canonical/lxd/lxd/db/cluster"
+	"github.com/canonical/lxd/shared"
+	"github.com/canonical/lxd/shared/api"
+	"github.com/canonical/lxd/shared/entity"
+)
+
+func Test_patchSplitIdentityCertificateEntityTypes(t *testing.T) {
+	// Set up test database.
+	cluster, cleanup := db.NewTestCluster(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	var groupID int
+	var certificateID int
+	var identityID int
+	err := cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
+		// Create a group.
+		groupIDint64, err := dbCluster.CreateAuthGroup(ctx, tx.Tx(), dbCluster.AuthGroup{
+			Name: "test-group",
+		})
+		require.NoError(t, err)
+		groupID = int(groupIDint64)
+
+		// Create a certificate
+		cert, _, err := shared.GenerateMemCert(true, shared.CertOptions{})
+		require.NoError(t, err)
+		x509Cert, err := shared.ParseCert(cert)
+		require.NoError(t, err)
+
+		certificateIDint64, err := dbCluster.CreateCertificate(ctx, tx.Tx(), dbCluster.Certificate{
+			Fingerprint: shared.CertFingerprint(x509Cert),
+			Type:        certificate.TypeClient,
+			Name:        "test-cert",
+			Certificate: string(cert),
+			Restricted:  false,
+		})
+		require.NoError(t, err)
+		certificateID = int(certificateIDint64)
+
+		// Create an OIDC identity
+		oidcMetadata, err := json.Marshal(dbCluster.OIDCMetadata{Subject: "test-subject"})
+		require.NoError(t, err)
+		identityIDint64, err := dbCluster.CreateIdentity(ctx, tx.Tx(), dbCluster.Identity{
+			AuthMethod: api.AuthenticationMethodOIDC,
+			Type:       api.IdentityTypeOIDCClient,
+			Identifier: "jane.doe@example.com",
+			Name:       "Jane Doe",
+			Metadata:   string(oidcMetadata),
+		})
+		require.NoError(t, err)
+		identityID = int(identityIDint64)
+
+		// Create three permissions for the group.
+		err = dbCluster.SetAuthGroupPermissions(ctx, tx.Tx(), groupID, []dbCluster.Permission{
+			{
+				// This permission has "identity" as the entity type but references a certificate. We expect the entity
+				// type to change to "certificate" after the patch.
+				Entitlement: auth.EntitlementCanView,
+				EntityType:  dbCluster.EntityType(entity.TypeIdentity),
+				EntityID:    certificateID,
+			},
+			{
+				// This permission has "certificate" as the entity type. We expect that this will be replaced after the patch.
+				Entitlement: auth.EntitlementCanView,
+				EntityType:  dbCluster.EntityType(entity.TypeCertificate),
+				EntityID:    certificateID,
+			},
+			{
+				// This permission also has "identity" as the entity type and this references an OIDC client. The entity
+				// type for this permission should not change.
+				Entitlement: auth.EntitlementCanView,
+				EntityType:  dbCluster.EntityType(entity.TypeIdentity),
+				EntityID:    identityID,
+			},
+		})
+		require.NoError(t, err)
+		return nil
+	})
+	require.NoError(t, err)
+
+	// Run the patch.
+	daemonDB := &db.DB{Cluster: cluster}
+	daemon := &Daemon{db: daemonDB, shutdownCtx: ctx}
+	err = patchSplitIdentityCertificateEntityTypes("", daemon)
+	require.NoError(t, err)
+
+	// Get the permissions.
+	err = cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
+		permissions, err := dbCluster.GetPermissionsByAuthGroupID(ctx, tx.Tx(), groupID)
+		require.NoError(t, err)
+
+		// The second permission should have been overwritten, so there should now only be two permissions.
+		assert.Len(t, permissions, 2)
+
+		// The first permission we created should have the entity type changed to "certificate".
+		assert.Equal(t, entity.TypeCertificate, entity.Type(permissions[0].EntityType))
+
+		// The entity type of the third permission should not have changed.
+		assert.Equal(t, entity.TypeIdentity, entity.Type(permissions[1].EntityType))
+		return nil
+	})
+	require.NoError(t, err)
+}

--- a/test/suites/auth.sh
+++ b/test/suites/auth.sh
@@ -35,7 +35,7 @@ test_authorization() {
   ! lxc auth group permission add test-group identity "tls/${tls_user_fingerprint}" can_view || false # The certificate is not an identity, it is a certificate.
 
   # Project permissions.
-  ! lxc auth group permission add test-group project not-found operator # Not found
+  ! lxc auth group permission add test-group project not-found operator || false # Not found
   lxc auth group permission add test-group project default operator # Valid
   lxc auth group permission remove test-group project default operator # Valid
   ! lxc auth group permission remove test-group project default operator || false # Already removed

--- a/test/suites/auth.sh
+++ b/test/suites/auth.sh
@@ -27,11 +27,12 @@ test_authorization() {
   ! lxc auth group permission remove test-group server admin || false # Permission already removed
   ! lxc auth group permission add test-group server not_a_server_entitlement || false # Invalid entitlement
 
-  # Identity permissions.
-  ! lxc auth group permission add test-group identity "${tls_user_fingerprint}" can_view || false # Missing authentication method
-  lxc auth group permission add test-group identity "tls/${tls_user_fingerprint}" can_view # Valid
-  lxc auth group permission remove test-group identity "tls/${tls_user_fingerprint}" can_view
-  ! lxc auth group permission remove test-group identity "tls/${tls_user_fingerprint}" can_view || false # Already removed
+  # Certificate permissions.
+  ! lxc auth group permission add test-group certificate notacertificate can_view || false # Not found
+  lxc auth group permission add test-group certificate "${tls_user_fingerprint}" can_view # Valid
+  lxc auth group permission remove test-group certificate "${tls_user_fingerprint}" can_view
+  ! lxc auth group permission remove test-group certificate "${tls_user_fingerprint}" can_view || false # Already removed
+  ! lxc auth group permission add test-group identity "tls/${tls_user_fingerprint}" can_view || false # The certificate is not an identity, it is a certificate.
 
   # Project permissions.
   ! lxc auth group permission add test-group project not-found operator # Not found
@@ -95,6 +96,12 @@ effective_permissions: []
 EOF
 )
   lxc auth identity info oidc: | grep -Fz "${expected}"
+
+  # Identity permissions.
+  ! lxc auth group permission add test-group identity test-user@example.com can_view || false # Missing authentication method
+  lxc auth group permission add test-group identity oidc/test-user@example.com can_view # Valid
+  lxc auth group permission remove test-group identity oidc/test-user@example.com can_view
+  ! lxc auth group permission remove test-group identity oidc/test-user@example.com can_view || false # Already removed
 
   ### IDENTITY PROVIDER GROUP MANAGEMENT ###
   lxc auth identity-provider-group create test-idp-group


### PR DESCRIPTION
This PR redefines the `identity` and `certificate` entity types such that a `certificate` is considered to be any existing certificate type (e.g. client, metrics, server) and an `identity` is any identity whose permissions are managed via group membership.

Closes #13372 

Opening as draft as I would like to perform more testing on the patch before merging.