### PR TITLE
WIP: Fix liblxc stop hooks when snap base changes

### DIFF
--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -4354,7 +4354,8 @@ func (d *lxc) Update(args db.InstanceArgs, userRequested bool) error {
 	// If raw.lxc changed, re-validate the config.
 	if shared.ValueInSlice("raw.lxc", changedConfig) && d.expandedConfig["raw.lxc"] != "" {
 		// Get a new liblxc instance.
-		cc, err := liblxc.NewContainer(d.name, d.state.OS.LxcPath)
+		cname := project.Instance(d.Project().Name, d.Name())
+		cc, err := liblxc.NewContainer(cname, d.state.OS.LxcPath)
 		if err != nil {
 			return err
 		}

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -934,13 +934,13 @@ func (d *lxc) initLXC(config bool) (*liblxc.Container, error) {
 	}
 
 	// Call the onstopns hook on stop but before namespaces are unmounted.
-	err = lxcSetConfigItem(cc, "lxc.hook.stop", fmt.Sprintf("%s callhook %s %s %s stopns", d.state.OS.ExecPath, shared.VarPath(""), strconv.Quote(d.Project().Name), strconv.Quote(d.Name())))
+	err = lxcSetConfigItem(cc, "lxc.hook.stop", fmt.Sprintf("%s callhook %s %s %s stopns", "/snap/lxd/current/bin/lxd-lxc-stop", shared.VarPath(""), strconv.Quote(d.Project().Name), strconv.Quote(d.Name())))
 	if err != nil {
 		return nil, err
 	}
 
 	// Call the onstop hook on stop.
-	err = lxcSetConfigItem(cc, "lxc.hook.post-stop", fmt.Sprintf("%s callhook %s %s %s stop", d.state.OS.ExecPath, shared.VarPath(""), strconv.Quote(d.Project().Name), strconv.Quote(d.Name())))
+	err = lxcSetConfigItem(cc, "lxc.hook.post-stop", fmt.Sprintf("%s callhook %s %s %s stop", "/snap/lxd/current/bin/lxd-lxc-stop", shared.VarPath(""), strconv.Quote(d.Project().Name), strconv.Quote(d.Name())))
 	if err != nil {
 		return nil, err
 	}

--- a/lxd/patches.go
+++ b/lxd/patches.go
@@ -494,10 +494,10 @@ func patchVMRenameUUIDKey(name string, d *Daemon) error {
 					newUUIDKey: uuid,
 				}
 
-				logger.Debugf("Renaming config key %q to %q for VM %q (Project %q)", oldUUIDKey, newUUIDKey, inst.Name, inst.Project)
+				logger.Debugf("Renaming config key %q to %q for VM %q (project %q)", oldUUIDKey, newUUIDKey, inst.Name, inst.Project)
 				err := tx.UpdateInstanceConfig(inst.ID, changes)
 				if err != nil {
-					return fmt.Errorf("Failed renaming config key %q to %q for VM %q (Project %q): %w", oldUUIDKey, newUUIDKey, inst.Name, inst.Project, err)
+					return fmt.Errorf("Failed renaming config key %q to %q for VM %q (project %q): %w", oldUUIDKey, newUUIDKey, inst.Name, inst.Project, err)
 				}
 			}
 
@@ -519,10 +519,10 @@ func patchVMRenameUUIDKey(name string, d *Daemon) error {
 						newUUIDKey: uuid,
 					}
 
-					logger.Debugf("Renaming config key %q to %q for VM %q (Project %q)", oldUUIDKey, newUUIDKey, snap.Name, snap.Project)
+					logger.Debugf("Renaming config key %q to %q for VM %q (project %q)", oldUUIDKey, newUUIDKey, snap.Name, snap.Project)
 					err = tx.UpdateInstanceSnapshotConfig(snap.ID, changes)
 					if err != nil {
-						return fmt.Errorf("Failed renaming config key %q to %q for VM %q (Project %q): %w", oldUUIDKey, newUUIDKey, snap.Name, snap.Project, err)
+						return fmt.Errorf("Failed renaming config key %q to %q for VM %q (project %q): %w", oldUUIDKey, newUUIDKey, snap.Name, snap.Project, err)
 					}
 				}
 			}
@@ -1395,14 +1395,14 @@ func patchInstanceRemoveVolatileLastStateIPAddresses(_ string, d *Daemon) error 
 				l.Debug("Removing config key from instance", logger.Ctx{"key": k})
 				err := tx.UpdateInstanceConfig(dbInst.ID, changes)
 				if err != nil {
-					return fmt.Errorf("Failed removing config key %q for instance %q (Project %q): %w", k, dbInst.Name, dbInst.Project, err)
+					return fmt.Errorf("Failed removing config key %q for instance %q (project %q): %w", k, dbInst.Name, dbInst.Project, err)
 				}
 			}
 
 			// Get snapshots for instance so we can check those too.
 			dbSnaps, err := tx.GetInstanceSnapshotsWithName(ctx, dbInst.Project, dbInst.Name)
 			if err != nil {
-				return fmt.Errorf("Failed getting snapshots for %q (Project %q): %w", dbInst.Name, dbInst.Project, err)
+				return fmt.Errorf("Failed getting snapshots for %q (project %q): %w", dbInst.Name, dbInst.Project, err)
 			}
 
 			for _, dbSnap := range dbSnaps {
@@ -1424,7 +1424,7 @@ func patchInstanceRemoveVolatileLastStateIPAddresses(_ string, d *Daemon) error 
 					l.Debug("Removing config key from instance snapshot", logger.Ctx{"snapshot": dbSnap.Name, "key": k})
 					err := tx.UpdateInstanceSnapshotConfig(dbSnap.ID, changes)
 					if err != nil {
-						return fmt.Errorf("Failed removing config key %q for instance %q (Project %q): %w", k, dbSnap.Name, dbSnap.Project, err)
+						return fmt.Errorf("Failed removing config key %q for instance %q (project %q): %w", k, dbSnap.Name, dbSnap.Project, err)
 					}
 				}
 			}


### PR DESCRIPTION
Used with a new wrapper stop script in the snap:

bin/lxd-lxc-stop
```
#!/bin/sh
export LD_LIBRARY_PATH="/snap/lxd/current/lib:/snap/lxd/current/lib/${ARCH}"
/snap/lxd/current/bin/lxd "$@"
```