### PR TITLE
Add `lxc file create` subcommand (from Incus)

### DIFF
--- a/lxc/file.go
+++ b/lxc/file.go
@@ -30,8 +30,12 @@ import (
 	"github.com/canonical/lxd/shared/units"
 )
 
-// DirMode represents the file mode for creating dirs on `lxc file pull/push`.
-const DirMode = 0755
+const (
+	// DirMode represents the file mode for creating dirs on `lxc file pull/push`.
+	DirMode = 0755
+	// FileMode represents the file mode for creating files on `lxc file create`.
+	FileMode = 0644
+)
 
 type cmdFile struct {
 	global *cmdGlobal
@@ -84,6 +88,10 @@ func (c *cmdFile) command() *cobra.Command {
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Manage files in instances`))
 
+	// Create
+	fileCreateCmd := cmdFileCreate{global: c.global, file: c}
+	cmd.AddCommand(fileCreateCmd.command())
+
 	// Delete
 	fileDeleteCmd := cmdFileDelete{global: c.global, file: c}
 	cmd.AddCommand(fileDeleteCmd.command())
@@ -108,6 +116,187 @@ func (c *cmdFile) command() *cobra.Command {
 	cmd.Args = cobra.NoArgs
 	cmd.Run = func(cmd *cobra.Command, args []string) { _ = cmd.Usage() }
 	return cmd
+}
+
+// Create.
+type cmdFileCreate struct {
+	global *cmdGlobal
+	file   *cmdFile
+
+	flagForce   bool
+	flagType    string
+}
+
+// Command returns the cobra command for `file create`.
+func (c *cmdFileCreate) command() *cobra.Command {
+	cmd := &cobra.Command{}
+	cmd.Use = usage("create", i18n.G("[<remote>:]<instance>/<path> [<symlink target path>]"))
+	cmd.Short = i18n.G("Create files and directories in instances")
+	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
+		`Create files and directories in instances`))
+	cmd.Example = cli.FormatSection("", i18n.G(
+		`lxc file create foo/bar
+	   To create a file /bar in the foo instance.
+lxc file create --type=symlink foo/bar baz
+	   To create a symlink /bar in instance foo whose target is baz.`))
+
+	cmd.Flags().BoolVarP(&c.file.flagMkdir, "create-dirs", "p", false, i18n.G("Create any directories necessary")+"``")
+	cmd.Flags().BoolVarP(&c.flagForce, "force", "f", false, i18n.G("Force creating files or directories")+"``")
+	cmd.Flags().IntVar(&c.file.flagGID, "gid", -1, i18n.G("Set the file's gid on create")+"``")
+	cmd.Flags().IntVar(&c.file.flagUID, "uid", -1, i18n.G("Set the file's uid on create")+"``")
+	cmd.Flags().StringVar(&c.file.flagMode, "mode", "", i18n.G("Set the file's perms on create")+"``")
+	cmd.Flags().StringVar(&c.flagType, "type", "file", i18n.G("The type to create (file, symlink, or directory)")+"``")
+	cmd.RunE = c.run
+
+	return cmd
+}
+
+// Run runs the `file create` command.
+func (c *cmdFileCreate) run(cmd *cobra.Command, args []string) error {
+	// Quick checks.
+	exit, err := c.global.CheckArgs(cmd, args, 1, 2)
+	if exit {
+		return err
+	}
+
+	if !shared.ValueInSlice(c.flagType, []string{"file", "symlink", "directory"}) {
+		return fmt.Errorf(i18n.G("Invalid type %q"), c.flagType)
+	}
+
+	if len(args) == 2 && c.flagType != "symlink" {
+		return errors.New(i18n.G(`Symlink target path can only be used for type "symlink"`))
+	}
+
+	if strings.HasSuffix(args[0], "/") {
+		c.flagType = "directory"
+	}
+
+	pathSpec := strings.SplitN(args[0], "/", 2)
+
+	if len(pathSpec) != 2 {
+		return fmt.Errorf(i18n.G("Invalid target %s"), args[0])
+	}
+
+	// Parse remote.
+	resources, err := c.global.ParseServers(pathSpec[0])
+	if err != nil {
+		return err
+	}
+
+	resource := resources[0]
+
+	// re-add leading / that got stripped by the SplitN
+	targetPath := path.Clean("/" + pathSpec[1])
+
+	// normalization may reveal that path is still a dir, e.g. /.
+	if strings.HasSuffix(targetPath, "/") {
+		c.flagType = "directory"
+	}
+
+	var symlinkTargetPath string
+
+	// Determine the target if specified.
+	if len(args) == 2 {
+		symlinkTargetPath = filepath.Clean(args[1])
+	}
+
+	// Determine the target uid
+	uid := 0
+	if c.file.flagUID > 0 {
+		uid = c.file.flagUID
+	}
+
+	// Determine the target gid
+	gid := 0
+	if c.file.flagGID > 0 {
+		gid = c.file.flagGID
+	}
+
+	var mode os.FileMode
+
+	// Determine the target mode
+	if c.flagType == "directory" {
+		mode = os.FileMode(DirMode)
+	} else if c.flagType == "file" {
+		mode = os.FileMode(FileMode)
+	}
+
+	if c.file.flagMode != "" {
+		if len(c.file.flagMode) == 3 {
+			c.file.flagMode = "0" + c.file.flagMode
+		}
+
+		m, err := strconv.ParseUint(c.file.flagMode, 8, 32)
+		if err != nil {
+			return err
+		}
+
+		mode = os.FileMode(m)
+	}
+
+	// Create needed paths if requested
+	if c.file.flagMkdir {
+		err = c.file.recursiveMkdir(resource.server, resource.name, path.Dir(targetPath), nil, int64(uid), int64(gid))
+		if err != nil {
+			return err
+		}
+	}
+
+	var content io.ReadSeeker
+	var readCloser io.ReadCloser
+	var contentLength int64
+
+	if c.flagType == "symlink" {
+		content = strings.NewReader(symlinkTargetPath)
+		readCloser = io.NopCloser(content)
+		contentLength = int64(len(symlinkTargetPath))
+	} else if c.flagType == "file" {
+		// Just creating an empty file.
+		content = strings.NewReader("")
+		readCloser = io.NopCloser(content)
+		contentLength = 0
+	}
+
+	fileArgs := lxd.InstanceFileArgs{
+		Type:    c.flagType,
+		UID:     int64(uid),
+		GID:     int64(gid),
+		Mode:    int(mode.Perm()),
+		Content: content,
+	}
+
+	if c.flagForce {
+		fileArgs.WriteMode = "overwrite"
+	}
+
+	progress := cli.ProgressRenderer{
+		Format: fmt.Sprintf(i18n.G("Creating %s: %%s"), targetPath),
+		Quiet:  c.global.flagQuiet,
+	}
+
+	if readCloser != nil {
+		fileArgs.Content = shared.NewReadSeeker(&ioprogress.ProgressReader{
+			ReadCloser: readCloser,
+			Tracker: &ioprogress.ProgressTracker{
+				Length: contentLength,
+				Handler: func(percent int64, speed int64) {
+					progress.UpdateProgress(ioprogress.ProgressData{
+						Text: fmt.Sprintf("%d%% (%s/s)", percent, units.GetByteSizeString(speed, 2)),
+					})
+				},
+			},
+		}, fileArgs.Content)
+	}
+
+	err = resource.server.CreateInstanceFile(resource.name, targetPath, fileArgs)
+	if err != nil {
+		progress.Done("")
+		return err
+	}
+
+	progress.Done("")
+
+	return nil
 }
 
 // Delete.

--- a/lxc/file.go
+++ b/lxc/file.go
@@ -753,7 +753,7 @@ func (c *cmdFilePush) run(cmd *cobra.Command, args []string) error {
 			c.file.flagMode = "0" + c.file.flagMode
 		}
 
-		m, err := strconv.ParseInt(c.file.flagMode, 0, 0)
+		m, err := strconv.ParseUint(c.file.flagMode, 8, 32)
 		if err != nil {
 			return err
 		}

--- a/lxc/file.go
+++ b/lxc/file.go
@@ -123,8 +123,8 @@ type cmdFileCreate struct {
 	global *cmdGlobal
 	file   *cmdFile
 
-	flagForce   bool
-	flagType    string
+	flagForce bool
+	flagType  string
 }
 
 // Command returns the cobra command for `file create`.
@@ -147,6 +147,14 @@ lxc file create --type=symlink foo/bar baz
 	cmd.Flags().StringVar(&c.file.flagMode, "mode", "", i18n.G("Set the file's perms on create")+"``")
 	cmd.Flags().StringVar(&c.flagType, "type", "file", i18n.G("The type to create (file, symlink, or directory)")+"``")
 	cmd.RunE = c.run
+
+	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		if len(args) == 0 {
+			return c.global.cmpInstances(toComplete)
+		}
+
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
 
 	return cmd
 }
@@ -315,6 +323,14 @@ func (c *cmdFileDelete) command() *cobra.Command {
 
 	cmd.RunE = c.run
 
+	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		if len(args) == 0 {
+			return c.global.cmpInstances(toComplete)
+		}
+
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
 	return cmd
 }
 
@@ -363,6 +379,14 @@ func (c *cmdFileEdit) command() *cobra.Command {
 		`Edit files in instances`))
 
 	cmd.RunE = c.run
+
+	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		if len(args) == 0 {
+			return c.global.cmpInstances(toComplete)
+		}
+
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
 
 	return cmd
 }
@@ -438,6 +462,14 @@ func (c *cmdFilePull) command() *cobra.Command {
 	cmd.Flags().BoolVarP(&c.file.flagMkdir, "create-dirs", "p", false, i18n.G("Create any directories necessary"))
 	cmd.Flags().BoolVarP(&c.file.flagRecursive, "recursive", "r", false, i18n.G("Recursively transfer files"))
 	cmd.RunE = c.run
+
+	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		if len(args) == 0 {
+			return c.global.cmpInstances(toComplete)
+		}
+
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
 
 	return cmd
 }
@@ -1183,6 +1215,14 @@ func (c *cmdFileMount) command() *cobra.Command {
 	cmd.Flags().StringVar(&c.flagListen, "listen", "", i18n.G("Setup SSH SFTP listener on address:port instead of mounting"))
 	cmd.Flags().BoolVar(&c.flagAuthNone, "no-auth", false, i18n.G("Disable authentication when using SSH SFTP listener"))
 	cmd.Flags().StringVar(&c.flagAuthUser, "auth-user", "", i18n.G("Set authentication user when using SSH SFTP listener"))
+
+	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		if len(args) == 0 {
+			return c.global.cmpInstances(toComplete)
+		}
+
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
 
 	return cmd
 }

--- a/po/ar.po
+++ b/po/ar.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-30 13:36-0400\n"
+"POT-Creation-Date: 2024-10-01 10:45-0600\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -430,12 +430,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:936
+#: lxc/file.go:1125
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:826
+#: lxc/file.go:1015
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -524,7 +524,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:466
+#: lxc/file.go:655
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -979,7 +979,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:341
+#: lxc/file.go:530
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1008,7 +1008,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:547
+#: lxc/file.go:736
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1394,8 +1394,12 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:249 lxc/file.go:475
+#: lxc/file.go:143 lxc/file.go:438 lxc/file.go:664
 msgid "Create any directories necessary"
+msgstr ""
+
+#: lxc/file.go:134 lxc/file.go:135
+msgid "Create files and directories in instances"
 msgstr ""
 
 #: lxc/auth.go:98 lxc/auth.go:99
@@ -1492,6 +1496,11 @@ msgstr ""
 msgid "Creating %s"
 msgstr ""
 
+#: lxc/file.go:273
+#, c-format
+msgid "Creating %s: %%s"
+msgstr ""
+
 #: lxc/init.go:184
 msgid "Creating the instance"
 msgstr ""
@@ -1548,7 +1557,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:123 lxc/file.go:124
+#: lxc/file.go:312 lxc/file.go:313
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1665,70 +1674,71 @@ msgstr ""
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
-#: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
-#: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
-#: lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090 lxc/image.go:1417
-#: lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638 lxc/image.go:1701
-#: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
-#: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
-#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33
-#: lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405
-#: lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793
-#: lxc/network.go:874 lxc/network.go:1005 lxc/network.go:1106
-#: lxc/network.go:1185 lxc/network.go:1245 lxc/network.go:1341
-#: lxc/network.go:1413 lxc/network_acl.go:30 lxc/network_acl.go:95
-#: lxc/network_acl.go:174 lxc/network_acl.go:235 lxc/network_acl.go:291
-#: lxc/network_acl.go:364 lxc/network_acl.go:461 lxc/network_acl.go:549
-#: lxc/network_acl.go:592 lxc/network_acl.go:731 lxc/network_acl.go:788
-#: lxc/network_acl.go:845 lxc/network_acl.go:860 lxc/network_acl.go:997
-#: lxc/network_allocations.go:51 lxc/network_forward.go:33
-#: lxc/network_forward.go:90 lxc/network_forward.go:179
-#: lxc/network_forward.go:256 lxc/network_forward.go:404
-#: lxc/network_forward.go:489 lxc/network_forward.go:599
-#: lxc/network_forward.go:646 lxc/network_forward.go:800
-#: lxc/network_forward.go:874 lxc/network_forward.go:889
-#: lxc/network_forward.go:970 lxc/network_load_balancer.go:33
-#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:181
-#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:408
-#: lxc/network_load_balancer.go:476 lxc/network_load_balancer.go:586
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:771
-#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:859
-#: lxc/network_load_balancer.go:935 lxc/network_load_balancer.go:1033
-#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1121
-#: lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:167
-#: lxc/network_peer.go:236 lxc/network_peer.go:360 lxc/network_peer.go:445
-#: lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731
-#: lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:165
-#: lxc/network_zone.go:228 lxc/network_zone.go:301 lxc/network_zone.go:396
-#: lxc/network_zone.go:484 lxc/network_zone.go:527 lxc/network_zone.go:654
-#: lxc/network_zone.go:710 lxc/network_zone.go:767 lxc/network_zone.go:845
-#: lxc/network_zone.go:909 lxc/network_zone.go:985 lxc/network_zone.go:1083
-#: lxc/network_zone.go:1172 lxc/network_zone.go:1219 lxc/network_zone.go:1349
-#: lxc/network_zone.go:1410 lxc/network_zone.go:1425 lxc/network_zone.go:1483
-#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
-#: lxc/operation.go:194 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
-#: lxc/profile.go:271 lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493
-#: lxc/profile.go:629 lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860
-#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31
-#: lxc/project.go:95 lxc/project.go:191 lxc/project.go:262 lxc/project.go:398
-#: lxc/project.go:472 lxc/project.go:592 lxc/project.go:657 lxc/project.go:745
-#: lxc/project.go:789 lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34
-#: lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91
-#: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853
-#: lxc/remote.go:917 lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24
-#: lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203
-#: lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655
-#: lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940
-#: lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189
-#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:383
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:536
-#: lxc/storage_bucket.go:630 lxc/storage_bucket.go:699
-#: lxc/storage_bucket.go:733 lxc/storage_bucket.go:774
-#: lxc/storage_bucket.go:853 lxc/storage_bucket.go:959
-#: lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158
-#: lxc/storage_volume.go:58 lxc/storage_volume.go:169 lxc/storage_volume.go:283
+#: lxc/export.go:32 lxc/file.go:88 lxc/file.go:135 lxc/file.go:313
+#: lxc/file.go:362 lxc/file.go:432 lxc/file.go:657 lxc/file.go:1176
+#: lxc/image.go:38 lxc/image.go:159 lxc/image.go:337 lxc/image.go:396
+#: lxc/image.go:525 lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090
+#: lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638
+#: lxc/image.go:1701 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255
+#: lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34
+#: lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233
+#: lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560
+#: lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1005
+#: lxc/network.go:1106 lxc/network.go:1185 lxc/network.go:1245
+#: lxc/network.go:1341 lxc/network.go:1413 lxc/network_acl.go:30
+#: lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235
+#: lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461
+#: lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731
+#: lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860
+#: lxc/network_acl.go:997 lxc/network_allocations.go:51
+#: lxc/network_forward.go:33 lxc/network_forward.go:90
+#: lxc/network_forward.go:179 lxc/network_forward.go:256
+#: lxc/network_forward.go:404 lxc/network_forward.go:489
+#: lxc/network_forward.go:599 lxc/network_forward.go:646
+#: lxc/network_forward.go:800 lxc/network_forward.go:874
+#: lxc/network_forward.go:889 lxc/network_forward.go:970
+#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
+#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844
+#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1121 lxc/network_peer.go:29
+#: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
+#: lxc/network_peer.go:360 lxc/network_peer.go:445 lxc/network_peer.go:547
+#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:29
+#: lxc/network_zone.go:86 lxc/network_zone.go:165 lxc/network_zone.go:228
+#: lxc/network_zone.go:301 lxc/network_zone.go:396 lxc/network_zone.go:484
+#: lxc/network_zone.go:527 lxc/network_zone.go:654 lxc/network_zone.go:710
+#: lxc/network_zone.go:767 lxc/network_zone.go:845 lxc/network_zone.go:909
+#: lxc/network_zone.go:985 lxc/network_zone.go:1083 lxc/network_zone.go:1172
+#: lxc/network_zone.go:1219 lxc/network_zone.go:1349 lxc/network_zone.go:1410
+#: lxc/network_zone.go:1425 lxc/network_zone.go:1483 lxc/operation.go:25
+#: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
+#: lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180 lxc/profile.go:271
+#: lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493 lxc/profile.go:629
+#: lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860 lxc/profile.go:920
+#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31 lxc/project.go:95
+#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
+#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
+#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:648
+#: lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853 lxc/remote.go:917
+#: lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
+#: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
+#: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:459
+#: lxc/storage_bucket.go:536 lxc/storage_bucket.go:630
+#: lxc/storage_bucket.go:699 lxc/storage_bucket.go:733
+#: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
+#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:283
 #: lxc/storage_volume.go:390 lxc/storage_volume.go:605
 #: lxc/storage_volume.go:714 lxc/storage_volume.go:801
 #: lxc/storage_volume.go:899 lxc/storage_volume.go:996
@@ -1826,7 +1836,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:995
+#: lxc/file.go:1184
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1892,7 +1902,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:75
+#: lxc/file.go:79
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1910,7 +1920,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:172 lxc/file.go:173
+#: lxc/file.go:361 lxc/file.go:362
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2180,12 +2190,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1238
+#: lxc/file.go:1427
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1261
+#: lxc/file.go:1450
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2200,12 +2210,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1288
+#: lxc/file.go:1477
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1073
+#: lxc/file.go:1262
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2235,7 +2245,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1194
+#: lxc/file.go:1383
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2250,7 +2260,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1199
+#: lxc/file.go:1388
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2260,12 +2270,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1099
+#: lxc/file.go:1288
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1226
+#: lxc/file.go:1415
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2304,7 +2314,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1400
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2319,7 +2329,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:821
+#: lxc/file.go:1010
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2345,6 +2355,10 @@ msgstr ""
 
 #: lxc/cluster.go:1302
 msgid "Force a particular evacuation action"
+msgstr ""
+
+#: lxc/file.go:144
+msgid "Force creating files or directories"
 msgstr ""
 
 #: lxc/cluster.go:1301
@@ -2641,22 +2655,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1311
+#: lxc/file.go:1500
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1300
+#: lxc/file.go:1489
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1312
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1133
+#: lxc/file.go:1322
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2849,11 +2863,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1125
+#: lxc/file.go:1314
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1302
+#: lxc/file.go:1491
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2871,7 +2885,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1045
+#: lxc/file.go:1234
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2923,7 +2937,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1040
+#: lxc/file.go:1229
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2965,7 +2979,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:148
+#: lxc/file.go:337
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2981,14 +2995,19 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:314
+#: lxc/file.go:503
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:496
+#: lxc/file.go:177 lxc/file.go:685
 #, c-format
 msgid "Invalid target %s"
+msgstr ""
+
+#: lxc/file.go:163
+#, c-format
+msgid "Invalid type %q"
 msgstr ""
 
 #: lxc/info.go:238
@@ -3493,7 +3512,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:83 lxc/file.go:84
+#: lxc/file.go:87 lxc/file.go:88
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3879,7 +3898,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:599
+#: lxc/file.go:788
 msgid "Missing target directory"
 msgstr ""
 
@@ -3917,11 +3936,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:286
+#: lxc/file.go:475
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:986 lxc/file.go:987
+#: lxc/file.go:1175 lxc/file.go:1176
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4373,7 +4392,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1103
+#: lxc/file.go:1292
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4607,20 +4626,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:242 lxc/file.go:243
+#: lxc/file.go:431 lxc/file.go:432
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:417 lxc/file.go:768
+#: lxc/file.go:606 lxc/file.go:957
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:467 lxc/file.go:468
+#: lxc/file.go:656 lxc/file.go:657
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:702 lxc/file.go:868
+#: lxc/file.go:891 lxc/file.go:1057
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4658,7 +4677,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:250 lxc/file.go:474
+#: lxc/file.go:439 lxc/file.go:663
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4987,12 +5006,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1231
+#: lxc/file.go:1420
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1232
+#: lxc/file.go:1421
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5068,7 +5087,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:996
+#: lxc/file.go:1185
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5262,15 +5281,27 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:477
+#: lxc/file.go:145
+msgid "Set the file's gid on create"
+msgstr ""
+
+#: lxc/file.go:666
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:478
+#: lxc/file.go:147
+msgid "Set the file's perms on create"
+msgstr ""
+
+#: lxc/file.go:667
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:476
+#: lxc/file.go:146
+msgid "Set the file's uid on create"
+msgstr ""
+
+#: lxc/file.go:665
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5330,7 +5361,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:994
+#: lxc/file.go:1183
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5705,6 +5736,10 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
+#: lxc/file.go:167
+msgid "Symlink target path can only be used for type \"symlink\""
+msgstr ""
+
 #: lxc/alias.go:140
 msgid "TARGET"
 msgstr ""
@@ -5724,11 +5759,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1033
+#: lxc/file.go:1222
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1027
+#: lxc/file.go:1216
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5897,6 +5932,10 @@ msgstr ""
 
 #: lxc/network.go:537 lxc/network.go:634
 msgid "The specified device doesn't match the network"
+msgstr ""
+
+#: lxc/file.go:148
+msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
 #: lxc/publish.go:97
@@ -6077,7 +6116,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:198
+#: lxc/file.go:387
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6091,7 +6130,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1254
+#: lxc/file.go:1443
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6107,7 +6146,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:808
+#: lxc/file.go:997
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6325,7 +6364,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:72
+#: lxc/file.go:76
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6674,20 +6713,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:171
+#: lxc/file.go:360
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:121
+#: lxc/file.go:133
+msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
+msgstr ""
+
+#: lxc/file.go:310
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:241
+#: lxc/file.go:430
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:985
+#: lxc/file.go:1174
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7196,20 +7239,28 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:989
+#: lxc/file.go:137
+msgid ""
+"lxc file create foo/bar\n"
+"\t   To create a file /bar in the foo instance.\n"
+"lxc file create --type=symlink foo/bar baz\n"
+"\t   To create a symlink /bar in instance foo whose target is baz."
+msgstr ""
+
+#: lxc/file.go:1178
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:245
+#: lxc/file.go:434
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:470
+#: lxc/file.go:659
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7558,16 +7609,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1143
+#: lxc/file.go:1332
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1102
+#: lxc/file.go:1291
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1055
+#: lxc/file.go:1244
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/ber.po
+++ b/po/ber.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-30 13:36-0400\n"
+"POT-Creation-Date: 2024-10-01 10:45-0600\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Berber <https://hosted.weblate.org/projects/linux-containers/"
@@ -433,12 +433,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:936
+#: lxc/file.go:1125
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:826
+#: lxc/file.go:1015
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -527,7 +527,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:466
+#: lxc/file.go:655
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -982,7 +982,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:341
+#: lxc/file.go:530
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1011,7 +1011,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:547
+#: lxc/file.go:736
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1397,8 +1397,12 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:249 lxc/file.go:475
+#: lxc/file.go:143 lxc/file.go:438 lxc/file.go:664
 msgid "Create any directories necessary"
+msgstr ""
+
+#: lxc/file.go:134 lxc/file.go:135
+msgid "Create files and directories in instances"
 msgstr ""
 
 #: lxc/auth.go:98 lxc/auth.go:99
@@ -1495,6 +1499,11 @@ msgstr ""
 msgid "Creating %s"
 msgstr ""
 
+#: lxc/file.go:273
+#, c-format
+msgid "Creating %s: %%s"
+msgstr ""
+
 #: lxc/init.go:184
 msgid "Creating the instance"
 msgstr ""
@@ -1551,7 +1560,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:123 lxc/file.go:124
+#: lxc/file.go:312 lxc/file.go:313
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1668,70 +1677,71 @@ msgstr ""
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
-#: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
-#: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
-#: lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090 lxc/image.go:1417
-#: lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638 lxc/image.go:1701
-#: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
-#: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
-#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33
-#: lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405
-#: lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793
-#: lxc/network.go:874 lxc/network.go:1005 lxc/network.go:1106
-#: lxc/network.go:1185 lxc/network.go:1245 lxc/network.go:1341
-#: lxc/network.go:1413 lxc/network_acl.go:30 lxc/network_acl.go:95
-#: lxc/network_acl.go:174 lxc/network_acl.go:235 lxc/network_acl.go:291
-#: lxc/network_acl.go:364 lxc/network_acl.go:461 lxc/network_acl.go:549
-#: lxc/network_acl.go:592 lxc/network_acl.go:731 lxc/network_acl.go:788
-#: lxc/network_acl.go:845 lxc/network_acl.go:860 lxc/network_acl.go:997
-#: lxc/network_allocations.go:51 lxc/network_forward.go:33
-#: lxc/network_forward.go:90 lxc/network_forward.go:179
-#: lxc/network_forward.go:256 lxc/network_forward.go:404
-#: lxc/network_forward.go:489 lxc/network_forward.go:599
-#: lxc/network_forward.go:646 lxc/network_forward.go:800
-#: lxc/network_forward.go:874 lxc/network_forward.go:889
-#: lxc/network_forward.go:970 lxc/network_load_balancer.go:33
-#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:181
-#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:408
-#: lxc/network_load_balancer.go:476 lxc/network_load_balancer.go:586
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:771
-#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:859
-#: lxc/network_load_balancer.go:935 lxc/network_load_balancer.go:1033
-#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1121
-#: lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:167
-#: lxc/network_peer.go:236 lxc/network_peer.go:360 lxc/network_peer.go:445
-#: lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731
-#: lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:165
-#: lxc/network_zone.go:228 lxc/network_zone.go:301 lxc/network_zone.go:396
-#: lxc/network_zone.go:484 lxc/network_zone.go:527 lxc/network_zone.go:654
-#: lxc/network_zone.go:710 lxc/network_zone.go:767 lxc/network_zone.go:845
-#: lxc/network_zone.go:909 lxc/network_zone.go:985 lxc/network_zone.go:1083
-#: lxc/network_zone.go:1172 lxc/network_zone.go:1219 lxc/network_zone.go:1349
-#: lxc/network_zone.go:1410 lxc/network_zone.go:1425 lxc/network_zone.go:1483
-#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
-#: lxc/operation.go:194 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
-#: lxc/profile.go:271 lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493
-#: lxc/profile.go:629 lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860
-#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31
-#: lxc/project.go:95 lxc/project.go:191 lxc/project.go:262 lxc/project.go:398
-#: lxc/project.go:472 lxc/project.go:592 lxc/project.go:657 lxc/project.go:745
-#: lxc/project.go:789 lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34
-#: lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91
-#: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853
-#: lxc/remote.go:917 lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24
-#: lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203
-#: lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655
-#: lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940
-#: lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189
-#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:383
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:536
-#: lxc/storage_bucket.go:630 lxc/storage_bucket.go:699
-#: lxc/storage_bucket.go:733 lxc/storage_bucket.go:774
-#: lxc/storage_bucket.go:853 lxc/storage_bucket.go:959
-#: lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158
-#: lxc/storage_volume.go:58 lxc/storage_volume.go:169 lxc/storage_volume.go:283
+#: lxc/export.go:32 lxc/file.go:88 lxc/file.go:135 lxc/file.go:313
+#: lxc/file.go:362 lxc/file.go:432 lxc/file.go:657 lxc/file.go:1176
+#: lxc/image.go:38 lxc/image.go:159 lxc/image.go:337 lxc/image.go:396
+#: lxc/image.go:525 lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090
+#: lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638
+#: lxc/image.go:1701 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255
+#: lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34
+#: lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233
+#: lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560
+#: lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1005
+#: lxc/network.go:1106 lxc/network.go:1185 lxc/network.go:1245
+#: lxc/network.go:1341 lxc/network.go:1413 lxc/network_acl.go:30
+#: lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235
+#: lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461
+#: lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731
+#: lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860
+#: lxc/network_acl.go:997 lxc/network_allocations.go:51
+#: lxc/network_forward.go:33 lxc/network_forward.go:90
+#: lxc/network_forward.go:179 lxc/network_forward.go:256
+#: lxc/network_forward.go:404 lxc/network_forward.go:489
+#: lxc/network_forward.go:599 lxc/network_forward.go:646
+#: lxc/network_forward.go:800 lxc/network_forward.go:874
+#: lxc/network_forward.go:889 lxc/network_forward.go:970
+#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
+#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844
+#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1121 lxc/network_peer.go:29
+#: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
+#: lxc/network_peer.go:360 lxc/network_peer.go:445 lxc/network_peer.go:547
+#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:29
+#: lxc/network_zone.go:86 lxc/network_zone.go:165 lxc/network_zone.go:228
+#: lxc/network_zone.go:301 lxc/network_zone.go:396 lxc/network_zone.go:484
+#: lxc/network_zone.go:527 lxc/network_zone.go:654 lxc/network_zone.go:710
+#: lxc/network_zone.go:767 lxc/network_zone.go:845 lxc/network_zone.go:909
+#: lxc/network_zone.go:985 lxc/network_zone.go:1083 lxc/network_zone.go:1172
+#: lxc/network_zone.go:1219 lxc/network_zone.go:1349 lxc/network_zone.go:1410
+#: lxc/network_zone.go:1425 lxc/network_zone.go:1483 lxc/operation.go:25
+#: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
+#: lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180 lxc/profile.go:271
+#: lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493 lxc/profile.go:629
+#: lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860 lxc/profile.go:920
+#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31 lxc/project.go:95
+#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
+#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
+#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:648
+#: lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853 lxc/remote.go:917
+#: lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
+#: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
+#: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:459
+#: lxc/storage_bucket.go:536 lxc/storage_bucket.go:630
+#: lxc/storage_bucket.go:699 lxc/storage_bucket.go:733
+#: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
+#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:283
 #: lxc/storage_volume.go:390 lxc/storage_volume.go:605
 #: lxc/storage_volume.go:714 lxc/storage_volume.go:801
 #: lxc/storage_volume.go:899 lxc/storage_volume.go:996
@@ -1829,7 +1839,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:995
+#: lxc/file.go:1184
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1895,7 +1905,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:75
+#: lxc/file.go:79
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1913,7 +1923,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:172 lxc/file.go:173
+#: lxc/file.go:361 lxc/file.go:362
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2183,12 +2193,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1238
+#: lxc/file.go:1427
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1261
+#: lxc/file.go:1450
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2203,12 +2213,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1288
+#: lxc/file.go:1477
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1073
+#: lxc/file.go:1262
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2238,7 +2248,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1194
+#: lxc/file.go:1383
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2253,7 +2263,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1199
+#: lxc/file.go:1388
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2263,12 +2273,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1099
+#: lxc/file.go:1288
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1226
+#: lxc/file.go:1415
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2307,7 +2317,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1400
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2322,7 +2332,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:821
+#: lxc/file.go:1010
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2348,6 +2358,10 @@ msgstr ""
 
 #: lxc/cluster.go:1302
 msgid "Force a particular evacuation action"
+msgstr ""
+
+#: lxc/file.go:144
+msgid "Force creating files or directories"
 msgstr ""
 
 #: lxc/cluster.go:1301
@@ -2644,22 +2658,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1311
+#: lxc/file.go:1500
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1300
+#: lxc/file.go:1489
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1312
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1133
+#: lxc/file.go:1322
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2852,11 +2866,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1125
+#: lxc/file.go:1314
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1302
+#: lxc/file.go:1491
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2874,7 +2888,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1045
+#: lxc/file.go:1234
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2926,7 +2940,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1040
+#: lxc/file.go:1229
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2968,7 +2982,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:148
+#: lxc/file.go:337
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2984,14 +2998,19 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:314
+#: lxc/file.go:503
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:496
+#: lxc/file.go:177 lxc/file.go:685
 #, c-format
 msgid "Invalid target %s"
+msgstr ""
+
+#: lxc/file.go:163
+#, c-format
+msgid "Invalid type %q"
 msgstr ""
 
 #: lxc/info.go:238
@@ -3496,7 +3515,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:83 lxc/file.go:84
+#: lxc/file.go:87 lxc/file.go:88
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3882,7 +3901,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:599
+#: lxc/file.go:788
 msgid "Missing target directory"
 msgstr ""
 
@@ -3920,11 +3939,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:286
+#: lxc/file.go:475
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:986 lxc/file.go:987
+#: lxc/file.go:1175 lxc/file.go:1176
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4376,7 +4395,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1103
+#: lxc/file.go:1292
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4610,20 +4629,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:242 lxc/file.go:243
+#: lxc/file.go:431 lxc/file.go:432
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:417 lxc/file.go:768
+#: lxc/file.go:606 lxc/file.go:957
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:467 lxc/file.go:468
+#: lxc/file.go:656 lxc/file.go:657
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:702 lxc/file.go:868
+#: lxc/file.go:891 lxc/file.go:1057
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4661,7 +4680,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:250 lxc/file.go:474
+#: lxc/file.go:439 lxc/file.go:663
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4990,12 +5009,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1231
+#: lxc/file.go:1420
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1232
+#: lxc/file.go:1421
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5071,7 +5090,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:996
+#: lxc/file.go:1185
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5265,15 +5284,27 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:477
+#: lxc/file.go:145
+msgid "Set the file's gid on create"
+msgstr ""
+
+#: lxc/file.go:666
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:478
+#: lxc/file.go:147
+msgid "Set the file's perms on create"
+msgstr ""
+
+#: lxc/file.go:667
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:476
+#: lxc/file.go:146
+msgid "Set the file's uid on create"
+msgstr ""
+
+#: lxc/file.go:665
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5333,7 +5364,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:994
+#: lxc/file.go:1183
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5708,6 +5739,10 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
+#: lxc/file.go:167
+msgid "Symlink target path can only be used for type \"symlink\""
+msgstr ""
+
 #: lxc/alias.go:140
 msgid "TARGET"
 msgstr ""
@@ -5727,11 +5762,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1033
+#: lxc/file.go:1222
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1027
+#: lxc/file.go:1216
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5900,6 +5935,10 @@ msgstr ""
 
 #: lxc/network.go:537 lxc/network.go:634
 msgid "The specified device doesn't match the network"
+msgstr ""
+
+#: lxc/file.go:148
+msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
 #: lxc/publish.go:97
@@ -6080,7 +6119,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:198
+#: lxc/file.go:387
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6094,7 +6133,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1254
+#: lxc/file.go:1443
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6110,7 +6149,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:808
+#: lxc/file.go:997
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6328,7 +6367,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:72
+#: lxc/file.go:76
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6677,20 +6716,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:171
+#: lxc/file.go:360
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:121
+#: lxc/file.go:133
+msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
+msgstr ""
+
+#: lxc/file.go:310
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:241
+#: lxc/file.go:430
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:985
+#: lxc/file.go:1174
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7199,20 +7242,28 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:989
+#: lxc/file.go:137
+msgid ""
+"lxc file create foo/bar\n"
+"\t   To create a file /bar in the foo instance.\n"
+"lxc file create --type=symlink foo/bar baz\n"
+"\t   To create a symlink /bar in instance foo whose target is baz."
+msgstr ""
+
+#: lxc/file.go:1178
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:245
+#: lxc/file.go:434
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:470
+#: lxc/file.go:659
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7561,16 +7612,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1143
+#: lxc/file.go:1332
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1102
+#: lxc/file.go:1291
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1055
+#: lxc/file.go:1244
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/bg.po
+++ b/po/bg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-30 13:36-0400\n"
+"POT-Creation-Date: 2024-10-01 10:45-0600\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Bulgarian <https://hosted.weblate.org/projects/linux-"
@@ -433,12 +433,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:936
+#: lxc/file.go:1125
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:826
+#: lxc/file.go:1015
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -527,7 +527,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:466
+#: lxc/file.go:655
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -982,7 +982,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:341
+#: lxc/file.go:530
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1011,7 +1011,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:547
+#: lxc/file.go:736
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1397,8 +1397,12 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:249 lxc/file.go:475
+#: lxc/file.go:143 lxc/file.go:438 lxc/file.go:664
 msgid "Create any directories necessary"
+msgstr ""
+
+#: lxc/file.go:134 lxc/file.go:135
+msgid "Create files and directories in instances"
 msgstr ""
 
 #: lxc/auth.go:98 lxc/auth.go:99
@@ -1495,6 +1499,11 @@ msgstr ""
 msgid "Creating %s"
 msgstr ""
 
+#: lxc/file.go:273
+#, c-format
+msgid "Creating %s: %%s"
+msgstr ""
+
 #: lxc/init.go:184
 msgid "Creating the instance"
 msgstr ""
@@ -1551,7 +1560,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:123 lxc/file.go:124
+#: lxc/file.go:312 lxc/file.go:313
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1668,70 +1677,71 @@ msgstr ""
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
-#: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
-#: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
-#: lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090 lxc/image.go:1417
-#: lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638 lxc/image.go:1701
-#: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
-#: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
-#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33
-#: lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405
-#: lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793
-#: lxc/network.go:874 lxc/network.go:1005 lxc/network.go:1106
-#: lxc/network.go:1185 lxc/network.go:1245 lxc/network.go:1341
-#: lxc/network.go:1413 lxc/network_acl.go:30 lxc/network_acl.go:95
-#: lxc/network_acl.go:174 lxc/network_acl.go:235 lxc/network_acl.go:291
-#: lxc/network_acl.go:364 lxc/network_acl.go:461 lxc/network_acl.go:549
-#: lxc/network_acl.go:592 lxc/network_acl.go:731 lxc/network_acl.go:788
-#: lxc/network_acl.go:845 lxc/network_acl.go:860 lxc/network_acl.go:997
-#: lxc/network_allocations.go:51 lxc/network_forward.go:33
-#: lxc/network_forward.go:90 lxc/network_forward.go:179
-#: lxc/network_forward.go:256 lxc/network_forward.go:404
-#: lxc/network_forward.go:489 lxc/network_forward.go:599
-#: lxc/network_forward.go:646 lxc/network_forward.go:800
-#: lxc/network_forward.go:874 lxc/network_forward.go:889
-#: lxc/network_forward.go:970 lxc/network_load_balancer.go:33
-#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:181
-#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:408
-#: lxc/network_load_balancer.go:476 lxc/network_load_balancer.go:586
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:771
-#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:859
-#: lxc/network_load_balancer.go:935 lxc/network_load_balancer.go:1033
-#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1121
-#: lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:167
-#: lxc/network_peer.go:236 lxc/network_peer.go:360 lxc/network_peer.go:445
-#: lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731
-#: lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:165
-#: lxc/network_zone.go:228 lxc/network_zone.go:301 lxc/network_zone.go:396
-#: lxc/network_zone.go:484 lxc/network_zone.go:527 lxc/network_zone.go:654
-#: lxc/network_zone.go:710 lxc/network_zone.go:767 lxc/network_zone.go:845
-#: lxc/network_zone.go:909 lxc/network_zone.go:985 lxc/network_zone.go:1083
-#: lxc/network_zone.go:1172 lxc/network_zone.go:1219 lxc/network_zone.go:1349
-#: lxc/network_zone.go:1410 lxc/network_zone.go:1425 lxc/network_zone.go:1483
-#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
-#: lxc/operation.go:194 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
-#: lxc/profile.go:271 lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493
-#: lxc/profile.go:629 lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860
-#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31
-#: lxc/project.go:95 lxc/project.go:191 lxc/project.go:262 lxc/project.go:398
-#: lxc/project.go:472 lxc/project.go:592 lxc/project.go:657 lxc/project.go:745
-#: lxc/project.go:789 lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34
-#: lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91
-#: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853
-#: lxc/remote.go:917 lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24
-#: lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203
-#: lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655
-#: lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940
-#: lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189
-#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:383
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:536
-#: lxc/storage_bucket.go:630 lxc/storage_bucket.go:699
-#: lxc/storage_bucket.go:733 lxc/storage_bucket.go:774
-#: lxc/storage_bucket.go:853 lxc/storage_bucket.go:959
-#: lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158
-#: lxc/storage_volume.go:58 lxc/storage_volume.go:169 lxc/storage_volume.go:283
+#: lxc/export.go:32 lxc/file.go:88 lxc/file.go:135 lxc/file.go:313
+#: lxc/file.go:362 lxc/file.go:432 lxc/file.go:657 lxc/file.go:1176
+#: lxc/image.go:38 lxc/image.go:159 lxc/image.go:337 lxc/image.go:396
+#: lxc/image.go:525 lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090
+#: lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638
+#: lxc/image.go:1701 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255
+#: lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34
+#: lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233
+#: lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560
+#: lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1005
+#: lxc/network.go:1106 lxc/network.go:1185 lxc/network.go:1245
+#: lxc/network.go:1341 lxc/network.go:1413 lxc/network_acl.go:30
+#: lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235
+#: lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461
+#: lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731
+#: lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860
+#: lxc/network_acl.go:997 lxc/network_allocations.go:51
+#: lxc/network_forward.go:33 lxc/network_forward.go:90
+#: lxc/network_forward.go:179 lxc/network_forward.go:256
+#: lxc/network_forward.go:404 lxc/network_forward.go:489
+#: lxc/network_forward.go:599 lxc/network_forward.go:646
+#: lxc/network_forward.go:800 lxc/network_forward.go:874
+#: lxc/network_forward.go:889 lxc/network_forward.go:970
+#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
+#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844
+#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1121 lxc/network_peer.go:29
+#: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
+#: lxc/network_peer.go:360 lxc/network_peer.go:445 lxc/network_peer.go:547
+#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:29
+#: lxc/network_zone.go:86 lxc/network_zone.go:165 lxc/network_zone.go:228
+#: lxc/network_zone.go:301 lxc/network_zone.go:396 lxc/network_zone.go:484
+#: lxc/network_zone.go:527 lxc/network_zone.go:654 lxc/network_zone.go:710
+#: lxc/network_zone.go:767 lxc/network_zone.go:845 lxc/network_zone.go:909
+#: lxc/network_zone.go:985 lxc/network_zone.go:1083 lxc/network_zone.go:1172
+#: lxc/network_zone.go:1219 lxc/network_zone.go:1349 lxc/network_zone.go:1410
+#: lxc/network_zone.go:1425 lxc/network_zone.go:1483 lxc/operation.go:25
+#: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
+#: lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180 lxc/profile.go:271
+#: lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493 lxc/profile.go:629
+#: lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860 lxc/profile.go:920
+#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31 lxc/project.go:95
+#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
+#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
+#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:648
+#: lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853 lxc/remote.go:917
+#: lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
+#: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
+#: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:459
+#: lxc/storage_bucket.go:536 lxc/storage_bucket.go:630
+#: lxc/storage_bucket.go:699 lxc/storage_bucket.go:733
+#: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
+#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:283
 #: lxc/storage_volume.go:390 lxc/storage_volume.go:605
 #: lxc/storage_volume.go:714 lxc/storage_volume.go:801
 #: lxc/storage_volume.go:899 lxc/storage_volume.go:996
@@ -1829,7 +1839,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:995
+#: lxc/file.go:1184
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1895,7 +1905,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:75
+#: lxc/file.go:79
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1913,7 +1923,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:172 lxc/file.go:173
+#: lxc/file.go:361 lxc/file.go:362
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2183,12 +2193,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1238
+#: lxc/file.go:1427
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1261
+#: lxc/file.go:1450
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2203,12 +2213,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1288
+#: lxc/file.go:1477
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1073
+#: lxc/file.go:1262
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2238,7 +2248,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1194
+#: lxc/file.go:1383
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2253,7 +2263,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1199
+#: lxc/file.go:1388
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2263,12 +2273,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1099
+#: lxc/file.go:1288
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1226
+#: lxc/file.go:1415
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2307,7 +2317,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1400
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2322,7 +2332,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:821
+#: lxc/file.go:1010
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2348,6 +2358,10 @@ msgstr ""
 
 #: lxc/cluster.go:1302
 msgid "Force a particular evacuation action"
+msgstr ""
+
+#: lxc/file.go:144
+msgid "Force creating files or directories"
 msgstr ""
 
 #: lxc/cluster.go:1301
@@ -2644,22 +2658,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1311
+#: lxc/file.go:1500
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1300
+#: lxc/file.go:1489
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1312
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1133
+#: lxc/file.go:1322
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2852,11 +2866,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1125
+#: lxc/file.go:1314
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1302
+#: lxc/file.go:1491
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2874,7 +2888,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1045
+#: lxc/file.go:1234
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2926,7 +2940,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1040
+#: lxc/file.go:1229
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2968,7 +2982,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:148
+#: lxc/file.go:337
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2984,14 +2998,19 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:314
+#: lxc/file.go:503
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:496
+#: lxc/file.go:177 lxc/file.go:685
 #, c-format
 msgid "Invalid target %s"
+msgstr ""
+
+#: lxc/file.go:163
+#, c-format
+msgid "Invalid type %q"
 msgstr ""
 
 #: lxc/info.go:238
@@ -3496,7 +3515,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:83 lxc/file.go:84
+#: lxc/file.go:87 lxc/file.go:88
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3882,7 +3901,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:599
+#: lxc/file.go:788
 msgid "Missing target directory"
 msgstr ""
 
@@ -3920,11 +3939,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:286
+#: lxc/file.go:475
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:986 lxc/file.go:987
+#: lxc/file.go:1175 lxc/file.go:1176
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4376,7 +4395,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1103
+#: lxc/file.go:1292
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4610,20 +4629,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:242 lxc/file.go:243
+#: lxc/file.go:431 lxc/file.go:432
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:417 lxc/file.go:768
+#: lxc/file.go:606 lxc/file.go:957
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:467 lxc/file.go:468
+#: lxc/file.go:656 lxc/file.go:657
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:702 lxc/file.go:868
+#: lxc/file.go:891 lxc/file.go:1057
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4661,7 +4680,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:250 lxc/file.go:474
+#: lxc/file.go:439 lxc/file.go:663
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4990,12 +5009,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1231
+#: lxc/file.go:1420
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1232
+#: lxc/file.go:1421
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5071,7 +5090,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:996
+#: lxc/file.go:1185
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5265,15 +5284,27 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:477
+#: lxc/file.go:145
+msgid "Set the file's gid on create"
+msgstr ""
+
+#: lxc/file.go:666
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:478
+#: lxc/file.go:147
+msgid "Set the file's perms on create"
+msgstr ""
+
+#: lxc/file.go:667
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:476
+#: lxc/file.go:146
+msgid "Set the file's uid on create"
+msgstr ""
+
+#: lxc/file.go:665
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5333,7 +5364,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:994
+#: lxc/file.go:1183
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5708,6 +5739,10 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
+#: lxc/file.go:167
+msgid "Symlink target path can only be used for type \"symlink\""
+msgstr ""
+
 #: lxc/alias.go:140
 msgid "TARGET"
 msgstr ""
@@ -5727,11 +5762,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1033
+#: lxc/file.go:1222
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1027
+#: lxc/file.go:1216
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5900,6 +5935,10 @@ msgstr ""
 
 #: lxc/network.go:537 lxc/network.go:634
 msgid "The specified device doesn't match the network"
+msgstr ""
+
+#: lxc/file.go:148
+msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
 #: lxc/publish.go:97
@@ -6080,7 +6119,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:198
+#: lxc/file.go:387
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6094,7 +6133,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1254
+#: lxc/file.go:1443
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6110,7 +6149,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:808
+#: lxc/file.go:997
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6328,7 +6367,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:72
+#: lxc/file.go:76
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6677,20 +6716,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:171
+#: lxc/file.go:360
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:121
+#: lxc/file.go:133
+msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
+msgstr ""
+
+#: lxc/file.go:310
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:241
+#: lxc/file.go:430
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:985
+#: lxc/file.go:1174
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7199,20 +7242,28 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:989
+#: lxc/file.go:137
+msgid ""
+"lxc file create foo/bar\n"
+"\t   To create a file /bar in the foo instance.\n"
+"lxc file create --type=symlink foo/bar baz\n"
+"\t   To create a symlink /bar in instance foo whose target is baz."
+msgstr ""
+
+#: lxc/file.go:1178
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:245
+#: lxc/file.go:434
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:470
+#: lxc/file.go:659
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7561,16 +7612,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1143
+#: lxc/file.go:1332
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1102
+#: lxc/file.go:1291
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1055
+#: lxc/file.go:1244
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/ca.po
+++ b/po/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-30 13:36-0400\n"
+"POT-Creation-Date: 2024-10-01 10:45-0600\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Catalan <https://hosted.weblate.org/projects/linux-containers/"
@@ -433,12 +433,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:936
+#: lxc/file.go:1125
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:826
+#: lxc/file.go:1015
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -527,7 +527,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:466
+#: lxc/file.go:655
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -982,7 +982,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:341
+#: lxc/file.go:530
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1011,7 +1011,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:547
+#: lxc/file.go:736
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1397,8 +1397,12 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:249 lxc/file.go:475
+#: lxc/file.go:143 lxc/file.go:438 lxc/file.go:664
 msgid "Create any directories necessary"
+msgstr ""
+
+#: lxc/file.go:134 lxc/file.go:135
+msgid "Create files and directories in instances"
 msgstr ""
 
 #: lxc/auth.go:98 lxc/auth.go:99
@@ -1495,6 +1499,11 @@ msgstr ""
 msgid "Creating %s"
 msgstr ""
 
+#: lxc/file.go:273
+#, c-format
+msgid "Creating %s: %%s"
+msgstr ""
+
 #: lxc/init.go:184
 msgid "Creating the instance"
 msgstr ""
@@ -1551,7 +1560,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:123 lxc/file.go:124
+#: lxc/file.go:312 lxc/file.go:313
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1668,70 +1677,71 @@ msgstr ""
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
-#: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
-#: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
-#: lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090 lxc/image.go:1417
-#: lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638 lxc/image.go:1701
-#: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
-#: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
-#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33
-#: lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405
-#: lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793
-#: lxc/network.go:874 lxc/network.go:1005 lxc/network.go:1106
-#: lxc/network.go:1185 lxc/network.go:1245 lxc/network.go:1341
-#: lxc/network.go:1413 lxc/network_acl.go:30 lxc/network_acl.go:95
-#: lxc/network_acl.go:174 lxc/network_acl.go:235 lxc/network_acl.go:291
-#: lxc/network_acl.go:364 lxc/network_acl.go:461 lxc/network_acl.go:549
-#: lxc/network_acl.go:592 lxc/network_acl.go:731 lxc/network_acl.go:788
-#: lxc/network_acl.go:845 lxc/network_acl.go:860 lxc/network_acl.go:997
-#: lxc/network_allocations.go:51 lxc/network_forward.go:33
-#: lxc/network_forward.go:90 lxc/network_forward.go:179
-#: lxc/network_forward.go:256 lxc/network_forward.go:404
-#: lxc/network_forward.go:489 lxc/network_forward.go:599
-#: lxc/network_forward.go:646 lxc/network_forward.go:800
-#: lxc/network_forward.go:874 lxc/network_forward.go:889
-#: lxc/network_forward.go:970 lxc/network_load_balancer.go:33
-#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:181
-#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:408
-#: lxc/network_load_balancer.go:476 lxc/network_load_balancer.go:586
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:771
-#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:859
-#: lxc/network_load_balancer.go:935 lxc/network_load_balancer.go:1033
-#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1121
-#: lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:167
-#: lxc/network_peer.go:236 lxc/network_peer.go:360 lxc/network_peer.go:445
-#: lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731
-#: lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:165
-#: lxc/network_zone.go:228 lxc/network_zone.go:301 lxc/network_zone.go:396
-#: lxc/network_zone.go:484 lxc/network_zone.go:527 lxc/network_zone.go:654
-#: lxc/network_zone.go:710 lxc/network_zone.go:767 lxc/network_zone.go:845
-#: lxc/network_zone.go:909 lxc/network_zone.go:985 lxc/network_zone.go:1083
-#: lxc/network_zone.go:1172 lxc/network_zone.go:1219 lxc/network_zone.go:1349
-#: lxc/network_zone.go:1410 lxc/network_zone.go:1425 lxc/network_zone.go:1483
-#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
-#: lxc/operation.go:194 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
-#: lxc/profile.go:271 lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493
-#: lxc/profile.go:629 lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860
-#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31
-#: lxc/project.go:95 lxc/project.go:191 lxc/project.go:262 lxc/project.go:398
-#: lxc/project.go:472 lxc/project.go:592 lxc/project.go:657 lxc/project.go:745
-#: lxc/project.go:789 lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34
-#: lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91
-#: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853
-#: lxc/remote.go:917 lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24
-#: lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203
-#: lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655
-#: lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940
-#: lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189
-#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:383
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:536
-#: lxc/storage_bucket.go:630 lxc/storage_bucket.go:699
-#: lxc/storage_bucket.go:733 lxc/storage_bucket.go:774
-#: lxc/storage_bucket.go:853 lxc/storage_bucket.go:959
-#: lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158
-#: lxc/storage_volume.go:58 lxc/storage_volume.go:169 lxc/storage_volume.go:283
+#: lxc/export.go:32 lxc/file.go:88 lxc/file.go:135 lxc/file.go:313
+#: lxc/file.go:362 lxc/file.go:432 lxc/file.go:657 lxc/file.go:1176
+#: lxc/image.go:38 lxc/image.go:159 lxc/image.go:337 lxc/image.go:396
+#: lxc/image.go:525 lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090
+#: lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638
+#: lxc/image.go:1701 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255
+#: lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34
+#: lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233
+#: lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560
+#: lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1005
+#: lxc/network.go:1106 lxc/network.go:1185 lxc/network.go:1245
+#: lxc/network.go:1341 lxc/network.go:1413 lxc/network_acl.go:30
+#: lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235
+#: lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461
+#: lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731
+#: lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860
+#: lxc/network_acl.go:997 lxc/network_allocations.go:51
+#: lxc/network_forward.go:33 lxc/network_forward.go:90
+#: lxc/network_forward.go:179 lxc/network_forward.go:256
+#: lxc/network_forward.go:404 lxc/network_forward.go:489
+#: lxc/network_forward.go:599 lxc/network_forward.go:646
+#: lxc/network_forward.go:800 lxc/network_forward.go:874
+#: lxc/network_forward.go:889 lxc/network_forward.go:970
+#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
+#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844
+#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1121 lxc/network_peer.go:29
+#: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
+#: lxc/network_peer.go:360 lxc/network_peer.go:445 lxc/network_peer.go:547
+#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:29
+#: lxc/network_zone.go:86 lxc/network_zone.go:165 lxc/network_zone.go:228
+#: lxc/network_zone.go:301 lxc/network_zone.go:396 lxc/network_zone.go:484
+#: lxc/network_zone.go:527 lxc/network_zone.go:654 lxc/network_zone.go:710
+#: lxc/network_zone.go:767 lxc/network_zone.go:845 lxc/network_zone.go:909
+#: lxc/network_zone.go:985 lxc/network_zone.go:1083 lxc/network_zone.go:1172
+#: lxc/network_zone.go:1219 lxc/network_zone.go:1349 lxc/network_zone.go:1410
+#: lxc/network_zone.go:1425 lxc/network_zone.go:1483 lxc/operation.go:25
+#: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
+#: lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180 lxc/profile.go:271
+#: lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493 lxc/profile.go:629
+#: lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860 lxc/profile.go:920
+#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31 lxc/project.go:95
+#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
+#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
+#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:648
+#: lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853 lxc/remote.go:917
+#: lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
+#: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
+#: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:459
+#: lxc/storage_bucket.go:536 lxc/storage_bucket.go:630
+#: lxc/storage_bucket.go:699 lxc/storage_bucket.go:733
+#: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
+#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:283
 #: lxc/storage_volume.go:390 lxc/storage_volume.go:605
 #: lxc/storage_volume.go:714 lxc/storage_volume.go:801
 #: lxc/storage_volume.go:899 lxc/storage_volume.go:996
@@ -1829,7 +1839,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:995
+#: lxc/file.go:1184
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1895,7 +1905,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:75
+#: lxc/file.go:79
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1913,7 +1923,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:172 lxc/file.go:173
+#: lxc/file.go:361 lxc/file.go:362
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2183,12 +2193,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1238
+#: lxc/file.go:1427
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1261
+#: lxc/file.go:1450
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2203,12 +2213,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1288
+#: lxc/file.go:1477
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1073
+#: lxc/file.go:1262
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2238,7 +2248,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1194
+#: lxc/file.go:1383
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2253,7 +2263,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1199
+#: lxc/file.go:1388
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2263,12 +2273,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1099
+#: lxc/file.go:1288
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1226
+#: lxc/file.go:1415
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2307,7 +2317,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1400
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2322,7 +2332,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:821
+#: lxc/file.go:1010
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2348,6 +2358,10 @@ msgstr ""
 
 #: lxc/cluster.go:1302
 msgid "Force a particular evacuation action"
+msgstr ""
+
+#: lxc/file.go:144
+msgid "Force creating files or directories"
 msgstr ""
 
 #: lxc/cluster.go:1301
@@ -2644,22 +2658,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1311
+#: lxc/file.go:1500
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1300
+#: lxc/file.go:1489
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1312
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1133
+#: lxc/file.go:1322
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2852,11 +2866,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1125
+#: lxc/file.go:1314
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1302
+#: lxc/file.go:1491
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2874,7 +2888,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1045
+#: lxc/file.go:1234
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2926,7 +2940,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1040
+#: lxc/file.go:1229
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2968,7 +2982,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:148
+#: lxc/file.go:337
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2984,14 +2998,19 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:314
+#: lxc/file.go:503
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:496
+#: lxc/file.go:177 lxc/file.go:685
 #, c-format
 msgid "Invalid target %s"
+msgstr ""
+
+#: lxc/file.go:163
+#, c-format
+msgid "Invalid type %q"
 msgstr ""
 
 #: lxc/info.go:238
@@ -3496,7 +3515,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:83 lxc/file.go:84
+#: lxc/file.go:87 lxc/file.go:88
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3882,7 +3901,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:599
+#: lxc/file.go:788
 msgid "Missing target directory"
 msgstr ""
 
@@ -3920,11 +3939,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:286
+#: lxc/file.go:475
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:986 lxc/file.go:987
+#: lxc/file.go:1175 lxc/file.go:1176
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4376,7 +4395,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1103
+#: lxc/file.go:1292
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4610,20 +4629,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:242 lxc/file.go:243
+#: lxc/file.go:431 lxc/file.go:432
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:417 lxc/file.go:768
+#: lxc/file.go:606 lxc/file.go:957
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:467 lxc/file.go:468
+#: lxc/file.go:656 lxc/file.go:657
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:702 lxc/file.go:868
+#: lxc/file.go:891 lxc/file.go:1057
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4661,7 +4680,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:250 lxc/file.go:474
+#: lxc/file.go:439 lxc/file.go:663
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4990,12 +5009,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1231
+#: lxc/file.go:1420
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1232
+#: lxc/file.go:1421
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5071,7 +5090,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:996
+#: lxc/file.go:1185
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5265,15 +5284,27 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:477
+#: lxc/file.go:145
+msgid "Set the file's gid on create"
+msgstr ""
+
+#: lxc/file.go:666
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:478
+#: lxc/file.go:147
+msgid "Set the file's perms on create"
+msgstr ""
+
+#: lxc/file.go:667
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:476
+#: lxc/file.go:146
+msgid "Set the file's uid on create"
+msgstr ""
+
+#: lxc/file.go:665
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5333,7 +5364,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:994
+#: lxc/file.go:1183
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5708,6 +5739,10 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
+#: lxc/file.go:167
+msgid "Symlink target path can only be used for type \"symlink\""
+msgstr ""
+
 #: lxc/alias.go:140
 msgid "TARGET"
 msgstr ""
@@ -5727,11 +5762,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1033
+#: lxc/file.go:1222
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1027
+#: lxc/file.go:1216
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5900,6 +5935,10 @@ msgstr ""
 
 #: lxc/network.go:537 lxc/network.go:634
 msgid "The specified device doesn't match the network"
+msgstr ""
+
+#: lxc/file.go:148
+msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
 #: lxc/publish.go:97
@@ -6080,7 +6119,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:198
+#: lxc/file.go:387
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6094,7 +6133,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1254
+#: lxc/file.go:1443
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6110,7 +6149,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:808
+#: lxc/file.go:997
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6328,7 +6367,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:72
+#: lxc/file.go:76
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6677,20 +6716,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:171
+#: lxc/file.go:360
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:121
+#: lxc/file.go:133
+msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
+msgstr ""
+
+#: lxc/file.go:310
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:241
+#: lxc/file.go:430
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:985
+#: lxc/file.go:1174
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7199,20 +7242,28 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:989
+#: lxc/file.go:137
+msgid ""
+"lxc file create foo/bar\n"
+"\t   To create a file /bar in the foo instance.\n"
+"lxc file create --type=symlink foo/bar baz\n"
+"\t   To create a symlink /bar in instance foo whose target is baz."
+msgstr ""
+
+#: lxc/file.go:1178
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:245
+#: lxc/file.go:434
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:470
+#: lxc/file.go:659
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7561,16 +7612,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1143
+#: lxc/file.go:1332
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1102
+#: lxc/file.go:1291
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1055
+#: lxc/file.go:1244
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/cs.po
+++ b/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-30 13:36-0400\n"
+"POT-Creation-Date: 2024-10-01 10:45-0600\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Czech <https://hosted.weblate.org/projects/linux-containers/"
@@ -433,12 +433,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:936
+#: lxc/file.go:1125
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:826
+#: lxc/file.go:1015
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -527,7 +527,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:466
+#: lxc/file.go:655
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -982,7 +982,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:341
+#: lxc/file.go:530
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1011,7 +1011,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:547
+#: lxc/file.go:736
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1397,8 +1397,12 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:249 lxc/file.go:475
+#: lxc/file.go:143 lxc/file.go:438 lxc/file.go:664
 msgid "Create any directories necessary"
+msgstr ""
+
+#: lxc/file.go:134 lxc/file.go:135
+msgid "Create files and directories in instances"
 msgstr ""
 
 #: lxc/auth.go:98 lxc/auth.go:99
@@ -1495,6 +1499,11 @@ msgstr ""
 msgid "Creating %s"
 msgstr ""
 
+#: lxc/file.go:273
+#, c-format
+msgid "Creating %s: %%s"
+msgstr ""
+
 #: lxc/init.go:184
 msgid "Creating the instance"
 msgstr ""
@@ -1551,7 +1560,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:123 lxc/file.go:124
+#: lxc/file.go:312 lxc/file.go:313
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1668,70 +1677,71 @@ msgstr ""
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
-#: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
-#: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
-#: lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090 lxc/image.go:1417
-#: lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638 lxc/image.go:1701
-#: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
-#: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
-#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33
-#: lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405
-#: lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793
-#: lxc/network.go:874 lxc/network.go:1005 lxc/network.go:1106
-#: lxc/network.go:1185 lxc/network.go:1245 lxc/network.go:1341
-#: lxc/network.go:1413 lxc/network_acl.go:30 lxc/network_acl.go:95
-#: lxc/network_acl.go:174 lxc/network_acl.go:235 lxc/network_acl.go:291
-#: lxc/network_acl.go:364 lxc/network_acl.go:461 lxc/network_acl.go:549
-#: lxc/network_acl.go:592 lxc/network_acl.go:731 lxc/network_acl.go:788
-#: lxc/network_acl.go:845 lxc/network_acl.go:860 lxc/network_acl.go:997
-#: lxc/network_allocations.go:51 lxc/network_forward.go:33
-#: lxc/network_forward.go:90 lxc/network_forward.go:179
-#: lxc/network_forward.go:256 lxc/network_forward.go:404
-#: lxc/network_forward.go:489 lxc/network_forward.go:599
-#: lxc/network_forward.go:646 lxc/network_forward.go:800
-#: lxc/network_forward.go:874 lxc/network_forward.go:889
-#: lxc/network_forward.go:970 lxc/network_load_balancer.go:33
-#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:181
-#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:408
-#: lxc/network_load_balancer.go:476 lxc/network_load_balancer.go:586
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:771
-#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:859
-#: lxc/network_load_balancer.go:935 lxc/network_load_balancer.go:1033
-#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1121
-#: lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:167
-#: lxc/network_peer.go:236 lxc/network_peer.go:360 lxc/network_peer.go:445
-#: lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731
-#: lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:165
-#: lxc/network_zone.go:228 lxc/network_zone.go:301 lxc/network_zone.go:396
-#: lxc/network_zone.go:484 lxc/network_zone.go:527 lxc/network_zone.go:654
-#: lxc/network_zone.go:710 lxc/network_zone.go:767 lxc/network_zone.go:845
-#: lxc/network_zone.go:909 lxc/network_zone.go:985 lxc/network_zone.go:1083
-#: lxc/network_zone.go:1172 lxc/network_zone.go:1219 lxc/network_zone.go:1349
-#: lxc/network_zone.go:1410 lxc/network_zone.go:1425 lxc/network_zone.go:1483
-#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
-#: lxc/operation.go:194 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
-#: lxc/profile.go:271 lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493
-#: lxc/profile.go:629 lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860
-#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31
-#: lxc/project.go:95 lxc/project.go:191 lxc/project.go:262 lxc/project.go:398
-#: lxc/project.go:472 lxc/project.go:592 lxc/project.go:657 lxc/project.go:745
-#: lxc/project.go:789 lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34
-#: lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91
-#: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853
-#: lxc/remote.go:917 lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24
-#: lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203
-#: lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655
-#: lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940
-#: lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189
-#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:383
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:536
-#: lxc/storage_bucket.go:630 lxc/storage_bucket.go:699
-#: lxc/storage_bucket.go:733 lxc/storage_bucket.go:774
-#: lxc/storage_bucket.go:853 lxc/storage_bucket.go:959
-#: lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158
-#: lxc/storage_volume.go:58 lxc/storage_volume.go:169 lxc/storage_volume.go:283
+#: lxc/export.go:32 lxc/file.go:88 lxc/file.go:135 lxc/file.go:313
+#: lxc/file.go:362 lxc/file.go:432 lxc/file.go:657 lxc/file.go:1176
+#: lxc/image.go:38 lxc/image.go:159 lxc/image.go:337 lxc/image.go:396
+#: lxc/image.go:525 lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090
+#: lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638
+#: lxc/image.go:1701 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255
+#: lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34
+#: lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233
+#: lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560
+#: lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1005
+#: lxc/network.go:1106 lxc/network.go:1185 lxc/network.go:1245
+#: lxc/network.go:1341 lxc/network.go:1413 lxc/network_acl.go:30
+#: lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235
+#: lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461
+#: lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731
+#: lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860
+#: lxc/network_acl.go:997 lxc/network_allocations.go:51
+#: lxc/network_forward.go:33 lxc/network_forward.go:90
+#: lxc/network_forward.go:179 lxc/network_forward.go:256
+#: lxc/network_forward.go:404 lxc/network_forward.go:489
+#: lxc/network_forward.go:599 lxc/network_forward.go:646
+#: lxc/network_forward.go:800 lxc/network_forward.go:874
+#: lxc/network_forward.go:889 lxc/network_forward.go:970
+#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
+#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844
+#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1121 lxc/network_peer.go:29
+#: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
+#: lxc/network_peer.go:360 lxc/network_peer.go:445 lxc/network_peer.go:547
+#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:29
+#: lxc/network_zone.go:86 lxc/network_zone.go:165 lxc/network_zone.go:228
+#: lxc/network_zone.go:301 lxc/network_zone.go:396 lxc/network_zone.go:484
+#: lxc/network_zone.go:527 lxc/network_zone.go:654 lxc/network_zone.go:710
+#: lxc/network_zone.go:767 lxc/network_zone.go:845 lxc/network_zone.go:909
+#: lxc/network_zone.go:985 lxc/network_zone.go:1083 lxc/network_zone.go:1172
+#: lxc/network_zone.go:1219 lxc/network_zone.go:1349 lxc/network_zone.go:1410
+#: lxc/network_zone.go:1425 lxc/network_zone.go:1483 lxc/operation.go:25
+#: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
+#: lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180 lxc/profile.go:271
+#: lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493 lxc/profile.go:629
+#: lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860 lxc/profile.go:920
+#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31 lxc/project.go:95
+#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
+#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
+#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:648
+#: lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853 lxc/remote.go:917
+#: lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
+#: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
+#: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:459
+#: lxc/storage_bucket.go:536 lxc/storage_bucket.go:630
+#: lxc/storage_bucket.go:699 lxc/storage_bucket.go:733
+#: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
+#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:283
 #: lxc/storage_volume.go:390 lxc/storage_volume.go:605
 #: lxc/storage_volume.go:714 lxc/storage_volume.go:801
 #: lxc/storage_volume.go:899 lxc/storage_volume.go:996
@@ -1829,7 +1839,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:995
+#: lxc/file.go:1184
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1895,7 +1905,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:75
+#: lxc/file.go:79
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1913,7 +1923,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:172 lxc/file.go:173
+#: lxc/file.go:361 lxc/file.go:362
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2183,12 +2193,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1238
+#: lxc/file.go:1427
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1261
+#: lxc/file.go:1450
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2203,12 +2213,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1288
+#: lxc/file.go:1477
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1073
+#: lxc/file.go:1262
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2238,7 +2248,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1194
+#: lxc/file.go:1383
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2253,7 +2263,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1199
+#: lxc/file.go:1388
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2263,12 +2273,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1099
+#: lxc/file.go:1288
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1226
+#: lxc/file.go:1415
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2307,7 +2317,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1400
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2322,7 +2332,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:821
+#: lxc/file.go:1010
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2348,6 +2358,10 @@ msgstr ""
 
 #: lxc/cluster.go:1302
 msgid "Force a particular evacuation action"
+msgstr ""
+
+#: lxc/file.go:144
+msgid "Force creating files or directories"
 msgstr ""
 
 #: lxc/cluster.go:1301
@@ -2644,22 +2658,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1311
+#: lxc/file.go:1500
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1300
+#: lxc/file.go:1489
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1312
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1133
+#: lxc/file.go:1322
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2852,11 +2866,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1125
+#: lxc/file.go:1314
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1302
+#: lxc/file.go:1491
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2874,7 +2888,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1045
+#: lxc/file.go:1234
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2926,7 +2940,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1040
+#: lxc/file.go:1229
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2968,7 +2982,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:148
+#: lxc/file.go:337
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2984,14 +2998,19 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:314
+#: lxc/file.go:503
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:496
+#: lxc/file.go:177 lxc/file.go:685
 #, c-format
 msgid "Invalid target %s"
+msgstr ""
+
+#: lxc/file.go:163
+#, c-format
+msgid "Invalid type %q"
 msgstr ""
 
 #: lxc/info.go:238
@@ -3496,7 +3515,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:83 lxc/file.go:84
+#: lxc/file.go:87 lxc/file.go:88
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3882,7 +3901,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:599
+#: lxc/file.go:788
 msgid "Missing target directory"
 msgstr ""
 
@@ -3920,11 +3939,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:286
+#: lxc/file.go:475
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:986 lxc/file.go:987
+#: lxc/file.go:1175 lxc/file.go:1176
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4376,7 +4395,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1103
+#: lxc/file.go:1292
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4610,20 +4629,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:242 lxc/file.go:243
+#: lxc/file.go:431 lxc/file.go:432
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:417 lxc/file.go:768
+#: lxc/file.go:606 lxc/file.go:957
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:467 lxc/file.go:468
+#: lxc/file.go:656 lxc/file.go:657
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:702 lxc/file.go:868
+#: lxc/file.go:891 lxc/file.go:1057
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4661,7 +4680,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:250 lxc/file.go:474
+#: lxc/file.go:439 lxc/file.go:663
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4990,12 +5009,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1231
+#: lxc/file.go:1420
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1232
+#: lxc/file.go:1421
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5071,7 +5090,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:996
+#: lxc/file.go:1185
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5265,15 +5284,27 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:477
+#: lxc/file.go:145
+msgid "Set the file's gid on create"
+msgstr ""
+
+#: lxc/file.go:666
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:478
+#: lxc/file.go:147
+msgid "Set the file's perms on create"
+msgstr ""
+
+#: lxc/file.go:667
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:476
+#: lxc/file.go:146
+msgid "Set the file's uid on create"
+msgstr ""
+
+#: lxc/file.go:665
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5333,7 +5364,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:994
+#: lxc/file.go:1183
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5708,6 +5739,10 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
+#: lxc/file.go:167
+msgid "Symlink target path can only be used for type \"symlink\""
+msgstr ""
+
 #: lxc/alias.go:140
 msgid "TARGET"
 msgstr ""
@@ -5727,11 +5762,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1033
+#: lxc/file.go:1222
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1027
+#: lxc/file.go:1216
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5900,6 +5935,10 @@ msgstr ""
 
 #: lxc/network.go:537 lxc/network.go:634
 msgid "The specified device doesn't match the network"
+msgstr ""
+
+#: lxc/file.go:148
+msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
 #: lxc/publish.go:97
@@ -6080,7 +6119,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:198
+#: lxc/file.go:387
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6094,7 +6133,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1254
+#: lxc/file.go:1443
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6110,7 +6149,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:808
+#: lxc/file.go:997
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6328,7 +6367,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:72
+#: lxc/file.go:76
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6677,20 +6716,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:171
+#: lxc/file.go:360
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:121
+#: lxc/file.go:133
+msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
+msgstr ""
+
+#: lxc/file.go:310
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:241
+#: lxc/file.go:430
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:985
+#: lxc/file.go:1174
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7199,20 +7242,28 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:989
+#: lxc/file.go:137
+msgid ""
+"lxc file create foo/bar\n"
+"\t   To create a file /bar in the foo instance.\n"
+"lxc file create --type=symlink foo/bar baz\n"
+"\t   To create a symlink /bar in instance foo whose target is baz."
+msgstr ""
+
+#: lxc/file.go:1178
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:245
+#: lxc/file.go:434
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:470
+#: lxc/file.go:659
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7561,16 +7612,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1143
+#: lxc/file.go:1332
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1102
+#: lxc/file.go:1291
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1055
+#: lxc/file.go:1244
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-30 13:36-0400\n"
+"POT-Creation-Date: 2024-10-01 10:45-0600\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Krombel <krombel@krombel.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/linux-containers/"
@@ -682,12 +682,12 @@ msgstr "%s (%d mehr)"
 msgid "%s (%s) (%d available)"
 msgstr "%s (%d mehr)"
 
-#: lxc/file.go:936
+#: lxc/file.go:1125
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s ist kein Verzeichnis"
 
-#: lxc/file.go:826
+#: lxc/file.go:1015
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' ist kein unterstützter Dateityp"
@@ -786,7 +786,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:466
+#: lxc/file.go:655
 #, fuzzy
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
@@ -1278,7 +1278,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:341
+#: lxc/file.go:530
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1307,7 +1307,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:547
+#: lxc/file.go:736
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1710,9 +1710,14 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Create and start instances from images"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/file.go:249 lxc/file.go:475
+#: lxc/file.go:143 lxc/file.go:438 lxc/file.go:664
 msgid "Create any directories necessary"
 msgstr ""
+
+#: lxc/file.go:134 lxc/file.go:135
+#, fuzzy
+msgid "Create files and directories in instances"
+msgstr "kann nicht zum selben Container Namen kopieren"
 
 #: lxc/auth.go:98 lxc/auth.go:99
 #, fuzzy
@@ -1825,6 +1830,11 @@ msgstr "Erstellt: %s"
 msgid "Creating %s"
 msgstr "Erstelle %s"
 
+#: lxc/file.go:273
+#, fuzzy, c-format
+msgid "Creating %s: %%s"
+msgstr "Erstelle %s"
+
 #: lxc/init.go:184
 #, fuzzy
 msgid "Creating the instance"
@@ -1882,7 +1892,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:123 lxc/file.go:124
+#: lxc/file.go:312 lxc/file.go:313
 #, fuzzy
 msgid "Delete files in instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -2010,70 +2020,71 @@ msgstr ""
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
-#: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
-#: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
-#: lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090 lxc/image.go:1417
-#: lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638 lxc/image.go:1701
-#: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
-#: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
-#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33
-#: lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405
-#: lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793
-#: lxc/network.go:874 lxc/network.go:1005 lxc/network.go:1106
-#: lxc/network.go:1185 lxc/network.go:1245 lxc/network.go:1341
-#: lxc/network.go:1413 lxc/network_acl.go:30 lxc/network_acl.go:95
-#: lxc/network_acl.go:174 lxc/network_acl.go:235 lxc/network_acl.go:291
-#: lxc/network_acl.go:364 lxc/network_acl.go:461 lxc/network_acl.go:549
-#: lxc/network_acl.go:592 lxc/network_acl.go:731 lxc/network_acl.go:788
-#: lxc/network_acl.go:845 lxc/network_acl.go:860 lxc/network_acl.go:997
-#: lxc/network_allocations.go:51 lxc/network_forward.go:33
-#: lxc/network_forward.go:90 lxc/network_forward.go:179
-#: lxc/network_forward.go:256 lxc/network_forward.go:404
-#: lxc/network_forward.go:489 lxc/network_forward.go:599
-#: lxc/network_forward.go:646 lxc/network_forward.go:800
-#: lxc/network_forward.go:874 lxc/network_forward.go:889
-#: lxc/network_forward.go:970 lxc/network_load_balancer.go:33
-#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:181
-#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:408
-#: lxc/network_load_balancer.go:476 lxc/network_load_balancer.go:586
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:771
-#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:859
-#: lxc/network_load_balancer.go:935 lxc/network_load_balancer.go:1033
-#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1121
-#: lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:167
-#: lxc/network_peer.go:236 lxc/network_peer.go:360 lxc/network_peer.go:445
-#: lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731
-#: lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:165
-#: lxc/network_zone.go:228 lxc/network_zone.go:301 lxc/network_zone.go:396
-#: lxc/network_zone.go:484 lxc/network_zone.go:527 lxc/network_zone.go:654
-#: lxc/network_zone.go:710 lxc/network_zone.go:767 lxc/network_zone.go:845
-#: lxc/network_zone.go:909 lxc/network_zone.go:985 lxc/network_zone.go:1083
-#: lxc/network_zone.go:1172 lxc/network_zone.go:1219 lxc/network_zone.go:1349
-#: lxc/network_zone.go:1410 lxc/network_zone.go:1425 lxc/network_zone.go:1483
-#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
-#: lxc/operation.go:194 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
-#: lxc/profile.go:271 lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493
-#: lxc/profile.go:629 lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860
-#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31
-#: lxc/project.go:95 lxc/project.go:191 lxc/project.go:262 lxc/project.go:398
-#: lxc/project.go:472 lxc/project.go:592 lxc/project.go:657 lxc/project.go:745
-#: lxc/project.go:789 lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34
-#: lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91
-#: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853
-#: lxc/remote.go:917 lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24
-#: lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203
-#: lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655
-#: lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940
-#: lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189
-#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:383
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:536
-#: lxc/storage_bucket.go:630 lxc/storage_bucket.go:699
-#: lxc/storage_bucket.go:733 lxc/storage_bucket.go:774
-#: lxc/storage_bucket.go:853 lxc/storage_bucket.go:959
-#: lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158
-#: lxc/storage_volume.go:58 lxc/storage_volume.go:169 lxc/storage_volume.go:283
+#: lxc/export.go:32 lxc/file.go:88 lxc/file.go:135 lxc/file.go:313
+#: lxc/file.go:362 lxc/file.go:432 lxc/file.go:657 lxc/file.go:1176
+#: lxc/image.go:38 lxc/image.go:159 lxc/image.go:337 lxc/image.go:396
+#: lxc/image.go:525 lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090
+#: lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638
+#: lxc/image.go:1701 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255
+#: lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34
+#: lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233
+#: lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560
+#: lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1005
+#: lxc/network.go:1106 lxc/network.go:1185 lxc/network.go:1245
+#: lxc/network.go:1341 lxc/network.go:1413 lxc/network_acl.go:30
+#: lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235
+#: lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461
+#: lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731
+#: lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860
+#: lxc/network_acl.go:997 lxc/network_allocations.go:51
+#: lxc/network_forward.go:33 lxc/network_forward.go:90
+#: lxc/network_forward.go:179 lxc/network_forward.go:256
+#: lxc/network_forward.go:404 lxc/network_forward.go:489
+#: lxc/network_forward.go:599 lxc/network_forward.go:646
+#: lxc/network_forward.go:800 lxc/network_forward.go:874
+#: lxc/network_forward.go:889 lxc/network_forward.go:970
+#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
+#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844
+#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1121 lxc/network_peer.go:29
+#: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
+#: lxc/network_peer.go:360 lxc/network_peer.go:445 lxc/network_peer.go:547
+#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:29
+#: lxc/network_zone.go:86 lxc/network_zone.go:165 lxc/network_zone.go:228
+#: lxc/network_zone.go:301 lxc/network_zone.go:396 lxc/network_zone.go:484
+#: lxc/network_zone.go:527 lxc/network_zone.go:654 lxc/network_zone.go:710
+#: lxc/network_zone.go:767 lxc/network_zone.go:845 lxc/network_zone.go:909
+#: lxc/network_zone.go:985 lxc/network_zone.go:1083 lxc/network_zone.go:1172
+#: lxc/network_zone.go:1219 lxc/network_zone.go:1349 lxc/network_zone.go:1410
+#: lxc/network_zone.go:1425 lxc/network_zone.go:1483 lxc/operation.go:25
+#: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
+#: lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180 lxc/profile.go:271
+#: lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493 lxc/profile.go:629
+#: lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860 lxc/profile.go:920
+#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31 lxc/project.go:95
+#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
+#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
+#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:648
+#: lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853 lxc/remote.go:917
+#: lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
+#: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
+#: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:459
+#: lxc/storage_bucket.go:536 lxc/storage_bucket.go:630
+#: lxc/storage_bucket.go:699 lxc/storage_bucket.go:733
+#: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
+#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:283
 #: lxc/storage_volume.go:390 lxc/storage_volume.go:605
 #: lxc/storage_volume.go:714 lxc/storage_volume.go:801
 #: lxc/storage_volume.go:899 lxc/storage_volume.go:996
@@ -2181,7 +2192,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:995
+#: lxc/file.go:1184
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2252,7 +2263,7 @@ msgstr "ABLAUFDATUM"
 msgid "EXPIRY DATE"
 msgstr "ABLAUFDATUM"
 
-#: lxc/file.go:75
+#: lxc/file.go:79
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -2271,7 +2282,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/file.go:172 lxc/file.go:173
+#: lxc/file.go:361 lxc/file.go:362
 #, fuzzy
 msgid "Edit files in instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -2570,12 +2581,12 @@ msgstr "FINGERABDRUCK"
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1238
+#: lxc/file.go:1427
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1261
+#: lxc/file.go:1450
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2590,12 +2601,12 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/file.go:1288
+#: lxc/file.go:1477
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1073
+#: lxc/file.go:1262
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -2625,7 +2636,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Failed fetching fingerprint %q: %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/file.go:1194
+#: lxc/file.go:1383
 #, fuzzy, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "Akzeptiere Zertifikat"
@@ -2640,7 +2651,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/file.go:1199
+#: lxc/file.go:1388
 #, fuzzy, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "Akzeptiere Zertifikat"
@@ -2650,12 +2661,12 @@ msgstr "Akzeptiere Zertifikat"
 msgid "Failed starting command: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/file.go:1099
+#: lxc/file.go:1288
 #, fuzzy, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/file.go:1226
+#: lxc/file.go:1415
 #, fuzzy, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "Akzeptiere Zertifikat"
@@ -2694,7 +2705,7 @@ msgstr "Akzeptiere Zertifikat"
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1400
 #, fuzzy, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "Akzeptiere Zertifikat"
@@ -2709,7 +2720,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Failed to remove alias %s: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/file.go:821
+#: lxc/file.go:1010
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2738,6 +2749,10 @@ msgstr "Fingerabdruck: %s\n"
 
 #: lxc/cluster.go:1302
 msgid "Force a particular evacuation action"
+msgstr ""
+
+#: lxc/file.go:144
+msgid "Force creating files or directories"
 msgstr ""
 
 #: lxc/cluster.go:1301
@@ -3057,22 +3072,22 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1311
+#: lxc/file.go:1500
 #, fuzzy, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/file.go:1300
+#: lxc/file.go:1489
 #, fuzzy, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/file.go:1123
+#: lxc/file.go:1312
 #, fuzzy, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/file.go:1133
+#: lxc/file.go:1322
 #, fuzzy, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -3271,12 +3286,12 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1125
+#: lxc/file.go:1314
 #, fuzzy
 msgid "Instance disconnected"
 msgstr "Entferntes Administrator Passwort"
 
-#: lxc/file.go:1302
+#: lxc/file.go:1491
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3294,7 +3309,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1045
+#: lxc/file.go:1234
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3347,7 +3362,7 @@ msgstr "Ungültiges Ziel %s"
 msgid "Invalid instance name: %s"
 msgstr "Ungültige Quelle %s"
 
-#: lxc/file.go:1040
+#: lxc/file.go:1229
 #, fuzzy, c-format
 msgid "Invalid instance path: %q"
 msgstr "Ungültige Quelle %s"
@@ -3391,7 +3406,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr "ungültiges Argument %s"
 
-#: lxc/file.go:148
+#: lxc/file.go:337
 #, fuzzy, c-format
 msgid "Invalid path %s"
 msgstr "Ungültiges Ziel %s"
@@ -3408,14 +3423,19 @@ msgstr "Ungültiges Ziel %s"
 msgid "Invalid snapshot name"
 msgstr "Ungültige Quelle %s"
 
-#: lxc/file.go:314
+#: lxc/file.go:503
 #, c-format
 msgid "Invalid source %s"
 msgstr "Ungültige Quelle %s"
 
-#: lxc/file.go:496
+#: lxc/file.go:177 lxc/file.go:685
 #, c-format
 msgid "Invalid target %s"
+msgstr "Ungültiges Ziel %s"
+
+#: lxc/file.go:163
+#, fuzzy, c-format
+msgid "Invalid type %q"
 msgstr "Ungültiges Ziel %s"
 
 #: lxc/info.go:238
@@ -3967,7 +3987,7 @@ msgstr "Unbekannter Befehl %s für Abbild"
 msgid "Manage devices"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/file.go:83 lxc/file.go:84
+#: lxc/file.go:87 lxc/file.go:88
 #, fuzzy
 msgid "Manage files in instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -4404,7 +4424,7 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Missing storage pool name"
 msgstr "Profilname kann nicht geändert werden"
 
-#: lxc/file.go:599
+#: lxc/file.go:788
 msgid "Missing target directory"
 msgstr ""
 
@@ -4443,12 +4463,12 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:286
+#: lxc/file.go:475
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 "Mehr als eine Datei herunterzuladen, aber das Ziel ist kein Verzeichnis"
 
-#: lxc/file.go:986 lxc/file.go:987
+#: lxc/file.go:1175 lxc/file.go:1176
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -4914,7 +4934,7 @@ msgstr "Erstellt: %s"
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1103
+#: lxc/file.go:1292
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -5155,22 +5175,22 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Publishing instance: %s"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/file.go:242 lxc/file.go:243
+#: lxc/file.go:431 lxc/file.go:432
 #, fuzzy
 msgid "Pull files from instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/file.go:417 lxc/file.go:768
+#: lxc/file.go:606 lxc/file.go:957
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:467 lxc/file.go:468
+#: lxc/file.go:656 lxc/file.go:657
 #, fuzzy
 msgid "Push files into instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/file.go:702 lxc/file.go:868
+#: lxc/file.go:891 lxc/file.go:1057
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -5210,7 +5230,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Rebuild instances"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/file.go:250 lxc/file.go:474
+#: lxc/file.go:439 lxc/file.go:663
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -5570,12 +5590,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1231
+#: lxc/file.go:1420
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1232
+#: lxc/file.go:1421
 #, fuzzy, c-format
 msgid "SSH client disconnected %q"
 msgstr "Entferntes Administrator Passwort"
@@ -5655,7 +5675,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Set a cluster member's configuration keys"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/file.go:996
+#: lxc/file.go:1185
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5861,15 +5881,30 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:477
+#: lxc/file.go:145
+#, fuzzy
+msgid "Set the file's gid on create"
+msgstr "Setzt die gid der Datei beim Übertragen"
+
+#: lxc/file.go:666
 msgid "Set the file's gid on push"
 msgstr "Setzt die gid der Datei beim Übertragen"
 
-#: lxc/file.go:478
+#: lxc/file.go:147
+#, fuzzy
+msgid "Set the file's perms on create"
+msgstr "Setzt die Dateiberechtigungen beim Übertragen"
+
+#: lxc/file.go:667
 msgid "Set the file's perms on push"
 msgstr "Setzt die Dateiberechtigungen beim Übertragen"
 
-#: lxc/file.go:476
+#: lxc/file.go:146
+#, fuzzy
+msgid "Set the file's uid on create"
+msgstr "Setzt die uid der Datei beim Übertragen"
+
+#: lxc/file.go:665
 msgid "Set the file's uid on push"
 msgstr "Setzt die uid der Datei beim Übertragen"
 
@@ -5937,7 +5972,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:994
+#: lxc/file.go:1183
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -6344,6 +6379,10 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
+#: lxc/file.go:167
+msgid "Symlink target path can only be used for type \"symlink\""
+msgstr ""
+
 #: lxc/alias.go:140
 msgid "TARGET"
 msgstr ""
@@ -6363,12 +6402,12 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1033
+#: lxc/file.go:1222
 #, fuzzy
 msgid "Target path and --listen flag cannot be used together"
 msgstr "--refresh kann nur mit Containern verwendet werden"
 
-#: lxc/file.go:1027
+#: lxc/file.go:1216
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -6545,6 +6584,10 @@ msgstr "entfernte Instanz %s existiert nicht"
 #, fuzzy
 msgid "The specified device doesn't match the network"
 msgstr "entfernte Instanz %s existiert nicht"
+
+#: lxc/file.go:148
+msgid "The type to create (file, symlink, or directory)"
+msgstr ""
 
 #: lxc/publish.go:97
 msgid "There is no \"image name\".  Did you want an alias?"
@@ -6728,7 +6771,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:198
+#: lxc/file.go:387
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6743,7 +6786,7 @@ msgstr "Neue entfernte Server hinzufügen"
 msgid "Unknown certificate type %q"
 msgstr "Unbekannter Befehl %s für Abbild"
 
-#: lxc/file.go:1254
+#: lxc/file.go:1443
 #, fuzzy, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr "Unbekannter Befehl %s für Abbild"
@@ -6759,7 +6802,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr "Unbekannter Befehl %s für Abbild"
 
-#: lxc/file.go:808
+#: lxc/file.go:997
 #, fuzzy, c-format
 msgid "Unknown file type '%s'"
 msgstr "Unbekannter Befehl %s für Abbild"
@@ -7005,7 +7048,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:72
+#: lxc/file.go:76
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -7604,7 +7647,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/file.go:171
+#: lxc/file.go:360
 #, fuzzy
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
@@ -7613,7 +7656,16 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/file.go:121
+#: lxc/file.go:133
+#, fuzzy
+msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
+msgstr ""
+"Löscht einen Container oder Container Sicherungspunkt.\n"
+"\n"
+"Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
+"Daten (Konfiguration, Sicherungspunkte, ...).\n"
+
+#: lxc/file.go:310
 #, fuzzy
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
@@ -7621,7 +7673,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/file.go:241
+#: lxc/file.go:430
 #, fuzzy
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
@@ -7631,7 +7683,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/file.go:985
+#: lxc/file.go:1174
 #, fuzzy
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
@@ -8505,20 +8557,28 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:989
+#: lxc/file.go:137
+msgid ""
+"lxc file create foo/bar\n"
+"\t   To create a file /bar in the foo instance.\n"
+"lxc file create --type=symlink foo/bar baz\n"
+"\t   To create a symlink /bar in instance foo whose target is baz."
+msgstr ""
+
+#: lxc/file.go:1178
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:245
+#: lxc/file.go:434
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:470
+#: lxc/file.go:659
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -8871,16 +8931,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1143
+#: lxc/file.go:1332
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1102
+#: lxc/file.go:1291
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1055
+#: lxc/file.go:1244
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-30 13:36-0400\n"
+"POT-Creation-Date: 2024-10-01 10:45-0600\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/linux-containers/"
@@ -433,12 +433,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:936
+#: lxc/file.go:1125
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:826
+#: lxc/file.go:1015
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -527,7 +527,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:466
+#: lxc/file.go:655
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -986,7 +986,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:341
+#: lxc/file.go:530
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:547
+#: lxc/file.go:736
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1401,8 +1401,12 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:249 lxc/file.go:475
+#: lxc/file.go:143 lxc/file.go:438 lxc/file.go:664
 msgid "Create any directories necessary"
+msgstr ""
+
+#: lxc/file.go:134 lxc/file.go:135
+msgid "Create files and directories in instances"
 msgstr ""
 
 #: lxc/auth.go:98 lxc/auth.go:99
@@ -1502,6 +1506,11 @@ msgstr ""
 msgid "Creating %s"
 msgstr ""
 
+#: lxc/file.go:273
+#, c-format
+msgid "Creating %s: %%s"
+msgstr ""
+
 #: lxc/init.go:184
 msgid "Creating the instance"
 msgstr ""
@@ -1558,7 +1567,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:123 lxc/file.go:124
+#: lxc/file.go:312 lxc/file.go:313
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1680,70 +1689,71 @@ msgstr ""
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
-#: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
-#: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
-#: lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090 lxc/image.go:1417
-#: lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638 lxc/image.go:1701
-#: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
-#: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
-#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33
-#: lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405
-#: lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793
-#: lxc/network.go:874 lxc/network.go:1005 lxc/network.go:1106
-#: lxc/network.go:1185 lxc/network.go:1245 lxc/network.go:1341
-#: lxc/network.go:1413 lxc/network_acl.go:30 lxc/network_acl.go:95
-#: lxc/network_acl.go:174 lxc/network_acl.go:235 lxc/network_acl.go:291
-#: lxc/network_acl.go:364 lxc/network_acl.go:461 lxc/network_acl.go:549
-#: lxc/network_acl.go:592 lxc/network_acl.go:731 lxc/network_acl.go:788
-#: lxc/network_acl.go:845 lxc/network_acl.go:860 lxc/network_acl.go:997
-#: lxc/network_allocations.go:51 lxc/network_forward.go:33
-#: lxc/network_forward.go:90 lxc/network_forward.go:179
-#: lxc/network_forward.go:256 lxc/network_forward.go:404
-#: lxc/network_forward.go:489 lxc/network_forward.go:599
-#: lxc/network_forward.go:646 lxc/network_forward.go:800
-#: lxc/network_forward.go:874 lxc/network_forward.go:889
-#: lxc/network_forward.go:970 lxc/network_load_balancer.go:33
-#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:181
-#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:408
-#: lxc/network_load_balancer.go:476 lxc/network_load_balancer.go:586
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:771
-#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:859
-#: lxc/network_load_balancer.go:935 lxc/network_load_balancer.go:1033
-#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1121
-#: lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:167
-#: lxc/network_peer.go:236 lxc/network_peer.go:360 lxc/network_peer.go:445
-#: lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731
-#: lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:165
-#: lxc/network_zone.go:228 lxc/network_zone.go:301 lxc/network_zone.go:396
-#: lxc/network_zone.go:484 lxc/network_zone.go:527 lxc/network_zone.go:654
-#: lxc/network_zone.go:710 lxc/network_zone.go:767 lxc/network_zone.go:845
-#: lxc/network_zone.go:909 lxc/network_zone.go:985 lxc/network_zone.go:1083
-#: lxc/network_zone.go:1172 lxc/network_zone.go:1219 lxc/network_zone.go:1349
-#: lxc/network_zone.go:1410 lxc/network_zone.go:1425 lxc/network_zone.go:1483
-#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
-#: lxc/operation.go:194 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
-#: lxc/profile.go:271 lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493
-#: lxc/profile.go:629 lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860
-#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31
-#: lxc/project.go:95 lxc/project.go:191 lxc/project.go:262 lxc/project.go:398
-#: lxc/project.go:472 lxc/project.go:592 lxc/project.go:657 lxc/project.go:745
-#: lxc/project.go:789 lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34
-#: lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91
-#: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853
-#: lxc/remote.go:917 lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24
-#: lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203
-#: lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655
-#: lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940
-#: lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189
-#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:383
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:536
-#: lxc/storage_bucket.go:630 lxc/storage_bucket.go:699
-#: lxc/storage_bucket.go:733 lxc/storage_bucket.go:774
-#: lxc/storage_bucket.go:853 lxc/storage_bucket.go:959
-#: lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158
-#: lxc/storage_volume.go:58 lxc/storage_volume.go:169 lxc/storage_volume.go:283
+#: lxc/export.go:32 lxc/file.go:88 lxc/file.go:135 lxc/file.go:313
+#: lxc/file.go:362 lxc/file.go:432 lxc/file.go:657 lxc/file.go:1176
+#: lxc/image.go:38 lxc/image.go:159 lxc/image.go:337 lxc/image.go:396
+#: lxc/image.go:525 lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090
+#: lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638
+#: lxc/image.go:1701 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255
+#: lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34
+#: lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233
+#: lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560
+#: lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1005
+#: lxc/network.go:1106 lxc/network.go:1185 lxc/network.go:1245
+#: lxc/network.go:1341 lxc/network.go:1413 lxc/network_acl.go:30
+#: lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235
+#: lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461
+#: lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731
+#: lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860
+#: lxc/network_acl.go:997 lxc/network_allocations.go:51
+#: lxc/network_forward.go:33 lxc/network_forward.go:90
+#: lxc/network_forward.go:179 lxc/network_forward.go:256
+#: lxc/network_forward.go:404 lxc/network_forward.go:489
+#: lxc/network_forward.go:599 lxc/network_forward.go:646
+#: lxc/network_forward.go:800 lxc/network_forward.go:874
+#: lxc/network_forward.go:889 lxc/network_forward.go:970
+#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
+#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844
+#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1121 lxc/network_peer.go:29
+#: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
+#: lxc/network_peer.go:360 lxc/network_peer.go:445 lxc/network_peer.go:547
+#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:29
+#: lxc/network_zone.go:86 lxc/network_zone.go:165 lxc/network_zone.go:228
+#: lxc/network_zone.go:301 lxc/network_zone.go:396 lxc/network_zone.go:484
+#: lxc/network_zone.go:527 lxc/network_zone.go:654 lxc/network_zone.go:710
+#: lxc/network_zone.go:767 lxc/network_zone.go:845 lxc/network_zone.go:909
+#: lxc/network_zone.go:985 lxc/network_zone.go:1083 lxc/network_zone.go:1172
+#: lxc/network_zone.go:1219 lxc/network_zone.go:1349 lxc/network_zone.go:1410
+#: lxc/network_zone.go:1425 lxc/network_zone.go:1483 lxc/operation.go:25
+#: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
+#: lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180 lxc/profile.go:271
+#: lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493 lxc/profile.go:629
+#: lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860 lxc/profile.go:920
+#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31 lxc/project.go:95
+#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
+#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
+#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:648
+#: lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853 lxc/remote.go:917
+#: lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
+#: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
+#: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:459
+#: lxc/storage_bucket.go:536 lxc/storage_bucket.go:630
+#: lxc/storage_bucket.go:699 lxc/storage_bucket.go:733
+#: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
+#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:283
 #: lxc/storage_volume.go:390 lxc/storage_volume.go:605
 #: lxc/storage_volume.go:714 lxc/storage_volume.go:801
 #: lxc/storage_volume.go:899 lxc/storage_volume.go:996
@@ -1842,7 +1852,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:995
+#: lxc/file.go:1184
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1911,7 +1921,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:75
+#: lxc/file.go:79
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1929,7 +1939,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:172 lxc/file.go:173
+#: lxc/file.go:361 lxc/file.go:362
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2205,12 +2215,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1238
+#: lxc/file.go:1427
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1261
+#: lxc/file.go:1450
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2225,12 +2235,12 @@ msgstr "  Χρήση δικτύου:"
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/file.go:1288
+#: lxc/file.go:1477
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1073
+#: lxc/file.go:1262
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "  Χρήση δικτύου:"
@@ -2260,7 +2270,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Failed fetching fingerprint %q: %w"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/file.go:1194
+#: lxc/file.go:1383
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2275,7 +2285,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/file.go:1199
+#: lxc/file.go:1388
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2285,12 +2295,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1099
+#: lxc/file.go:1288
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1226
+#: lxc/file.go:1415
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2329,7 +2339,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1400
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2344,7 +2354,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:821
+#: lxc/file.go:1010
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2370,6 +2380,10 @@ msgstr ""
 
 #: lxc/cluster.go:1302
 msgid "Force a particular evacuation action"
+msgstr ""
+
+#: lxc/file.go:144
+msgid "Force creating files or directories"
 msgstr ""
 
 #: lxc/cluster.go:1301
@@ -2679,22 +2693,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1311
+#: lxc/file.go:1500
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1300
+#: lxc/file.go:1489
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1312
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1133
+#: lxc/file.go:1322
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2887,11 +2901,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1125
+#: lxc/file.go:1314
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1302
+#: lxc/file.go:1491
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2909,7 +2923,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1045
+#: lxc/file.go:1234
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2961,7 +2975,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1040
+#: lxc/file.go:1229
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3003,7 +3017,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:148
+#: lxc/file.go:337
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -3019,14 +3033,19 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:314
+#: lxc/file.go:503
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:496
+#: lxc/file.go:177 lxc/file.go:685
 #, c-format
 msgid "Invalid target %s"
+msgstr ""
+
+#: lxc/file.go:163
+#, c-format
+msgid "Invalid type %q"
 msgstr ""
 
 #: lxc/info.go:238
@@ -3534,7 +3553,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:83 lxc/file.go:84
+#: lxc/file.go:87 lxc/file.go:88
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3944,7 +3963,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/file.go:599
+#: lxc/file.go:788
 msgid "Missing target directory"
 msgstr ""
 
@@ -3982,11 +4001,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:286
+#: lxc/file.go:475
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:986 lxc/file.go:987
+#: lxc/file.go:1175 lxc/file.go:1176
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4441,7 +4460,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1103
+#: lxc/file.go:1292
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4675,20 +4694,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:242 lxc/file.go:243
+#: lxc/file.go:431 lxc/file.go:432
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:417 lxc/file.go:768
+#: lxc/file.go:606 lxc/file.go:957
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:467 lxc/file.go:468
+#: lxc/file.go:656 lxc/file.go:657
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:702 lxc/file.go:868
+#: lxc/file.go:891 lxc/file.go:1057
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4726,7 +4745,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:250 lxc/file.go:474
+#: lxc/file.go:439 lxc/file.go:663
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -5061,12 +5080,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1231
+#: lxc/file.go:1420
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1232
+#: lxc/file.go:1421
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5143,7 +5162,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/file.go:996
+#: lxc/file.go:1185
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5343,15 +5362,27 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:477
+#: lxc/file.go:145
+msgid "Set the file's gid on create"
+msgstr ""
+
+#: lxc/file.go:666
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:478
+#: lxc/file.go:147
+msgid "Set the file's perms on create"
+msgstr ""
+
+#: lxc/file.go:667
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:476
+#: lxc/file.go:146
+msgid "Set the file's uid on create"
+msgstr ""
+
+#: lxc/file.go:665
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5417,7 +5448,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:994
+#: lxc/file.go:1183
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5803,6 +5834,10 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
+#: lxc/file.go:167
+msgid "Symlink target path can only be used for type \"symlink\""
+msgstr ""
+
 #: lxc/alias.go:140
 msgid "TARGET"
 msgstr ""
@@ -5822,11 +5857,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1033
+#: lxc/file.go:1222
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1027
+#: lxc/file.go:1216
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5995,6 +6030,10 @@ msgstr ""
 
 #: lxc/network.go:537 lxc/network.go:634
 msgid "The specified device doesn't match the network"
+msgstr ""
+
+#: lxc/file.go:148
+msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
 #: lxc/publish.go:97
@@ -6176,7 +6215,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:198
+#: lxc/file.go:387
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6190,7 +6229,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1254
+#: lxc/file.go:1443
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6206,7 +6245,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:808
+#: lxc/file.go:997
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6441,7 +6480,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:72
+#: lxc/file.go:76
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6790,20 +6829,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:171
+#: lxc/file.go:360
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:121
+#: lxc/file.go:133
+msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
+msgstr ""
+
+#: lxc/file.go:310
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:241
+#: lxc/file.go:430
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:985
+#: lxc/file.go:1174
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7312,20 +7355,28 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:989
+#: lxc/file.go:137
+msgid ""
+"lxc file create foo/bar\n"
+"\t   To create a file /bar in the foo instance.\n"
+"lxc file create --type=symlink foo/bar baz\n"
+"\t   To create a symlink /bar in instance foo whose target is baz."
+msgstr ""
+
+#: lxc/file.go:1178
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:245
+#: lxc/file.go:434
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:470
+#: lxc/file.go:659
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7674,16 +7725,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1143
+#: lxc/file.go:1332
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1102
+#: lxc/file.go:1291
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1055
+#: lxc/file.go:1244
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/eo.po
+++ b/po/eo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-30 13:36-0400\n"
+"POT-Creation-Date: 2024-10-01 10:45-0600\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Esperanto <https://hosted.weblate.org/projects/linux-"
@@ -433,12 +433,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:936
+#: lxc/file.go:1125
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:826
+#: lxc/file.go:1015
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -527,7 +527,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:466
+#: lxc/file.go:655
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -982,7 +982,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:341
+#: lxc/file.go:530
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1011,7 +1011,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:547
+#: lxc/file.go:736
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1397,8 +1397,12 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:249 lxc/file.go:475
+#: lxc/file.go:143 lxc/file.go:438 lxc/file.go:664
 msgid "Create any directories necessary"
+msgstr ""
+
+#: lxc/file.go:134 lxc/file.go:135
+msgid "Create files and directories in instances"
 msgstr ""
 
 #: lxc/auth.go:98 lxc/auth.go:99
@@ -1495,6 +1499,11 @@ msgstr ""
 msgid "Creating %s"
 msgstr ""
 
+#: lxc/file.go:273
+#, c-format
+msgid "Creating %s: %%s"
+msgstr ""
+
 #: lxc/init.go:184
 msgid "Creating the instance"
 msgstr ""
@@ -1551,7 +1560,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:123 lxc/file.go:124
+#: lxc/file.go:312 lxc/file.go:313
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1668,70 +1677,71 @@ msgstr ""
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
-#: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
-#: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
-#: lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090 lxc/image.go:1417
-#: lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638 lxc/image.go:1701
-#: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
-#: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
-#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33
-#: lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405
-#: lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793
-#: lxc/network.go:874 lxc/network.go:1005 lxc/network.go:1106
-#: lxc/network.go:1185 lxc/network.go:1245 lxc/network.go:1341
-#: lxc/network.go:1413 lxc/network_acl.go:30 lxc/network_acl.go:95
-#: lxc/network_acl.go:174 lxc/network_acl.go:235 lxc/network_acl.go:291
-#: lxc/network_acl.go:364 lxc/network_acl.go:461 lxc/network_acl.go:549
-#: lxc/network_acl.go:592 lxc/network_acl.go:731 lxc/network_acl.go:788
-#: lxc/network_acl.go:845 lxc/network_acl.go:860 lxc/network_acl.go:997
-#: lxc/network_allocations.go:51 lxc/network_forward.go:33
-#: lxc/network_forward.go:90 lxc/network_forward.go:179
-#: lxc/network_forward.go:256 lxc/network_forward.go:404
-#: lxc/network_forward.go:489 lxc/network_forward.go:599
-#: lxc/network_forward.go:646 lxc/network_forward.go:800
-#: lxc/network_forward.go:874 lxc/network_forward.go:889
-#: lxc/network_forward.go:970 lxc/network_load_balancer.go:33
-#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:181
-#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:408
-#: lxc/network_load_balancer.go:476 lxc/network_load_balancer.go:586
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:771
-#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:859
-#: lxc/network_load_balancer.go:935 lxc/network_load_balancer.go:1033
-#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1121
-#: lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:167
-#: lxc/network_peer.go:236 lxc/network_peer.go:360 lxc/network_peer.go:445
-#: lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731
-#: lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:165
-#: lxc/network_zone.go:228 lxc/network_zone.go:301 lxc/network_zone.go:396
-#: lxc/network_zone.go:484 lxc/network_zone.go:527 lxc/network_zone.go:654
-#: lxc/network_zone.go:710 lxc/network_zone.go:767 lxc/network_zone.go:845
-#: lxc/network_zone.go:909 lxc/network_zone.go:985 lxc/network_zone.go:1083
-#: lxc/network_zone.go:1172 lxc/network_zone.go:1219 lxc/network_zone.go:1349
-#: lxc/network_zone.go:1410 lxc/network_zone.go:1425 lxc/network_zone.go:1483
-#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
-#: lxc/operation.go:194 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
-#: lxc/profile.go:271 lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493
-#: lxc/profile.go:629 lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860
-#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31
-#: lxc/project.go:95 lxc/project.go:191 lxc/project.go:262 lxc/project.go:398
-#: lxc/project.go:472 lxc/project.go:592 lxc/project.go:657 lxc/project.go:745
-#: lxc/project.go:789 lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34
-#: lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91
-#: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853
-#: lxc/remote.go:917 lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24
-#: lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203
-#: lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655
-#: lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940
-#: lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189
-#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:383
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:536
-#: lxc/storage_bucket.go:630 lxc/storage_bucket.go:699
-#: lxc/storage_bucket.go:733 lxc/storage_bucket.go:774
-#: lxc/storage_bucket.go:853 lxc/storage_bucket.go:959
-#: lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158
-#: lxc/storage_volume.go:58 lxc/storage_volume.go:169 lxc/storage_volume.go:283
+#: lxc/export.go:32 lxc/file.go:88 lxc/file.go:135 lxc/file.go:313
+#: lxc/file.go:362 lxc/file.go:432 lxc/file.go:657 lxc/file.go:1176
+#: lxc/image.go:38 lxc/image.go:159 lxc/image.go:337 lxc/image.go:396
+#: lxc/image.go:525 lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090
+#: lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638
+#: lxc/image.go:1701 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255
+#: lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34
+#: lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233
+#: lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560
+#: lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1005
+#: lxc/network.go:1106 lxc/network.go:1185 lxc/network.go:1245
+#: lxc/network.go:1341 lxc/network.go:1413 lxc/network_acl.go:30
+#: lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235
+#: lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461
+#: lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731
+#: lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860
+#: lxc/network_acl.go:997 lxc/network_allocations.go:51
+#: lxc/network_forward.go:33 lxc/network_forward.go:90
+#: lxc/network_forward.go:179 lxc/network_forward.go:256
+#: lxc/network_forward.go:404 lxc/network_forward.go:489
+#: lxc/network_forward.go:599 lxc/network_forward.go:646
+#: lxc/network_forward.go:800 lxc/network_forward.go:874
+#: lxc/network_forward.go:889 lxc/network_forward.go:970
+#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
+#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844
+#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1121 lxc/network_peer.go:29
+#: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
+#: lxc/network_peer.go:360 lxc/network_peer.go:445 lxc/network_peer.go:547
+#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:29
+#: lxc/network_zone.go:86 lxc/network_zone.go:165 lxc/network_zone.go:228
+#: lxc/network_zone.go:301 lxc/network_zone.go:396 lxc/network_zone.go:484
+#: lxc/network_zone.go:527 lxc/network_zone.go:654 lxc/network_zone.go:710
+#: lxc/network_zone.go:767 lxc/network_zone.go:845 lxc/network_zone.go:909
+#: lxc/network_zone.go:985 lxc/network_zone.go:1083 lxc/network_zone.go:1172
+#: lxc/network_zone.go:1219 lxc/network_zone.go:1349 lxc/network_zone.go:1410
+#: lxc/network_zone.go:1425 lxc/network_zone.go:1483 lxc/operation.go:25
+#: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
+#: lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180 lxc/profile.go:271
+#: lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493 lxc/profile.go:629
+#: lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860 lxc/profile.go:920
+#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31 lxc/project.go:95
+#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
+#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
+#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:648
+#: lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853 lxc/remote.go:917
+#: lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
+#: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
+#: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:459
+#: lxc/storage_bucket.go:536 lxc/storage_bucket.go:630
+#: lxc/storage_bucket.go:699 lxc/storage_bucket.go:733
+#: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
+#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:283
 #: lxc/storage_volume.go:390 lxc/storage_volume.go:605
 #: lxc/storage_volume.go:714 lxc/storage_volume.go:801
 #: lxc/storage_volume.go:899 lxc/storage_volume.go:996
@@ -1829,7 +1839,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:995
+#: lxc/file.go:1184
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1895,7 +1905,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:75
+#: lxc/file.go:79
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1913,7 +1923,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:172 lxc/file.go:173
+#: lxc/file.go:361 lxc/file.go:362
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2183,12 +2193,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1238
+#: lxc/file.go:1427
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1261
+#: lxc/file.go:1450
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2203,12 +2213,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1288
+#: lxc/file.go:1477
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1073
+#: lxc/file.go:1262
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2238,7 +2248,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1194
+#: lxc/file.go:1383
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2253,7 +2263,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1199
+#: lxc/file.go:1388
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2263,12 +2273,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1099
+#: lxc/file.go:1288
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1226
+#: lxc/file.go:1415
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2307,7 +2317,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1400
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2322,7 +2332,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:821
+#: lxc/file.go:1010
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2348,6 +2358,10 @@ msgstr ""
 
 #: lxc/cluster.go:1302
 msgid "Force a particular evacuation action"
+msgstr ""
+
+#: lxc/file.go:144
+msgid "Force creating files or directories"
 msgstr ""
 
 #: lxc/cluster.go:1301
@@ -2644,22 +2658,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1311
+#: lxc/file.go:1500
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1300
+#: lxc/file.go:1489
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1312
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1133
+#: lxc/file.go:1322
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2852,11 +2866,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1125
+#: lxc/file.go:1314
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1302
+#: lxc/file.go:1491
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2874,7 +2888,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1045
+#: lxc/file.go:1234
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2926,7 +2940,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1040
+#: lxc/file.go:1229
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2968,7 +2982,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:148
+#: lxc/file.go:337
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2984,14 +2998,19 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:314
+#: lxc/file.go:503
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:496
+#: lxc/file.go:177 lxc/file.go:685
 #, c-format
 msgid "Invalid target %s"
+msgstr ""
+
+#: lxc/file.go:163
+#, c-format
+msgid "Invalid type %q"
 msgstr ""
 
 #: lxc/info.go:238
@@ -3496,7 +3515,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:83 lxc/file.go:84
+#: lxc/file.go:87 lxc/file.go:88
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3882,7 +3901,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:599
+#: lxc/file.go:788
 msgid "Missing target directory"
 msgstr ""
 
@@ -3920,11 +3939,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:286
+#: lxc/file.go:475
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:986 lxc/file.go:987
+#: lxc/file.go:1175 lxc/file.go:1176
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4376,7 +4395,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1103
+#: lxc/file.go:1292
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4610,20 +4629,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:242 lxc/file.go:243
+#: lxc/file.go:431 lxc/file.go:432
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:417 lxc/file.go:768
+#: lxc/file.go:606 lxc/file.go:957
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:467 lxc/file.go:468
+#: lxc/file.go:656 lxc/file.go:657
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:702 lxc/file.go:868
+#: lxc/file.go:891 lxc/file.go:1057
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4661,7 +4680,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:250 lxc/file.go:474
+#: lxc/file.go:439 lxc/file.go:663
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4990,12 +5009,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1231
+#: lxc/file.go:1420
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1232
+#: lxc/file.go:1421
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5071,7 +5090,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:996
+#: lxc/file.go:1185
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5265,15 +5284,27 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:477
+#: lxc/file.go:145
+msgid "Set the file's gid on create"
+msgstr ""
+
+#: lxc/file.go:666
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:478
+#: lxc/file.go:147
+msgid "Set the file's perms on create"
+msgstr ""
+
+#: lxc/file.go:667
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:476
+#: lxc/file.go:146
+msgid "Set the file's uid on create"
+msgstr ""
+
+#: lxc/file.go:665
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5333,7 +5364,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:994
+#: lxc/file.go:1183
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5708,6 +5739,10 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
+#: lxc/file.go:167
+msgid "Symlink target path can only be used for type \"symlink\""
+msgstr ""
+
 #: lxc/alias.go:140
 msgid "TARGET"
 msgstr ""
@@ -5727,11 +5762,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1033
+#: lxc/file.go:1222
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1027
+#: lxc/file.go:1216
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5900,6 +5935,10 @@ msgstr ""
 
 #: lxc/network.go:537 lxc/network.go:634
 msgid "The specified device doesn't match the network"
+msgstr ""
+
+#: lxc/file.go:148
+msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
 #: lxc/publish.go:97
@@ -6080,7 +6119,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:198
+#: lxc/file.go:387
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6094,7 +6133,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1254
+#: lxc/file.go:1443
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6110,7 +6149,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:808
+#: lxc/file.go:997
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6328,7 +6367,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:72
+#: lxc/file.go:76
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6677,20 +6716,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:171
+#: lxc/file.go:360
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:121
+#: lxc/file.go:133
+msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
+msgstr ""
+
+#: lxc/file.go:310
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:241
+#: lxc/file.go:430
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:985
+#: lxc/file.go:1174
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7199,20 +7242,28 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:989
+#: lxc/file.go:137
+msgid ""
+"lxc file create foo/bar\n"
+"\t   To create a file /bar in the foo instance.\n"
+"lxc file create --type=symlink foo/bar baz\n"
+"\t   To create a symlink /bar in instance foo whose target is baz."
+msgstr ""
+
+#: lxc/file.go:1178
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:245
+#: lxc/file.go:434
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:470
+#: lxc/file.go:659
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7561,16 +7612,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1143
+#: lxc/file.go:1332
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1102
+#: lxc/file.go:1291
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1055
+#: lxc/file.go:1244
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-30 13:36-0400\n"
+"POT-Creation-Date: 2024-10-01 10:45-0600\n"
 "PO-Revision-Date: 2023-06-16 20:55+0000\n"
 "Last-Translator: Francisco Serrador <fserrador@gmail.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -670,12 +670,12 @@ msgstr "%s (%d más)"
 msgid "%s (%s) (%d available)"
 msgstr "%s (%d más)"
 
-#: lxc/file.go:936
+#: lxc/file.go:1125
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s no es un directorio"
 
-#: lxc/file.go:826
+#: lxc/file.go:1015
 #, fuzzy, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "%s no es un tipo de archivo soportado."
@@ -769,7 +769,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:466
+#: lxc/file.go:655
 #, fuzzy
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -1235,7 +1235,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr "No se puede proporcionar un nombre para la imagen de destino"
 
-#: lxc/file.go:341
+#: lxc/file.go:530
 msgid "Can't pull a directory without --recursive"
 msgstr "No se puede jalar un directorio sin - recursivo"
 
@@ -1265,7 +1265,7 @@ msgstr "No se puede especificar un remote diferente para renombrar."
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:547
+#: lxc/file.go:736
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1659,9 +1659,14 @@ msgstr "Creando el contenedor"
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:249 lxc/file.go:475
+#: lxc/file.go:143 lxc/file.go:438 lxc/file.go:664
 msgid "Create any directories necessary"
 msgstr ""
+
+#: lxc/file.go:134 lxc/file.go:135
+#, fuzzy
+msgid "Create files and directories in instances"
+msgstr "Creando el contenedor"
 
 #: lxc/auth.go:98 lxc/auth.go:99
 #, fuzzy
@@ -1762,6 +1767,11 @@ msgstr "Creado: %s"
 msgid "Creating %s"
 msgstr "Creando %s"
 
+#: lxc/file.go:273
+#, fuzzy, c-format
+msgid "Creating %s: %%s"
+msgstr "Creando %s"
+
 #: lxc/init.go:184
 #, fuzzy
 msgid "Creating the instance"
@@ -1819,7 +1829,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:123 lxc/file.go:124
+#: lxc/file.go:312 lxc/file.go:313
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1942,70 +1952,71 @@ msgstr ""
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
-#: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
-#: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
-#: lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090 lxc/image.go:1417
-#: lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638 lxc/image.go:1701
-#: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
-#: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
-#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33
-#: lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405
-#: lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793
-#: lxc/network.go:874 lxc/network.go:1005 lxc/network.go:1106
-#: lxc/network.go:1185 lxc/network.go:1245 lxc/network.go:1341
-#: lxc/network.go:1413 lxc/network_acl.go:30 lxc/network_acl.go:95
-#: lxc/network_acl.go:174 lxc/network_acl.go:235 lxc/network_acl.go:291
-#: lxc/network_acl.go:364 lxc/network_acl.go:461 lxc/network_acl.go:549
-#: lxc/network_acl.go:592 lxc/network_acl.go:731 lxc/network_acl.go:788
-#: lxc/network_acl.go:845 lxc/network_acl.go:860 lxc/network_acl.go:997
-#: lxc/network_allocations.go:51 lxc/network_forward.go:33
-#: lxc/network_forward.go:90 lxc/network_forward.go:179
-#: lxc/network_forward.go:256 lxc/network_forward.go:404
-#: lxc/network_forward.go:489 lxc/network_forward.go:599
-#: lxc/network_forward.go:646 lxc/network_forward.go:800
-#: lxc/network_forward.go:874 lxc/network_forward.go:889
-#: lxc/network_forward.go:970 lxc/network_load_balancer.go:33
-#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:181
-#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:408
-#: lxc/network_load_balancer.go:476 lxc/network_load_balancer.go:586
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:771
-#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:859
-#: lxc/network_load_balancer.go:935 lxc/network_load_balancer.go:1033
-#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1121
-#: lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:167
-#: lxc/network_peer.go:236 lxc/network_peer.go:360 lxc/network_peer.go:445
-#: lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731
-#: lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:165
-#: lxc/network_zone.go:228 lxc/network_zone.go:301 lxc/network_zone.go:396
-#: lxc/network_zone.go:484 lxc/network_zone.go:527 lxc/network_zone.go:654
-#: lxc/network_zone.go:710 lxc/network_zone.go:767 lxc/network_zone.go:845
-#: lxc/network_zone.go:909 lxc/network_zone.go:985 lxc/network_zone.go:1083
-#: lxc/network_zone.go:1172 lxc/network_zone.go:1219 lxc/network_zone.go:1349
-#: lxc/network_zone.go:1410 lxc/network_zone.go:1425 lxc/network_zone.go:1483
-#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
-#: lxc/operation.go:194 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
-#: lxc/profile.go:271 lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493
-#: lxc/profile.go:629 lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860
-#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31
-#: lxc/project.go:95 lxc/project.go:191 lxc/project.go:262 lxc/project.go:398
-#: lxc/project.go:472 lxc/project.go:592 lxc/project.go:657 lxc/project.go:745
-#: lxc/project.go:789 lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34
-#: lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91
-#: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853
-#: lxc/remote.go:917 lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24
-#: lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203
-#: lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655
-#: lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940
-#: lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189
-#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:383
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:536
-#: lxc/storage_bucket.go:630 lxc/storage_bucket.go:699
-#: lxc/storage_bucket.go:733 lxc/storage_bucket.go:774
-#: lxc/storage_bucket.go:853 lxc/storage_bucket.go:959
-#: lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158
-#: lxc/storage_volume.go:58 lxc/storage_volume.go:169 lxc/storage_volume.go:283
+#: lxc/export.go:32 lxc/file.go:88 lxc/file.go:135 lxc/file.go:313
+#: lxc/file.go:362 lxc/file.go:432 lxc/file.go:657 lxc/file.go:1176
+#: lxc/image.go:38 lxc/image.go:159 lxc/image.go:337 lxc/image.go:396
+#: lxc/image.go:525 lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090
+#: lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638
+#: lxc/image.go:1701 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255
+#: lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34
+#: lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233
+#: lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560
+#: lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1005
+#: lxc/network.go:1106 lxc/network.go:1185 lxc/network.go:1245
+#: lxc/network.go:1341 lxc/network.go:1413 lxc/network_acl.go:30
+#: lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235
+#: lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461
+#: lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731
+#: lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860
+#: lxc/network_acl.go:997 lxc/network_allocations.go:51
+#: lxc/network_forward.go:33 lxc/network_forward.go:90
+#: lxc/network_forward.go:179 lxc/network_forward.go:256
+#: lxc/network_forward.go:404 lxc/network_forward.go:489
+#: lxc/network_forward.go:599 lxc/network_forward.go:646
+#: lxc/network_forward.go:800 lxc/network_forward.go:874
+#: lxc/network_forward.go:889 lxc/network_forward.go:970
+#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
+#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844
+#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1121 lxc/network_peer.go:29
+#: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
+#: lxc/network_peer.go:360 lxc/network_peer.go:445 lxc/network_peer.go:547
+#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:29
+#: lxc/network_zone.go:86 lxc/network_zone.go:165 lxc/network_zone.go:228
+#: lxc/network_zone.go:301 lxc/network_zone.go:396 lxc/network_zone.go:484
+#: lxc/network_zone.go:527 lxc/network_zone.go:654 lxc/network_zone.go:710
+#: lxc/network_zone.go:767 lxc/network_zone.go:845 lxc/network_zone.go:909
+#: lxc/network_zone.go:985 lxc/network_zone.go:1083 lxc/network_zone.go:1172
+#: lxc/network_zone.go:1219 lxc/network_zone.go:1349 lxc/network_zone.go:1410
+#: lxc/network_zone.go:1425 lxc/network_zone.go:1483 lxc/operation.go:25
+#: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
+#: lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180 lxc/profile.go:271
+#: lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493 lxc/profile.go:629
+#: lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860 lxc/profile.go:920
+#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31 lxc/project.go:95
+#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
+#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
+#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:648
+#: lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853 lxc/remote.go:917
+#: lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
+#: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
+#: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:459
+#: lxc/storage_bucket.go:536 lxc/storage_bucket.go:630
+#: lxc/storage_bucket.go:699 lxc/storage_bucket.go:733
+#: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
+#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:283
 #: lxc/storage_volume.go:390 lxc/storage_volume.go:605
 #: lxc/storage_volume.go:714 lxc/storage_volume.go:801
 #: lxc/storage_volume.go:899 lxc/storage_volume.go:996
@@ -2105,7 +2116,7 @@ msgstr "El directorio importado no está disponible en esta plataforma"
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:995
+#: lxc/file.go:1184
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2173,7 +2184,7 @@ msgstr "FECHA DE EXPIRACIÓN"
 msgid "EXPIRY DATE"
 msgstr "FECHA DE EXPIRACIÓN"
 
-#: lxc/file.go:75
+#: lxc/file.go:79
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -2191,7 +2202,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:172 lxc/file.go:173
+#: lxc/file.go:361 lxc/file.go:362
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2471,12 +2482,12 @@ msgstr "HUELLA DIGITAL"
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1238
+#: lxc/file.go:1427
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1261
+#: lxc/file.go:1450
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2491,12 +2502,12 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/file.go:1288
+#: lxc/file.go:1477
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1073
+#: lxc/file.go:1262
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "Nombre del Miembro del Cluster"
@@ -2526,7 +2537,7 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "Failed fetching fingerprint %q: %w"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/file.go:1194
+#: lxc/file.go:1383
 #, fuzzy, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "Acepta certificado"
@@ -2541,7 +2552,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/file.go:1199
+#: lxc/file.go:1388
 #, fuzzy, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "Acepta certificado"
@@ -2551,12 +2562,12 @@ msgstr "Acepta certificado"
 msgid "Failed starting command: %w"
 msgstr "Acepta certificado"
 
-#: lxc/file.go:1099
+#: lxc/file.go:1288
 #, fuzzy, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "Acepta certificado"
 
-#: lxc/file.go:1226
+#: lxc/file.go:1415
 #, fuzzy, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "Acepta certificado"
@@ -2595,7 +2606,7 @@ msgstr "Acepta certificado"
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1400
 #, fuzzy, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "Acepta certificado"
@@ -2610,7 +2621,7 @@ msgstr "Perfil para aplicar al nuevo contenedor"
 msgid "Failed to remove alias %s: %w"
 msgstr "Acepta certificado"
 
-#: lxc/file.go:821
+#: lxc/file.go:1010
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2636,6 +2647,10 @@ msgstr "Huella dactilar: %s"
 
 #: lxc/cluster.go:1302
 msgid "Force a particular evacuation action"
+msgstr ""
+
+#: lxc/file.go:144
+msgid "Force creating files or directories"
 msgstr ""
 
 #: lxc/cluster.go:1301
@@ -2948,22 +2963,22 @@ msgstr "Aliases:"
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1311
+#: lxc/file.go:1500
 #, fuzzy, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "Copiando la imagen: %s"
 
-#: lxc/file.go:1300
+#: lxc/file.go:1489
 #, fuzzy, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "Copiando la imagen: %s"
 
-#: lxc/file.go:1123
+#: lxc/file.go:1312
 #, fuzzy, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "Dispositivo %s añadido a %s"
 
-#: lxc/file.go:1133
+#: lxc/file.go:1322
 #, fuzzy, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "Copiando la imagen: %s"
@@ -3160,11 +3175,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/file.go:1125
+#: lxc/file.go:1314
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1302
+#: lxc/file.go:1491
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3184,7 +3199,7 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Instance name must be specified"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/file.go:1045
+#: lxc/file.go:1234
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3236,7 +3251,7 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Invalid instance name: %s"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/file.go:1040
+#: lxc/file.go:1229
 #, fuzzy, c-format
 msgid "Invalid instance path: %q"
 msgstr "Nombre del contenedor es: %s"
@@ -3279,7 +3294,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:148
+#: lxc/file.go:337
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -3296,15 +3311,20 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/file.go:314
+#: lxc/file.go:503
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:496
+#: lxc/file.go:177 lxc/file.go:685
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
+
+#: lxc/file.go:163
+#, fuzzy, c-format
+msgid "Invalid type %q"
+msgstr "Nombre del contenedor es: %s"
 
 #: lxc/info.go:238
 #, fuzzy, c-format
@@ -3824,7 +3844,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:83 lxc/file.go:84
+#: lxc/file.go:87 lxc/file.go:88
 msgid "Manage files in instances"
 msgstr ""
 
@@ -4241,7 +4261,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/file.go:599
+#: lxc/file.go:788
 #, fuzzy
 msgid "Missing target directory"
 msgstr "%s no es un directorio"
@@ -4281,11 +4301,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:286
+#: lxc/file.go:475
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:986 lxc/file.go:987
+#: lxc/file.go:1175 lxc/file.go:1176
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "Aliases:"
@@ -4739,7 +4759,7 @@ msgstr "Auto actualización: %s"
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1103
+#: lxc/file.go:1292
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4977,20 +4997,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/file.go:242 lxc/file.go:243
+#: lxc/file.go:431 lxc/file.go:432
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:417 lxc/file.go:768
+#: lxc/file.go:606 lxc/file.go:957
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:467 lxc/file.go:468
+#: lxc/file.go:656 lxc/file.go:657
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:702 lxc/file.go:868
+#: lxc/file.go:891 lxc/file.go:1057
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -5030,7 +5050,7 @@ msgstr "Creando el contenedor"
 msgid "Rebuild instances"
 msgstr "Aliases:"
 
-#: lxc/file.go:250 lxc/file.go:474
+#: lxc/file.go:439 lxc/file.go:663
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -5373,12 +5393,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1231
+#: lxc/file.go:1420
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1232
+#: lxc/file.go:1421
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5456,7 +5476,7 @@ msgstr "Aliases:"
 msgid "Set a cluster member's configuration keys"
 msgstr "Perfil %s creado"
 
-#: lxc/file.go:996
+#: lxc/file.go:1185
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5656,15 +5676,27 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:477
+#: lxc/file.go:145
+msgid "Set the file's gid on create"
+msgstr ""
+
+#: lxc/file.go:666
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:478
+#: lxc/file.go:147
+msgid "Set the file's perms on create"
+msgstr ""
+
+#: lxc/file.go:667
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:476
+#: lxc/file.go:146
+msgid "Set the file's uid on create"
+msgstr ""
+
+#: lxc/file.go:665
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5730,7 +5762,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:994
+#: lxc/file.go:1183
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -6118,6 +6150,10 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
+#: lxc/file.go:167
+msgid "Symlink target path can only be used for type \"symlink\""
+msgstr ""
+
 #: lxc/alias.go:140
 msgid "TARGET"
 msgstr ""
@@ -6137,11 +6173,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1033
+#: lxc/file.go:1222
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1027
+#: lxc/file.go:1216
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -6312,6 +6348,10 @@ msgstr ""
 
 #: lxc/network.go:537 lxc/network.go:634
 msgid "The specified device doesn't match the network"
+msgstr ""
+
+#: lxc/file.go:148
+msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
 #: lxc/publish.go:97
@@ -6496,7 +6536,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:198
+#: lxc/file.go:387
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6510,7 +6550,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1254
+#: lxc/file.go:1443
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6526,7 +6566,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:808
+#: lxc/file.go:997
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6763,7 +6803,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:72
+#: lxc/file.go:76
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -7166,23 +7206,28 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:171
+#: lxc/file.go:360
 #, fuzzy
 msgid "[<remote>:]<instance>/<path>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/file.go:121
+#: lxc/file.go:133
+#, fuzzy
+msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
+msgstr "No se puede proveer el nombre del container a la lista"
+
+#: lxc/file.go:310
 #, fuzzy
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/file.go:241
+#: lxc/file.go:430
 #, fuzzy
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/file.go:985
+#: lxc/file.go:1174
 #, fuzzy
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7777,20 +7822,28 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:989
+#: lxc/file.go:137
+msgid ""
+"lxc file create foo/bar\n"
+"\t   To create a file /bar in the foo instance.\n"
+"lxc file create --type=symlink foo/bar baz\n"
+"\t   To create a symlink /bar in instance foo whose target is baz."
+msgstr ""
+
+#: lxc/file.go:1178
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:245
+#: lxc/file.go:434
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:470
+#: lxc/file.go:659
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -8139,16 +8192,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1143
+#: lxc/file.go:1332
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1102
+#: lxc/file.go:1291
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1055
+#: lxc/file.go:1244
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/fa.po
+++ b/po/fa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-30 13:36-0400\n"
+"POT-Creation-Date: 2024-10-01 10:45-0600\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Persian <https://hosted.weblate.org/projects/linux-containers/"
@@ -433,12 +433,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:936
+#: lxc/file.go:1125
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:826
+#: lxc/file.go:1015
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -527,7 +527,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:466
+#: lxc/file.go:655
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -982,7 +982,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:341
+#: lxc/file.go:530
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1011,7 +1011,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:547
+#: lxc/file.go:736
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1397,8 +1397,12 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:249 lxc/file.go:475
+#: lxc/file.go:143 lxc/file.go:438 lxc/file.go:664
 msgid "Create any directories necessary"
+msgstr ""
+
+#: lxc/file.go:134 lxc/file.go:135
+msgid "Create files and directories in instances"
 msgstr ""
 
 #: lxc/auth.go:98 lxc/auth.go:99
@@ -1495,6 +1499,11 @@ msgstr ""
 msgid "Creating %s"
 msgstr ""
 
+#: lxc/file.go:273
+#, c-format
+msgid "Creating %s: %%s"
+msgstr ""
+
 #: lxc/init.go:184
 msgid "Creating the instance"
 msgstr ""
@@ -1551,7 +1560,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:123 lxc/file.go:124
+#: lxc/file.go:312 lxc/file.go:313
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1668,70 +1677,71 @@ msgstr ""
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
-#: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
-#: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
-#: lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090 lxc/image.go:1417
-#: lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638 lxc/image.go:1701
-#: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
-#: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
-#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33
-#: lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405
-#: lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793
-#: lxc/network.go:874 lxc/network.go:1005 lxc/network.go:1106
-#: lxc/network.go:1185 lxc/network.go:1245 lxc/network.go:1341
-#: lxc/network.go:1413 lxc/network_acl.go:30 lxc/network_acl.go:95
-#: lxc/network_acl.go:174 lxc/network_acl.go:235 lxc/network_acl.go:291
-#: lxc/network_acl.go:364 lxc/network_acl.go:461 lxc/network_acl.go:549
-#: lxc/network_acl.go:592 lxc/network_acl.go:731 lxc/network_acl.go:788
-#: lxc/network_acl.go:845 lxc/network_acl.go:860 lxc/network_acl.go:997
-#: lxc/network_allocations.go:51 lxc/network_forward.go:33
-#: lxc/network_forward.go:90 lxc/network_forward.go:179
-#: lxc/network_forward.go:256 lxc/network_forward.go:404
-#: lxc/network_forward.go:489 lxc/network_forward.go:599
-#: lxc/network_forward.go:646 lxc/network_forward.go:800
-#: lxc/network_forward.go:874 lxc/network_forward.go:889
-#: lxc/network_forward.go:970 lxc/network_load_balancer.go:33
-#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:181
-#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:408
-#: lxc/network_load_balancer.go:476 lxc/network_load_balancer.go:586
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:771
-#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:859
-#: lxc/network_load_balancer.go:935 lxc/network_load_balancer.go:1033
-#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1121
-#: lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:167
-#: lxc/network_peer.go:236 lxc/network_peer.go:360 lxc/network_peer.go:445
-#: lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731
-#: lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:165
-#: lxc/network_zone.go:228 lxc/network_zone.go:301 lxc/network_zone.go:396
-#: lxc/network_zone.go:484 lxc/network_zone.go:527 lxc/network_zone.go:654
-#: lxc/network_zone.go:710 lxc/network_zone.go:767 lxc/network_zone.go:845
-#: lxc/network_zone.go:909 lxc/network_zone.go:985 lxc/network_zone.go:1083
-#: lxc/network_zone.go:1172 lxc/network_zone.go:1219 lxc/network_zone.go:1349
-#: lxc/network_zone.go:1410 lxc/network_zone.go:1425 lxc/network_zone.go:1483
-#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
-#: lxc/operation.go:194 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
-#: lxc/profile.go:271 lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493
-#: lxc/profile.go:629 lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860
-#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31
-#: lxc/project.go:95 lxc/project.go:191 lxc/project.go:262 lxc/project.go:398
-#: lxc/project.go:472 lxc/project.go:592 lxc/project.go:657 lxc/project.go:745
-#: lxc/project.go:789 lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34
-#: lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91
-#: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853
-#: lxc/remote.go:917 lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24
-#: lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203
-#: lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655
-#: lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940
-#: lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189
-#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:383
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:536
-#: lxc/storage_bucket.go:630 lxc/storage_bucket.go:699
-#: lxc/storage_bucket.go:733 lxc/storage_bucket.go:774
-#: lxc/storage_bucket.go:853 lxc/storage_bucket.go:959
-#: lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158
-#: lxc/storage_volume.go:58 lxc/storage_volume.go:169 lxc/storage_volume.go:283
+#: lxc/export.go:32 lxc/file.go:88 lxc/file.go:135 lxc/file.go:313
+#: lxc/file.go:362 lxc/file.go:432 lxc/file.go:657 lxc/file.go:1176
+#: lxc/image.go:38 lxc/image.go:159 lxc/image.go:337 lxc/image.go:396
+#: lxc/image.go:525 lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090
+#: lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638
+#: lxc/image.go:1701 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255
+#: lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34
+#: lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233
+#: lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560
+#: lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1005
+#: lxc/network.go:1106 lxc/network.go:1185 lxc/network.go:1245
+#: lxc/network.go:1341 lxc/network.go:1413 lxc/network_acl.go:30
+#: lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235
+#: lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461
+#: lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731
+#: lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860
+#: lxc/network_acl.go:997 lxc/network_allocations.go:51
+#: lxc/network_forward.go:33 lxc/network_forward.go:90
+#: lxc/network_forward.go:179 lxc/network_forward.go:256
+#: lxc/network_forward.go:404 lxc/network_forward.go:489
+#: lxc/network_forward.go:599 lxc/network_forward.go:646
+#: lxc/network_forward.go:800 lxc/network_forward.go:874
+#: lxc/network_forward.go:889 lxc/network_forward.go:970
+#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
+#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844
+#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1121 lxc/network_peer.go:29
+#: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
+#: lxc/network_peer.go:360 lxc/network_peer.go:445 lxc/network_peer.go:547
+#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:29
+#: lxc/network_zone.go:86 lxc/network_zone.go:165 lxc/network_zone.go:228
+#: lxc/network_zone.go:301 lxc/network_zone.go:396 lxc/network_zone.go:484
+#: lxc/network_zone.go:527 lxc/network_zone.go:654 lxc/network_zone.go:710
+#: lxc/network_zone.go:767 lxc/network_zone.go:845 lxc/network_zone.go:909
+#: lxc/network_zone.go:985 lxc/network_zone.go:1083 lxc/network_zone.go:1172
+#: lxc/network_zone.go:1219 lxc/network_zone.go:1349 lxc/network_zone.go:1410
+#: lxc/network_zone.go:1425 lxc/network_zone.go:1483 lxc/operation.go:25
+#: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
+#: lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180 lxc/profile.go:271
+#: lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493 lxc/profile.go:629
+#: lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860 lxc/profile.go:920
+#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31 lxc/project.go:95
+#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
+#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
+#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:648
+#: lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853 lxc/remote.go:917
+#: lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
+#: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
+#: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:459
+#: lxc/storage_bucket.go:536 lxc/storage_bucket.go:630
+#: lxc/storage_bucket.go:699 lxc/storage_bucket.go:733
+#: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
+#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:283
 #: lxc/storage_volume.go:390 lxc/storage_volume.go:605
 #: lxc/storage_volume.go:714 lxc/storage_volume.go:801
 #: lxc/storage_volume.go:899 lxc/storage_volume.go:996
@@ -1829,7 +1839,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:995
+#: lxc/file.go:1184
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1895,7 +1905,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:75
+#: lxc/file.go:79
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1913,7 +1923,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:172 lxc/file.go:173
+#: lxc/file.go:361 lxc/file.go:362
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2183,12 +2193,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1238
+#: lxc/file.go:1427
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1261
+#: lxc/file.go:1450
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2203,12 +2213,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1288
+#: lxc/file.go:1477
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1073
+#: lxc/file.go:1262
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2238,7 +2248,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1194
+#: lxc/file.go:1383
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2253,7 +2263,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1199
+#: lxc/file.go:1388
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2263,12 +2273,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1099
+#: lxc/file.go:1288
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1226
+#: lxc/file.go:1415
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2307,7 +2317,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1400
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2322,7 +2332,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:821
+#: lxc/file.go:1010
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2348,6 +2358,10 @@ msgstr ""
 
 #: lxc/cluster.go:1302
 msgid "Force a particular evacuation action"
+msgstr ""
+
+#: lxc/file.go:144
+msgid "Force creating files or directories"
 msgstr ""
 
 #: lxc/cluster.go:1301
@@ -2644,22 +2658,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1311
+#: lxc/file.go:1500
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1300
+#: lxc/file.go:1489
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1312
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1133
+#: lxc/file.go:1322
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2852,11 +2866,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1125
+#: lxc/file.go:1314
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1302
+#: lxc/file.go:1491
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2874,7 +2888,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1045
+#: lxc/file.go:1234
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2926,7 +2940,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1040
+#: lxc/file.go:1229
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2968,7 +2982,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:148
+#: lxc/file.go:337
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2984,14 +2998,19 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:314
+#: lxc/file.go:503
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:496
+#: lxc/file.go:177 lxc/file.go:685
 #, c-format
 msgid "Invalid target %s"
+msgstr ""
+
+#: lxc/file.go:163
+#, c-format
+msgid "Invalid type %q"
 msgstr ""
 
 #: lxc/info.go:238
@@ -3496,7 +3515,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:83 lxc/file.go:84
+#: lxc/file.go:87 lxc/file.go:88
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3882,7 +3901,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:599
+#: lxc/file.go:788
 msgid "Missing target directory"
 msgstr ""
 
@@ -3920,11 +3939,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:286
+#: lxc/file.go:475
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:986 lxc/file.go:987
+#: lxc/file.go:1175 lxc/file.go:1176
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4376,7 +4395,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1103
+#: lxc/file.go:1292
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4610,20 +4629,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:242 lxc/file.go:243
+#: lxc/file.go:431 lxc/file.go:432
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:417 lxc/file.go:768
+#: lxc/file.go:606 lxc/file.go:957
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:467 lxc/file.go:468
+#: lxc/file.go:656 lxc/file.go:657
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:702 lxc/file.go:868
+#: lxc/file.go:891 lxc/file.go:1057
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4661,7 +4680,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:250 lxc/file.go:474
+#: lxc/file.go:439 lxc/file.go:663
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4990,12 +5009,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1231
+#: lxc/file.go:1420
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1232
+#: lxc/file.go:1421
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5071,7 +5090,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:996
+#: lxc/file.go:1185
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5265,15 +5284,27 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:477
+#: lxc/file.go:145
+msgid "Set the file's gid on create"
+msgstr ""
+
+#: lxc/file.go:666
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:478
+#: lxc/file.go:147
+msgid "Set the file's perms on create"
+msgstr ""
+
+#: lxc/file.go:667
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:476
+#: lxc/file.go:146
+msgid "Set the file's uid on create"
+msgstr ""
+
+#: lxc/file.go:665
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5333,7 +5364,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:994
+#: lxc/file.go:1183
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5708,6 +5739,10 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
+#: lxc/file.go:167
+msgid "Symlink target path can only be used for type \"symlink\""
+msgstr ""
+
 #: lxc/alias.go:140
 msgid "TARGET"
 msgstr ""
@@ -5727,11 +5762,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1033
+#: lxc/file.go:1222
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1027
+#: lxc/file.go:1216
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5900,6 +5935,10 @@ msgstr ""
 
 #: lxc/network.go:537 lxc/network.go:634
 msgid "The specified device doesn't match the network"
+msgstr ""
+
+#: lxc/file.go:148
+msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
 #: lxc/publish.go:97
@@ -6080,7 +6119,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:198
+#: lxc/file.go:387
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6094,7 +6133,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1254
+#: lxc/file.go:1443
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6110,7 +6149,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:808
+#: lxc/file.go:997
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6328,7 +6367,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:72
+#: lxc/file.go:76
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6677,20 +6716,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:171
+#: lxc/file.go:360
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:121
+#: lxc/file.go:133
+msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
+msgstr ""
+
+#: lxc/file.go:310
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:241
+#: lxc/file.go:430
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:985
+#: lxc/file.go:1174
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7199,20 +7242,28 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:989
+#: lxc/file.go:137
+msgid ""
+"lxc file create foo/bar\n"
+"\t   To create a file /bar in the foo instance.\n"
+"lxc file create --type=symlink foo/bar baz\n"
+"\t   To create a symlink /bar in instance foo whose target is baz."
+msgstr ""
+
+#: lxc/file.go:1178
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:245
+#: lxc/file.go:434
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:470
+#: lxc/file.go:659
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7561,16 +7612,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1143
+#: lxc/file.go:1332
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1102
+#: lxc/file.go:1291
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1055
+#: lxc/file.go:1244
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-30 13:36-0400\n"
+"POT-Creation-Date: 2024-10-01 10:45-0600\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/linux-containers/"
@@ -433,12 +433,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:936
+#: lxc/file.go:1125
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:826
+#: lxc/file.go:1015
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -527,7 +527,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:466
+#: lxc/file.go:655
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -982,7 +982,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:341
+#: lxc/file.go:530
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1011,7 +1011,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:547
+#: lxc/file.go:736
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1397,8 +1397,12 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:249 lxc/file.go:475
+#: lxc/file.go:143 lxc/file.go:438 lxc/file.go:664
 msgid "Create any directories necessary"
+msgstr ""
+
+#: lxc/file.go:134 lxc/file.go:135
+msgid "Create files and directories in instances"
 msgstr ""
 
 #: lxc/auth.go:98 lxc/auth.go:99
@@ -1495,6 +1499,11 @@ msgstr ""
 msgid "Creating %s"
 msgstr ""
 
+#: lxc/file.go:273
+#, c-format
+msgid "Creating %s: %%s"
+msgstr ""
+
 #: lxc/init.go:184
 msgid "Creating the instance"
 msgstr ""
@@ -1551,7 +1560,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:123 lxc/file.go:124
+#: lxc/file.go:312 lxc/file.go:313
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1668,70 +1677,71 @@ msgstr ""
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
-#: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
-#: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
-#: lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090 lxc/image.go:1417
-#: lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638 lxc/image.go:1701
-#: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
-#: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
-#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33
-#: lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405
-#: lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793
-#: lxc/network.go:874 lxc/network.go:1005 lxc/network.go:1106
-#: lxc/network.go:1185 lxc/network.go:1245 lxc/network.go:1341
-#: lxc/network.go:1413 lxc/network_acl.go:30 lxc/network_acl.go:95
-#: lxc/network_acl.go:174 lxc/network_acl.go:235 lxc/network_acl.go:291
-#: lxc/network_acl.go:364 lxc/network_acl.go:461 lxc/network_acl.go:549
-#: lxc/network_acl.go:592 lxc/network_acl.go:731 lxc/network_acl.go:788
-#: lxc/network_acl.go:845 lxc/network_acl.go:860 lxc/network_acl.go:997
-#: lxc/network_allocations.go:51 lxc/network_forward.go:33
-#: lxc/network_forward.go:90 lxc/network_forward.go:179
-#: lxc/network_forward.go:256 lxc/network_forward.go:404
-#: lxc/network_forward.go:489 lxc/network_forward.go:599
-#: lxc/network_forward.go:646 lxc/network_forward.go:800
-#: lxc/network_forward.go:874 lxc/network_forward.go:889
-#: lxc/network_forward.go:970 lxc/network_load_balancer.go:33
-#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:181
-#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:408
-#: lxc/network_load_balancer.go:476 lxc/network_load_balancer.go:586
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:771
-#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:859
-#: lxc/network_load_balancer.go:935 lxc/network_load_balancer.go:1033
-#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1121
-#: lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:167
-#: lxc/network_peer.go:236 lxc/network_peer.go:360 lxc/network_peer.go:445
-#: lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731
-#: lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:165
-#: lxc/network_zone.go:228 lxc/network_zone.go:301 lxc/network_zone.go:396
-#: lxc/network_zone.go:484 lxc/network_zone.go:527 lxc/network_zone.go:654
-#: lxc/network_zone.go:710 lxc/network_zone.go:767 lxc/network_zone.go:845
-#: lxc/network_zone.go:909 lxc/network_zone.go:985 lxc/network_zone.go:1083
-#: lxc/network_zone.go:1172 lxc/network_zone.go:1219 lxc/network_zone.go:1349
-#: lxc/network_zone.go:1410 lxc/network_zone.go:1425 lxc/network_zone.go:1483
-#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
-#: lxc/operation.go:194 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
-#: lxc/profile.go:271 lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493
-#: lxc/profile.go:629 lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860
-#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31
-#: lxc/project.go:95 lxc/project.go:191 lxc/project.go:262 lxc/project.go:398
-#: lxc/project.go:472 lxc/project.go:592 lxc/project.go:657 lxc/project.go:745
-#: lxc/project.go:789 lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34
-#: lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91
-#: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853
-#: lxc/remote.go:917 lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24
-#: lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203
-#: lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655
-#: lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940
-#: lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189
-#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:383
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:536
-#: lxc/storage_bucket.go:630 lxc/storage_bucket.go:699
-#: lxc/storage_bucket.go:733 lxc/storage_bucket.go:774
-#: lxc/storage_bucket.go:853 lxc/storage_bucket.go:959
-#: lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158
-#: lxc/storage_volume.go:58 lxc/storage_volume.go:169 lxc/storage_volume.go:283
+#: lxc/export.go:32 lxc/file.go:88 lxc/file.go:135 lxc/file.go:313
+#: lxc/file.go:362 lxc/file.go:432 lxc/file.go:657 lxc/file.go:1176
+#: lxc/image.go:38 lxc/image.go:159 lxc/image.go:337 lxc/image.go:396
+#: lxc/image.go:525 lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090
+#: lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638
+#: lxc/image.go:1701 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255
+#: lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34
+#: lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233
+#: lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560
+#: lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1005
+#: lxc/network.go:1106 lxc/network.go:1185 lxc/network.go:1245
+#: lxc/network.go:1341 lxc/network.go:1413 lxc/network_acl.go:30
+#: lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235
+#: lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461
+#: lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731
+#: lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860
+#: lxc/network_acl.go:997 lxc/network_allocations.go:51
+#: lxc/network_forward.go:33 lxc/network_forward.go:90
+#: lxc/network_forward.go:179 lxc/network_forward.go:256
+#: lxc/network_forward.go:404 lxc/network_forward.go:489
+#: lxc/network_forward.go:599 lxc/network_forward.go:646
+#: lxc/network_forward.go:800 lxc/network_forward.go:874
+#: lxc/network_forward.go:889 lxc/network_forward.go:970
+#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
+#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844
+#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1121 lxc/network_peer.go:29
+#: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
+#: lxc/network_peer.go:360 lxc/network_peer.go:445 lxc/network_peer.go:547
+#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:29
+#: lxc/network_zone.go:86 lxc/network_zone.go:165 lxc/network_zone.go:228
+#: lxc/network_zone.go:301 lxc/network_zone.go:396 lxc/network_zone.go:484
+#: lxc/network_zone.go:527 lxc/network_zone.go:654 lxc/network_zone.go:710
+#: lxc/network_zone.go:767 lxc/network_zone.go:845 lxc/network_zone.go:909
+#: lxc/network_zone.go:985 lxc/network_zone.go:1083 lxc/network_zone.go:1172
+#: lxc/network_zone.go:1219 lxc/network_zone.go:1349 lxc/network_zone.go:1410
+#: lxc/network_zone.go:1425 lxc/network_zone.go:1483 lxc/operation.go:25
+#: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
+#: lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180 lxc/profile.go:271
+#: lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493 lxc/profile.go:629
+#: lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860 lxc/profile.go:920
+#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31 lxc/project.go:95
+#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
+#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
+#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:648
+#: lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853 lxc/remote.go:917
+#: lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
+#: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
+#: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:459
+#: lxc/storage_bucket.go:536 lxc/storage_bucket.go:630
+#: lxc/storage_bucket.go:699 lxc/storage_bucket.go:733
+#: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
+#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:283
 #: lxc/storage_volume.go:390 lxc/storage_volume.go:605
 #: lxc/storage_volume.go:714 lxc/storage_volume.go:801
 #: lxc/storage_volume.go:899 lxc/storage_volume.go:996
@@ -1829,7 +1839,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:995
+#: lxc/file.go:1184
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1895,7 +1905,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:75
+#: lxc/file.go:79
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1913,7 +1923,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:172 lxc/file.go:173
+#: lxc/file.go:361 lxc/file.go:362
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2183,12 +2193,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1238
+#: lxc/file.go:1427
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1261
+#: lxc/file.go:1450
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2203,12 +2213,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1288
+#: lxc/file.go:1477
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1073
+#: lxc/file.go:1262
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2238,7 +2248,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1194
+#: lxc/file.go:1383
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2253,7 +2263,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1199
+#: lxc/file.go:1388
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2263,12 +2273,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1099
+#: lxc/file.go:1288
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1226
+#: lxc/file.go:1415
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2307,7 +2317,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1400
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2322,7 +2332,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:821
+#: lxc/file.go:1010
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2348,6 +2358,10 @@ msgstr ""
 
 #: lxc/cluster.go:1302
 msgid "Force a particular evacuation action"
+msgstr ""
+
+#: lxc/file.go:144
+msgid "Force creating files or directories"
 msgstr ""
 
 #: lxc/cluster.go:1301
@@ -2644,22 +2658,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1311
+#: lxc/file.go:1500
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1300
+#: lxc/file.go:1489
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1312
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1133
+#: lxc/file.go:1322
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2852,11 +2866,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1125
+#: lxc/file.go:1314
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1302
+#: lxc/file.go:1491
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2874,7 +2888,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1045
+#: lxc/file.go:1234
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2926,7 +2940,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1040
+#: lxc/file.go:1229
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2968,7 +2982,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:148
+#: lxc/file.go:337
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2984,14 +2998,19 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:314
+#: lxc/file.go:503
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:496
+#: lxc/file.go:177 lxc/file.go:685
 #, c-format
 msgid "Invalid target %s"
+msgstr ""
+
+#: lxc/file.go:163
+#, c-format
+msgid "Invalid type %q"
 msgstr ""
 
 #: lxc/info.go:238
@@ -3496,7 +3515,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:83 lxc/file.go:84
+#: lxc/file.go:87 lxc/file.go:88
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3882,7 +3901,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:599
+#: lxc/file.go:788
 msgid "Missing target directory"
 msgstr ""
 
@@ -3920,11 +3939,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:286
+#: lxc/file.go:475
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:986 lxc/file.go:987
+#: lxc/file.go:1175 lxc/file.go:1176
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4376,7 +4395,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1103
+#: lxc/file.go:1292
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4610,20 +4629,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:242 lxc/file.go:243
+#: lxc/file.go:431 lxc/file.go:432
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:417 lxc/file.go:768
+#: lxc/file.go:606 lxc/file.go:957
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:467 lxc/file.go:468
+#: lxc/file.go:656 lxc/file.go:657
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:702 lxc/file.go:868
+#: lxc/file.go:891 lxc/file.go:1057
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4661,7 +4680,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:250 lxc/file.go:474
+#: lxc/file.go:439 lxc/file.go:663
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4990,12 +5009,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1231
+#: lxc/file.go:1420
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1232
+#: lxc/file.go:1421
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5071,7 +5090,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:996
+#: lxc/file.go:1185
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5265,15 +5284,27 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:477
+#: lxc/file.go:145
+msgid "Set the file's gid on create"
+msgstr ""
+
+#: lxc/file.go:666
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:478
+#: lxc/file.go:147
+msgid "Set the file's perms on create"
+msgstr ""
+
+#: lxc/file.go:667
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:476
+#: lxc/file.go:146
+msgid "Set the file's uid on create"
+msgstr ""
+
+#: lxc/file.go:665
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5333,7 +5364,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:994
+#: lxc/file.go:1183
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5708,6 +5739,10 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
+#: lxc/file.go:167
+msgid "Symlink target path can only be used for type \"symlink\""
+msgstr ""
+
 #: lxc/alias.go:140
 msgid "TARGET"
 msgstr ""
@@ -5727,11 +5762,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1033
+#: lxc/file.go:1222
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1027
+#: lxc/file.go:1216
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5900,6 +5935,10 @@ msgstr ""
 
 #: lxc/network.go:537 lxc/network.go:634
 msgid "The specified device doesn't match the network"
+msgstr ""
+
+#: lxc/file.go:148
+msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
 #: lxc/publish.go:97
@@ -6080,7 +6119,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:198
+#: lxc/file.go:387
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6094,7 +6133,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1254
+#: lxc/file.go:1443
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6110,7 +6149,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:808
+#: lxc/file.go:997
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6328,7 +6367,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:72
+#: lxc/file.go:76
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6677,20 +6716,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:171
+#: lxc/file.go:360
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:121
+#: lxc/file.go:133
+msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
+msgstr ""
+
+#: lxc/file.go:310
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:241
+#: lxc/file.go:430
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:985
+#: lxc/file.go:1174
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7199,20 +7242,28 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:989
+#: lxc/file.go:137
+msgid ""
+"lxc file create foo/bar\n"
+"\t   To create a file /bar in the foo instance.\n"
+"lxc file create --type=symlink foo/bar baz\n"
+"\t   To create a symlink /bar in instance foo whose target is baz."
+msgstr ""
+
+#: lxc/file.go:1178
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:245
+#: lxc/file.go:434
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:470
+#: lxc/file.go:659
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7561,16 +7612,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1143
+#: lxc/file.go:1332
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1102
+#: lxc/file.go:1291
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1055
+#: lxc/file.go:1244
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-30 13:36-0400\n"
+"POT-Creation-Date: 2024-10-01 10:45-0600\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Wivik <seb+weblate@zedas.fr>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/linux-containers/"
@@ -679,12 +679,12 @@ msgstr "%s (%d de plus)"
 msgid "%s (%s) (%d available)"
 msgstr "%s (%d de plus)"
 
-#: lxc/file.go:936
+#: lxc/file.go:1125
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s n'est pas un répertoire"
 
-#: lxc/file.go:826
+#: lxc/file.go:1015
 #, fuzzy, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' n'est pas un format de fichier pris en charge."
@@ -778,7 +778,7 @@ msgstr "Serveur distant : %s"
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:466
+#: lxc/file.go:655
 #, fuzzy
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
@@ -1272,7 +1272,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:341
+#: lxc/file.go:530
 #, fuzzy
 msgid "Can't pull a directory without --recursive"
 msgstr "impossible de récupérer un répertoire sans --recursive"
@@ -1303,7 +1303,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:547
+#: lxc/file.go:736
 #, fuzzy
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr "impossible de spécifier uid/gid/mode en mode récursif"
@@ -1713,8 +1713,13 @@ msgstr "Création du conteneur"
 msgid "Create and start instances from images"
 msgstr "Création du conteneur"
 
-#: lxc/file.go:249 lxc/file.go:475
+#: lxc/file.go:143 lxc/file.go:438 lxc/file.go:664
 msgid "Create any directories necessary"
+msgstr "Créer tous répertoires nécessaires"
+
+#: lxc/file.go:134 lxc/file.go:135
+#, fuzzy
+msgid "Create files and directories in instances"
 msgstr "Créer tous répertoires nécessaires"
 
 #: lxc/auth.go:98 lxc/auth.go:99
@@ -1844,6 +1849,11 @@ msgstr "Créé : %s"
 msgid "Creating %s"
 msgstr "Création de %s"
 
+#: lxc/file.go:273
+#, fuzzy, c-format
+msgid "Creating %s: %%s"
+msgstr "Création de %s"
+
 #: lxc/init.go:184
 #, fuzzy
 msgid "Creating the instance"
@@ -1903,7 +1913,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr "Récupération de l'image : %s"
 
-#: lxc/file.go:123 lxc/file.go:124
+#: lxc/file.go:312 lxc/file.go:313
 #, fuzzy
 msgid "Delete files in instances"
 msgstr "Création du conteneur"
@@ -2034,70 +2044,71 @@ msgstr "Récupération de l'image : %s"
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
-#: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
-#: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
-#: lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090 lxc/image.go:1417
-#: lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638 lxc/image.go:1701
-#: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
-#: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
-#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33
-#: lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405
-#: lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793
-#: lxc/network.go:874 lxc/network.go:1005 lxc/network.go:1106
-#: lxc/network.go:1185 lxc/network.go:1245 lxc/network.go:1341
-#: lxc/network.go:1413 lxc/network_acl.go:30 lxc/network_acl.go:95
-#: lxc/network_acl.go:174 lxc/network_acl.go:235 lxc/network_acl.go:291
-#: lxc/network_acl.go:364 lxc/network_acl.go:461 lxc/network_acl.go:549
-#: lxc/network_acl.go:592 lxc/network_acl.go:731 lxc/network_acl.go:788
-#: lxc/network_acl.go:845 lxc/network_acl.go:860 lxc/network_acl.go:997
-#: lxc/network_allocations.go:51 lxc/network_forward.go:33
-#: lxc/network_forward.go:90 lxc/network_forward.go:179
-#: lxc/network_forward.go:256 lxc/network_forward.go:404
-#: lxc/network_forward.go:489 lxc/network_forward.go:599
-#: lxc/network_forward.go:646 lxc/network_forward.go:800
-#: lxc/network_forward.go:874 lxc/network_forward.go:889
-#: lxc/network_forward.go:970 lxc/network_load_balancer.go:33
-#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:181
-#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:408
-#: lxc/network_load_balancer.go:476 lxc/network_load_balancer.go:586
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:771
-#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:859
-#: lxc/network_load_balancer.go:935 lxc/network_load_balancer.go:1033
-#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1121
-#: lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:167
-#: lxc/network_peer.go:236 lxc/network_peer.go:360 lxc/network_peer.go:445
-#: lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731
-#: lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:165
-#: lxc/network_zone.go:228 lxc/network_zone.go:301 lxc/network_zone.go:396
-#: lxc/network_zone.go:484 lxc/network_zone.go:527 lxc/network_zone.go:654
-#: lxc/network_zone.go:710 lxc/network_zone.go:767 lxc/network_zone.go:845
-#: lxc/network_zone.go:909 lxc/network_zone.go:985 lxc/network_zone.go:1083
-#: lxc/network_zone.go:1172 lxc/network_zone.go:1219 lxc/network_zone.go:1349
-#: lxc/network_zone.go:1410 lxc/network_zone.go:1425 lxc/network_zone.go:1483
-#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
-#: lxc/operation.go:194 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
-#: lxc/profile.go:271 lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493
-#: lxc/profile.go:629 lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860
-#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31
-#: lxc/project.go:95 lxc/project.go:191 lxc/project.go:262 lxc/project.go:398
-#: lxc/project.go:472 lxc/project.go:592 lxc/project.go:657 lxc/project.go:745
-#: lxc/project.go:789 lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34
-#: lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91
-#: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853
-#: lxc/remote.go:917 lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24
-#: lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203
-#: lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655
-#: lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940
-#: lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189
-#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:383
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:536
-#: lxc/storage_bucket.go:630 lxc/storage_bucket.go:699
-#: lxc/storage_bucket.go:733 lxc/storage_bucket.go:774
-#: lxc/storage_bucket.go:853 lxc/storage_bucket.go:959
-#: lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158
-#: lxc/storage_volume.go:58 lxc/storage_volume.go:169 lxc/storage_volume.go:283
+#: lxc/export.go:32 lxc/file.go:88 lxc/file.go:135 lxc/file.go:313
+#: lxc/file.go:362 lxc/file.go:432 lxc/file.go:657 lxc/file.go:1176
+#: lxc/image.go:38 lxc/image.go:159 lxc/image.go:337 lxc/image.go:396
+#: lxc/image.go:525 lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090
+#: lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638
+#: lxc/image.go:1701 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255
+#: lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34
+#: lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233
+#: lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560
+#: lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1005
+#: lxc/network.go:1106 lxc/network.go:1185 lxc/network.go:1245
+#: lxc/network.go:1341 lxc/network.go:1413 lxc/network_acl.go:30
+#: lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235
+#: lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461
+#: lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731
+#: lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860
+#: lxc/network_acl.go:997 lxc/network_allocations.go:51
+#: lxc/network_forward.go:33 lxc/network_forward.go:90
+#: lxc/network_forward.go:179 lxc/network_forward.go:256
+#: lxc/network_forward.go:404 lxc/network_forward.go:489
+#: lxc/network_forward.go:599 lxc/network_forward.go:646
+#: lxc/network_forward.go:800 lxc/network_forward.go:874
+#: lxc/network_forward.go:889 lxc/network_forward.go:970
+#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
+#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844
+#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1121 lxc/network_peer.go:29
+#: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
+#: lxc/network_peer.go:360 lxc/network_peer.go:445 lxc/network_peer.go:547
+#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:29
+#: lxc/network_zone.go:86 lxc/network_zone.go:165 lxc/network_zone.go:228
+#: lxc/network_zone.go:301 lxc/network_zone.go:396 lxc/network_zone.go:484
+#: lxc/network_zone.go:527 lxc/network_zone.go:654 lxc/network_zone.go:710
+#: lxc/network_zone.go:767 lxc/network_zone.go:845 lxc/network_zone.go:909
+#: lxc/network_zone.go:985 lxc/network_zone.go:1083 lxc/network_zone.go:1172
+#: lxc/network_zone.go:1219 lxc/network_zone.go:1349 lxc/network_zone.go:1410
+#: lxc/network_zone.go:1425 lxc/network_zone.go:1483 lxc/operation.go:25
+#: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
+#: lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180 lxc/profile.go:271
+#: lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493 lxc/profile.go:629
+#: lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860 lxc/profile.go:920
+#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31 lxc/project.go:95
+#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
+#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
+#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:648
+#: lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853 lxc/remote.go:917
+#: lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
+#: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
+#: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:459
+#: lxc/storage_bucket.go:536 lxc/storage_bucket.go:630
+#: lxc/storage_bucket.go:699 lxc/storage_bucket.go:733
+#: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
+#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:283
 #: lxc/storage_volume.go:390 lxc/storage_volume.go:605
 #: lxc/storage_volume.go:714 lxc/storage_volume.go:801
 #: lxc/storage_volume.go:899 lxc/storage_volume.go:996
@@ -2199,7 +2210,7 @@ msgstr "L'importation de répertoire n'est pas disponible sur cette plateforme"
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:995
+#: lxc/file.go:1184
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2271,7 +2282,7 @@ msgstr "DATE D'EXPIRATION"
 msgid "EXPIRY DATE"
 msgstr "DATE D'EXPIRATION"
 
-#: lxc/file.go:75
+#: lxc/file.go:79
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -2290,7 +2301,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr "Clé de configuration invalide"
 
-#: lxc/file.go:172 lxc/file.go:173
+#: lxc/file.go:361 lxc/file.go:362
 #, fuzzy
 msgid "Edit files in instances"
 msgstr "Création du conteneur"
@@ -2601,12 +2612,12 @@ msgstr "EMPREINTE"
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1238
+#: lxc/file.go:1427
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1261
+#: lxc/file.go:1450
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2621,12 +2632,12 @@ msgstr "Profil à appliquer au nouveau conteneur"
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "Profil à appliquer au nouveau conteneur"
 
-#: lxc/file.go:1288
+#: lxc/file.go:1477
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1073
+#: lxc/file.go:1262
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "Profil à appliquer au nouveau conteneur"
@@ -2656,7 +2667,7 @@ msgstr "Profil à appliquer au nouveau conteneur"
 msgid "Failed fetching fingerprint %q: %w"
 msgstr "Profil à appliquer au nouveau conteneur"
 
-#: lxc/file.go:1194
+#: lxc/file.go:1383
 #, fuzzy, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
@@ -2671,7 +2682,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
-#: lxc/file.go:1199
+#: lxc/file.go:1388
 #, fuzzy, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
@@ -2681,12 +2692,12 @@ msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 msgid "Failed starting command: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
-#: lxc/file.go:1099
+#: lxc/file.go:1288
 #, fuzzy, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
-#: lxc/file.go:1226
+#: lxc/file.go:1415
 #, fuzzy, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "Échec lors de la génération de 'lxc.1': %v"
@@ -2726,7 +2737,7 @@ msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 msgid "Failed to find project: %w"
 msgstr "Échec lors de la génération de 'lxc.1': %v"
 
-#: lxc/file.go:1211
+#: lxc/file.go:1400
 #, fuzzy, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "Échec lors de la génération de 'lxc.1': %v"
@@ -2741,7 +2752,7 @@ msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 msgid "Failed to remove alias %s: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
-#: lxc/file.go:821
+#: lxc/file.go:1010
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2768,6 +2779,10 @@ msgstr "Empreinte : %s"
 
 #: lxc/cluster.go:1302
 msgid "Force a particular evacuation action"
+msgstr ""
+
+#: lxc/file.go:144
+msgid "Force creating files or directories"
 msgstr ""
 
 #: lxc/cluster.go:1301
@@ -3092,22 +3107,22 @@ msgstr "L'arrêt du conteneur a échoué !"
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1311
+#: lxc/file.go:1500
 #, fuzzy, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/file.go:1300
+#: lxc/file.go:1489
 #, fuzzy, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/file.go:1123
+#: lxc/file.go:1312
 #, fuzzy, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/file.go:1133
+#: lxc/file.go:1322
 #, fuzzy, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "L'arrêt du conteneur a échoué !"
@@ -3314,12 +3329,12 @@ msgstr ""
 msgid "Instance Only"
 msgstr "Le nom du conteneur est : %s"
 
-#: lxc/file.go:1125
+#: lxc/file.go:1314
 #, fuzzy
 msgid "Instance disconnected"
 msgstr "Mot de passe de l'administrateur distant"
 
-#: lxc/file.go:1302
+#: lxc/file.go:1491
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3339,7 +3354,7 @@ msgstr "Le nom du conteneur est : %s"
 msgid "Instance name must be specified"
 msgstr "Le nom du conteneur est : %s"
 
-#: lxc/file.go:1045
+#: lxc/file.go:1234
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3391,7 +3406,7 @@ msgstr "Cible invalide %s"
 msgid "Invalid instance name: %s"
 msgstr "Le nom du conteneur est : %s"
 
-#: lxc/file.go:1040
+#: lxc/file.go:1229
 #, fuzzy, c-format
 msgid "Invalid instance path: %q"
 msgstr "Le nom du conteneur est : %s"
@@ -3435,7 +3450,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr "nombre d'arguments incorrect pour la sous-comande"
 
-#: lxc/file.go:148
+#: lxc/file.go:337
 #, fuzzy, c-format
 msgid "Invalid path %s"
 msgstr "Cible invalide %s"
@@ -3452,14 +3467,19 @@ msgstr "Cible invalide %s"
 msgid "Invalid snapshot name"
 msgstr "Le nom du conteneur est : %s"
 
-#: lxc/file.go:314
+#: lxc/file.go:503
 #, c-format
 msgid "Invalid source %s"
 msgstr "Source invalide %s"
 
-#: lxc/file.go:496
+#: lxc/file.go:177 lxc/file.go:685
 #, c-format
 msgid "Invalid target %s"
+msgstr "Cible invalide %s"
+
+#: lxc/file.go:163
+#, fuzzy, c-format
+msgid "Invalid type %q"
 msgstr "Cible invalide %s"
 
 #: lxc/info.go:238
@@ -4049,7 +4069,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr "Création du conteneur"
 
-#: lxc/file.go:83 lxc/file.go:84
+#: lxc/file.go:87 lxc/file.go:88
 #, fuzzy
 msgid "Manage files in instances"
 msgstr "Transfert de l'image : %s"
@@ -4489,7 +4509,7 @@ msgstr "Copie de l'image : %s"
 msgid "Missing storage pool name"
 msgstr "Nom de l'ensemble de stockage"
 
-#: lxc/file.go:599
+#: lxc/file.go:788
 #, fuzzy
 msgid "Missing target directory"
 msgstr "%s n'est pas un répertoire"
@@ -4531,12 +4551,12 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr "Plus d'un périphérique correspond, spécifier le nom du périphérique."
 
-#: lxc/file.go:286
+#: lxc/file.go:475
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 "Plusieurs fichiers à télécharger, mais la destination n'est pas un dossier"
 
-#: lxc/file.go:986 lxc/file.go:987
+#: lxc/file.go:1175 lxc/file.go:1176
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "Création du conteneur"
@@ -5015,7 +5035,7 @@ msgstr "État : %s"
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1103
+#: lxc/file.go:1292
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -5256,22 +5276,22 @@ msgstr "Création du conteneur"
 msgid "Publishing instance: %s"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
 
-#: lxc/file.go:242 lxc/file.go:243
+#: lxc/file.go:431 lxc/file.go:432
 #, fuzzy
 msgid "Pull files from instances"
 msgstr "Création du conteneur"
 
-#: lxc/file.go:417 lxc/file.go:768
+#: lxc/file.go:606 lxc/file.go:957
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:467 lxc/file.go:468
+#: lxc/file.go:656 lxc/file.go:657
 #, fuzzy
 msgid "Push files into instances"
 msgstr "Création du conteneur"
 
-#: lxc/file.go:702 lxc/file.go:868
+#: lxc/file.go:891 lxc/file.go:1057
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -5312,7 +5332,7 @@ msgstr "Création du conteneur"
 msgid "Rebuild instances"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/file.go:250 lxc/file.go:474
+#: lxc/file.go:439 lxc/file.go:663
 #, fuzzy
 msgid "Recursively transfer files"
 msgstr "Pousser ou récupérer des fichiers récursivement"
@@ -5692,12 +5712,12 @@ msgstr "SOURCE"
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1231
+#: lxc/file.go:1420
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1232
+#: lxc/file.go:1421
 #, fuzzy, c-format
 msgid "SSH client disconnected %q"
 msgstr "Mot de passe de l'administrateur distant"
@@ -5780,7 +5800,7 @@ msgstr "Création du conteneur"
 msgid "Set a cluster member's configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/file.go:996
+#: lxc/file.go:1185
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5988,15 +6008,30 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:477
+#: lxc/file.go:145
+#, fuzzy
+msgid "Set the file's gid on create"
+msgstr "Définir le gid du fichier lors de l'envoi"
+
+#: lxc/file.go:666
 msgid "Set the file's gid on push"
 msgstr "Définir le gid du fichier lors de l'envoi"
 
-#: lxc/file.go:478
+#: lxc/file.go:147
+#, fuzzy
+msgid "Set the file's perms on create"
+msgstr "Définir les permissions du fichier lors de l'envoi"
+
+#: lxc/file.go:667
 msgid "Set the file's perms on push"
 msgstr "Définir les permissions du fichier lors de l'envoi"
 
-#: lxc/file.go:476
+#: lxc/file.go:146
+#, fuzzy
+msgid "Set the file's uid on create"
+msgstr "Définir l'uid du fichier lors de l'envoi"
+
+#: lxc/file.go:665
 msgid "Set the file's uid on push"
 msgstr "Définir l'uid du fichier lors de l'envoi"
 
@@ -6064,7 +6099,7 @@ msgstr "Copie de l'image : %s"
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:994
+#: lxc/file.go:1183
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -6480,6 +6515,10 @@ msgstr "impossible de supprimer le serveur distant par défaut"
 msgid "Switch the default remote"
 msgstr "impossible de supprimer le serveur distant par défaut"
 
+#: lxc/file.go:167
+msgid "Symlink target path can only be used for type \"symlink\""
+msgstr ""
+
 #: lxc/alias.go:140
 msgid "TARGET"
 msgstr ""
@@ -6500,11 +6539,11 @@ msgstr "TYPE"
 msgid "Taken at"
 msgstr "pris à %s"
 
-#: lxc/file.go:1033
+#: lxc/file.go:1222
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1027
+#: lxc/file.go:1216
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -6683,6 +6722,10 @@ msgstr "Le périphérique indiqué n'existe pas"
 #: lxc/network.go:537 lxc/network.go:634
 msgid "The specified device doesn't match the network"
 msgstr "le périphérique indiqué ne correspond pas au réseau"
+
+#: lxc/file.go:148
+msgid "The type to create (file, symlink, or directory)"
+msgstr ""
 
 #: lxc/publish.go:97
 msgid "There is no \"image name\".  Did you want an alias?"
@@ -6870,7 +6913,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:198
+#: lxc/file.go:387
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6885,7 +6928,7 @@ msgstr "Ajouter de nouveaux serveurs distants"
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1254
+#: lxc/file.go:1443
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6901,7 +6944,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:808
+#: lxc/file.go:997
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -7151,7 +7194,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr "L'utilisateur a annulé l'opération de suppression."
 
-#: lxc/file.go:72
+#: lxc/file.go:76
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -7792,7 +7835,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/file.go:171
+#: lxc/file.go:360
 #, fuzzy
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
@@ -7804,7 +7847,19 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/file.go:121
+#: lxc/file.go:133
+#, fuzzy
+msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
+msgstr ""
+"Supprimer des conteneurs ou des instantanés.\n"
+"\n"
+"lxc delete [<remote>:]<container>[/<snapshot>] [<remote>:][<container>[/"
+"<snapshot>]...]\n"
+"\n"
+"Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
+"(configuration, instantanés, …)."
+
+#: lxc/file.go:310
 #, fuzzy
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
@@ -7812,7 +7867,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/file.go:241
+#: lxc/file.go:430
 #, fuzzy
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
@@ -7825,7 +7880,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/file.go:985
+#: lxc/file.go:1174
 #, fuzzy
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
@@ -8760,20 +8815,28 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:989
+#: lxc/file.go:137
+msgid ""
+"lxc file create foo/bar\n"
+"\t   To create a file /bar in the foo instance.\n"
+"lxc file create --type=symlink foo/bar baz\n"
+"\t   To create a symlink /bar in instance foo whose target is baz."
+msgstr ""
+
+#: lxc/file.go:1178
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:245
+#: lxc/file.go:434
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:470
+#: lxc/file.go:659
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -9145,16 +9208,16 @@ msgstr "s'il vous plaît utilisez  `lxc profile`"
 msgid "space used"
 msgstr "espace utilisé"
 
-#: lxc/file.go:1143
+#: lxc/file.go:1332
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1102
+#: lxc/file.go:1291
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1055
+#: lxc/file.go:1244
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/he.po
+++ b/po/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-30 13:36-0400\n"
+"POT-Creation-Date: 2024-10-01 10:45-0600\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hebrew <https://hosted.weblate.org/projects/linux-containers/"
@@ -434,12 +434,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:936
+#: lxc/file.go:1125
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:826
+#: lxc/file.go:1015
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -528,7 +528,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:466
+#: lxc/file.go:655
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -983,7 +983,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:341
+#: lxc/file.go:530
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1012,7 +1012,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:547
+#: lxc/file.go:736
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1398,8 +1398,12 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:249 lxc/file.go:475
+#: lxc/file.go:143 lxc/file.go:438 lxc/file.go:664
 msgid "Create any directories necessary"
+msgstr ""
+
+#: lxc/file.go:134 lxc/file.go:135
+msgid "Create files and directories in instances"
 msgstr ""
 
 #: lxc/auth.go:98 lxc/auth.go:99
@@ -1496,6 +1500,11 @@ msgstr ""
 msgid "Creating %s"
 msgstr ""
 
+#: lxc/file.go:273
+#, c-format
+msgid "Creating %s: %%s"
+msgstr ""
+
 #: lxc/init.go:184
 msgid "Creating the instance"
 msgstr ""
@@ -1552,7 +1561,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:123 lxc/file.go:124
+#: lxc/file.go:312 lxc/file.go:313
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1669,70 +1678,71 @@ msgstr ""
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
-#: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
-#: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
-#: lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090 lxc/image.go:1417
-#: lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638 lxc/image.go:1701
-#: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
-#: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
-#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33
-#: lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405
-#: lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793
-#: lxc/network.go:874 lxc/network.go:1005 lxc/network.go:1106
-#: lxc/network.go:1185 lxc/network.go:1245 lxc/network.go:1341
-#: lxc/network.go:1413 lxc/network_acl.go:30 lxc/network_acl.go:95
-#: lxc/network_acl.go:174 lxc/network_acl.go:235 lxc/network_acl.go:291
-#: lxc/network_acl.go:364 lxc/network_acl.go:461 lxc/network_acl.go:549
-#: lxc/network_acl.go:592 lxc/network_acl.go:731 lxc/network_acl.go:788
-#: lxc/network_acl.go:845 lxc/network_acl.go:860 lxc/network_acl.go:997
-#: lxc/network_allocations.go:51 lxc/network_forward.go:33
-#: lxc/network_forward.go:90 lxc/network_forward.go:179
-#: lxc/network_forward.go:256 lxc/network_forward.go:404
-#: lxc/network_forward.go:489 lxc/network_forward.go:599
-#: lxc/network_forward.go:646 lxc/network_forward.go:800
-#: lxc/network_forward.go:874 lxc/network_forward.go:889
-#: lxc/network_forward.go:970 lxc/network_load_balancer.go:33
-#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:181
-#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:408
-#: lxc/network_load_balancer.go:476 lxc/network_load_balancer.go:586
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:771
-#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:859
-#: lxc/network_load_balancer.go:935 lxc/network_load_balancer.go:1033
-#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1121
-#: lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:167
-#: lxc/network_peer.go:236 lxc/network_peer.go:360 lxc/network_peer.go:445
-#: lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731
-#: lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:165
-#: lxc/network_zone.go:228 lxc/network_zone.go:301 lxc/network_zone.go:396
-#: lxc/network_zone.go:484 lxc/network_zone.go:527 lxc/network_zone.go:654
-#: lxc/network_zone.go:710 lxc/network_zone.go:767 lxc/network_zone.go:845
-#: lxc/network_zone.go:909 lxc/network_zone.go:985 lxc/network_zone.go:1083
-#: lxc/network_zone.go:1172 lxc/network_zone.go:1219 lxc/network_zone.go:1349
-#: lxc/network_zone.go:1410 lxc/network_zone.go:1425 lxc/network_zone.go:1483
-#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
-#: lxc/operation.go:194 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
-#: lxc/profile.go:271 lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493
-#: lxc/profile.go:629 lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860
-#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31
-#: lxc/project.go:95 lxc/project.go:191 lxc/project.go:262 lxc/project.go:398
-#: lxc/project.go:472 lxc/project.go:592 lxc/project.go:657 lxc/project.go:745
-#: lxc/project.go:789 lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34
-#: lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91
-#: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853
-#: lxc/remote.go:917 lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24
-#: lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203
-#: lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655
-#: lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940
-#: lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189
-#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:383
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:536
-#: lxc/storage_bucket.go:630 lxc/storage_bucket.go:699
-#: lxc/storage_bucket.go:733 lxc/storage_bucket.go:774
-#: lxc/storage_bucket.go:853 lxc/storage_bucket.go:959
-#: lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158
-#: lxc/storage_volume.go:58 lxc/storage_volume.go:169 lxc/storage_volume.go:283
+#: lxc/export.go:32 lxc/file.go:88 lxc/file.go:135 lxc/file.go:313
+#: lxc/file.go:362 lxc/file.go:432 lxc/file.go:657 lxc/file.go:1176
+#: lxc/image.go:38 lxc/image.go:159 lxc/image.go:337 lxc/image.go:396
+#: lxc/image.go:525 lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090
+#: lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638
+#: lxc/image.go:1701 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255
+#: lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34
+#: lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233
+#: lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560
+#: lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1005
+#: lxc/network.go:1106 lxc/network.go:1185 lxc/network.go:1245
+#: lxc/network.go:1341 lxc/network.go:1413 lxc/network_acl.go:30
+#: lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235
+#: lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461
+#: lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731
+#: lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860
+#: lxc/network_acl.go:997 lxc/network_allocations.go:51
+#: lxc/network_forward.go:33 lxc/network_forward.go:90
+#: lxc/network_forward.go:179 lxc/network_forward.go:256
+#: lxc/network_forward.go:404 lxc/network_forward.go:489
+#: lxc/network_forward.go:599 lxc/network_forward.go:646
+#: lxc/network_forward.go:800 lxc/network_forward.go:874
+#: lxc/network_forward.go:889 lxc/network_forward.go:970
+#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
+#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844
+#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1121 lxc/network_peer.go:29
+#: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
+#: lxc/network_peer.go:360 lxc/network_peer.go:445 lxc/network_peer.go:547
+#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:29
+#: lxc/network_zone.go:86 lxc/network_zone.go:165 lxc/network_zone.go:228
+#: lxc/network_zone.go:301 lxc/network_zone.go:396 lxc/network_zone.go:484
+#: lxc/network_zone.go:527 lxc/network_zone.go:654 lxc/network_zone.go:710
+#: lxc/network_zone.go:767 lxc/network_zone.go:845 lxc/network_zone.go:909
+#: lxc/network_zone.go:985 lxc/network_zone.go:1083 lxc/network_zone.go:1172
+#: lxc/network_zone.go:1219 lxc/network_zone.go:1349 lxc/network_zone.go:1410
+#: lxc/network_zone.go:1425 lxc/network_zone.go:1483 lxc/operation.go:25
+#: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
+#: lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180 lxc/profile.go:271
+#: lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493 lxc/profile.go:629
+#: lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860 lxc/profile.go:920
+#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31 lxc/project.go:95
+#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
+#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
+#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:648
+#: lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853 lxc/remote.go:917
+#: lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
+#: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
+#: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:459
+#: lxc/storage_bucket.go:536 lxc/storage_bucket.go:630
+#: lxc/storage_bucket.go:699 lxc/storage_bucket.go:733
+#: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
+#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:283
 #: lxc/storage_volume.go:390 lxc/storage_volume.go:605
 #: lxc/storage_volume.go:714 lxc/storage_volume.go:801
 #: lxc/storage_volume.go:899 lxc/storage_volume.go:996
@@ -1830,7 +1840,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:995
+#: lxc/file.go:1184
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1896,7 +1906,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:75
+#: lxc/file.go:79
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1914,7 +1924,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:172 lxc/file.go:173
+#: lxc/file.go:361 lxc/file.go:362
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2184,12 +2194,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1238
+#: lxc/file.go:1427
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1261
+#: lxc/file.go:1450
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2204,12 +2214,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1288
+#: lxc/file.go:1477
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1073
+#: lxc/file.go:1262
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2239,7 +2249,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1194
+#: lxc/file.go:1383
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2254,7 +2264,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1199
+#: lxc/file.go:1388
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2264,12 +2274,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1099
+#: lxc/file.go:1288
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1226
+#: lxc/file.go:1415
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2308,7 +2318,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1400
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2323,7 +2333,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:821
+#: lxc/file.go:1010
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2349,6 +2359,10 @@ msgstr ""
 
 #: lxc/cluster.go:1302
 msgid "Force a particular evacuation action"
+msgstr ""
+
+#: lxc/file.go:144
+msgid "Force creating files or directories"
 msgstr ""
 
 #: lxc/cluster.go:1301
@@ -2645,22 +2659,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1311
+#: lxc/file.go:1500
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1300
+#: lxc/file.go:1489
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1312
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1133
+#: lxc/file.go:1322
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2853,11 +2867,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1125
+#: lxc/file.go:1314
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1302
+#: lxc/file.go:1491
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2875,7 +2889,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1045
+#: lxc/file.go:1234
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2927,7 +2941,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1040
+#: lxc/file.go:1229
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2969,7 +2983,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:148
+#: lxc/file.go:337
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2985,14 +2999,19 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:314
+#: lxc/file.go:503
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:496
+#: lxc/file.go:177 lxc/file.go:685
 #, c-format
 msgid "Invalid target %s"
+msgstr ""
+
+#: lxc/file.go:163
+#, c-format
+msgid "Invalid type %q"
 msgstr ""
 
 #: lxc/info.go:238
@@ -3497,7 +3516,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:83 lxc/file.go:84
+#: lxc/file.go:87 lxc/file.go:88
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3883,7 +3902,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:599
+#: lxc/file.go:788
 msgid "Missing target directory"
 msgstr ""
 
@@ -3921,11 +3940,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:286
+#: lxc/file.go:475
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:986 lxc/file.go:987
+#: lxc/file.go:1175 lxc/file.go:1176
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4377,7 +4396,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1103
+#: lxc/file.go:1292
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4611,20 +4630,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:242 lxc/file.go:243
+#: lxc/file.go:431 lxc/file.go:432
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:417 lxc/file.go:768
+#: lxc/file.go:606 lxc/file.go:957
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:467 lxc/file.go:468
+#: lxc/file.go:656 lxc/file.go:657
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:702 lxc/file.go:868
+#: lxc/file.go:891 lxc/file.go:1057
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4662,7 +4681,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:250 lxc/file.go:474
+#: lxc/file.go:439 lxc/file.go:663
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4991,12 +5010,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1231
+#: lxc/file.go:1420
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1232
+#: lxc/file.go:1421
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5072,7 +5091,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:996
+#: lxc/file.go:1185
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5266,15 +5285,27 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:477
+#: lxc/file.go:145
+msgid "Set the file's gid on create"
+msgstr ""
+
+#: lxc/file.go:666
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:478
+#: lxc/file.go:147
+msgid "Set the file's perms on create"
+msgstr ""
+
+#: lxc/file.go:667
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:476
+#: lxc/file.go:146
+msgid "Set the file's uid on create"
+msgstr ""
+
+#: lxc/file.go:665
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5334,7 +5365,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:994
+#: lxc/file.go:1183
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5709,6 +5740,10 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
+#: lxc/file.go:167
+msgid "Symlink target path can only be used for type \"symlink\""
+msgstr ""
+
 #: lxc/alias.go:140
 msgid "TARGET"
 msgstr ""
@@ -5728,11 +5763,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1033
+#: lxc/file.go:1222
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1027
+#: lxc/file.go:1216
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5901,6 +5936,10 @@ msgstr ""
 
 #: lxc/network.go:537 lxc/network.go:634
 msgid "The specified device doesn't match the network"
+msgstr ""
+
+#: lxc/file.go:148
+msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
 #: lxc/publish.go:97
@@ -6081,7 +6120,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:198
+#: lxc/file.go:387
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6095,7 +6134,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1254
+#: lxc/file.go:1443
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6111,7 +6150,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:808
+#: lxc/file.go:997
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6329,7 +6368,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:72
+#: lxc/file.go:76
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6678,20 +6717,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:171
+#: lxc/file.go:360
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:121
+#: lxc/file.go:133
+msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
+msgstr ""
+
+#: lxc/file.go:310
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:241
+#: lxc/file.go:430
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:985
+#: lxc/file.go:1174
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7200,20 +7243,28 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:989
+#: lxc/file.go:137
+msgid ""
+"lxc file create foo/bar\n"
+"\t   To create a file /bar in the foo instance.\n"
+"lxc file create --type=symlink foo/bar baz\n"
+"\t   To create a symlink /bar in instance foo whose target is baz."
+msgstr ""
+
+#: lxc/file.go:1178
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:245
+#: lxc/file.go:434
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:470
+#: lxc/file.go:659
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7562,16 +7613,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1143
+#: lxc/file.go:1332
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1102
+#: lxc/file.go:1291
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1055
+#: lxc/file.go:1244
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/hi.po
+++ b/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-30 13:36-0400\n"
+"POT-Creation-Date: 2024-10-01 10:45-0600\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hindi <https://hosted.weblate.org/projects/linux-containers/"
@@ -433,12 +433,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:936
+#: lxc/file.go:1125
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:826
+#: lxc/file.go:1015
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -527,7 +527,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:466
+#: lxc/file.go:655
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -982,7 +982,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:341
+#: lxc/file.go:530
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1011,7 +1011,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:547
+#: lxc/file.go:736
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1397,8 +1397,12 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:249 lxc/file.go:475
+#: lxc/file.go:143 lxc/file.go:438 lxc/file.go:664
 msgid "Create any directories necessary"
+msgstr ""
+
+#: lxc/file.go:134 lxc/file.go:135
+msgid "Create files and directories in instances"
 msgstr ""
 
 #: lxc/auth.go:98 lxc/auth.go:99
@@ -1495,6 +1499,11 @@ msgstr ""
 msgid "Creating %s"
 msgstr ""
 
+#: lxc/file.go:273
+#, c-format
+msgid "Creating %s: %%s"
+msgstr ""
+
 #: lxc/init.go:184
 msgid "Creating the instance"
 msgstr ""
@@ -1551,7 +1560,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:123 lxc/file.go:124
+#: lxc/file.go:312 lxc/file.go:313
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1668,70 +1677,71 @@ msgstr ""
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
-#: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
-#: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
-#: lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090 lxc/image.go:1417
-#: lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638 lxc/image.go:1701
-#: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
-#: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
-#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33
-#: lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405
-#: lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793
-#: lxc/network.go:874 lxc/network.go:1005 lxc/network.go:1106
-#: lxc/network.go:1185 lxc/network.go:1245 lxc/network.go:1341
-#: lxc/network.go:1413 lxc/network_acl.go:30 lxc/network_acl.go:95
-#: lxc/network_acl.go:174 lxc/network_acl.go:235 lxc/network_acl.go:291
-#: lxc/network_acl.go:364 lxc/network_acl.go:461 lxc/network_acl.go:549
-#: lxc/network_acl.go:592 lxc/network_acl.go:731 lxc/network_acl.go:788
-#: lxc/network_acl.go:845 lxc/network_acl.go:860 lxc/network_acl.go:997
-#: lxc/network_allocations.go:51 lxc/network_forward.go:33
-#: lxc/network_forward.go:90 lxc/network_forward.go:179
-#: lxc/network_forward.go:256 lxc/network_forward.go:404
-#: lxc/network_forward.go:489 lxc/network_forward.go:599
-#: lxc/network_forward.go:646 lxc/network_forward.go:800
-#: lxc/network_forward.go:874 lxc/network_forward.go:889
-#: lxc/network_forward.go:970 lxc/network_load_balancer.go:33
-#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:181
-#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:408
-#: lxc/network_load_balancer.go:476 lxc/network_load_balancer.go:586
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:771
-#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:859
-#: lxc/network_load_balancer.go:935 lxc/network_load_balancer.go:1033
-#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1121
-#: lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:167
-#: lxc/network_peer.go:236 lxc/network_peer.go:360 lxc/network_peer.go:445
-#: lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731
-#: lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:165
-#: lxc/network_zone.go:228 lxc/network_zone.go:301 lxc/network_zone.go:396
-#: lxc/network_zone.go:484 lxc/network_zone.go:527 lxc/network_zone.go:654
-#: lxc/network_zone.go:710 lxc/network_zone.go:767 lxc/network_zone.go:845
-#: lxc/network_zone.go:909 lxc/network_zone.go:985 lxc/network_zone.go:1083
-#: lxc/network_zone.go:1172 lxc/network_zone.go:1219 lxc/network_zone.go:1349
-#: lxc/network_zone.go:1410 lxc/network_zone.go:1425 lxc/network_zone.go:1483
-#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
-#: lxc/operation.go:194 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
-#: lxc/profile.go:271 lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493
-#: lxc/profile.go:629 lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860
-#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31
-#: lxc/project.go:95 lxc/project.go:191 lxc/project.go:262 lxc/project.go:398
-#: lxc/project.go:472 lxc/project.go:592 lxc/project.go:657 lxc/project.go:745
-#: lxc/project.go:789 lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34
-#: lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91
-#: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853
-#: lxc/remote.go:917 lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24
-#: lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203
-#: lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655
-#: lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940
-#: lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189
-#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:383
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:536
-#: lxc/storage_bucket.go:630 lxc/storage_bucket.go:699
-#: lxc/storage_bucket.go:733 lxc/storage_bucket.go:774
-#: lxc/storage_bucket.go:853 lxc/storage_bucket.go:959
-#: lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158
-#: lxc/storage_volume.go:58 lxc/storage_volume.go:169 lxc/storage_volume.go:283
+#: lxc/export.go:32 lxc/file.go:88 lxc/file.go:135 lxc/file.go:313
+#: lxc/file.go:362 lxc/file.go:432 lxc/file.go:657 lxc/file.go:1176
+#: lxc/image.go:38 lxc/image.go:159 lxc/image.go:337 lxc/image.go:396
+#: lxc/image.go:525 lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090
+#: lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638
+#: lxc/image.go:1701 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255
+#: lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34
+#: lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233
+#: lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560
+#: lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1005
+#: lxc/network.go:1106 lxc/network.go:1185 lxc/network.go:1245
+#: lxc/network.go:1341 lxc/network.go:1413 lxc/network_acl.go:30
+#: lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235
+#: lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461
+#: lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731
+#: lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860
+#: lxc/network_acl.go:997 lxc/network_allocations.go:51
+#: lxc/network_forward.go:33 lxc/network_forward.go:90
+#: lxc/network_forward.go:179 lxc/network_forward.go:256
+#: lxc/network_forward.go:404 lxc/network_forward.go:489
+#: lxc/network_forward.go:599 lxc/network_forward.go:646
+#: lxc/network_forward.go:800 lxc/network_forward.go:874
+#: lxc/network_forward.go:889 lxc/network_forward.go:970
+#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
+#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844
+#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1121 lxc/network_peer.go:29
+#: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
+#: lxc/network_peer.go:360 lxc/network_peer.go:445 lxc/network_peer.go:547
+#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:29
+#: lxc/network_zone.go:86 lxc/network_zone.go:165 lxc/network_zone.go:228
+#: lxc/network_zone.go:301 lxc/network_zone.go:396 lxc/network_zone.go:484
+#: lxc/network_zone.go:527 lxc/network_zone.go:654 lxc/network_zone.go:710
+#: lxc/network_zone.go:767 lxc/network_zone.go:845 lxc/network_zone.go:909
+#: lxc/network_zone.go:985 lxc/network_zone.go:1083 lxc/network_zone.go:1172
+#: lxc/network_zone.go:1219 lxc/network_zone.go:1349 lxc/network_zone.go:1410
+#: lxc/network_zone.go:1425 lxc/network_zone.go:1483 lxc/operation.go:25
+#: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
+#: lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180 lxc/profile.go:271
+#: lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493 lxc/profile.go:629
+#: lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860 lxc/profile.go:920
+#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31 lxc/project.go:95
+#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
+#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
+#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:648
+#: lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853 lxc/remote.go:917
+#: lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
+#: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
+#: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:459
+#: lxc/storage_bucket.go:536 lxc/storage_bucket.go:630
+#: lxc/storage_bucket.go:699 lxc/storage_bucket.go:733
+#: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
+#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:283
 #: lxc/storage_volume.go:390 lxc/storage_volume.go:605
 #: lxc/storage_volume.go:714 lxc/storage_volume.go:801
 #: lxc/storage_volume.go:899 lxc/storage_volume.go:996
@@ -1829,7 +1839,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:995
+#: lxc/file.go:1184
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1895,7 +1905,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:75
+#: lxc/file.go:79
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1913,7 +1923,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:172 lxc/file.go:173
+#: lxc/file.go:361 lxc/file.go:362
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2183,12 +2193,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1238
+#: lxc/file.go:1427
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1261
+#: lxc/file.go:1450
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2203,12 +2213,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1288
+#: lxc/file.go:1477
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1073
+#: lxc/file.go:1262
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2238,7 +2248,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1194
+#: lxc/file.go:1383
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2253,7 +2263,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1199
+#: lxc/file.go:1388
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2263,12 +2273,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1099
+#: lxc/file.go:1288
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1226
+#: lxc/file.go:1415
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2307,7 +2317,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1400
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2322,7 +2332,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:821
+#: lxc/file.go:1010
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2348,6 +2358,10 @@ msgstr ""
 
 #: lxc/cluster.go:1302
 msgid "Force a particular evacuation action"
+msgstr ""
+
+#: lxc/file.go:144
+msgid "Force creating files or directories"
 msgstr ""
 
 #: lxc/cluster.go:1301
@@ -2644,22 +2658,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1311
+#: lxc/file.go:1500
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1300
+#: lxc/file.go:1489
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1312
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1133
+#: lxc/file.go:1322
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2852,11 +2866,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1125
+#: lxc/file.go:1314
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1302
+#: lxc/file.go:1491
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2874,7 +2888,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1045
+#: lxc/file.go:1234
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2926,7 +2940,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1040
+#: lxc/file.go:1229
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2968,7 +2982,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:148
+#: lxc/file.go:337
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2984,14 +2998,19 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:314
+#: lxc/file.go:503
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:496
+#: lxc/file.go:177 lxc/file.go:685
 #, c-format
 msgid "Invalid target %s"
+msgstr ""
+
+#: lxc/file.go:163
+#, c-format
+msgid "Invalid type %q"
 msgstr ""
 
 #: lxc/info.go:238
@@ -3496,7 +3515,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:83 lxc/file.go:84
+#: lxc/file.go:87 lxc/file.go:88
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3882,7 +3901,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:599
+#: lxc/file.go:788
 msgid "Missing target directory"
 msgstr ""
 
@@ -3920,11 +3939,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:286
+#: lxc/file.go:475
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:986 lxc/file.go:987
+#: lxc/file.go:1175 lxc/file.go:1176
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4376,7 +4395,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1103
+#: lxc/file.go:1292
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4610,20 +4629,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:242 lxc/file.go:243
+#: lxc/file.go:431 lxc/file.go:432
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:417 lxc/file.go:768
+#: lxc/file.go:606 lxc/file.go:957
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:467 lxc/file.go:468
+#: lxc/file.go:656 lxc/file.go:657
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:702 lxc/file.go:868
+#: lxc/file.go:891 lxc/file.go:1057
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4661,7 +4680,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:250 lxc/file.go:474
+#: lxc/file.go:439 lxc/file.go:663
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4990,12 +5009,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1231
+#: lxc/file.go:1420
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1232
+#: lxc/file.go:1421
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5071,7 +5090,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:996
+#: lxc/file.go:1185
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5265,15 +5284,27 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:477
+#: lxc/file.go:145
+msgid "Set the file's gid on create"
+msgstr ""
+
+#: lxc/file.go:666
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:478
+#: lxc/file.go:147
+msgid "Set the file's perms on create"
+msgstr ""
+
+#: lxc/file.go:667
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:476
+#: lxc/file.go:146
+msgid "Set the file's uid on create"
+msgstr ""
+
+#: lxc/file.go:665
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5333,7 +5364,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:994
+#: lxc/file.go:1183
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5708,6 +5739,10 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
+#: lxc/file.go:167
+msgid "Symlink target path can only be used for type \"symlink\""
+msgstr ""
+
 #: lxc/alias.go:140
 msgid "TARGET"
 msgstr ""
@@ -5727,11 +5762,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1033
+#: lxc/file.go:1222
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1027
+#: lxc/file.go:1216
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5900,6 +5935,10 @@ msgstr ""
 
 #: lxc/network.go:537 lxc/network.go:634
 msgid "The specified device doesn't match the network"
+msgstr ""
+
+#: lxc/file.go:148
+msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
 #: lxc/publish.go:97
@@ -6080,7 +6119,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:198
+#: lxc/file.go:387
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6094,7 +6133,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1254
+#: lxc/file.go:1443
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6110,7 +6149,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:808
+#: lxc/file.go:997
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6328,7 +6367,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:72
+#: lxc/file.go:76
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6677,20 +6716,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:171
+#: lxc/file.go:360
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:121
+#: lxc/file.go:133
+msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
+msgstr ""
+
+#: lxc/file.go:310
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:241
+#: lxc/file.go:430
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:985
+#: lxc/file.go:1174
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7199,20 +7242,28 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:989
+#: lxc/file.go:137
+msgid ""
+"lxc file create foo/bar\n"
+"\t   To create a file /bar in the foo instance.\n"
+"lxc file create --type=symlink foo/bar baz\n"
+"\t   To create a symlink /bar in instance foo whose target is baz."
+msgstr ""
+
+#: lxc/file.go:1178
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:245
+#: lxc/file.go:434
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:470
+#: lxc/file.go:659
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7561,16 +7612,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1143
+#: lxc/file.go:1332
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1102
+#: lxc/file.go:1291
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1055
+#: lxc/file.go:1244
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-30 13:36-0400\n"
+"POT-Creation-Date: 2024-10-01 10:45-0600\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Indonesian <https://hosted.weblate.org/projects/linux-"
@@ -433,12 +433,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:936
+#: lxc/file.go:1125
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:826
+#: lxc/file.go:1015
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -527,7 +527,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:466
+#: lxc/file.go:655
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -982,7 +982,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:341
+#: lxc/file.go:530
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1011,7 +1011,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:547
+#: lxc/file.go:736
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1397,8 +1397,12 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:249 lxc/file.go:475
+#: lxc/file.go:143 lxc/file.go:438 lxc/file.go:664
 msgid "Create any directories necessary"
+msgstr ""
+
+#: lxc/file.go:134 lxc/file.go:135
+msgid "Create files and directories in instances"
 msgstr ""
 
 #: lxc/auth.go:98 lxc/auth.go:99
@@ -1495,6 +1499,11 @@ msgstr ""
 msgid "Creating %s"
 msgstr ""
 
+#: lxc/file.go:273
+#, c-format
+msgid "Creating %s: %%s"
+msgstr ""
+
 #: lxc/init.go:184
 msgid "Creating the instance"
 msgstr ""
@@ -1551,7 +1560,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:123 lxc/file.go:124
+#: lxc/file.go:312 lxc/file.go:313
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1668,70 +1677,71 @@ msgstr ""
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
-#: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
-#: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
-#: lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090 lxc/image.go:1417
-#: lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638 lxc/image.go:1701
-#: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
-#: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
-#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33
-#: lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405
-#: lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793
-#: lxc/network.go:874 lxc/network.go:1005 lxc/network.go:1106
-#: lxc/network.go:1185 lxc/network.go:1245 lxc/network.go:1341
-#: lxc/network.go:1413 lxc/network_acl.go:30 lxc/network_acl.go:95
-#: lxc/network_acl.go:174 lxc/network_acl.go:235 lxc/network_acl.go:291
-#: lxc/network_acl.go:364 lxc/network_acl.go:461 lxc/network_acl.go:549
-#: lxc/network_acl.go:592 lxc/network_acl.go:731 lxc/network_acl.go:788
-#: lxc/network_acl.go:845 lxc/network_acl.go:860 lxc/network_acl.go:997
-#: lxc/network_allocations.go:51 lxc/network_forward.go:33
-#: lxc/network_forward.go:90 lxc/network_forward.go:179
-#: lxc/network_forward.go:256 lxc/network_forward.go:404
-#: lxc/network_forward.go:489 lxc/network_forward.go:599
-#: lxc/network_forward.go:646 lxc/network_forward.go:800
-#: lxc/network_forward.go:874 lxc/network_forward.go:889
-#: lxc/network_forward.go:970 lxc/network_load_balancer.go:33
-#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:181
-#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:408
-#: lxc/network_load_balancer.go:476 lxc/network_load_balancer.go:586
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:771
-#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:859
-#: lxc/network_load_balancer.go:935 lxc/network_load_balancer.go:1033
-#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1121
-#: lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:167
-#: lxc/network_peer.go:236 lxc/network_peer.go:360 lxc/network_peer.go:445
-#: lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731
-#: lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:165
-#: lxc/network_zone.go:228 lxc/network_zone.go:301 lxc/network_zone.go:396
-#: lxc/network_zone.go:484 lxc/network_zone.go:527 lxc/network_zone.go:654
-#: lxc/network_zone.go:710 lxc/network_zone.go:767 lxc/network_zone.go:845
-#: lxc/network_zone.go:909 lxc/network_zone.go:985 lxc/network_zone.go:1083
-#: lxc/network_zone.go:1172 lxc/network_zone.go:1219 lxc/network_zone.go:1349
-#: lxc/network_zone.go:1410 lxc/network_zone.go:1425 lxc/network_zone.go:1483
-#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
-#: lxc/operation.go:194 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
-#: lxc/profile.go:271 lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493
-#: lxc/profile.go:629 lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860
-#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31
-#: lxc/project.go:95 lxc/project.go:191 lxc/project.go:262 lxc/project.go:398
-#: lxc/project.go:472 lxc/project.go:592 lxc/project.go:657 lxc/project.go:745
-#: lxc/project.go:789 lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34
-#: lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91
-#: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853
-#: lxc/remote.go:917 lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24
-#: lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203
-#: lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655
-#: lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940
-#: lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189
-#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:383
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:536
-#: lxc/storage_bucket.go:630 lxc/storage_bucket.go:699
-#: lxc/storage_bucket.go:733 lxc/storage_bucket.go:774
-#: lxc/storage_bucket.go:853 lxc/storage_bucket.go:959
-#: lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158
-#: lxc/storage_volume.go:58 lxc/storage_volume.go:169 lxc/storage_volume.go:283
+#: lxc/export.go:32 lxc/file.go:88 lxc/file.go:135 lxc/file.go:313
+#: lxc/file.go:362 lxc/file.go:432 lxc/file.go:657 lxc/file.go:1176
+#: lxc/image.go:38 lxc/image.go:159 lxc/image.go:337 lxc/image.go:396
+#: lxc/image.go:525 lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090
+#: lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638
+#: lxc/image.go:1701 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255
+#: lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34
+#: lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233
+#: lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560
+#: lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1005
+#: lxc/network.go:1106 lxc/network.go:1185 lxc/network.go:1245
+#: lxc/network.go:1341 lxc/network.go:1413 lxc/network_acl.go:30
+#: lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235
+#: lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461
+#: lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731
+#: lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860
+#: lxc/network_acl.go:997 lxc/network_allocations.go:51
+#: lxc/network_forward.go:33 lxc/network_forward.go:90
+#: lxc/network_forward.go:179 lxc/network_forward.go:256
+#: lxc/network_forward.go:404 lxc/network_forward.go:489
+#: lxc/network_forward.go:599 lxc/network_forward.go:646
+#: lxc/network_forward.go:800 lxc/network_forward.go:874
+#: lxc/network_forward.go:889 lxc/network_forward.go:970
+#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
+#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844
+#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1121 lxc/network_peer.go:29
+#: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
+#: lxc/network_peer.go:360 lxc/network_peer.go:445 lxc/network_peer.go:547
+#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:29
+#: lxc/network_zone.go:86 lxc/network_zone.go:165 lxc/network_zone.go:228
+#: lxc/network_zone.go:301 lxc/network_zone.go:396 lxc/network_zone.go:484
+#: lxc/network_zone.go:527 lxc/network_zone.go:654 lxc/network_zone.go:710
+#: lxc/network_zone.go:767 lxc/network_zone.go:845 lxc/network_zone.go:909
+#: lxc/network_zone.go:985 lxc/network_zone.go:1083 lxc/network_zone.go:1172
+#: lxc/network_zone.go:1219 lxc/network_zone.go:1349 lxc/network_zone.go:1410
+#: lxc/network_zone.go:1425 lxc/network_zone.go:1483 lxc/operation.go:25
+#: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
+#: lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180 lxc/profile.go:271
+#: lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493 lxc/profile.go:629
+#: lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860 lxc/profile.go:920
+#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31 lxc/project.go:95
+#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
+#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
+#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:648
+#: lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853 lxc/remote.go:917
+#: lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
+#: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
+#: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:459
+#: lxc/storage_bucket.go:536 lxc/storage_bucket.go:630
+#: lxc/storage_bucket.go:699 lxc/storage_bucket.go:733
+#: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
+#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:283
 #: lxc/storage_volume.go:390 lxc/storage_volume.go:605
 #: lxc/storage_volume.go:714 lxc/storage_volume.go:801
 #: lxc/storage_volume.go:899 lxc/storage_volume.go:996
@@ -1829,7 +1839,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:995
+#: lxc/file.go:1184
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1895,7 +1905,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:75
+#: lxc/file.go:79
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1913,7 +1923,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:172 lxc/file.go:173
+#: lxc/file.go:361 lxc/file.go:362
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2183,12 +2193,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1238
+#: lxc/file.go:1427
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1261
+#: lxc/file.go:1450
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2203,12 +2213,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1288
+#: lxc/file.go:1477
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1073
+#: lxc/file.go:1262
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2238,7 +2248,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1194
+#: lxc/file.go:1383
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2253,7 +2263,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1199
+#: lxc/file.go:1388
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2263,12 +2273,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1099
+#: lxc/file.go:1288
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1226
+#: lxc/file.go:1415
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2307,7 +2317,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1400
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2322,7 +2332,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:821
+#: lxc/file.go:1010
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2348,6 +2358,10 @@ msgstr ""
 
 #: lxc/cluster.go:1302
 msgid "Force a particular evacuation action"
+msgstr ""
+
+#: lxc/file.go:144
+msgid "Force creating files or directories"
 msgstr ""
 
 #: lxc/cluster.go:1301
@@ -2644,22 +2658,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1311
+#: lxc/file.go:1500
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1300
+#: lxc/file.go:1489
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1312
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1133
+#: lxc/file.go:1322
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2852,11 +2866,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1125
+#: lxc/file.go:1314
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1302
+#: lxc/file.go:1491
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2874,7 +2888,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1045
+#: lxc/file.go:1234
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2926,7 +2940,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1040
+#: lxc/file.go:1229
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2968,7 +2982,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:148
+#: lxc/file.go:337
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2984,14 +2998,19 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:314
+#: lxc/file.go:503
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:496
+#: lxc/file.go:177 lxc/file.go:685
 #, c-format
 msgid "Invalid target %s"
+msgstr ""
+
+#: lxc/file.go:163
+#, c-format
+msgid "Invalid type %q"
 msgstr ""
 
 #: lxc/info.go:238
@@ -3496,7 +3515,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:83 lxc/file.go:84
+#: lxc/file.go:87 lxc/file.go:88
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3882,7 +3901,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:599
+#: lxc/file.go:788
 msgid "Missing target directory"
 msgstr ""
 
@@ -3920,11 +3939,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:286
+#: lxc/file.go:475
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:986 lxc/file.go:987
+#: lxc/file.go:1175 lxc/file.go:1176
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4376,7 +4395,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1103
+#: lxc/file.go:1292
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4610,20 +4629,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:242 lxc/file.go:243
+#: lxc/file.go:431 lxc/file.go:432
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:417 lxc/file.go:768
+#: lxc/file.go:606 lxc/file.go:957
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:467 lxc/file.go:468
+#: lxc/file.go:656 lxc/file.go:657
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:702 lxc/file.go:868
+#: lxc/file.go:891 lxc/file.go:1057
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4661,7 +4680,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:250 lxc/file.go:474
+#: lxc/file.go:439 lxc/file.go:663
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4990,12 +5009,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1231
+#: lxc/file.go:1420
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1232
+#: lxc/file.go:1421
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5071,7 +5090,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:996
+#: lxc/file.go:1185
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5265,15 +5284,27 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:477
+#: lxc/file.go:145
+msgid "Set the file's gid on create"
+msgstr ""
+
+#: lxc/file.go:666
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:478
+#: lxc/file.go:147
+msgid "Set the file's perms on create"
+msgstr ""
+
+#: lxc/file.go:667
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:476
+#: lxc/file.go:146
+msgid "Set the file's uid on create"
+msgstr ""
+
+#: lxc/file.go:665
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5333,7 +5364,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:994
+#: lxc/file.go:1183
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5708,6 +5739,10 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
+#: lxc/file.go:167
+msgid "Symlink target path can only be used for type \"symlink\""
+msgstr ""
+
 #: lxc/alias.go:140
 msgid "TARGET"
 msgstr ""
@@ -5727,11 +5762,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1033
+#: lxc/file.go:1222
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1027
+#: lxc/file.go:1216
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5900,6 +5935,10 @@ msgstr ""
 
 #: lxc/network.go:537 lxc/network.go:634
 msgid "The specified device doesn't match the network"
+msgstr ""
+
+#: lxc/file.go:148
+msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
 #: lxc/publish.go:97
@@ -6080,7 +6119,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:198
+#: lxc/file.go:387
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6094,7 +6133,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1254
+#: lxc/file.go:1443
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6110,7 +6149,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:808
+#: lxc/file.go:997
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6328,7 +6367,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:72
+#: lxc/file.go:76
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6677,20 +6716,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:171
+#: lxc/file.go:360
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:121
+#: lxc/file.go:133
+msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
+msgstr ""
+
+#: lxc/file.go:310
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:241
+#: lxc/file.go:430
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:985
+#: lxc/file.go:1174
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7199,20 +7242,28 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:989
+#: lxc/file.go:137
+msgid ""
+"lxc file create foo/bar\n"
+"\t   To create a file /bar in the foo instance.\n"
+"lxc file create --type=symlink foo/bar baz\n"
+"\t   To create a symlink /bar in instance foo whose target is baz."
+msgstr ""
+
+#: lxc/file.go:1178
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:245
+#: lxc/file.go:434
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:470
+#: lxc/file.go:659
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7561,16 +7612,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1143
+#: lxc/file.go:1332
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1102
+#: lxc/file.go:1291
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1055
+#: lxc/file.go:1244
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-30 13:36-0400\n"
+"POT-Creation-Date: 2024-10-01 10:45-0600\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Luigi Operoso <brokenpip3@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/linux-containers/"
@@ -675,12 +675,12 @@ msgstr "%s (altri %d)"
 msgid "%s (%s) (%d available)"
 msgstr "%s (altri %d)"
 
-#: lxc/file.go:936
+#: lxc/file.go:1125
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s non è una directory"
 
-#: lxc/file.go:826
+#: lxc/file.go:1015
 #, fuzzy, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' non è un tipo di file supportato."
@@ -771,7 +771,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:466
+#: lxc/file.go:655
 #, fuzzy
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr "Creazione del container in corso"
@@ -1234,7 +1234,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:341
+#: lxc/file.go:530
 msgid "Can't pull a directory without --recursive"
 msgstr "Impossibile effettuare il pull di una directory senza --recursive"
 
@@ -1263,7 +1263,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:547
+#: lxc/file.go:736
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1654,9 +1654,14 @@ msgstr "Creazione del container in corso"
 msgid "Create and start instances from images"
 msgstr "Creazione del container in corso"
 
-#: lxc/file.go:249 lxc/file.go:475
+#: lxc/file.go:143 lxc/file.go:438 lxc/file.go:664
 msgid "Create any directories necessary"
 msgstr ""
+
+#: lxc/file.go:134 lxc/file.go:135
+#, fuzzy
+msgid "Create files and directories in instances"
+msgstr "Creazione del container in corso"
 
 #: lxc/auth.go:98 lxc/auth.go:99
 msgid "Create groups"
@@ -1758,6 +1763,11 @@ msgstr ""
 msgid "Creating %s"
 msgstr "Creazione di %s in corso"
 
+#: lxc/file.go:273
+#, fuzzy, c-format
+msgid "Creating %s: %%s"
+msgstr "Creazione di %s in corso"
+
 #: lxc/init.go:184
 #, fuzzy
 msgid "Creating the instance"
@@ -1815,7 +1825,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:123 lxc/file.go:124
+#: lxc/file.go:312 lxc/file.go:313
 #, fuzzy
 msgid "Delete files in instances"
 msgstr "Creazione del container in corso"
@@ -1937,70 +1947,71 @@ msgstr ""
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
-#: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
-#: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
-#: lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090 lxc/image.go:1417
-#: lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638 lxc/image.go:1701
-#: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
-#: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
-#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33
-#: lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405
-#: lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793
-#: lxc/network.go:874 lxc/network.go:1005 lxc/network.go:1106
-#: lxc/network.go:1185 lxc/network.go:1245 lxc/network.go:1341
-#: lxc/network.go:1413 lxc/network_acl.go:30 lxc/network_acl.go:95
-#: lxc/network_acl.go:174 lxc/network_acl.go:235 lxc/network_acl.go:291
-#: lxc/network_acl.go:364 lxc/network_acl.go:461 lxc/network_acl.go:549
-#: lxc/network_acl.go:592 lxc/network_acl.go:731 lxc/network_acl.go:788
-#: lxc/network_acl.go:845 lxc/network_acl.go:860 lxc/network_acl.go:997
-#: lxc/network_allocations.go:51 lxc/network_forward.go:33
-#: lxc/network_forward.go:90 lxc/network_forward.go:179
-#: lxc/network_forward.go:256 lxc/network_forward.go:404
-#: lxc/network_forward.go:489 lxc/network_forward.go:599
-#: lxc/network_forward.go:646 lxc/network_forward.go:800
-#: lxc/network_forward.go:874 lxc/network_forward.go:889
-#: lxc/network_forward.go:970 lxc/network_load_balancer.go:33
-#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:181
-#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:408
-#: lxc/network_load_balancer.go:476 lxc/network_load_balancer.go:586
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:771
-#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:859
-#: lxc/network_load_balancer.go:935 lxc/network_load_balancer.go:1033
-#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1121
-#: lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:167
-#: lxc/network_peer.go:236 lxc/network_peer.go:360 lxc/network_peer.go:445
-#: lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731
-#: lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:165
-#: lxc/network_zone.go:228 lxc/network_zone.go:301 lxc/network_zone.go:396
-#: lxc/network_zone.go:484 lxc/network_zone.go:527 lxc/network_zone.go:654
-#: lxc/network_zone.go:710 lxc/network_zone.go:767 lxc/network_zone.go:845
-#: lxc/network_zone.go:909 lxc/network_zone.go:985 lxc/network_zone.go:1083
-#: lxc/network_zone.go:1172 lxc/network_zone.go:1219 lxc/network_zone.go:1349
-#: lxc/network_zone.go:1410 lxc/network_zone.go:1425 lxc/network_zone.go:1483
-#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
-#: lxc/operation.go:194 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
-#: lxc/profile.go:271 lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493
-#: lxc/profile.go:629 lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860
-#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31
-#: lxc/project.go:95 lxc/project.go:191 lxc/project.go:262 lxc/project.go:398
-#: lxc/project.go:472 lxc/project.go:592 lxc/project.go:657 lxc/project.go:745
-#: lxc/project.go:789 lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34
-#: lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91
-#: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853
-#: lxc/remote.go:917 lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24
-#: lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203
-#: lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655
-#: lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940
-#: lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189
-#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:383
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:536
-#: lxc/storage_bucket.go:630 lxc/storage_bucket.go:699
-#: lxc/storage_bucket.go:733 lxc/storage_bucket.go:774
-#: lxc/storage_bucket.go:853 lxc/storage_bucket.go:959
-#: lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158
-#: lxc/storage_volume.go:58 lxc/storage_volume.go:169 lxc/storage_volume.go:283
+#: lxc/export.go:32 lxc/file.go:88 lxc/file.go:135 lxc/file.go:313
+#: lxc/file.go:362 lxc/file.go:432 lxc/file.go:657 lxc/file.go:1176
+#: lxc/image.go:38 lxc/image.go:159 lxc/image.go:337 lxc/image.go:396
+#: lxc/image.go:525 lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090
+#: lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638
+#: lxc/image.go:1701 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255
+#: lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34
+#: lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233
+#: lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560
+#: lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1005
+#: lxc/network.go:1106 lxc/network.go:1185 lxc/network.go:1245
+#: lxc/network.go:1341 lxc/network.go:1413 lxc/network_acl.go:30
+#: lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235
+#: lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461
+#: lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731
+#: lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860
+#: lxc/network_acl.go:997 lxc/network_allocations.go:51
+#: lxc/network_forward.go:33 lxc/network_forward.go:90
+#: lxc/network_forward.go:179 lxc/network_forward.go:256
+#: lxc/network_forward.go:404 lxc/network_forward.go:489
+#: lxc/network_forward.go:599 lxc/network_forward.go:646
+#: lxc/network_forward.go:800 lxc/network_forward.go:874
+#: lxc/network_forward.go:889 lxc/network_forward.go:970
+#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
+#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844
+#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1121 lxc/network_peer.go:29
+#: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
+#: lxc/network_peer.go:360 lxc/network_peer.go:445 lxc/network_peer.go:547
+#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:29
+#: lxc/network_zone.go:86 lxc/network_zone.go:165 lxc/network_zone.go:228
+#: lxc/network_zone.go:301 lxc/network_zone.go:396 lxc/network_zone.go:484
+#: lxc/network_zone.go:527 lxc/network_zone.go:654 lxc/network_zone.go:710
+#: lxc/network_zone.go:767 lxc/network_zone.go:845 lxc/network_zone.go:909
+#: lxc/network_zone.go:985 lxc/network_zone.go:1083 lxc/network_zone.go:1172
+#: lxc/network_zone.go:1219 lxc/network_zone.go:1349 lxc/network_zone.go:1410
+#: lxc/network_zone.go:1425 lxc/network_zone.go:1483 lxc/operation.go:25
+#: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
+#: lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180 lxc/profile.go:271
+#: lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493 lxc/profile.go:629
+#: lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860 lxc/profile.go:920
+#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31 lxc/project.go:95
+#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
+#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
+#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:648
+#: lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853 lxc/remote.go:917
+#: lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
+#: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
+#: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:459
+#: lxc/storage_bucket.go:536 lxc/storage_bucket.go:630
+#: lxc/storage_bucket.go:699 lxc/storage_bucket.go:733
+#: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
+#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:283
 #: lxc/storage_volume.go:390 lxc/storage_volume.go:605
 #: lxc/storage_volume.go:714 lxc/storage_volume.go:801
 #: lxc/storage_volume.go:899 lxc/storage_volume.go:996
@@ -2100,7 +2111,7 @@ msgstr "Import da directory non disponibile su questa piattaforma"
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:995
+#: lxc/file.go:1184
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2170,7 +2181,7 @@ msgstr "DATA DI SCADENZA"
 msgid "EXPIRY DATE"
 msgstr "DATA DI SCADENZA"
 
-#: lxc/file.go:75
+#: lxc/file.go:79
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -2188,7 +2199,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:172 lxc/file.go:173
+#: lxc/file.go:361 lxc/file.go:362
 #, fuzzy
 msgid "Edit files in instances"
 msgstr "Creazione del container in corso"
@@ -2467,12 +2478,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1238
+#: lxc/file.go:1427
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1261
+#: lxc/file.go:1450
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2487,12 +2498,12 @@ msgstr "Il nome del container è: %s"
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "Il nome del container è: %s"
 
-#: lxc/file.go:1288
+#: lxc/file.go:1477
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1073
+#: lxc/file.go:1262
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "Il nome del container è: %s"
@@ -2522,7 +2533,7 @@ msgstr "Il nome del container è: %s"
 msgid "Failed fetching fingerprint %q: %w"
 msgstr "Il nome del container è: %s"
 
-#: lxc/file.go:1194
+#: lxc/file.go:1383
 #, fuzzy, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "Accetta certificato"
@@ -2537,7 +2548,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr "Il nome del container è: %s"
 
-#: lxc/file.go:1199
+#: lxc/file.go:1388
 #, fuzzy, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "Accetta certificato"
@@ -2547,12 +2558,12 @@ msgstr "Accetta certificato"
 msgid "Failed starting command: %w"
 msgstr "Accetta certificato"
 
-#: lxc/file.go:1099
+#: lxc/file.go:1288
 #, fuzzy, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "Accetta certificato"
 
-#: lxc/file.go:1226
+#: lxc/file.go:1415
 #, fuzzy, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "Accetta certificato"
@@ -2591,7 +2602,7 @@ msgstr "Accetta certificato"
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1400
 #, fuzzy, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "Accetta certificato"
@@ -2606,7 +2617,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr "Accetta certificato"
 
-#: lxc/file.go:821
+#: lxc/file.go:1010
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2633,6 +2644,10 @@ msgstr ""
 
 #: lxc/cluster.go:1302
 msgid "Force a particular evacuation action"
+msgstr ""
+
+#: lxc/file.go:144
+msgid "Force creating files or directories"
 msgstr ""
 
 #: lxc/cluster.go:1301
@@ -2942,22 +2957,22 @@ msgstr "Creazione del container in corso"
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1311
+#: lxc/file.go:1500
 #, fuzzy, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "errore di processamento degli alias %s\n"
 
-#: lxc/file.go:1300
+#: lxc/file.go:1489
 #, fuzzy, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "errore di processamento degli alias %s\n"
 
-#: lxc/file.go:1123
+#: lxc/file.go:1312
 #, fuzzy, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "errore di processamento degli alias %s\n"
 
-#: lxc/file.go:1133
+#: lxc/file.go:1322
 #, fuzzy, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "errore di processamento degli alias %s\n"
@@ -3153,11 +3168,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr "Il nome del container è: %s"
 
-#: lxc/file.go:1125
+#: lxc/file.go:1314
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1302
+#: lxc/file.go:1491
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3176,7 +3191,7 @@ msgstr "Il nome del container è: %s"
 msgid "Instance name must be specified"
 msgstr "Il nome del container è: %s"
 
-#: lxc/file.go:1045
+#: lxc/file.go:1234
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3228,7 +3243,7 @@ msgstr "Proprietà errata: %s"
 msgid "Invalid instance name: %s"
 msgstr "Il nome del container è: %s"
 
-#: lxc/file.go:1040
+#: lxc/file.go:1229
 #, fuzzy, c-format
 msgid "Invalid instance path: %q"
 msgstr "Il nome del container è: %s"
@@ -3272,7 +3287,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr "numero errato di argomenti del sottocomando"
 
-#: lxc/file.go:148
+#: lxc/file.go:337
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -3289,15 +3304,20 @@ msgstr "Proprietà errata: %s"
 msgid "Invalid snapshot name"
 msgstr "Il nome del container è: %s"
 
-#: lxc/file.go:314
+#: lxc/file.go:503
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:496
+#: lxc/file.go:177 lxc/file.go:685
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
+
+#: lxc/file.go:163
+#, fuzzy, c-format
+msgid "Invalid type %q"
+msgstr "Proprietà errata: %s"
 
 #: lxc/info.go:238
 #, c-format
@@ -3820,7 +3840,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr "Creazione del container in corso"
 
-#: lxc/file.go:83 lxc/file.go:84
+#: lxc/file.go:87 lxc/file.go:88
 #, fuzzy
 msgid "Manage files in instances"
 msgstr "Creazione del container in corso"
@@ -4240,7 +4260,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr "Il nome del container è: %s"
 
-#: lxc/file.go:599
+#: lxc/file.go:788
 msgid "Missing target directory"
 msgstr ""
 
@@ -4279,11 +4299,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:286
+#: lxc/file.go:475
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:986 lxc/file.go:987
+#: lxc/file.go:1175 lxc/file.go:1176
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "Creazione del container in corso"
@@ -4739,7 +4759,7 @@ msgstr "Aggiornamento automatico: %s"
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1103
+#: lxc/file.go:1292
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4975,21 +4995,21 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr "Creazione del container in corso"
 
-#: lxc/file.go:242 lxc/file.go:243
+#: lxc/file.go:431 lxc/file.go:432
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:417 lxc/file.go:768
+#: lxc/file.go:606 lxc/file.go:957
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:467 lxc/file.go:468
+#: lxc/file.go:656 lxc/file.go:657
 #, fuzzy
 msgid "Push files into instances"
 msgstr "Creazione del container in corso"
 
-#: lxc/file.go:702 lxc/file.go:868
+#: lxc/file.go:891 lxc/file.go:1057
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -5029,7 +5049,7 @@ msgstr "Creazione del container in corso"
 msgid "Rebuild instances"
 msgstr "Creazione del container in corso"
 
-#: lxc/file.go:250 lxc/file.go:474
+#: lxc/file.go:439 lxc/file.go:663
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -5373,12 +5393,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1231
+#: lxc/file.go:1420
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1232
+#: lxc/file.go:1421
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5456,7 +5476,7 @@ msgstr "Creazione del container in corso"
 msgid "Set a cluster member's configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: lxc/file.go:996
+#: lxc/file.go:1185
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5654,15 +5674,27 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:477
+#: lxc/file.go:145
+msgid "Set the file's gid on create"
+msgstr ""
+
+#: lxc/file.go:666
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:478
+#: lxc/file.go:147
+msgid "Set the file's perms on create"
+msgstr ""
+
+#: lxc/file.go:667
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:476
+#: lxc/file.go:146
+msgid "Set the file's uid on create"
+msgstr ""
+
+#: lxc/file.go:665
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5726,7 +5758,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:994
+#: lxc/file.go:1183
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -6116,6 +6148,10 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
+#: lxc/file.go:167
+msgid "Symlink target path can only be used for type \"symlink\""
+msgstr ""
+
 #: lxc/alias.go:140
 msgid "TARGET"
 msgstr ""
@@ -6136,11 +6172,11 @@ msgstr ""
 msgid "Taken at"
 msgstr "salvato alle %s"
 
-#: lxc/file.go:1033
+#: lxc/file.go:1222
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1027
+#: lxc/file.go:1216
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -6310,6 +6346,10 @@ msgstr ""
 
 #: lxc/network.go:537 lxc/network.go:634
 msgid "The specified device doesn't match the network"
+msgstr ""
+
+#: lxc/file.go:148
+msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
 #: lxc/publish.go:97
@@ -6493,7 +6533,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:198
+#: lxc/file.go:387
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6508,7 +6548,7 @@ msgstr "Aggiungi un nuovo server remoto"
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1254
+#: lxc/file.go:1443
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6524,7 +6564,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:808
+#: lxc/file.go:997
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6757,7 +6797,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:72
+#: lxc/file.go:76
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -7163,23 +7203,28 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:171
+#: lxc/file.go:360
 #, fuzzy
 msgid "[<remote>:]<instance>/<path>"
 msgstr "Creazione del container in corso"
 
-#: lxc/file.go:121
+#: lxc/file.go:133
+#, fuzzy
+msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
+msgstr "Creazione del container in corso"
+
+#: lxc/file.go:310
 #, fuzzy
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/file.go:241
+#: lxc/file.go:430
 #, fuzzy
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr "Creazione del container in corso"
 
-#: lxc/file.go:985
+#: lxc/file.go:1174
 #, fuzzy
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr "Creazione del container in corso"
@@ -7774,20 +7819,28 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:989
+#: lxc/file.go:137
+msgid ""
+"lxc file create foo/bar\n"
+"\t   To create a file /bar in the foo instance.\n"
+"lxc file create --type=symlink foo/bar baz\n"
+"\t   To create a symlink /bar in instance foo whose target is baz."
+msgstr ""
+
+#: lxc/file.go:1178
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:245
+#: lxc/file.go:434
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:470
+#: lxc/file.go:659
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -8137,16 +8190,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1143
+#: lxc/file.go:1332
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1102
+#: lxc/file.go:1291
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1055
+#: lxc/file.go:1244
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 
@@ -8193,10 +8246,6 @@ msgstr "si"
 
 #~ msgid "%v (interrupt two more times to force)"
 #~ msgstr "%v (interrompi altre due volte per forzare)"
-
-#, fuzzy
-#~ msgid "Invalid format %q"
-#~ msgstr "Proprietà errata: %s"
 
 #, fuzzy
 #~ msgid "[[<remote>:]<image>] [<remote>:][<name>] [< config"

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-30 13:36-0400\n"
+"POT-Creation-Date: 2024-10-01 10:45-0600\n"
 "PO-Revision-Date: 2023-03-10 15:14+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/linux-"
@@ -667,12 +667,12 @@ msgstr "%s (他%d個)"
 msgid "%s (%s) (%d available)"
 msgstr "%s (%d個使用可能)"
 
-#: lxc/file.go:936
+#: lxc/file.go:1125
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s はディレクトリではありません"
 
-#: lxc/file.go:826
+#: lxc/file.go:1015
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' はサポートされないタイプのファイルです"
@@ -761,7 +761,7 @@ msgstr "<remote> <URL>"
 msgid "<remote> <new-name>"
 msgstr "<remote> <new-name>"
 
-#: lxc/file.go:466
+#: lxc/file.go:655
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr "<source path>... [<remote>:]<instance>/<path>"
 
@@ -1246,7 +1246,7 @@ msgstr "ローカル上のリネームでは、設定やプロファイルの上
 msgid "Can't provide a name for the target image"
 msgstr "ターゲットイメージの名前を取得できません"
 
-#: lxc/file.go:341
+#: lxc/file.go:530
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 "ディレクトリを pull する場合は --recursive オプションを使用してください"
@@ -1276,7 +1276,7 @@ msgstr "リネームの場合は異なるリモートを指定できません"
 msgid "Can't specify column L when not clustered"
 msgstr "クラスタでない場合はカラムとして L は指定できません"
 
-#: lxc/file.go:547
+#: lxc/file.go:736
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr "再帰 (recursive) モードでは uid/gid/mode を指定できません"
 
@@ -1686,8 +1686,13 @@ msgstr "空のインスタンスを作成"
 msgid "Create and start instances from images"
 msgstr "イメージからインスタンスを作成し、起動します"
 
-#: lxc/file.go:249 lxc/file.go:475
+#: lxc/file.go:143 lxc/file.go:438 lxc/file.go:664
 msgid "Create any directories necessary"
+msgstr "必要なディレクトリをすべて作成します"
+
+#: lxc/file.go:134 lxc/file.go:135
+#, fuzzy
+msgid "Create files and directories in instances"
 msgstr "必要なディレクトリをすべて作成します"
 
 #: lxc/auth.go:98 lxc/auth.go:99
@@ -1790,6 +1795,11 @@ msgstr "作成日時: %s"
 msgid "Creating %s"
 msgstr "%s を作成中"
 
+#: lxc/file.go:273
+#, fuzzy, c-format
+msgid "Creating %s: %%s"
+msgstr "%s を作成中"
+
 #: lxc/init.go:184
 msgid "Creating the instance"
 msgstr "インスタンスを作成中"
@@ -1846,7 +1856,7 @@ msgstr "クラスタグループを削除します"
 msgid "Delete all warnings"
 msgstr "警告をすべて削除します"
 
-#: lxc/file.go:123 lxc/file.go:124
+#: lxc/file.go:312 lxc/file.go:313
 msgid "Delete files in instances"
 msgstr "インスタンス内のファイルを削除します"
 
@@ -1965,70 +1975,71 @@ msgstr "警告を削除します"
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
-#: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
-#: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
-#: lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090 lxc/image.go:1417
-#: lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638 lxc/image.go:1701
-#: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
-#: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
-#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33
-#: lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405
-#: lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793
-#: lxc/network.go:874 lxc/network.go:1005 lxc/network.go:1106
-#: lxc/network.go:1185 lxc/network.go:1245 lxc/network.go:1341
-#: lxc/network.go:1413 lxc/network_acl.go:30 lxc/network_acl.go:95
-#: lxc/network_acl.go:174 lxc/network_acl.go:235 lxc/network_acl.go:291
-#: lxc/network_acl.go:364 lxc/network_acl.go:461 lxc/network_acl.go:549
-#: lxc/network_acl.go:592 lxc/network_acl.go:731 lxc/network_acl.go:788
-#: lxc/network_acl.go:845 lxc/network_acl.go:860 lxc/network_acl.go:997
-#: lxc/network_allocations.go:51 lxc/network_forward.go:33
-#: lxc/network_forward.go:90 lxc/network_forward.go:179
-#: lxc/network_forward.go:256 lxc/network_forward.go:404
-#: lxc/network_forward.go:489 lxc/network_forward.go:599
-#: lxc/network_forward.go:646 lxc/network_forward.go:800
-#: lxc/network_forward.go:874 lxc/network_forward.go:889
-#: lxc/network_forward.go:970 lxc/network_load_balancer.go:33
-#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:181
-#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:408
-#: lxc/network_load_balancer.go:476 lxc/network_load_balancer.go:586
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:771
-#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:859
-#: lxc/network_load_balancer.go:935 lxc/network_load_balancer.go:1033
-#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1121
-#: lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:167
-#: lxc/network_peer.go:236 lxc/network_peer.go:360 lxc/network_peer.go:445
-#: lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731
-#: lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:165
-#: lxc/network_zone.go:228 lxc/network_zone.go:301 lxc/network_zone.go:396
-#: lxc/network_zone.go:484 lxc/network_zone.go:527 lxc/network_zone.go:654
-#: lxc/network_zone.go:710 lxc/network_zone.go:767 lxc/network_zone.go:845
-#: lxc/network_zone.go:909 lxc/network_zone.go:985 lxc/network_zone.go:1083
-#: lxc/network_zone.go:1172 lxc/network_zone.go:1219 lxc/network_zone.go:1349
-#: lxc/network_zone.go:1410 lxc/network_zone.go:1425 lxc/network_zone.go:1483
-#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
-#: lxc/operation.go:194 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
-#: lxc/profile.go:271 lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493
-#: lxc/profile.go:629 lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860
-#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31
-#: lxc/project.go:95 lxc/project.go:191 lxc/project.go:262 lxc/project.go:398
-#: lxc/project.go:472 lxc/project.go:592 lxc/project.go:657 lxc/project.go:745
-#: lxc/project.go:789 lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34
-#: lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91
-#: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853
-#: lxc/remote.go:917 lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24
-#: lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203
-#: lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655
-#: lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940
-#: lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189
-#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:383
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:536
-#: lxc/storage_bucket.go:630 lxc/storage_bucket.go:699
-#: lxc/storage_bucket.go:733 lxc/storage_bucket.go:774
-#: lxc/storage_bucket.go:853 lxc/storage_bucket.go:959
-#: lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158
-#: lxc/storage_volume.go:58 lxc/storage_volume.go:169 lxc/storage_volume.go:283
+#: lxc/export.go:32 lxc/file.go:88 lxc/file.go:135 lxc/file.go:313
+#: lxc/file.go:362 lxc/file.go:432 lxc/file.go:657 lxc/file.go:1176
+#: lxc/image.go:38 lxc/image.go:159 lxc/image.go:337 lxc/image.go:396
+#: lxc/image.go:525 lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090
+#: lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638
+#: lxc/image.go:1701 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255
+#: lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34
+#: lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233
+#: lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560
+#: lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1005
+#: lxc/network.go:1106 lxc/network.go:1185 lxc/network.go:1245
+#: lxc/network.go:1341 lxc/network.go:1413 lxc/network_acl.go:30
+#: lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235
+#: lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461
+#: lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731
+#: lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860
+#: lxc/network_acl.go:997 lxc/network_allocations.go:51
+#: lxc/network_forward.go:33 lxc/network_forward.go:90
+#: lxc/network_forward.go:179 lxc/network_forward.go:256
+#: lxc/network_forward.go:404 lxc/network_forward.go:489
+#: lxc/network_forward.go:599 lxc/network_forward.go:646
+#: lxc/network_forward.go:800 lxc/network_forward.go:874
+#: lxc/network_forward.go:889 lxc/network_forward.go:970
+#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
+#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844
+#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1121 lxc/network_peer.go:29
+#: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
+#: lxc/network_peer.go:360 lxc/network_peer.go:445 lxc/network_peer.go:547
+#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:29
+#: lxc/network_zone.go:86 lxc/network_zone.go:165 lxc/network_zone.go:228
+#: lxc/network_zone.go:301 lxc/network_zone.go:396 lxc/network_zone.go:484
+#: lxc/network_zone.go:527 lxc/network_zone.go:654 lxc/network_zone.go:710
+#: lxc/network_zone.go:767 lxc/network_zone.go:845 lxc/network_zone.go:909
+#: lxc/network_zone.go:985 lxc/network_zone.go:1083 lxc/network_zone.go:1172
+#: lxc/network_zone.go:1219 lxc/network_zone.go:1349 lxc/network_zone.go:1410
+#: lxc/network_zone.go:1425 lxc/network_zone.go:1483 lxc/operation.go:25
+#: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
+#: lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180 lxc/profile.go:271
+#: lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493 lxc/profile.go:629
+#: lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860 lxc/profile.go:920
+#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31 lxc/project.go:95
+#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
+#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
+#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:648
+#: lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853 lxc/remote.go:917
+#: lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
+#: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
+#: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:459
+#: lxc/storage_bucket.go:536 lxc/storage_bucket.go:630
+#: lxc/storage_bucket.go:699 lxc/storage_bucket.go:733
+#: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
+#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:283
 #: lxc/storage_volume.go:390 lxc/storage_volume.go:605
 #: lxc/storage_volume.go:714 lxc/storage_volume.go:801
 #: lxc/storage_volume.go:899 lxc/storage_volume.go:996
@@ -2132,7 +2143,7 @@ msgstr "このプラットフォーム上ではディレクトリのインポー
 msgid "Directory to run the command in (default /root)"
 msgstr "コマンドを実行するディレクトリ (デフォルト /root)"
 
-#: lxc/file.go:995
+#: lxc/file.go:1184
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr "SSH SFTP リスナーを使う際に認証を無効化します"
 
@@ -2198,7 +2209,7 @@ msgstr "EXPIRES AT"
 msgid "EXPIRY DATE"
 msgstr "EXPIRY DATE"
 
-#: lxc/file.go:75
+#: lxc/file.go:79
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -2219,7 +2230,7 @@ msgstr "ストレージバケットの設定をYAMLで編集します"
 msgid "Edit cluster member configurations as YAML"
 msgstr "クラスターメンバーの設定をYAMLファイルで編集します"
 
-#: lxc/file.go:172 lxc/file.go:173
+#: lxc/file.go:361 lxc/file.go:362
 msgid "Edit files in instances"
 msgstr "インスタンス内のファイルを編集します"
 
@@ -2518,12 +2529,12 @@ msgstr "FINGERPRINT"
 msgid "FIRST SEEN"
 msgstr "FIRST SEEN"
 
-#: lxc/file.go:1238
+#: lxc/file.go:1427
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr "クライアント %q との SSH ハンドシェイクに失敗しました: %v"
 
-#: lxc/file.go:1261
+#: lxc/file.go:1450
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr "クライアント %q のチャンネルの受け入れに失敗しました: %v"
@@ -2538,12 +2549,12 @@ msgstr "インスタンスの存在確認に失敗しました \"%s:%s\": %w"
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "インスタンスのスナップショットの存在確認に失敗しました \"%s:%s\": %w"
 
-#: lxc/file.go:1288
+#: lxc/file.go:1477
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr "クライアント %q に対する SFTP インスタンスの接続に失敗しました: %v"
 
-#: lxc/file.go:1073
+#: lxc/file.go:1262
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "インスタンスの SFTP への接続に失敗しました: %w"
@@ -2573,7 +2584,7 @@ msgstr "クライアント %q のチャンネルの受け入れに失敗しま�
 msgid "Failed fetching fingerprint %q: %w"
 msgstr "クライアント %q のチャンネルの受け入れに失敗しました: %v"
 
-#: lxc/file.go:1194
+#: lxc/file.go:1383
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "SSH ホスト鍵の生成に失敗しました: %w"
@@ -2588,7 +2599,7 @@ msgstr "ピアのステータスの取得に失敗しました: %w"
 msgid "Failed loading profile %q: %w"
 msgstr "デバイス上書きのためのプロファイル %q のロードに失敗しました: %w"
 
-#: lxc/file.go:1199
+#: lxc/file.go:1388
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "SSH ホスト鍵の読み取りに失敗しました: %w"
@@ -2598,12 +2609,12 @@ msgstr "SSH ホスト鍵の読み取りに失敗しました: %w"
 msgid "Failed starting command: %w"
 msgstr "コマンドの実行に失敗しました: %w"
 
-#: lxc/file.go:1099
+#: lxc/file.go:1288
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "sshfs の起動に失敗しました: %w"
 
-#: lxc/file.go:1226
+#: lxc/file.go:1415
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "受信接続の受け入れに失敗しました: %w"
@@ -2642,7 +2653,7 @@ msgstr "証明書の作成に失敗しました: %w"
 msgid "Failed to find project: %w"
 msgstr "プロジェクトが見つけられませんでした: %w"
 
-#: lxc/file.go:1211
+#: lxc/file.go:1400
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "コネクションのリッスンに失敗しました: %w"
@@ -2657,7 +2668,7 @@ msgstr "コピー先のインスタンス '%s' のリフレッシュに失敗し
 msgid "Failed to remove alias %s: %w"
 msgstr "エイリアス %s の削除に失敗しました: %w"
 
-#: lxc/file.go:821
+#: lxc/file.go:1010
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr "パス %s にアクセスできませんでした: %s"
@@ -2684,6 +2695,10 @@ msgstr "証明書のフィンガープリント: %s"
 #: lxc/cluster.go:1302
 msgid "Force a particular evacuation action"
 msgstr "特定の待避アクションを強制します"
+
+#: lxc/file.go:144
+msgid "Force creating files or directories"
+msgstr ""
 
 #: lxc/cluster.go:1301
 msgid "Force evacuation without user confirmation"
@@ -3006,22 +3021,22 @@ msgstr "ホストインターフェース"
 msgid "Hugepages:\n"
 msgstr "Hugepages:\n"
 
-#: lxc/file.go:1311
+#: lxc/file.go:1500
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "SSH 経由のインスタンスへの I/O コピーが失敗しました: %v"
 
-#: lxc/file.go:1300
+#: lxc/file.go:1489
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "インスタンスから SSH 経由の I/O コピーに失敗しました: %v"
 
-#: lxc/file.go:1123
+#: lxc/file.go:1312
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "インスタンスから sshfs への I/O コピーに失敗しました: %v"
 
-#: lxc/file.go:1133
+#: lxc/file.go:1322
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "sshfs からインスタンスへの I/O コピーに失敗しました: %v"
@@ -3227,11 +3242,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr "インスタンスのみ"
 
-#: lxc/file.go:1125
+#: lxc/file.go:1314
 msgid "Instance disconnected"
 msgstr "インスタンスが切断されました"
 
-#: lxc/file.go:1302
+#: lxc/file.go:1491
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr "クライアント %q に対するインスタンスが切断されました"
@@ -3250,7 +3265,7 @@ msgstr "インスタンス名: %s"
 msgid "Instance name must be specified"
 msgstr "インスタンス名: %s"
 
-#: lxc/file.go:1045
+#: lxc/file.go:1234
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr "SSH SFTP リスナーモードではインスタンスのパスを使用できません"
 
@@ -3303,7 +3318,7 @@ msgstr "不正なフォーマット %s"
 msgid "Invalid instance name: %s"
 msgstr "不正なインスタンス名: %s"
 
-#: lxc/file.go:1040
+#: lxc/file.go:1229
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr "不正なインスタンスのパス: %q"
@@ -3352,7 +3367,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr "引数の数が不正です"
 
-#: lxc/file.go:148
+#: lxc/file.go:337
 #, c-format
 msgid "Invalid path %s"
 msgstr "不正なパス %s"
@@ -3368,14 +3383,19 @@ msgstr "不正なプロトコル: %s"
 msgid "Invalid snapshot name"
 msgstr "不正なスナップショット名"
 
-#: lxc/file.go:314
+#: lxc/file.go:503
 #, c-format
 msgid "Invalid source %s"
 msgstr "不正なソース %s"
 
-#: lxc/file.go:496
+#: lxc/file.go:177 lxc/file.go:685
 #, c-format
 msgid "Invalid target %s"
+msgstr "不正な送り先 %s"
+
+#: lxc/file.go:163
+#, fuzzy, c-format
+msgid "Invalid type %q"
 msgstr "不正な送り先 %s"
 
 #: lxc/info.go:238
@@ -4026,7 +4046,7 @@ msgstr "コマンドのエイリアスを管理します"
 msgid "Manage devices"
 msgstr "デバイスを管理します"
 
-#: lxc/file.go:83 lxc/file.go:84
+#: lxc/file.go:87 lxc/file.go:88
 msgid "Manage files in instances"
 msgstr "インスタンス内のファイルを管理します"
 
@@ -4439,7 +4459,7 @@ msgstr "コピー元のボリューム名を指定する必要があります"
 msgid "Missing storage pool name"
 msgstr "ストレージプール名を指定する必要があります"
 
-#: lxc/file.go:599
+#: lxc/file.go:788
 msgid "Missing target directory"
 msgstr "コピー先のディレクトリを指定する必要があります"
 
@@ -4480,13 +4500,13 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr "複数のデバイスとマッチします。デバイス名を指定してください"
 
-#: lxc/file.go:286
+#: lxc/file.go:475
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 "ダウンロード対象のファイルが複数ありますが、コピー先がディレクトリではありま"
 "せん"
 
-#: lxc/file.go:986 lxc/file.go:987
+#: lxc/file.go:1175 lxc/file.go:1176
 msgid "Mount files from instances"
 msgstr "インスタンスからファイルをマウントします"
 
@@ -4954,7 +4974,7 @@ msgstr "ポートタイプ: %s"
 msgid "Ports:"
 msgstr "ポート:"
 
-#: lxc/file.go:1103
+#: lxc/file.go:1292
 msgid "Press ctrl+c to finish"
 msgstr "終了するには ctrl+c を押してください"
 
@@ -5193,20 +5213,20 @@ msgstr "インスタンスをイメージとして出力します"
 msgid "Publishing instance: %s"
 msgstr "インスタンスの出力中: %s"
 
-#: lxc/file.go:242 lxc/file.go:243
+#: lxc/file.go:431 lxc/file.go:432
 msgid "Pull files from instances"
 msgstr "インスタンスからファイルを取得します"
 
-#: lxc/file.go:417 lxc/file.go:768
+#: lxc/file.go:606 lxc/file.go:957
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr "ファイル %s を %s から取得します: %%s"
 
-#: lxc/file.go:467 lxc/file.go:468
+#: lxc/file.go:656 lxc/file.go:657
 msgid "Push files into instances"
 msgstr "インスタンス内にファイルをコピーします"
 
-#: lxc/file.go:702 lxc/file.go:868
+#: lxc/file.go:891 lxc/file.go:1057
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr "ファイル %s をコンテナ %s 内にコピーします: %%s"
@@ -5246,7 +5266,7 @@ msgstr "空のインスタンスを作成"
 msgid "Rebuild instances"
 msgstr "インスタンスを一覧表示します"
 
-#: lxc/file.go:250 lxc/file.go:474
+#: lxc/file.go:439 lxc/file.go:663
 msgid "Recursively transfer files"
 msgstr "再帰的にファイルを転送します"
 
@@ -5590,12 +5610,12 @@ msgstr "SOURCE"
 msgid "SR-IOV information:"
 msgstr "SR-IOV 情報:"
 
-#: lxc/file.go:1231
+#: lxc/file.go:1420
 #, c-format
 msgid "SSH client connected %q"
 msgstr "SSH クライアントが %q に接続されました"
 
-#: lxc/file.go:1232
+#: lxc/file.go:1421
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr "SSH クライアントが切断されました %q"
@@ -5673,7 +5693,7 @@ msgstr "インスタンスからファイルをマウントします"
 msgid "Set a cluster member's configuration keys"
 msgstr "クラスターメンバーの設定を行います"
 
-#: lxc/file.go:996
+#: lxc/file.go:1185
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr "SSH SFTP リスナーを使う際の認証ユーザーを設定する"
 
@@ -5924,15 +5944,30 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr "リモートの URL を設定します"
 
-#: lxc/file.go:477
+#: lxc/file.go:145
+#, fuzzy
+msgid "Set the file's gid on create"
+msgstr "プッシュ時にファイルのgidを設定します"
+
+#: lxc/file.go:666
 msgid "Set the file's gid on push"
 msgstr "プッシュ時にファイルのgidを設定します"
 
-#: lxc/file.go:478
+#: lxc/file.go:147
+#, fuzzy
+msgid "Set the file's perms on create"
+msgstr "プッシュ時にファイルのパーミションを設定します"
+
+#: lxc/file.go:667
 msgid "Set the file's perms on push"
 msgstr "プッシュ時にファイルのパーミションを設定します"
 
-#: lxc/file.go:476
+#: lxc/file.go:146
+#, fuzzy
+msgid "Set the file's uid on create"
+msgstr "プッシュ時にファイルのuidを設定します"
+
+#: lxc/file.go:665
 msgid "Set the file's uid on push"
 msgstr "プッシュ時にファイルのuidを設定します"
 
@@ -6001,7 +6036,7 @@ msgstr "新しいストレージボリュームをプロファイルに追加し
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:994
+#: lxc/file.go:1183
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 "マウントの代わりに address:port で SSH SFTP リスナーをセットアップします"
@@ -6379,6 +6414,10 @@ msgstr "現在のプロジェクトを切り替えます"
 msgid "Switch the default remote"
 msgstr "デフォルトのリモートを切り替えます"
 
+#: lxc/file.go:167
+msgid "Symlink target path can only be used for type \"symlink\""
+msgstr ""
+
 #: lxc/alias.go:140
 msgid "TARGET"
 msgstr "TARGET"
@@ -6398,11 +6437,11 @@ msgstr "TYPE"
 msgid "Taken at"
 msgstr "取得日時"
 
-#: lxc/file.go:1033
+#: lxc/file.go:1222
 msgid "Target path and --listen flag cannot be used together"
 msgstr "ターゲットのパスと --listen オプションは同時に指定できません"
 
-#: lxc/file.go:1027
+#: lxc/file.go:1216
 msgid "Target path must be a directory"
 msgstr "ターゲットのパスはディレクトリでなければなりません"
 
@@ -6578,6 +6617,10 @@ msgstr "指定したデバイスが存在しません"
 #: lxc/network.go:537 lxc/network.go:634
 msgid "The specified device doesn't match the network"
 msgstr "指定したデバイスはネットワークとマッチしません"
+
+#: lxc/file.go:148
+msgid "The type to create (file, symlink, or directory)"
+msgstr ""
 
 #: lxc/publish.go:97
 msgid "There is no \"image name\".  Did you want an alias?"
@@ -6780,7 +6823,7 @@ msgstr "UUID"
 msgid "UUID: %v"
 msgstr "UUID: %v"
 
-#: lxc/file.go:198
+#: lxc/file.go:387
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr "テンポラリファイルを作成できません: %v"
@@ -6794,7 +6837,7 @@ msgstr "リモートサーバーが利用できません"
 msgid "Unknown certificate type %q"
 msgstr "未知の証明書タイプ %q"
 
-#: lxc/file.go:1254
+#: lxc/file.go:1443
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr "クライアント %q の未知のチャンネルタイプ: %s"
@@ -6810,7 +6853,7 @@ msgstr "未知のカラム名の短縮形です '%c' ('%s' 中)"
 msgid "Unknown console type %q"
 msgstr "未知のコンソールタイプ %q"
 
-#: lxc/file.go:808
+#: lxc/file.go:997
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr "未知のファイルタイプ '%s'"
@@ -7042,7 +7085,7 @@ msgstr "コマンドを実行する際のユーザ ID (UID) (デフォルト 0)"
 msgid "User aborted delete operation"
 msgstr "ユーザが削除操作を中断しました"
 
-#: lxc/file.go:72
+#: lxc/file.go:76
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -7407,21 +7450,26 @@ msgstr "[<remote>:]<instance> [flags] [--] <command line>"
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 
-#: lxc/file.go:171
+#: lxc/file.go:360
 msgid "[<remote>:]<instance>/<path>"
 msgstr "[<remote>:]<instance>/<path>"
 
-#: lxc/file.go:121
+#: lxc/file.go:133
+#, fuzzy
+msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
+msgstr "[<remote>:]<instance>[/<path>] [<target path>]"
+
+#: lxc/file.go:310
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 
-#: lxc/file.go:241
+#: lxc/file.go:430
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 
-#: lxc/file.go:985
+#: lxc/file.go:1174
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr "[<remote>:]<instance>[/<path>] [<target path>]"
 
@@ -8001,7 +8049,15 @@ msgstr ""
 "lxc export u1 backup0.tar.gz\n"
 "    u1 インスタンスのバックアップ tarball をダウンロードします。"
 
-#: lxc/file.go:989
+#: lxc/file.go:137
+msgid ""
+"lxc file create foo/bar\n"
+"\t   To create a file /bar in the foo instance.\n"
+"lxc file create --type=symlink foo/bar baz\n"
+"\t   To create a symlink /bar in instance foo whose target is baz."
+msgstr ""
+
+#: lxc/file.go:1178
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -8010,7 +8066,7 @@ msgstr ""
 "   インスタンス foo の /root をローカルの fooroot ディレクトリにマウントしま"
 "す。"
 
-#: lxc/file.go:245
+#: lxc/file.go:434
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
@@ -8020,7 +8076,7 @@ msgstr ""
 "   インスタンスの /etc/hosts ファイルを取得し、カレントディレクトリにコピーし"
 "ます。"
 
-#: lxc/file.go:470
+#: lxc/file.go:659
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -8522,16 +8578,16 @@ msgstr "`lxc profile` コマンドを使ってください"
 msgid "space used"
 msgstr "使用量"
 
-#: lxc/file.go:1143
+#: lxc/file.go:1332
 msgid "sshfs has stopped"
 msgstr "sshfs が停止しました"
 
-#: lxc/file.go:1102
+#: lxc/file.go:1291
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr "sshfs で %q を %q にマウントします"
 
-#: lxc/file.go:1055
+#: lxc/file.go:1244
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 "sshfs が見つかりません。--listen オプションを使って SSH SFTP モードを試してみ"

--- a/po/ka.po
+++ b/po/ka.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-30 13:36-0400\n"
+"POT-Creation-Date: 2024-10-01 10:45-0600\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -430,12 +430,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:936
+#: lxc/file.go:1125
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:826
+#: lxc/file.go:1015
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -524,7 +524,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:466
+#: lxc/file.go:655
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -979,7 +979,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:341
+#: lxc/file.go:530
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1008,7 +1008,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:547
+#: lxc/file.go:736
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1394,8 +1394,12 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:249 lxc/file.go:475
+#: lxc/file.go:143 lxc/file.go:438 lxc/file.go:664
 msgid "Create any directories necessary"
+msgstr ""
+
+#: lxc/file.go:134 lxc/file.go:135
+msgid "Create files and directories in instances"
 msgstr ""
 
 #: lxc/auth.go:98 lxc/auth.go:99
@@ -1492,6 +1496,11 @@ msgstr ""
 msgid "Creating %s"
 msgstr ""
 
+#: lxc/file.go:273
+#, c-format
+msgid "Creating %s: %%s"
+msgstr ""
+
 #: lxc/init.go:184
 msgid "Creating the instance"
 msgstr ""
@@ -1548,7 +1557,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:123 lxc/file.go:124
+#: lxc/file.go:312 lxc/file.go:313
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1665,70 +1674,71 @@ msgstr ""
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
-#: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
-#: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
-#: lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090 lxc/image.go:1417
-#: lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638 lxc/image.go:1701
-#: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
-#: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
-#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33
-#: lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405
-#: lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793
-#: lxc/network.go:874 lxc/network.go:1005 lxc/network.go:1106
-#: lxc/network.go:1185 lxc/network.go:1245 lxc/network.go:1341
-#: lxc/network.go:1413 lxc/network_acl.go:30 lxc/network_acl.go:95
-#: lxc/network_acl.go:174 lxc/network_acl.go:235 lxc/network_acl.go:291
-#: lxc/network_acl.go:364 lxc/network_acl.go:461 lxc/network_acl.go:549
-#: lxc/network_acl.go:592 lxc/network_acl.go:731 lxc/network_acl.go:788
-#: lxc/network_acl.go:845 lxc/network_acl.go:860 lxc/network_acl.go:997
-#: lxc/network_allocations.go:51 lxc/network_forward.go:33
-#: lxc/network_forward.go:90 lxc/network_forward.go:179
-#: lxc/network_forward.go:256 lxc/network_forward.go:404
-#: lxc/network_forward.go:489 lxc/network_forward.go:599
-#: lxc/network_forward.go:646 lxc/network_forward.go:800
-#: lxc/network_forward.go:874 lxc/network_forward.go:889
-#: lxc/network_forward.go:970 lxc/network_load_balancer.go:33
-#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:181
-#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:408
-#: lxc/network_load_balancer.go:476 lxc/network_load_balancer.go:586
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:771
-#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:859
-#: lxc/network_load_balancer.go:935 lxc/network_load_balancer.go:1033
-#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1121
-#: lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:167
-#: lxc/network_peer.go:236 lxc/network_peer.go:360 lxc/network_peer.go:445
-#: lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731
-#: lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:165
-#: lxc/network_zone.go:228 lxc/network_zone.go:301 lxc/network_zone.go:396
-#: lxc/network_zone.go:484 lxc/network_zone.go:527 lxc/network_zone.go:654
-#: lxc/network_zone.go:710 lxc/network_zone.go:767 lxc/network_zone.go:845
-#: lxc/network_zone.go:909 lxc/network_zone.go:985 lxc/network_zone.go:1083
-#: lxc/network_zone.go:1172 lxc/network_zone.go:1219 lxc/network_zone.go:1349
-#: lxc/network_zone.go:1410 lxc/network_zone.go:1425 lxc/network_zone.go:1483
-#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
-#: lxc/operation.go:194 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
-#: lxc/profile.go:271 lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493
-#: lxc/profile.go:629 lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860
-#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31
-#: lxc/project.go:95 lxc/project.go:191 lxc/project.go:262 lxc/project.go:398
-#: lxc/project.go:472 lxc/project.go:592 lxc/project.go:657 lxc/project.go:745
-#: lxc/project.go:789 lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34
-#: lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91
-#: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853
-#: lxc/remote.go:917 lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24
-#: lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203
-#: lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655
-#: lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940
-#: lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189
-#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:383
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:536
-#: lxc/storage_bucket.go:630 lxc/storage_bucket.go:699
-#: lxc/storage_bucket.go:733 lxc/storage_bucket.go:774
-#: lxc/storage_bucket.go:853 lxc/storage_bucket.go:959
-#: lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158
-#: lxc/storage_volume.go:58 lxc/storage_volume.go:169 lxc/storage_volume.go:283
+#: lxc/export.go:32 lxc/file.go:88 lxc/file.go:135 lxc/file.go:313
+#: lxc/file.go:362 lxc/file.go:432 lxc/file.go:657 lxc/file.go:1176
+#: lxc/image.go:38 lxc/image.go:159 lxc/image.go:337 lxc/image.go:396
+#: lxc/image.go:525 lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090
+#: lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638
+#: lxc/image.go:1701 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255
+#: lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34
+#: lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233
+#: lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560
+#: lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1005
+#: lxc/network.go:1106 lxc/network.go:1185 lxc/network.go:1245
+#: lxc/network.go:1341 lxc/network.go:1413 lxc/network_acl.go:30
+#: lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235
+#: lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461
+#: lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731
+#: lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860
+#: lxc/network_acl.go:997 lxc/network_allocations.go:51
+#: lxc/network_forward.go:33 lxc/network_forward.go:90
+#: lxc/network_forward.go:179 lxc/network_forward.go:256
+#: lxc/network_forward.go:404 lxc/network_forward.go:489
+#: lxc/network_forward.go:599 lxc/network_forward.go:646
+#: lxc/network_forward.go:800 lxc/network_forward.go:874
+#: lxc/network_forward.go:889 lxc/network_forward.go:970
+#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
+#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844
+#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1121 lxc/network_peer.go:29
+#: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
+#: lxc/network_peer.go:360 lxc/network_peer.go:445 lxc/network_peer.go:547
+#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:29
+#: lxc/network_zone.go:86 lxc/network_zone.go:165 lxc/network_zone.go:228
+#: lxc/network_zone.go:301 lxc/network_zone.go:396 lxc/network_zone.go:484
+#: lxc/network_zone.go:527 lxc/network_zone.go:654 lxc/network_zone.go:710
+#: lxc/network_zone.go:767 lxc/network_zone.go:845 lxc/network_zone.go:909
+#: lxc/network_zone.go:985 lxc/network_zone.go:1083 lxc/network_zone.go:1172
+#: lxc/network_zone.go:1219 lxc/network_zone.go:1349 lxc/network_zone.go:1410
+#: lxc/network_zone.go:1425 lxc/network_zone.go:1483 lxc/operation.go:25
+#: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
+#: lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180 lxc/profile.go:271
+#: lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493 lxc/profile.go:629
+#: lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860 lxc/profile.go:920
+#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31 lxc/project.go:95
+#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
+#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
+#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:648
+#: lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853 lxc/remote.go:917
+#: lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
+#: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
+#: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:459
+#: lxc/storage_bucket.go:536 lxc/storage_bucket.go:630
+#: lxc/storage_bucket.go:699 lxc/storage_bucket.go:733
+#: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
+#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:283
 #: lxc/storage_volume.go:390 lxc/storage_volume.go:605
 #: lxc/storage_volume.go:714 lxc/storage_volume.go:801
 #: lxc/storage_volume.go:899 lxc/storage_volume.go:996
@@ -1826,7 +1836,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:995
+#: lxc/file.go:1184
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1892,7 +1902,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:75
+#: lxc/file.go:79
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1910,7 +1920,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:172 lxc/file.go:173
+#: lxc/file.go:361 lxc/file.go:362
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2180,12 +2190,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1238
+#: lxc/file.go:1427
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1261
+#: lxc/file.go:1450
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2200,12 +2210,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1288
+#: lxc/file.go:1477
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1073
+#: lxc/file.go:1262
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2235,7 +2245,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1194
+#: lxc/file.go:1383
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2250,7 +2260,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1199
+#: lxc/file.go:1388
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2260,12 +2270,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1099
+#: lxc/file.go:1288
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1226
+#: lxc/file.go:1415
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2304,7 +2314,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1400
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2319,7 +2329,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:821
+#: lxc/file.go:1010
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2345,6 +2355,10 @@ msgstr ""
 
 #: lxc/cluster.go:1302
 msgid "Force a particular evacuation action"
+msgstr ""
+
+#: lxc/file.go:144
+msgid "Force creating files or directories"
 msgstr ""
 
 #: lxc/cluster.go:1301
@@ -2641,22 +2655,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1311
+#: lxc/file.go:1500
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1300
+#: lxc/file.go:1489
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1312
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1133
+#: lxc/file.go:1322
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2849,11 +2863,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1125
+#: lxc/file.go:1314
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1302
+#: lxc/file.go:1491
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2871,7 +2885,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1045
+#: lxc/file.go:1234
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2923,7 +2937,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1040
+#: lxc/file.go:1229
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2965,7 +2979,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:148
+#: lxc/file.go:337
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2981,14 +2995,19 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:314
+#: lxc/file.go:503
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:496
+#: lxc/file.go:177 lxc/file.go:685
 #, c-format
 msgid "Invalid target %s"
+msgstr ""
+
+#: lxc/file.go:163
+#, c-format
+msgid "Invalid type %q"
 msgstr ""
 
 #: lxc/info.go:238
@@ -3493,7 +3512,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:83 lxc/file.go:84
+#: lxc/file.go:87 lxc/file.go:88
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3879,7 +3898,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:599
+#: lxc/file.go:788
 msgid "Missing target directory"
 msgstr ""
 
@@ -3917,11 +3936,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:286
+#: lxc/file.go:475
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:986 lxc/file.go:987
+#: lxc/file.go:1175 lxc/file.go:1176
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4373,7 +4392,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1103
+#: lxc/file.go:1292
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4607,20 +4626,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:242 lxc/file.go:243
+#: lxc/file.go:431 lxc/file.go:432
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:417 lxc/file.go:768
+#: lxc/file.go:606 lxc/file.go:957
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:467 lxc/file.go:468
+#: lxc/file.go:656 lxc/file.go:657
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:702 lxc/file.go:868
+#: lxc/file.go:891 lxc/file.go:1057
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4658,7 +4677,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:250 lxc/file.go:474
+#: lxc/file.go:439 lxc/file.go:663
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4987,12 +5006,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1231
+#: lxc/file.go:1420
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1232
+#: lxc/file.go:1421
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5068,7 +5087,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:996
+#: lxc/file.go:1185
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5262,15 +5281,27 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:477
+#: lxc/file.go:145
+msgid "Set the file's gid on create"
+msgstr ""
+
+#: lxc/file.go:666
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:478
+#: lxc/file.go:147
+msgid "Set the file's perms on create"
+msgstr ""
+
+#: lxc/file.go:667
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:476
+#: lxc/file.go:146
+msgid "Set the file's uid on create"
+msgstr ""
+
+#: lxc/file.go:665
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5330,7 +5361,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:994
+#: lxc/file.go:1183
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5705,6 +5736,10 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
+#: lxc/file.go:167
+msgid "Symlink target path can only be used for type \"symlink\""
+msgstr ""
+
 #: lxc/alias.go:140
 msgid "TARGET"
 msgstr ""
@@ -5724,11 +5759,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1033
+#: lxc/file.go:1222
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1027
+#: lxc/file.go:1216
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5897,6 +5932,10 @@ msgstr ""
 
 #: lxc/network.go:537 lxc/network.go:634
 msgid "The specified device doesn't match the network"
+msgstr ""
+
+#: lxc/file.go:148
+msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
 #: lxc/publish.go:97
@@ -6077,7 +6116,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:198
+#: lxc/file.go:387
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6091,7 +6130,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1254
+#: lxc/file.go:1443
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6107,7 +6146,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:808
+#: lxc/file.go:997
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6325,7 +6364,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:72
+#: lxc/file.go:76
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6674,20 +6713,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:171
+#: lxc/file.go:360
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:121
+#: lxc/file.go:133
+msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
+msgstr ""
+
+#: lxc/file.go:310
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:241
+#: lxc/file.go:430
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:985
+#: lxc/file.go:1174
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7196,20 +7239,28 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:989
+#: lxc/file.go:137
+msgid ""
+"lxc file create foo/bar\n"
+"\t   To create a file /bar in the foo instance.\n"
+"lxc file create --type=symlink foo/bar baz\n"
+"\t   To create a symlink /bar in instance foo whose target is baz."
+msgstr ""
+
+#: lxc/file.go:1178
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:245
+#: lxc/file.go:434
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:470
+#: lxc/file.go:659
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7558,16 +7609,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1143
+#: lxc/file.go:1332
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1102
+#: lxc/file.go:1291
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1055
+#: lxc/file.go:1244
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-30 13:36-0400\n"
+"POT-Creation-Date: 2024-10-01 10:45-0600\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Korean <https://hosted.weblate.org/projects/linux-containers/"
@@ -433,12 +433,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:936
+#: lxc/file.go:1125
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:826
+#: lxc/file.go:1015
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -527,7 +527,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:466
+#: lxc/file.go:655
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -982,7 +982,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:341
+#: lxc/file.go:530
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1011,7 +1011,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:547
+#: lxc/file.go:736
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1397,8 +1397,12 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:249 lxc/file.go:475
+#: lxc/file.go:143 lxc/file.go:438 lxc/file.go:664
 msgid "Create any directories necessary"
+msgstr ""
+
+#: lxc/file.go:134 lxc/file.go:135
+msgid "Create files and directories in instances"
 msgstr ""
 
 #: lxc/auth.go:98 lxc/auth.go:99
@@ -1495,6 +1499,11 @@ msgstr ""
 msgid "Creating %s"
 msgstr ""
 
+#: lxc/file.go:273
+#, c-format
+msgid "Creating %s: %%s"
+msgstr ""
+
 #: lxc/init.go:184
 msgid "Creating the instance"
 msgstr ""
@@ -1551,7 +1560,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:123 lxc/file.go:124
+#: lxc/file.go:312 lxc/file.go:313
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1668,70 +1677,71 @@ msgstr ""
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
-#: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
-#: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
-#: lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090 lxc/image.go:1417
-#: lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638 lxc/image.go:1701
-#: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
-#: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
-#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33
-#: lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405
-#: lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793
-#: lxc/network.go:874 lxc/network.go:1005 lxc/network.go:1106
-#: lxc/network.go:1185 lxc/network.go:1245 lxc/network.go:1341
-#: lxc/network.go:1413 lxc/network_acl.go:30 lxc/network_acl.go:95
-#: lxc/network_acl.go:174 lxc/network_acl.go:235 lxc/network_acl.go:291
-#: lxc/network_acl.go:364 lxc/network_acl.go:461 lxc/network_acl.go:549
-#: lxc/network_acl.go:592 lxc/network_acl.go:731 lxc/network_acl.go:788
-#: lxc/network_acl.go:845 lxc/network_acl.go:860 lxc/network_acl.go:997
-#: lxc/network_allocations.go:51 lxc/network_forward.go:33
-#: lxc/network_forward.go:90 lxc/network_forward.go:179
-#: lxc/network_forward.go:256 lxc/network_forward.go:404
-#: lxc/network_forward.go:489 lxc/network_forward.go:599
-#: lxc/network_forward.go:646 lxc/network_forward.go:800
-#: lxc/network_forward.go:874 lxc/network_forward.go:889
-#: lxc/network_forward.go:970 lxc/network_load_balancer.go:33
-#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:181
-#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:408
-#: lxc/network_load_balancer.go:476 lxc/network_load_balancer.go:586
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:771
-#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:859
-#: lxc/network_load_balancer.go:935 lxc/network_load_balancer.go:1033
-#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1121
-#: lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:167
-#: lxc/network_peer.go:236 lxc/network_peer.go:360 lxc/network_peer.go:445
-#: lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731
-#: lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:165
-#: lxc/network_zone.go:228 lxc/network_zone.go:301 lxc/network_zone.go:396
-#: lxc/network_zone.go:484 lxc/network_zone.go:527 lxc/network_zone.go:654
-#: lxc/network_zone.go:710 lxc/network_zone.go:767 lxc/network_zone.go:845
-#: lxc/network_zone.go:909 lxc/network_zone.go:985 lxc/network_zone.go:1083
-#: lxc/network_zone.go:1172 lxc/network_zone.go:1219 lxc/network_zone.go:1349
-#: lxc/network_zone.go:1410 lxc/network_zone.go:1425 lxc/network_zone.go:1483
-#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
-#: lxc/operation.go:194 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
-#: lxc/profile.go:271 lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493
-#: lxc/profile.go:629 lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860
-#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31
-#: lxc/project.go:95 lxc/project.go:191 lxc/project.go:262 lxc/project.go:398
-#: lxc/project.go:472 lxc/project.go:592 lxc/project.go:657 lxc/project.go:745
-#: lxc/project.go:789 lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34
-#: lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91
-#: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853
-#: lxc/remote.go:917 lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24
-#: lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203
-#: lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655
-#: lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940
-#: lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189
-#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:383
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:536
-#: lxc/storage_bucket.go:630 lxc/storage_bucket.go:699
-#: lxc/storage_bucket.go:733 lxc/storage_bucket.go:774
-#: lxc/storage_bucket.go:853 lxc/storage_bucket.go:959
-#: lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158
-#: lxc/storage_volume.go:58 lxc/storage_volume.go:169 lxc/storage_volume.go:283
+#: lxc/export.go:32 lxc/file.go:88 lxc/file.go:135 lxc/file.go:313
+#: lxc/file.go:362 lxc/file.go:432 lxc/file.go:657 lxc/file.go:1176
+#: lxc/image.go:38 lxc/image.go:159 lxc/image.go:337 lxc/image.go:396
+#: lxc/image.go:525 lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090
+#: lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638
+#: lxc/image.go:1701 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255
+#: lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34
+#: lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233
+#: lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560
+#: lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1005
+#: lxc/network.go:1106 lxc/network.go:1185 lxc/network.go:1245
+#: lxc/network.go:1341 lxc/network.go:1413 lxc/network_acl.go:30
+#: lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235
+#: lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461
+#: lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731
+#: lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860
+#: lxc/network_acl.go:997 lxc/network_allocations.go:51
+#: lxc/network_forward.go:33 lxc/network_forward.go:90
+#: lxc/network_forward.go:179 lxc/network_forward.go:256
+#: lxc/network_forward.go:404 lxc/network_forward.go:489
+#: lxc/network_forward.go:599 lxc/network_forward.go:646
+#: lxc/network_forward.go:800 lxc/network_forward.go:874
+#: lxc/network_forward.go:889 lxc/network_forward.go:970
+#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
+#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844
+#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1121 lxc/network_peer.go:29
+#: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
+#: lxc/network_peer.go:360 lxc/network_peer.go:445 lxc/network_peer.go:547
+#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:29
+#: lxc/network_zone.go:86 lxc/network_zone.go:165 lxc/network_zone.go:228
+#: lxc/network_zone.go:301 lxc/network_zone.go:396 lxc/network_zone.go:484
+#: lxc/network_zone.go:527 lxc/network_zone.go:654 lxc/network_zone.go:710
+#: lxc/network_zone.go:767 lxc/network_zone.go:845 lxc/network_zone.go:909
+#: lxc/network_zone.go:985 lxc/network_zone.go:1083 lxc/network_zone.go:1172
+#: lxc/network_zone.go:1219 lxc/network_zone.go:1349 lxc/network_zone.go:1410
+#: lxc/network_zone.go:1425 lxc/network_zone.go:1483 lxc/operation.go:25
+#: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
+#: lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180 lxc/profile.go:271
+#: lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493 lxc/profile.go:629
+#: lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860 lxc/profile.go:920
+#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31 lxc/project.go:95
+#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
+#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
+#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:648
+#: lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853 lxc/remote.go:917
+#: lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
+#: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
+#: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:459
+#: lxc/storage_bucket.go:536 lxc/storage_bucket.go:630
+#: lxc/storage_bucket.go:699 lxc/storage_bucket.go:733
+#: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
+#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:283
 #: lxc/storage_volume.go:390 lxc/storage_volume.go:605
 #: lxc/storage_volume.go:714 lxc/storage_volume.go:801
 #: lxc/storage_volume.go:899 lxc/storage_volume.go:996
@@ -1829,7 +1839,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:995
+#: lxc/file.go:1184
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1895,7 +1905,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:75
+#: lxc/file.go:79
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1913,7 +1923,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:172 lxc/file.go:173
+#: lxc/file.go:361 lxc/file.go:362
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2183,12 +2193,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1238
+#: lxc/file.go:1427
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1261
+#: lxc/file.go:1450
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2203,12 +2213,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1288
+#: lxc/file.go:1477
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1073
+#: lxc/file.go:1262
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2238,7 +2248,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1194
+#: lxc/file.go:1383
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2253,7 +2263,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1199
+#: lxc/file.go:1388
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2263,12 +2273,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1099
+#: lxc/file.go:1288
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1226
+#: lxc/file.go:1415
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2307,7 +2317,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1400
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2322,7 +2332,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:821
+#: lxc/file.go:1010
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2348,6 +2358,10 @@ msgstr ""
 
 #: lxc/cluster.go:1302
 msgid "Force a particular evacuation action"
+msgstr ""
+
+#: lxc/file.go:144
+msgid "Force creating files or directories"
 msgstr ""
 
 #: lxc/cluster.go:1301
@@ -2644,22 +2658,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1311
+#: lxc/file.go:1500
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1300
+#: lxc/file.go:1489
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1312
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1133
+#: lxc/file.go:1322
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2852,11 +2866,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1125
+#: lxc/file.go:1314
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1302
+#: lxc/file.go:1491
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2874,7 +2888,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1045
+#: lxc/file.go:1234
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2926,7 +2940,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1040
+#: lxc/file.go:1229
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2968,7 +2982,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:148
+#: lxc/file.go:337
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2984,14 +2998,19 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:314
+#: lxc/file.go:503
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:496
+#: lxc/file.go:177 lxc/file.go:685
 #, c-format
 msgid "Invalid target %s"
+msgstr ""
+
+#: lxc/file.go:163
+#, c-format
+msgid "Invalid type %q"
 msgstr ""
 
 #: lxc/info.go:238
@@ -3496,7 +3515,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:83 lxc/file.go:84
+#: lxc/file.go:87 lxc/file.go:88
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3882,7 +3901,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:599
+#: lxc/file.go:788
 msgid "Missing target directory"
 msgstr ""
 
@@ -3920,11 +3939,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:286
+#: lxc/file.go:475
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:986 lxc/file.go:987
+#: lxc/file.go:1175 lxc/file.go:1176
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4376,7 +4395,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1103
+#: lxc/file.go:1292
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4610,20 +4629,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:242 lxc/file.go:243
+#: lxc/file.go:431 lxc/file.go:432
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:417 lxc/file.go:768
+#: lxc/file.go:606 lxc/file.go:957
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:467 lxc/file.go:468
+#: lxc/file.go:656 lxc/file.go:657
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:702 lxc/file.go:868
+#: lxc/file.go:891 lxc/file.go:1057
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4661,7 +4680,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:250 lxc/file.go:474
+#: lxc/file.go:439 lxc/file.go:663
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4990,12 +5009,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1231
+#: lxc/file.go:1420
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1232
+#: lxc/file.go:1421
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5071,7 +5090,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:996
+#: lxc/file.go:1185
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5265,15 +5284,27 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:477
+#: lxc/file.go:145
+msgid "Set the file's gid on create"
+msgstr ""
+
+#: lxc/file.go:666
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:478
+#: lxc/file.go:147
+msgid "Set the file's perms on create"
+msgstr ""
+
+#: lxc/file.go:667
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:476
+#: lxc/file.go:146
+msgid "Set the file's uid on create"
+msgstr ""
+
+#: lxc/file.go:665
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5333,7 +5364,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:994
+#: lxc/file.go:1183
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5708,6 +5739,10 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
+#: lxc/file.go:167
+msgid "Symlink target path can only be used for type \"symlink\""
+msgstr ""
+
 #: lxc/alias.go:140
 msgid "TARGET"
 msgstr ""
@@ -5727,11 +5762,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1033
+#: lxc/file.go:1222
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1027
+#: lxc/file.go:1216
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5900,6 +5935,10 @@ msgstr ""
 
 #: lxc/network.go:537 lxc/network.go:634
 msgid "The specified device doesn't match the network"
+msgstr ""
+
+#: lxc/file.go:148
+msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
 #: lxc/publish.go:97
@@ -6080,7 +6119,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:198
+#: lxc/file.go:387
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6094,7 +6133,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1254
+#: lxc/file.go:1443
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6110,7 +6149,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:808
+#: lxc/file.go:997
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6328,7 +6367,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:72
+#: lxc/file.go:76
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6677,20 +6716,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:171
+#: lxc/file.go:360
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:121
+#: lxc/file.go:133
+msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
+msgstr ""
+
+#: lxc/file.go:310
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:241
+#: lxc/file.go:430
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:985
+#: lxc/file.go:1174
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7199,20 +7242,28 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:989
+#: lxc/file.go:137
+msgid ""
+"lxc file create foo/bar\n"
+"\t   To create a file /bar in the foo instance.\n"
+"lxc file create --type=symlink foo/bar baz\n"
+"\t   To create a symlink /bar in instance foo whose target is baz."
+msgstr ""
+
+#: lxc/file.go:1178
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:245
+#: lxc/file.go:434
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:470
+#: lxc/file.go:659
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7561,16 +7612,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1143
+#: lxc/file.go:1332
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1102
+#: lxc/file.go:1291
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1055
+#: lxc/file.go:1244
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-        "POT-Creation-Date: 2024-09-30 13:36-0400\n"
+        "POT-Creation-Date: 2024-10-01 10:45-0600\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -401,12 +401,12 @@ msgstr  ""
 msgid   "%s (%s) (%d available)"
 msgstr  ""
 
-#: lxc/file.go:936
+#: lxc/file.go:1125
 #, c-format
 msgid   "%s is not a directory"
 msgstr  ""
 
-#: lxc/file.go:826
+#: lxc/file.go:1015
 #, c-format
 msgid   "'%s' isn't a supported file type"
 msgstr  ""
@@ -494,7 +494,7 @@ msgstr  ""
 msgid   "<remote> <new-name>"
 msgstr  ""
 
-#: lxc/file.go:466
+#: lxc/file.go:655
 msgid   "<source path>... [<remote>:]<instance>/<path>"
 msgstr  ""
 
@@ -938,7 +938,7 @@ msgstr  ""
 msgid   "Can't provide a name for the target image"
 msgstr  ""
 
-#: lxc/file.go:341
+#: lxc/file.go:530
 msgid   "Can't pull a directory without --recursive"
 msgstr  ""
 
@@ -967,7 +967,7 @@ msgstr  ""
 msgid   "Can't specify column L when not clustered"
 msgstr  ""
 
-#: lxc/file.go:547
+#: lxc/file.go:736
 msgid   "Can't supply uid/gid/mode in recursive mode"
 msgstr  ""
 
@@ -1308,8 +1308,12 @@ msgstr  ""
 msgid   "Create and start instances from images"
 msgstr  ""
 
-#: lxc/file.go:249 lxc/file.go:475
+#: lxc/file.go:143 lxc/file.go:438 lxc/file.go:664
 msgid   "Create any directories necessary"
+msgstr  ""
+
+#: lxc/file.go:134 lxc/file.go:135
+msgid   "Create files and directories in instances"
 msgstr  ""
 
 #: lxc/auth.go:98 lxc/auth.go:99
@@ -1405,6 +1409,11 @@ msgstr  ""
 msgid   "Creating %s"
 msgstr  ""
 
+#: lxc/file.go:273
+#, c-format
+msgid   "Creating %s: %%s"
+msgstr  ""
+
 #: lxc/init.go:184
 msgid   "Creating the instance"
 msgstr  ""
@@ -1454,7 +1463,7 @@ msgstr  ""
 msgid   "Delete all warnings"
 msgstr  ""
 
-#: lxc/file.go:123 lxc/file.go:124
+#: lxc/file.go:312 lxc/file.go:313
 msgid   "Delete files in instances"
 msgstr  ""
 
@@ -1538,7 +1547,7 @@ msgstr  ""
 msgid   "Delete warning"
 msgstr  ""
 
-#: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159 lxc/alias.go:214 lxc/auth.go:31 lxc/auth.go:60 lxc/auth.go:99 lxc/auth.go:153 lxc/auth.go:202 lxc/auth.go:333 lxc/auth.go:393 lxc/auth.go:442 lxc/auth.go:494 lxc/auth.go:517 lxc/auth.go:576 lxc/auth.go:732 lxc/auth.go:766 lxc/auth.go:833 lxc/auth.go:896 lxc/auth.go:957 lxc/auth.go:1085 lxc/auth.go:1108 lxc/auth.go:1166 lxc/auth.go:1235 lxc/auth.go:1257 lxc/auth.go:1435 lxc/auth.go:1473 lxc/auth.go:1525 lxc/auth.go:1574 lxc/auth.go:1693 lxc/auth.go:1753 lxc/auth.go:1802 lxc/auth.go:1853 lxc/auth.go:1876 lxc/auth.go:1929 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677 lxc/cluster.go:770 lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087 lxc/cluster.go:1175 lxc/cluster.go:1299 lxc/cluster.go:1329 lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170 lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440 lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663 lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51 lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:955 lxc/config.go:995 lxc/config.go:1050 lxc/config.go:1141 lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:25 lxc/config_device.go:79 lxc/config_device.go:221 lxc/config_device.go:318 lxc/config_device.go:401 lxc/config_device.go:503 lxc/config_device.go:619 lxc/config_device.go:626 lxc/config_device.go:759 lxc/config_device.go:844 lxc/config_metadata.go:28 lxc/config_metadata.go:56 lxc/config_metadata.go:189 lxc/config_template.go:28 lxc/config_template.go:68 lxc/config_template.go:119 lxc/config_template.go:173 lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34 lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651 lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41 lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173 lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090 lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638 lxc/image.go:1701 lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1005 lxc/network.go:1106 lxc/network.go:1185 lxc/network.go:1245 lxc/network.go:1341 lxc/network.go:1413 lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731 lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:51 lxc/network_forward.go:33 lxc/network_forward.go:90 lxc/network_forward.go:179 lxc/network_forward.go:256 lxc/network_forward.go:404 lxc/network_forward.go:489 lxc/network_forward.go:599 lxc/network_forward.go:646 lxc/network_forward.go:800 lxc/network_forward.go:874 lxc/network_forward.go:889 lxc/network_forward.go:970 lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476 lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935 lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1121 lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236 lxc/network_peer.go:360 lxc/network_peer.go:445 lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:165 lxc/network_zone.go:228 lxc/network_zone.go:301 lxc/network_zone.go:396 lxc/network_zone.go:484 lxc/network_zone.go:527 lxc/network_zone.go:654 lxc/network_zone.go:710 lxc/network_zone.go:767 lxc/network_zone.go:845 lxc/network_zone.go:909 lxc/network_zone.go:985 lxc/network_zone.go:1083 lxc/network_zone.go:1172 lxc/network_zone.go:1219 lxc/network_zone.go:1349 lxc/network_zone.go:1410 lxc/network_zone.go:1425 lxc/network_zone.go:1483 lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180 lxc/profile.go:271 lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493 lxc/profile.go:629 lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860 lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31 lxc/project.go:95 lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472 lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789 lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853 lxc/remote.go:917 lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250 lxc/storage_bucket.go:383 lxc/storage_bucket.go:459 lxc/storage_bucket.go:536 lxc/storage_bucket.go:630 lxc/storage_bucket.go:699 lxc/storage_bucket.go:733 lxc/storage_bucket.go:774 lxc/storage_bucket.go:853 lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158 lxc/storage_volume.go:58 lxc/storage_volume.go:169 lxc/storage_volume.go:283 lxc/storage_volume.go:390 lxc/storage_volume.go:605 lxc/storage_volume.go:714 lxc/storage_volume.go:801 lxc/storage_volume.go:899 lxc/storage_volume.go:996 lxc/storage_volume.go:1217 lxc/storage_volume.go:1348 lxc/storage_volume.go:1507 lxc/storage_volume.go:1591 lxc/storage_volume.go:1844 lxc/storage_volume.go:1937 lxc/storage_volume.go:2064 lxc/storage_volume.go:2222 lxc/storage_volume.go:2343 lxc/storage_volume.go:2405 lxc/storage_volume.go:2541 lxc/storage_volume.go:2624 lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
+#: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159 lxc/alias.go:214 lxc/auth.go:31 lxc/auth.go:60 lxc/auth.go:99 lxc/auth.go:153 lxc/auth.go:202 lxc/auth.go:333 lxc/auth.go:393 lxc/auth.go:442 lxc/auth.go:494 lxc/auth.go:517 lxc/auth.go:576 lxc/auth.go:732 lxc/auth.go:766 lxc/auth.go:833 lxc/auth.go:896 lxc/auth.go:957 lxc/auth.go:1085 lxc/auth.go:1108 lxc/auth.go:1166 lxc/auth.go:1235 lxc/auth.go:1257 lxc/auth.go:1435 lxc/auth.go:1473 lxc/auth.go:1525 lxc/auth.go:1574 lxc/auth.go:1693 lxc/auth.go:1753 lxc/auth.go:1802 lxc/auth.go:1853 lxc/auth.go:1876 lxc/auth.go:1929 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677 lxc/cluster.go:770 lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087 lxc/cluster.go:1175 lxc/cluster.go:1299 lxc/cluster.go:1329 lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170 lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440 lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663 lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51 lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:955 lxc/config.go:995 lxc/config.go:1050 lxc/config.go:1141 lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:25 lxc/config_device.go:79 lxc/config_device.go:221 lxc/config_device.go:318 lxc/config_device.go:401 lxc/config_device.go:503 lxc/config_device.go:619 lxc/config_device.go:626 lxc/config_device.go:759 lxc/config_device.go:844 lxc/config_metadata.go:28 lxc/config_metadata.go:56 lxc/config_metadata.go:189 lxc/config_template.go:28 lxc/config_template.go:68 lxc/config_template.go:119 lxc/config_template.go:173 lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34 lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651 lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135 lxc/file.go:313 lxc/file.go:362 lxc/file.go:432 lxc/file.go:657 lxc/file.go:1176 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090 lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638 lxc/image.go:1701 lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1005 lxc/network.go:1106 lxc/network.go:1185 lxc/network.go:1245 lxc/network.go:1341 lxc/network.go:1413 lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731 lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:51 lxc/network_forward.go:33 lxc/network_forward.go:90 lxc/network_forward.go:179 lxc/network_forward.go:256 lxc/network_forward.go:404 lxc/network_forward.go:489 lxc/network_forward.go:599 lxc/network_forward.go:646 lxc/network_forward.go:800 lxc/network_forward.go:874 lxc/network_forward.go:889 lxc/network_forward.go:970 lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476 lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935 lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1121 lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236 lxc/network_peer.go:360 lxc/network_peer.go:445 lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:165 lxc/network_zone.go:228 lxc/network_zone.go:301 lxc/network_zone.go:396 lxc/network_zone.go:484 lxc/network_zone.go:527 lxc/network_zone.go:654 lxc/network_zone.go:710 lxc/network_zone.go:767 lxc/network_zone.go:845 lxc/network_zone.go:909 lxc/network_zone.go:985 lxc/network_zone.go:1083 lxc/network_zone.go:1172 lxc/network_zone.go:1219 lxc/network_zone.go:1349 lxc/network_zone.go:1410 lxc/network_zone.go:1425 lxc/network_zone.go:1483 lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180 lxc/profile.go:271 lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493 lxc/profile.go:629 lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860 lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31 lxc/project.go:95 lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472 lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789 lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853 lxc/remote.go:917 lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250 lxc/storage_bucket.go:383 lxc/storage_bucket.go:459 lxc/storage_bucket.go:536 lxc/storage_bucket.go:630 lxc/storage_bucket.go:699 lxc/storage_bucket.go:733 lxc/storage_bucket.go:774 lxc/storage_bucket.go:853 lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158 lxc/storage_volume.go:58 lxc/storage_volume.go:169 lxc/storage_volume.go:283 lxc/storage_volume.go:390 lxc/storage_volume.go:605 lxc/storage_volume.go:714 lxc/storage_volume.go:801 lxc/storage_volume.go:899 lxc/storage_volume.go:996 lxc/storage_volume.go:1217 lxc/storage_volume.go:1348 lxc/storage_volume.go:1507 lxc/storage_volume.go:1591 lxc/storage_volume.go:1844 lxc/storage_volume.go:1937 lxc/storage_volume.go:2064 lxc/storage_volume.go:2222 lxc/storage_volume.go:2343 lxc/storage_volume.go:2405 lxc/storage_volume.go:2541 lxc/storage_volume.go:2624 lxc/storage_volume.go:2790 lxc/version.go:22 lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid   "Description"
 msgstr  ""
 
@@ -1620,7 +1629,7 @@ msgstr  ""
 msgid   "Directory to run the command in (default /root)"
 msgstr  ""
 
-#: lxc/file.go:995
+#: lxc/file.go:1184
 msgid   "Disable authentication when using SSH SFTP listener"
 msgstr  ""
 
@@ -1686,7 +1695,7 @@ msgstr  ""
 msgid   "EXPIRY DATE"
 msgstr  ""
 
-#: lxc/file.go:75
+#: lxc/file.go:79
 msgid   "Early server side processing of file transfer requests cannot be canceled (interrupt two more times to force)"
 msgstr  ""
 
@@ -1702,7 +1711,7 @@ msgstr  ""
 msgid   "Edit cluster member configurations as YAML"
 msgstr  ""
 
-#: lxc/file.go:172 lxc/file.go:173
+#: lxc/file.go:361 lxc/file.go:362
 msgid   "Edit files in instances"
 msgstr  ""
 
@@ -1952,12 +1961,12 @@ msgstr  ""
 msgid   "FIRST SEEN"
 msgstr  ""
 
-#: lxc/file.go:1238
+#: lxc/file.go:1427
 #, c-format
 msgid   "Failed SSH handshake with client %q: %v"
 msgstr  ""
 
-#: lxc/file.go:1261
+#: lxc/file.go:1450
 #, c-format
 msgid   "Failed accepting channel client %q: %v"
 msgstr  ""
@@ -1972,12 +1981,12 @@ msgstr  ""
 msgid   "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr  ""
 
-#: lxc/file.go:1288
+#: lxc/file.go:1477
 #, c-format
 msgid   "Failed connecting to instance SFTP for client %q: %v"
 msgstr  ""
 
-#: lxc/file.go:1073
+#: lxc/file.go:1262
 #, c-format
 msgid   "Failed connecting to instance SFTP: %w"
 msgstr  ""
@@ -2007,7 +2016,7 @@ msgstr  ""
 msgid   "Failed fetching fingerprint %q: %w"
 msgstr  ""
 
-#: lxc/file.go:1194
+#: lxc/file.go:1383
 #, c-format
 msgid   "Failed generating SSH host key: %w"
 msgstr  ""
@@ -2022,7 +2031,7 @@ msgstr  ""
 msgid   "Failed loading profile %q: %w"
 msgstr  ""
 
-#: lxc/file.go:1199
+#: lxc/file.go:1388
 #, c-format
 msgid   "Failed parsing SSH host key: %w"
 msgstr  ""
@@ -2032,12 +2041,12 @@ msgstr  ""
 msgid   "Failed starting command: %w"
 msgstr  ""
 
-#: lxc/file.go:1099
+#: lxc/file.go:1288
 #, c-format
 msgid   "Failed starting sshfs: %w"
 msgstr  ""
 
-#: lxc/file.go:1226
+#: lxc/file.go:1415
 #, c-format
 msgid   "Failed to accept incoming connection: %w"
 msgstr  ""
@@ -2076,7 +2085,7 @@ msgstr  ""
 msgid   "Failed to find project: %w"
 msgstr  ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1400
 #, c-format
 msgid   "Failed to listen for connection: %w"
 msgstr  ""
@@ -2091,7 +2100,7 @@ msgstr  ""
 msgid   "Failed to remove alias %s: %w"
 msgstr  ""
 
-#: lxc/file.go:821
+#: lxc/file.go:1010
 #, c-format
 msgid   "Failed to walk path for %s: %s"
 msgstr  ""
@@ -2116,6 +2125,10 @@ msgstr  ""
 
 #: lxc/cluster.go:1302
 msgid   "Force a particular evacuation action"
+msgstr  ""
+
+#: lxc/file.go:144
+msgid   "Force creating files or directories"
 msgstr  ""
 
 #: lxc/cluster.go:1301
@@ -2397,22 +2410,22 @@ msgstr  ""
 msgid   "Hugepages:\n"
 msgstr  ""
 
-#: lxc/file.go:1311
+#: lxc/file.go:1500
 #, c-format
 msgid   "I/O copy from SSH to instance failed: %v"
 msgstr  ""
 
-#: lxc/file.go:1300
+#: lxc/file.go:1489
 #, c-format
 msgid   "I/O copy from instance to SSH failed: %v"
 msgstr  ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1312
 #, c-format
 msgid   "I/O copy from instance to sshfs failed: %v"
 msgstr  ""
 
-#: lxc/file.go:1133
+#: lxc/file.go:1322
 #, c-format
 msgid   "I/O copy from sshfs to instance failed: %v"
 msgstr  ""
@@ -2601,11 +2614,11 @@ msgstr  ""
 msgid   "Instance Only"
 msgstr  ""
 
-#: lxc/file.go:1125
+#: lxc/file.go:1314
 msgid   "Instance disconnected"
 msgstr  ""
 
-#: lxc/file.go:1302
+#: lxc/file.go:1491
 #, c-format
 msgid   "Instance disconnected for client %q"
 msgstr  ""
@@ -2623,7 +2636,7 @@ msgstr  ""
 msgid   "Instance name must be specified"
 msgstr  ""
 
-#: lxc/file.go:1045
+#: lxc/file.go:1234
 msgid   "Instance path cannot be used in SSH SFTP listener mode"
 msgstr  ""
 
@@ -2675,7 +2688,7 @@ msgstr  ""
 msgid   "Invalid instance name: %s"
 msgstr  ""
 
-#: lxc/file.go:1040
+#: lxc/file.go:1229
 #, c-format
 msgid   "Invalid instance path: %q"
 msgstr  ""
@@ -2716,7 +2729,7 @@ msgstr  ""
 msgid   "Invalid number of arguments"
 msgstr  ""
 
-#: lxc/file.go:148
+#: lxc/file.go:337
 #, c-format
 msgid   "Invalid path %s"
 msgstr  ""
@@ -2730,14 +2743,19 @@ msgstr  ""
 msgid   "Invalid snapshot name"
 msgstr  ""
 
-#: lxc/file.go:314
+#: lxc/file.go:503
 #, c-format
 msgid   "Invalid source %s"
 msgstr  ""
 
-#: lxc/file.go:496
+#: lxc/file.go:177 lxc/file.go:685
 #, c-format
 msgid   "Invalid target %s"
+msgstr  ""
+
+#: lxc/file.go:163
+#, c-format
+msgid   "Invalid type %q"
 msgstr  ""
 
 #: lxc/info.go:238
@@ -3227,7 +3245,7 @@ msgstr  ""
 msgid   "Manage devices"
 msgstr  ""
 
-#: lxc/file.go:83 lxc/file.go:84
+#: lxc/file.go:87 lxc/file.go:88
 msgid   "Manage files in instances"
 msgstr  ""
 
@@ -3547,7 +3565,7 @@ msgstr  ""
 msgid   "Missing storage pool name"
 msgstr  ""
 
-#: lxc/file.go:599
+#: lxc/file.go:788
 msgid   "Missing target directory"
 msgstr  ""
 
@@ -3583,11 +3601,11 @@ msgstr  ""
 msgid   "More than one device matches, specify the device name"
 msgstr  ""
 
-#: lxc/file.go:286
+#: lxc/file.go:475
 msgid   "More than one file to download, but target is not a directory"
 msgstr  ""
 
-#: lxc/file.go:986 lxc/file.go:987
+#: lxc/file.go:1175 lxc/file.go:1176
 msgid   "Mount files from instances"
 msgstr  ""
 
@@ -4024,7 +4042,7 @@ msgstr  ""
 msgid   "Ports:"
 msgstr  ""
 
-#: lxc/file.go:1103
+#: lxc/file.go:1292
 msgid   "Press ctrl+c to finish"
 msgstr  ""
 
@@ -4233,20 +4251,20 @@ msgstr  ""
 msgid   "Publishing instance: %s"
 msgstr  ""
 
-#: lxc/file.go:242 lxc/file.go:243
+#: lxc/file.go:431 lxc/file.go:432
 msgid   "Pull files from instances"
 msgstr  ""
 
-#: lxc/file.go:417 lxc/file.go:768
+#: lxc/file.go:606 lxc/file.go:957
 #, c-format
 msgid   "Pulling %s from %s: %%s"
 msgstr  ""
 
-#: lxc/file.go:467 lxc/file.go:468
+#: lxc/file.go:656 lxc/file.go:657
 msgid   "Push files into instances"
 msgstr  ""
 
-#: lxc/file.go:702 lxc/file.go:868
+#: lxc/file.go:891 lxc/file.go:1057
 #, c-format
 msgid   "Pushing %s to %s: %%s"
 msgstr  ""
@@ -4284,7 +4302,7 @@ msgstr  ""
 msgid   "Rebuild instances"
 msgstr  ""
 
-#: lxc/file.go:250 lxc/file.go:474
+#: lxc/file.go:439 lxc/file.go:663
 msgid   "Recursively transfer files"
 msgstr  ""
 
@@ -4609,12 +4627,12 @@ msgstr  ""
 msgid   "SR-IOV information:"
 msgstr  ""
 
-#: lxc/file.go:1231
+#: lxc/file.go:1420
 #, c-format
 msgid   "SSH client connected %q"
 msgstr  ""
 
-#: lxc/file.go:1232
+#: lxc/file.go:1421
 #, c-format
 msgid   "SSH client disconnected %q"
 msgstr  ""
@@ -4689,7 +4707,7 @@ msgstr  ""
 msgid   "Set a cluster member's configuration keys"
 msgstr  ""
 
-#: lxc/file.go:996
+#: lxc/file.go:1185
 msgid   "Set authentication user when using SSH SFTP listener"
 msgstr  ""
 
@@ -4855,15 +4873,27 @@ msgstr  ""
 msgid   "Set the URL for the remote"
 msgstr  ""
 
-#: lxc/file.go:477
+#: lxc/file.go:145
+msgid   "Set the file's gid on create"
+msgstr  ""
+
+#: lxc/file.go:666
 msgid   "Set the file's gid on push"
 msgstr  ""
 
-#: lxc/file.go:478
+#: lxc/file.go:147
+msgid   "Set the file's perms on create"
+msgstr  ""
+
+#: lxc/file.go:667
 msgid   "Set the file's perms on push"
 msgstr  ""
 
-#: lxc/file.go:476
+#: lxc/file.go:146
+msgid   "Set the file's uid on create"
+msgstr  ""
+
+#: lxc/file.go:665
 msgid   "Set the file's uid on push"
 msgstr  ""
 
@@ -4923,7 +4953,7 @@ msgstr  ""
 msgid   "Set the key as an instance property"
 msgstr  ""
 
-#: lxc/file.go:994
+#: lxc/file.go:1183
 msgid   "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr  ""
 
@@ -5292,6 +5322,10 @@ msgstr  ""
 msgid   "Switch the default remote"
 msgstr  ""
 
+#: lxc/file.go:167
+msgid   "Symlink target path can only be used for type \"symlink\""
+msgstr  ""
+
 #: lxc/alias.go:140
 msgid   "TARGET"
 msgstr  ""
@@ -5308,11 +5342,11 @@ msgstr  ""
 msgid   "Taken at"
 msgstr  ""
 
-#: lxc/file.go:1033
+#: lxc/file.go:1222
 msgid   "Target path and --listen flag cannot be used together"
 msgstr  ""
 
-#: lxc/file.go:1027
+#: lxc/file.go:1216
 msgid   "Target path must be a directory"
 msgstr  ""
 
@@ -5477,6 +5511,10 @@ msgstr  ""
 
 #: lxc/network.go:537 lxc/network.go:634
 msgid   "The specified device doesn't match the network"
+msgstr  ""
+
+#: lxc/file.go:148
+msgid   "The type to create (file, symlink, or directory)"
 msgstr  ""
 
 #: lxc/publish.go:97
@@ -5646,7 +5684,7 @@ msgstr  ""
 msgid   "UUID: %v"
 msgstr  ""
 
-#: lxc/file.go:198
+#: lxc/file.go:387
 #, c-format
 msgid   "Unable to create a temporary file: %v"
 msgstr  ""
@@ -5660,7 +5698,7 @@ msgstr  ""
 msgid   "Unknown certificate type %q"
 msgstr  ""
 
-#: lxc/file.go:1254
+#: lxc/file.go:1443
 #, c-format
 msgid   "Unknown channel type for client %q: %s"
 msgstr  ""
@@ -5675,7 +5713,7 @@ msgstr  ""
 msgid   "Unknown console type %q"
 msgstr  ""
 
-#: lxc/file.go:808
+#: lxc/file.go:997
 #, c-format
 msgid   "Unknown file type '%s'"
 msgstr  ""
@@ -5890,7 +5928,7 @@ msgstr  ""
 msgid   "User aborted delete operation"
 msgstr  ""
 
-#: lxc/file.go:72
+#: lxc/file.go:76
 msgid   "User signaled us three times, exiting. The remote operation will keep running"
 msgstr  ""
 
@@ -6219,19 +6257,23 @@ msgstr  ""
 msgid   "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr  ""
 
-#: lxc/file.go:171
+#: lxc/file.go:360
 msgid   "[<remote>:]<instance>/<path>"
 msgstr  ""
 
-#: lxc/file.go:121
+#: lxc/file.go:133
+msgid   "[<remote>:]<instance>/<path> [<symlink target path>]"
+msgstr  ""
+
+#: lxc/file.go:310
 msgid   "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr  ""
 
-#: lxc/file.go:241
+#: lxc/file.go:430
 msgid   "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr  ""
 
-#: lxc/file.go:985
+#: lxc/file.go:1174
 msgid   "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr  ""
 
@@ -6694,17 +6736,24 @@ msgid   "lxc export u1 backup0.tar.gz\n"
         "    Download a backup tarball of the u1 instance."
 msgstr  ""
 
-#: lxc/file.go:989
+#: lxc/file.go:137
+msgid   "lxc file create foo/bar\n"
+        "	   To create a file /bar in the foo instance.\n"
+        "lxc file create --type=symlink foo/bar baz\n"
+        "	   To create a symlink /bar in instance foo whose target is baz."
+msgstr  ""
+
+#: lxc/file.go:1178
 msgid   "lxc file mount foo/root fooroot\n"
         "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr  ""
 
-#: lxc/file.go:245
+#: lxc/file.go:434
 msgid   "lxc file pull foo/etc/hosts .\n"
         "   To pull /etc/hosts from the instance and write it to the current directory."
 msgstr  ""
 
-#: lxc/file.go:470
+#: lxc/file.go:659
 msgid   "lxc file push /etc/hosts foo/etc/hosts\n"
         "   To push /etc/hosts into the instance \"foo\"."
 msgstr  ""
@@ -6998,16 +7047,16 @@ msgstr  ""
 msgid   "space used"
 msgstr  ""
 
-#: lxc/file.go:1143
+#: lxc/file.go:1332
 msgid   "sshfs has stopped"
 msgstr  ""
 
-#: lxc/file.go:1102
+#: lxc/file.go:1291
 #, c-format
 msgid   "sshfs mounting %q on %q"
 msgstr  ""
 
-#: lxc/file.go:1055
+#: lxc/file.go:1244
 msgid   "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr  ""
 

--- a/po/mr.po
+++ b/po/mr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-30 13:36-0400\n"
+"POT-Creation-Date: 2024-10-01 10:45-0600\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Marathi <https://hosted.weblate.org/projects/linux-containers/"
@@ -433,12 +433,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:936
+#: lxc/file.go:1125
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:826
+#: lxc/file.go:1015
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -527,7 +527,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:466
+#: lxc/file.go:655
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -982,7 +982,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:341
+#: lxc/file.go:530
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1011,7 +1011,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:547
+#: lxc/file.go:736
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1397,8 +1397,12 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:249 lxc/file.go:475
+#: lxc/file.go:143 lxc/file.go:438 lxc/file.go:664
 msgid "Create any directories necessary"
+msgstr ""
+
+#: lxc/file.go:134 lxc/file.go:135
+msgid "Create files and directories in instances"
 msgstr ""
 
 #: lxc/auth.go:98 lxc/auth.go:99
@@ -1495,6 +1499,11 @@ msgstr ""
 msgid "Creating %s"
 msgstr ""
 
+#: lxc/file.go:273
+#, c-format
+msgid "Creating %s: %%s"
+msgstr ""
+
 #: lxc/init.go:184
 msgid "Creating the instance"
 msgstr ""
@@ -1551,7 +1560,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:123 lxc/file.go:124
+#: lxc/file.go:312 lxc/file.go:313
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1668,70 +1677,71 @@ msgstr ""
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
-#: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
-#: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
-#: lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090 lxc/image.go:1417
-#: lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638 lxc/image.go:1701
-#: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
-#: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
-#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33
-#: lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405
-#: lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793
-#: lxc/network.go:874 lxc/network.go:1005 lxc/network.go:1106
-#: lxc/network.go:1185 lxc/network.go:1245 lxc/network.go:1341
-#: lxc/network.go:1413 lxc/network_acl.go:30 lxc/network_acl.go:95
-#: lxc/network_acl.go:174 lxc/network_acl.go:235 lxc/network_acl.go:291
-#: lxc/network_acl.go:364 lxc/network_acl.go:461 lxc/network_acl.go:549
-#: lxc/network_acl.go:592 lxc/network_acl.go:731 lxc/network_acl.go:788
-#: lxc/network_acl.go:845 lxc/network_acl.go:860 lxc/network_acl.go:997
-#: lxc/network_allocations.go:51 lxc/network_forward.go:33
-#: lxc/network_forward.go:90 lxc/network_forward.go:179
-#: lxc/network_forward.go:256 lxc/network_forward.go:404
-#: lxc/network_forward.go:489 lxc/network_forward.go:599
-#: lxc/network_forward.go:646 lxc/network_forward.go:800
-#: lxc/network_forward.go:874 lxc/network_forward.go:889
-#: lxc/network_forward.go:970 lxc/network_load_balancer.go:33
-#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:181
-#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:408
-#: lxc/network_load_balancer.go:476 lxc/network_load_balancer.go:586
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:771
-#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:859
-#: lxc/network_load_balancer.go:935 lxc/network_load_balancer.go:1033
-#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1121
-#: lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:167
-#: lxc/network_peer.go:236 lxc/network_peer.go:360 lxc/network_peer.go:445
-#: lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731
-#: lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:165
-#: lxc/network_zone.go:228 lxc/network_zone.go:301 lxc/network_zone.go:396
-#: lxc/network_zone.go:484 lxc/network_zone.go:527 lxc/network_zone.go:654
-#: lxc/network_zone.go:710 lxc/network_zone.go:767 lxc/network_zone.go:845
-#: lxc/network_zone.go:909 lxc/network_zone.go:985 lxc/network_zone.go:1083
-#: lxc/network_zone.go:1172 lxc/network_zone.go:1219 lxc/network_zone.go:1349
-#: lxc/network_zone.go:1410 lxc/network_zone.go:1425 lxc/network_zone.go:1483
-#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
-#: lxc/operation.go:194 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
-#: lxc/profile.go:271 lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493
-#: lxc/profile.go:629 lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860
-#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31
-#: lxc/project.go:95 lxc/project.go:191 lxc/project.go:262 lxc/project.go:398
-#: lxc/project.go:472 lxc/project.go:592 lxc/project.go:657 lxc/project.go:745
-#: lxc/project.go:789 lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34
-#: lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91
-#: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853
-#: lxc/remote.go:917 lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24
-#: lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203
-#: lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655
-#: lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940
-#: lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189
-#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:383
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:536
-#: lxc/storage_bucket.go:630 lxc/storage_bucket.go:699
-#: lxc/storage_bucket.go:733 lxc/storage_bucket.go:774
-#: lxc/storage_bucket.go:853 lxc/storage_bucket.go:959
-#: lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158
-#: lxc/storage_volume.go:58 lxc/storage_volume.go:169 lxc/storage_volume.go:283
+#: lxc/export.go:32 lxc/file.go:88 lxc/file.go:135 lxc/file.go:313
+#: lxc/file.go:362 lxc/file.go:432 lxc/file.go:657 lxc/file.go:1176
+#: lxc/image.go:38 lxc/image.go:159 lxc/image.go:337 lxc/image.go:396
+#: lxc/image.go:525 lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090
+#: lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638
+#: lxc/image.go:1701 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255
+#: lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34
+#: lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233
+#: lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560
+#: lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1005
+#: lxc/network.go:1106 lxc/network.go:1185 lxc/network.go:1245
+#: lxc/network.go:1341 lxc/network.go:1413 lxc/network_acl.go:30
+#: lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235
+#: lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461
+#: lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731
+#: lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860
+#: lxc/network_acl.go:997 lxc/network_allocations.go:51
+#: lxc/network_forward.go:33 lxc/network_forward.go:90
+#: lxc/network_forward.go:179 lxc/network_forward.go:256
+#: lxc/network_forward.go:404 lxc/network_forward.go:489
+#: lxc/network_forward.go:599 lxc/network_forward.go:646
+#: lxc/network_forward.go:800 lxc/network_forward.go:874
+#: lxc/network_forward.go:889 lxc/network_forward.go:970
+#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
+#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844
+#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1121 lxc/network_peer.go:29
+#: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
+#: lxc/network_peer.go:360 lxc/network_peer.go:445 lxc/network_peer.go:547
+#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:29
+#: lxc/network_zone.go:86 lxc/network_zone.go:165 lxc/network_zone.go:228
+#: lxc/network_zone.go:301 lxc/network_zone.go:396 lxc/network_zone.go:484
+#: lxc/network_zone.go:527 lxc/network_zone.go:654 lxc/network_zone.go:710
+#: lxc/network_zone.go:767 lxc/network_zone.go:845 lxc/network_zone.go:909
+#: lxc/network_zone.go:985 lxc/network_zone.go:1083 lxc/network_zone.go:1172
+#: lxc/network_zone.go:1219 lxc/network_zone.go:1349 lxc/network_zone.go:1410
+#: lxc/network_zone.go:1425 lxc/network_zone.go:1483 lxc/operation.go:25
+#: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
+#: lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180 lxc/profile.go:271
+#: lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493 lxc/profile.go:629
+#: lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860 lxc/profile.go:920
+#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31 lxc/project.go:95
+#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
+#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
+#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:648
+#: lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853 lxc/remote.go:917
+#: lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
+#: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
+#: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:459
+#: lxc/storage_bucket.go:536 lxc/storage_bucket.go:630
+#: lxc/storage_bucket.go:699 lxc/storage_bucket.go:733
+#: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
+#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:283
 #: lxc/storage_volume.go:390 lxc/storage_volume.go:605
 #: lxc/storage_volume.go:714 lxc/storage_volume.go:801
 #: lxc/storage_volume.go:899 lxc/storage_volume.go:996
@@ -1829,7 +1839,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:995
+#: lxc/file.go:1184
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1895,7 +1905,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:75
+#: lxc/file.go:79
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1913,7 +1923,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:172 lxc/file.go:173
+#: lxc/file.go:361 lxc/file.go:362
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2183,12 +2193,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1238
+#: lxc/file.go:1427
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1261
+#: lxc/file.go:1450
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2203,12 +2213,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1288
+#: lxc/file.go:1477
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1073
+#: lxc/file.go:1262
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2238,7 +2248,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1194
+#: lxc/file.go:1383
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2253,7 +2263,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1199
+#: lxc/file.go:1388
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2263,12 +2273,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1099
+#: lxc/file.go:1288
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1226
+#: lxc/file.go:1415
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2307,7 +2317,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1400
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2322,7 +2332,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:821
+#: lxc/file.go:1010
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2348,6 +2358,10 @@ msgstr ""
 
 #: lxc/cluster.go:1302
 msgid "Force a particular evacuation action"
+msgstr ""
+
+#: lxc/file.go:144
+msgid "Force creating files or directories"
 msgstr ""
 
 #: lxc/cluster.go:1301
@@ -2644,22 +2658,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1311
+#: lxc/file.go:1500
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1300
+#: lxc/file.go:1489
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1312
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1133
+#: lxc/file.go:1322
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2852,11 +2866,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1125
+#: lxc/file.go:1314
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1302
+#: lxc/file.go:1491
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2874,7 +2888,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1045
+#: lxc/file.go:1234
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2926,7 +2940,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1040
+#: lxc/file.go:1229
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2968,7 +2982,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:148
+#: lxc/file.go:337
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2984,14 +2998,19 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:314
+#: lxc/file.go:503
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:496
+#: lxc/file.go:177 lxc/file.go:685
 #, c-format
 msgid "Invalid target %s"
+msgstr ""
+
+#: lxc/file.go:163
+#, c-format
+msgid "Invalid type %q"
 msgstr ""
 
 #: lxc/info.go:238
@@ -3496,7 +3515,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:83 lxc/file.go:84
+#: lxc/file.go:87 lxc/file.go:88
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3882,7 +3901,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:599
+#: lxc/file.go:788
 msgid "Missing target directory"
 msgstr ""
 
@@ -3920,11 +3939,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:286
+#: lxc/file.go:475
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:986 lxc/file.go:987
+#: lxc/file.go:1175 lxc/file.go:1176
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4376,7 +4395,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1103
+#: lxc/file.go:1292
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4610,20 +4629,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:242 lxc/file.go:243
+#: lxc/file.go:431 lxc/file.go:432
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:417 lxc/file.go:768
+#: lxc/file.go:606 lxc/file.go:957
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:467 lxc/file.go:468
+#: lxc/file.go:656 lxc/file.go:657
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:702 lxc/file.go:868
+#: lxc/file.go:891 lxc/file.go:1057
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4661,7 +4680,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:250 lxc/file.go:474
+#: lxc/file.go:439 lxc/file.go:663
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4990,12 +5009,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1231
+#: lxc/file.go:1420
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1232
+#: lxc/file.go:1421
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5071,7 +5090,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:996
+#: lxc/file.go:1185
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5265,15 +5284,27 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:477
+#: lxc/file.go:145
+msgid "Set the file's gid on create"
+msgstr ""
+
+#: lxc/file.go:666
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:478
+#: lxc/file.go:147
+msgid "Set the file's perms on create"
+msgstr ""
+
+#: lxc/file.go:667
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:476
+#: lxc/file.go:146
+msgid "Set the file's uid on create"
+msgstr ""
+
+#: lxc/file.go:665
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5333,7 +5364,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:994
+#: lxc/file.go:1183
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5708,6 +5739,10 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
+#: lxc/file.go:167
+msgid "Symlink target path can only be used for type \"symlink\""
+msgstr ""
+
 #: lxc/alias.go:140
 msgid "TARGET"
 msgstr ""
@@ -5727,11 +5762,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1033
+#: lxc/file.go:1222
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1027
+#: lxc/file.go:1216
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5900,6 +5935,10 @@ msgstr ""
 
 #: lxc/network.go:537 lxc/network.go:634
 msgid "The specified device doesn't match the network"
+msgstr ""
+
+#: lxc/file.go:148
+msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
 #: lxc/publish.go:97
@@ -6080,7 +6119,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:198
+#: lxc/file.go:387
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6094,7 +6133,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1254
+#: lxc/file.go:1443
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6110,7 +6149,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:808
+#: lxc/file.go:997
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6328,7 +6367,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:72
+#: lxc/file.go:76
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6677,20 +6716,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:171
+#: lxc/file.go:360
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:121
+#: lxc/file.go:133
+msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
+msgstr ""
+
+#: lxc/file.go:310
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:241
+#: lxc/file.go:430
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:985
+#: lxc/file.go:1174
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7199,20 +7242,28 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:989
+#: lxc/file.go:137
+msgid ""
+"lxc file create foo/bar\n"
+"\t   To create a file /bar in the foo instance.\n"
+"lxc file create --type=symlink foo/bar baz\n"
+"\t   To create a symlink /bar in instance foo whose target is baz."
+msgstr ""
+
+#: lxc/file.go:1178
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:245
+#: lxc/file.go:434
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:470
+#: lxc/file.go:659
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7561,16 +7612,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1143
+#: lxc/file.go:1332
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1102
+#: lxc/file.go:1291
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1055
+#: lxc/file.go:1244
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-30 13:36-0400\n"
+"POT-Creation-Date: 2024-10-01 10:45-0600\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Norwegian Bokmål <https://hosted.weblate.org/projects/linux-"
@@ -433,12 +433,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:936
+#: lxc/file.go:1125
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:826
+#: lxc/file.go:1015
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -527,7 +527,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:466
+#: lxc/file.go:655
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -982,7 +982,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:341
+#: lxc/file.go:530
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1011,7 +1011,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:547
+#: lxc/file.go:736
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1397,8 +1397,12 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:249 lxc/file.go:475
+#: lxc/file.go:143 lxc/file.go:438 lxc/file.go:664
 msgid "Create any directories necessary"
+msgstr ""
+
+#: lxc/file.go:134 lxc/file.go:135
+msgid "Create files and directories in instances"
 msgstr ""
 
 #: lxc/auth.go:98 lxc/auth.go:99
@@ -1495,6 +1499,11 @@ msgstr ""
 msgid "Creating %s"
 msgstr ""
 
+#: lxc/file.go:273
+#, c-format
+msgid "Creating %s: %%s"
+msgstr ""
+
 #: lxc/init.go:184
 msgid "Creating the instance"
 msgstr ""
@@ -1551,7 +1560,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:123 lxc/file.go:124
+#: lxc/file.go:312 lxc/file.go:313
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1668,70 +1677,71 @@ msgstr ""
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
-#: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
-#: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
-#: lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090 lxc/image.go:1417
-#: lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638 lxc/image.go:1701
-#: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
-#: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
-#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33
-#: lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405
-#: lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793
-#: lxc/network.go:874 lxc/network.go:1005 lxc/network.go:1106
-#: lxc/network.go:1185 lxc/network.go:1245 lxc/network.go:1341
-#: lxc/network.go:1413 lxc/network_acl.go:30 lxc/network_acl.go:95
-#: lxc/network_acl.go:174 lxc/network_acl.go:235 lxc/network_acl.go:291
-#: lxc/network_acl.go:364 lxc/network_acl.go:461 lxc/network_acl.go:549
-#: lxc/network_acl.go:592 lxc/network_acl.go:731 lxc/network_acl.go:788
-#: lxc/network_acl.go:845 lxc/network_acl.go:860 lxc/network_acl.go:997
-#: lxc/network_allocations.go:51 lxc/network_forward.go:33
-#: lxc/network_forward.go:90 lxc/network_forward.go:179
-#: lxc/network_forward.go:256 lxc/network_forward.go:404
-#: lxc/network_forward.go:489 lxc/network_forward.go:599
-#: lxc/network_forward.go:646 lxc/network_forward.go:800
-#: lxc/network_forward.go:874 lxc/network_forward.go:889
-#: lxc/network_forward.go:970 lxc/network_load_balancer.go:33
-#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:181
-#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:408
-#: lxc/network_load_balancer.go:476 lxc/network_load_balancer.go:586
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:771
-#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:859
-#: lxc/network_load_balancer.go:935 lxc/network_load_balancer.go:1033
-#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1121
-#: lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:167
-#: lxc/network_peer.go:236 lxc/network_peer.go:360 lxc/network_peer.go:445
-#: lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731
-#: lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:165
-#: lxc/network_zone.go:228 lxc/network_zone.go:301 lxc/network_zone.go:396
-#: lxc/network_zone.go:484 lxc/network_zone.go:527 lxc/network_zone.go:654
-#: lxc/network_zone.go:710 lxc/network_zone.go:767 lxc/network_zone.go:845
-#: lxc/network_zone.go:909 lxc/network_zone.go:985 lxc/network_zone.go:1083
-#: lxc/network_zone.go:1172 lxc/network_zone.go:1219 lxc/network_zone.go:1349
-#: lxc/network_zone.go:1410 lxc/network_zone.go:1425 lxc/network_zone.go:1483
-#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
-#: lxc/operation.go:194 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
-#: lxc/profile.go:271 lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493
-#: lxc/profile.go:629 lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860
-#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31
-#: lxc/project.go:95 lxc/project.go:191 lxc/project.go:262 lxc/project.go:398
-#: lxc/project.go:472 lxc/project.go:592 lxc/project.go:657 lxc/project.go:745
-#: lxc/project.go:789 lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34
-#: lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91
-#: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853
-#: lxc/remote.go:917 lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24
-#: lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203
-#: lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655
-#: lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940
-#: lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189
-#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:383
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:536
-#: lxc/storage_bucket.go:630 lxc/storage_bucket.go:699
-#: lxc/storage_bucket.go:733 lxc/storage_bucket.go:774
-#: lxc/storage_bucket.go:853 lxc/storage_bucket.go:959
-#: lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158
-#: lxc/storage_volume.go:58 lxc/storage_volume.go:169 lxc/storage_volume.go:283
+#: lxc/export.go:32 lxc/file.go:88 lxc/file.go:135 lxc/file.go:313
+#: lxc/file.go:362 lxc/file.go:432 lxc/file.go:657 lxc/file.go:1176
+#: lxc/image.go:38 lxc/image.go:159 lxc/image.go:337 lxc/image.go:396
+#: lxc/image.go:525 lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090
+#: lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638
+#: lxc/image.go:1701 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255
+#: lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34
+#: lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233
+#: lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560
+#: lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1005
+#: lxc/network.go:1106 lxc/network.go:1185 lxc/network.go:1245
+#: lxc/network.go:1341 lxc/network.go:1413 lxc/network_acl.go:30
+#: lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235
+#: lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461
+#: lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731
+#: lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860
+#: lxc/network_acl.go:997 lxc/network_allocations.go:51
+#: lxc/network_forward.go:33 lxc/network_forward.go:90
+#: lxc/network_forward.go:179 lxc/network_forward.go:256
+#: lxc/network_forward.go:404 lxc/network_forward.go:489
+#: lxc/network_forward.go:599 lxc/network_forward.go:646
+#: lxc/network_forward.go:800 lxc/network_forward.go:874
+#: lxc/network_forward.go:889 lxc/network_forward.go:970
+#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
+#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844
+#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1121 lxc/network_peer.go:29
+#: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
+#: lxc/network_peer.go:360 lxc/network_peer.go:445 lxc/network_peer.go:547
+#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:29
+#: lxc/network_zone.go:86 lxc/network_zone.go:165 lxc/network_zone.go:228
+#: lxc/network_zone.go:301 lxc/network_zone.go:396 lxc/network_zone.go:484
+#: lxc/network_zone.go:527 lxc/network_zone.go:654 lxc/network_zone.go:710
+#: lxc/network_zone.go:767 lxc/network_zone.go:845 lxc/network_zone.go:909
+#: lxc/network_zone.go:985 lxc/network_zone.go:1083 lxc/network_zone.go:1172
+#: lxc/network_zone.go:1219 lxc/network_zone.go:1349 lxc/network_zone.go:1410
+#: lxc/network_zone.go:1425 lxc/network_zone.go:1483 lxc/operation.go:25
+#: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
+#: lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180 lxc/profile.go:271
+#: lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493 lxc/profile.go:629
+#: lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860 lxc/profile.go:920
+#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31 lxc/project.go:95
+#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
+#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
+#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:648
+#: lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853 lxc/remote.go:917
+#: lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
+#: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
+#: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:459
+#: lxc/storage_bucket.go:536 lxc/storage_bucket.go:630
+#: lxc/storage_bucket.go:699 lxc/storage_bucket.go:733
+#: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
+#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:283
 #: lxc/storage_volume.go:390 lxc/storage_volume.go:605
 #: lxc/storage_volume.go:714 lxc/storage_volume.go:801
 #: lxc/storage_volume.go:899 lxc/storage_volume.go:996
@@ -1829,7 +1839,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:995
+#: lxc/file.go:1184
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1895,7 +1905,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:75
+#: lxc/file.go:79
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1913,7 +1923,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:172 lxc/file.go:173
+#: lxc/file.go:361 lxc/file.go:362
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2183,12 +2193,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1238
+#: lxc/file.go:1427
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1261
+#: lxc/file.go:1450
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2203,12 +2213,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1288
+#: lxc/file.go:1477
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1073
+#: lxc/file.go:1262
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2238,7 +2248,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1194
+#: lxc/file.go:1383
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2253,7 +2263,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1199
+#: lxc/file.go:1388
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2263,12 +2273,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1099
+#: lxc/file.go:1288
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1226
+#: lxc/file.go:1415
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2307,7 +2317,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1400
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2322,7 +2332,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:821
+#: lxc/file.go:1010
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2348,6 +2358,10 @@ msgstr ""
 
 #: lxc/cluster.go:1302
 msgid "Force a particular evacuation action"
+msgstr ""
+
+#: lxc/file.go:144
+msgid "Force creating files or directories"
 msgstr ""
 
 #: lxc/cluster.go:1301
@@ -2644,22 +2658,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1311
+#: lxc/file.go:1500
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1300
+#: lxc/file.go:1489
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1312
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1133
+#: lxc/file.go:1322
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2852,11 +2866,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1125
+#: lxc/file.go:1314
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1302
+#: lxc/file.go:1491
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2874,7 +2888,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1045
+#: lxc/file.go:1234
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2926,7 +2940,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1040
+#: lxc/file.go:1229
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2968,7 +2982,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:148
+#: lxc/file.go:337
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2984,14 +2998,19 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:314
+#: lxc/file.go:503
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:496
+#: lxc/file.go:177 lxc/file.go:685
 #, c-format
 msgid "Invalid target %s"
+msgstr ""
+
+#: lxc/file.go:163
+#, c-format
+msgid "Invalid type %q"
 msgstr ""
 
 #: lxc/info.go:238
@@ -3496,7 +3515,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:83 lxc/file.go:84
+#: lxc/file.go:87 lxc/file.go:88
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3882,7 +3901,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:599
+#: lxc/file.go:788
 msgid "Missing target directory"
 msgstr ""
 
@@ -3920,11 +3939,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:286
+#: lxc/file.go:475
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:986 lxc/file.go:987
+#: lxc/file.go:1175 lxc/file.go:1176
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4376,7 +4395,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1103
+#: lxc/file.go:1292
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4610,20 +4629,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:242 lxc/file.go:243
+#: lxc/file.go:431 lxc/file.go:432
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:417 lxc/file.go:768
+#: lxc/file.go:606 lxc/file.go:957
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:467 lxc/file.go:468
+#: lxc/file.go:656 lxc/file.go:657
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:702 lxc/file.go:868
+#: lxc/file.go:891 lxc/file.go:1057
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4661,7 +4680,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:250 lxc/file.go:474
+#: lxc/file.go:439 lxc/file.go:663
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4990,12 +5009,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1231
+#: lxc/file.go:1420
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1232
+#: lxc/file.go:1421
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5071,7 +5090,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:996
+#: lxc/file.go:1185
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5265,15 +5284,27 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:477
+#: lxc/file.go:145
+msgid "Set the file's gid on create"
+msgstr ""
+
+#: lxc/file.go:666
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:478
+#: lxc/file.go:147
+msgid "Set the file's perms on create"
+msgstr ""
+
+#: lxc/file.go:667
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:476
+#: lxc/file.go:146
+msgid "Set the file's uid on create"
+msgstr ""
+
+#: lxc/file.go:665
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5333,7 +5364,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:994
+#: lxc/file.go:1183
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5708,6 +5739,10 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
+#: lxc/file.go:167
+msgid "Symlink target path can only be used for type \"symlink\""
+msgstr ""
+
 #: lxc/alias.go:140
 msgid "TARGET"
 msgstr ""
@@ -5727,11 +5762,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1033
+#: lxc/file.go:1222
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1027
+#: lxc/file.go:1216
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5900,6 +5935,10 @@ msgstr ""
 
 #: lxc/network.go:537 lxc/network.go:634
 msgid "The specified device doesn't match the network"
+msgstr ""
+
+#: lxc/file.go:148
+msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
 #: lxc/publish.go:97
@@ -6080,7 +6119,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:198
+#: lxc/file.go:387
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6094,7 +6133,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1254
+#: lxc/file.go:1443
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6110,7 +6149,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:808
+#: lxc/file.go:997
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6328,7 +6367,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:72
+#: lxc/file.go:76
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6677,20 +6716,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:171
+#: lxc/file.go:360
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:121
+#: lxc/file.go:133
+msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
+msgstr ""
+
+#: lxc/file.go:310
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:241
+#: lxc/file.go:430
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:985
+#: lxc/file.go:1174
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7199,20 +7242,28 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:989
+#: lxc/file.go:137
+msgid ""
+"lxc file create foo/bar\n"
+"\t   To create a file /bar in the foo instance.\n"
+"lxc file create --type=symlink foo/bar baz\n"
+"\t   To create a symlink /bar in instance foo whose target is baz."
+msgstr ""
+
+#: lxc/file.go:1178
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:245
+#: lxc/file.go:434
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:470
+#: lxc/file.go:659
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7561,16 +7612,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1143
+#: lxc/file.go:1332
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1102
+#: lxc/file.go:1291
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1055
+#: lxc/file.go:1244
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-30 13:36-0400\n"
+"POT-Creation-Date: 2024-10-01 10:45-0600\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Heimen Stoffels <vistausss@fastmail.com>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/linux-containers/"
@@ -657,12 +657,12 @@ msgstr "%s (en nog %d)"
 msgid "%s (%s) (%d available)"
 msgstr "%s (en nog %d)"
 
-#: lxc/file.go:936
+#: lxc/file.go:1125
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:826
+#: lxc/file.go:1015
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -751,7 +751,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:466
+#: lxc/file.go:655
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -1206,7 +1206,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:341
+#: lxc/file.go:530
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1235,7 +1235,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:547
+#: lxc/file.go:736
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1621,8 +1621,12 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:249 lxc/file.go:475
+#: lxc/file.go:143 lxc/file.go:438 lxc/file.go:664
 msgid "Create any directories necessary"
+msgstr ""
+
+#: lxc/file.go:134 lxc/file.go:135
+msgid "Create files and directories in instances"
 msgstr ""
 
 #: lxc/auth.go:98 lxc/auth.go:99
@@ -1719,6 +1723,11 @@ msgstr ""
 msgid "Creating %s"
 msgstr ""
 
+#: lxc/file.go:273
+#, c-format
+msgid "Creating %s: %%s"
+msgstr ""
+
 #: lxc/init.go:184
 msgid "Creating the instance"
 msgstr ""
@@ -1775,7 +1784,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:123 lxc/file.go:124
+#: lxc/file.go:312 lxc/file.go:313
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1892,70 +1901,71 @@ msgstr ""
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
-#: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
-#: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
-#: lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090 lxc/image.go:1417
-#: lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638 lxc/image.go:1701
-#: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
-#: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
-#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33
-#: lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405
-#: lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793
-#: lxc/network.go:874 lxc/network.go:1005 lxc/network.go:1106
-#: lxc/network.go:1185 lxc/network.go:1245 lxc/network.go:1341
-#: lxc/network.go:1413 lxc/network_acl.go:30 lxc/network_acl.go:95
-#: lxc/network_acl.go:174 lxc/network_acl.go:235 lxc/network_acl.go:291
-#: lxc/network_acl.go:364 lxc/network_acl.go:461 lxc/network_acl.go:549
-#: lxc/network_acl.go:592 lxc/network_acl.go:731 lxc/network_acl.go:788
-#: lxc/network_acl.go:845 lxc/network_acl.go:860 lxc/network_acl.go:997
-#: lxc/network_allocations.go:51 lxc/network_forward.go:33
-#: lxc/network_forward.go:90 lxc/network_forward.go:179
-#: lxc/network_forward.go:256 lxc/network_forward.go:404
-#: lxc/network_forward.go:489 lxc/network_forward.go:599
-#: lxc/network_forward.go:646 lxc/network_forward.go:800
-#: lxc/network_forward.go:874 lxc/network_forward.go:889
-#: lxc/network_forward.go:970 lxc/network_load_balancer.go:33
-#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:181
-#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:408
-#: lxc/network_load_balancer.go:476 lxc/network_load_balancer.go:586
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:771
-#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:859
-#: lxc/network_load_balancer.go:935 lxc/network_load_balancer.go:1033
-#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1121
-#: lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:167
-#: lxc/network_peer.go:236 lxc/network_peer.go:360 lxc/network_peer.go:445
-#: lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731
-#: lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:165
-#: lxc/network_zone.go:228 lxc/network_zone.go:301 lxc/network_zone.go:396
-#: lxc/network_zone.go:484 lxc/network_zone.go:527 lxc/network_zone.go:654
-#: lxc/network_zone.go:710 lxc/network_zone.go:767 lxc/network_zone.go:845
-#: lxc/network_zone.go:909 lxc/network_zone.go:985 lxc/network_zone.go:1083
-#: lxc/network_zone.go:1172 lxc/network_zone.go:1219 lxc/network_zone.go:1349
-#: lxc/network_zone.go:1410 lxc/network_zone.go:1425 lxc/network_zone.go:1483
-#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
-#: lxc/operation.go:194 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
-#: lxc/profile.go:271 lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493
-#: lxc/profile.go:629 lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860
-#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31
-#: lxc/project.go:95 lxc/project.go:191 lxc/project.go:262 lxc/project.go:398
-#: lxc/project.go:472 lxc/project.go:592 lxc/project.go:657 lxc/project.go:745
-#: lxc/project.go:789 lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34
-#: lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91
-#: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853
-#: lxc/remote.go:917 lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24
-#: lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203
-#: lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655
-#: lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940
-#: lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189
-#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:383
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:536
-#: lxc/storage_bucket.go:630 lxc/storage_bucket.go:699
-#: lxc/storage_bucket.go:733 lxc/storage_bucket.go:774
-#: lxc/storage_bucket.go:853 lxc/storage_bucket.go:959
-#: lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158
-#: lxc/storage_volume.go:58 lxc/storage_volume.go:169 lxc/storage_volume.go:283
+#: lxc/export.go:32 lxc/file.go:88 lxc/file.go:135 lxc/file.go:313
+#: lxc/file.go:362 lxc/file.go:432 lxc/file.go:657 lxc/file.go:1176
+#: lxc/image.go:38 lxc/image.go:159 lxc/image.go:337 lxc/image.go:396
+#: lxc/image.go:525 lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090
+#: lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638
+#: lxc/image.go:1701 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255
+#: lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34
+#: lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233
+#: lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560
+#: lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1005
+#: lxc/network.go:1106 lxc/network.go:1185 lxc/network.go:1245
+#: lxc/network.go:1341 lxc/network.go:1413 lxc/network_acl.go:30
+#: lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235
+#: lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461
+#: lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731
+#: lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860
+#: lxc/network_acl.go:997 lxc/network_allocations.go:51
+#: lxc/network_forward.go:33 lxc/network_forward.go:90
+#: lxc/network_forward.go:179 lxc/network_forward.go:256
+#: lxc/network_forward.go:404 lxc/network_forward.go:489
+#: lxc/network_forward.go:599 lxc/network_forward.go:646
+#: lxc/network_forward.go:800 lxc/network_forward.go:874
+#: lxc/network_forward.go:889 lxc/network_forward.go:970
+#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
+#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844
+#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1121 lxc/network_peer.go:29
+#: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
+#: lxc/network_peer.go:360 lxc/network_peer.go:445 lxc/network_peer.go:547
+#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:29
+#: lxc/network_zone.go:86 lxc/network_zone.go:165 lxc/network_zone.go:228
+#: lxc/network_zone.go:301 lxc/network_zone.go:396 lxc/network_zone.go:484
+#: lxc/network_zone.go:527 lxc/network_zone.go:654 lxc/network_zone.go:710
+#: lxc/network_zone.go:767 lxc/network_zone.go:845 lxc/network_zone.go:909
+#: lxc/network_zone.go:985 lxc/network_zone.go:1083 lxc/network_zone.go:1172
+#: lxc/network_zone.go:1219 lxc/network_zone.go:1349 lxc/network_zone.go:1410
+#: lxc/network_zone.go:1425 lxc/network_zone.go:1483 lxc/operation.go:25
+#: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
+#: lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180 lxc/profile.go:271
+#: lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493 lxc/profile.go:629
+#: lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860 lxc/profile.go:920
+#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31 lxc/project.go:95
+#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
+#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
+#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:648
+#: lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853 lxc/remote.go:917
+#: lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
+#: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
+#: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:459
+#: lxc/storage_bucket.go:536 lxc/storage_bucket.go:630
+#: lxc/storage_bucket.go:699 lxc/storage_bucket.go:733
+#: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
+#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:283
 #: lxc/storage_volume.go:390 lxc/storage_volume.go:605
 #: lxc/storage_volume.go:714 lxc/storage_volume.go:801
 #: lxc/storage_volume.go:899 lxc/storage_volume.go:996
@@ -2053,7 +2063,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:995
+#: lxc/file.go:1184
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2119,7 +2129,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:75
+#: lxc/file.go:79
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -2137,7 +2147,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:172 lxc/file.go:173
+#: lxc/file.go:361 lxc/file.go:362
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2407,12 +2417,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1238
+#: lxc/file.go:1427
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1261
+#: lxc/file.go:1450
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2427,12 +2437,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1288
+#: lxc/file.go:1477
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1073
+#: lxc/file.go:1262
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2462,7 +2472,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1194
+#: lxc/file.go:1383
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2477,7 +2487,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1199
+#: lxc/file.go:1388
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2487,12 +2497,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1099
+#: lxc/file.go:1288
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1226
+#: lxc/file.go:1415
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2531,7 +2541,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1400
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2546,7 +2556,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:821
+#: lxc/file.go:1010
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2572,6 +2582,10 @@ msgstr ""
 
 #: lxc/cluster.go:1302
 msgid "Force a particular evacuation action"
+msgstr ""
+
+#: lxc/file.go:144
+msgid "Force creating files or directories"
 msgstr ""
 
 #: lxc/cluster.go:1301
@@ -2868,22 +2882,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1311
+#: lxc/file.go:1500
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1300
+#: lxc/file.go:1489
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1312
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1133
+#: lxc/file.go:1322
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -3076,11 +3090,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1125
+#: lxc/file.go:1314
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1302
+#: lxc/file.go:1491
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3098,7 +3112,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1045
+#: lxc/file.go:1234
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3150,7 +3164,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1040
+#: lxc/file.go:1229
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3192,7 +3206,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:148
+#: lxc/file.go:337
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -3208,14 +3222,19 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:314
+#: lxc/file.go:503
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:496
+#: lxc/file.go:177 lxc/file.go:685
 #, c-format
 msgid "Invalid target %s"
+msgstr ""
+
+#: lxc/file.go:163
+#, c-format
+msgid "Invalid type %q"
 msgstr ""
 
 #: lxc/info.go:238
@@ -3720,7 +3739,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:83 lxc/file.go:84
+#: lxc/file.go:87 lxc/file.go:88
 msgid "Manage files in instances"
 msgstr ""
 
@@ -4106,7 +4125,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:599
+#: lxc/file.go:788
 msgid "Missing target directory"
 msgstr ""
 
@@ -4144,11 +4163,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:286
+#: lxc/file.go:475
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:986 lxc/file.go:987
+#: lxc/file.go:1175 lxc/file.go:1176
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4600,7 +4619,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1103
+#: lxc/file.go:1292
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4834,20 +4853,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:242 lxc/file.go:243
+#: lxc/file.go:431 lxc/file.go:432
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:417 lxc/file.go:768
+#: lxc/file.go:606 lxc/file.go:957
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:467 lxc/file.go:468
+#: lxc/file.go:656 lxc/file.go:657
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:702 lxc/file.go:868
+#: lxc/file.go:891 lxc/file.go:1057
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4885,7 +4904,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:250 lxc/file.go:474
+#: lxc/file.go:439 lxc/file.go:663
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -5214,12 +5233,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1231
+#: lxc/file.go:1420
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1232
+#: lxc/file.go:1421
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5295,7 +5314,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:996
+#: lxc/file.go:1185
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5489,15 +5508,27 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:477
+#: lxc/file.go:145
+msgid "Set the file's gid on create"
+msgstr ""
+
+#: lxc/file.go:666
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:478
+#: lxc/file.go:147
+msgid "Set the file's perms on create"
+msgstr ""
+
+#: lxc/file.go:667
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:476
+#: lxc/file.go:146
+msgid "Set the file's uid on create"
+msgstr ""
+
+#: lxc/file.go:665
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5557,7 +5588,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:994
+#: lxc/file.go:1183
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5932,6 +5963,10 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
+#: lxc/file.go:167
+msgid "Symlink target path can only be used for type \"symlink\""
+msgstr ""
+
 #: lxc/alias.go:140
 msgid "TARGET"
 msgstr ""
@@ -5951,11 +5986,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1033
+#: lxc/file.go:1222
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1027
+#: lxc/file.go:1216
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -6124,6 +6159,10 @@ msgstr ""
 
 #: lxc/network.go:537 lxc/network.go:634
 msgid "The specified device doesn't match the network"
+msgstr ""
+
+#: lxc/file.go:148
+msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
 #: lxc/publish.go:97
@@ -6304,7 +6343,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:198
+#: lxc/file.go:387
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6318,7 +6357,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1254
+#: lxc/file.go:1443
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6334,7 +6373,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:808
+#: lxc/file.go:997
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6552,7 +6591,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:72
+#: lxc/file.go:76
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6901,20 +6940,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:171
+#: lxc/file.go:360
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:121
+#: lxc/file.go:133
+msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
+msgstr ""
+
+#: lxc/file.go:310
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:241
+#: lxc/file.go:430
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:985
+#: lxc/file.go:1174
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7423,20 +7466,28 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:989
+#: lxc/file.go:137
+msgid ""
+"lxc file create foo/bar\n"
+"\t   To create a file /bar in the foo instance.\n"
+"lxc file create --type=symlink foo/bar baz\n"
+"\t   To create a symlink /bar in instance foo whose target is baz."
+msgstr ""
+
+#: lxc/file.go:1178
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:245
+#: lxc/file.go:434
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:470
+#: lxc/file.go:659
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7785,16 +7836,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1143
+#: lxc/file.go:1332
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1102
+#: lxc/file.go:1291
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1055
+#: lxc/file.go:1244
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/pa.po
+++ b/po/pa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-30 13:36-0400\n"
+"POT-Creation-Date: 2024-10-01 10:45-0600\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Punjabi <https://hosted.weblate.org/projects/linux-containers/"
@@ -433,12 +433,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:936
+#: lxc/file.go:1125
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:826
+#: lxc/file.go:1015
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -527,7 +527,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:466
+#: lxc/file.go:655
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -982,7 +982,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:341
+#: lxc/file.go:530
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1011,7 +1011,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:547
+#: lxc/file.go:736
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1397,8 +1397,12 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:249 lxc/file.go:475
+#: lxc/file.go:143 lxc/file.go:438 lxc/file.go:664
 msgid "Create any directories necessary"
+msgstr ""
+
+#: lxc/file.go:134 lxc/file.go:135
+msgid "Create files and directories in instances"
 msgstr ""
 
 #: lxc/auth.go:98 lxc/auth.go:99
@@ -1495,6 +1499,11 @@ msgstr ""
 msgid "Creating %s"
 msgstr ""
 
+#: lxc/file.go:273
+#, c-format
+msgid "Creating %s: %%s"
+msgstr ""
+
 #: lxc/init.go:184
 msgid "Creating the instance"
 msgstr ""
@@ -1551,7 +1560,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:123 lxc/file.go:124
+#: lxc/file.go:312 lxc/file.go:313
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1668,70 +1677,71 @@ msgstr ""
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
-#: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
-#: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
-#: lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090 lxc/image.go:1417
-#: lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638 lxc/image.go:1701
-#: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
-#: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
-#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33
-#: lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405
-#: lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793
-#: lxc/network.go:874 lxc/network.go:1005 lxc/network.go:1106
-#: lxc/network.go:1185 lxc/network.go:1245 lxc/network.go:1341
-#: lxc/network.go:1413 lxc/network_acl.go:30 lxc/network_acl.go:95
-#: lxc/network_acl.go:174 lxc/network_acl.go:235 lxc/network_acl.go:291
-#: lxc/network_acl.go:364 lxc/network_acl.go:461 lxc/network_acl.go:549
-#: lxc/network_acl.go:592 lxc/network_acl.go:731 lxc/network_acl.go:788
-#: lxc/network_acl.go:845 lxc/network_acl.go:860 lxc/network_acl.go:997
-#: lxc/network_allocations.go:51 lxc/network_forward.go:33
-#: lxc/network_forward.go:90 lxc/network_forward.go:179
-#: lxc/network_forward.go:256 lxc/network_forward.go:404
-#: lxc/network_forward.go:489 lxc/network_forward.go:599
-#: lxc/network_forward.go:646 lxc/network_forward.go:800
-#: lxc/network_forward.go:874 lxc/network_forward.go:889
-#: lxc/network_forward.go:970 lxc/network_load_balancer.go:33
-#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:181
-#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:408
-#: lxc/network_load_balancer.go:476 lxc/network_load_balancer.go:586
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:771
-#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:859
-#: lxc/network_load_balancer.go:935 lxc/network_load_balancer.go:1033
-#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1121
-#: lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:167
-#: lxc/network_peer.go:236 lxc/network_peer.go:360 lxc/network_peer.go:445
-#: lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731
-#: lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:165
-#: lxc/network_zone.go:228 lxc/network_zone.go:301 lxc/network_zone.go:396
-#: lxc/network_zone.go:484 lxc/network_zone.go:527 lxc/network_zone.go:654
-#: lxc/network_zone.go:710 lxc/network_zone.go:767 lxc/network_zone.go:845
-#: lxc/network_zone.go:909 lxc/network_zone.go:985 lxc/network_zone.go:1083
-#: lxc/network_zone.go:1172 lxc/network_zone.go:1219 lxc/network_zone.go:1349
-#: lxc/network_zone.go:1410 lxc/network_zone.go:1425 lxc/network_zone.go:1483
-#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
-#: lxc/operation.go:194 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
-#: lxc/profile.go:271 lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493
-#: lxc/profile.go:629 lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860
-#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31
-#: lxc/project.go:95 lxc/project.go:191 lxc/project.go:262 lxc/project.go:398
-#: lxc/project.go:472 lxc/project.go:592 lxc/project.go:657 lxc/project.go:745
-#: lxc/project.go:789 lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34
-#: lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91
-#: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853
-#: lxc/remote.go:917 lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24
-#: lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203
-#: lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655
-#: lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940
-#: lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189
-#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:383
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:536
-#: lxc/storage_bucket.go:630 lxc/storage_bucket.go:699
-#: lxc/storage_bucket.go:733 lxc/storage_bucket.go:774
-#: lxc/storage_bucket.go:853 lxc/storage_bucket.go:959
-#: lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158
-#: lxc/storage_volume.go:58 lxc/storage_volume.go:169 lxc/storage_volume.go:283
+#: lxc/export.go:32 lxc/file.go:88 lxc/file.go:135 lxc/file.go:313
+#: lxc/file.go:362 lxc/file.go:432 lxc/file.go:657 lxc/file.go:1176
+#: lxc/image.go:38 lxc/image.go:159 lxc/image.go:337 lxc/image.go:396
+#: lxc/image.go:525 lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090
+#: lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638
+#: lxc/image.go:1701 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255
+#: lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34
+#: lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233
+#: lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560
+#: lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1005
+#: lxc/network.go:1106 lxc/network.go:1185 lxc/network.go:1245
+#: lxc/network.go:1341 lxc/network.go:1413 lxc/network_acl.go:30
+#: lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235
+#: lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461
+#: lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731
+#: lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860
+#: lxc/network_acl.go:997 lxc/network_allocations.go:51
+#: lxc/network_forward.go:33 lxc/network_forward.go:90
+#: lxc/network_forward.go:179 lxc/network_forward.go:256
+#: lxc/network_forward.go:404 lxc/network_forward.go:489
+#: lxc/network_forward.go:599 lxc/network_forward.go:646
+#: lxc/network_forward.go:800 lxc/network_forward.go:874
+#: lxc/network_forward.go:889 lxc/network_forward.go:970
+#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
+#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844
+#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1121 lxc/network_peer.go:29
+#: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
+#: lxc/network_peer.go:360 lxc/network_peer.go:445 lxc/network_peer.go:547
+#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:29
+#: lxc/network_zone.go:86 lxc/network_zone.go:165 lxc/network_zone.go:228
+#: lxc/network_zone.go:301 lxc/network_zone.go:396 lxc/network_zone.go:484
+#: lxc/network_zone.go:527 lxc/network_zone.go:654 lxc/network_zone.go:710
+#: lxc/network_zone.go:767 lxc/network_zone.go:845 lxc/network_zone.go:909
+#: lxc/network_zone.go:985 lxc/network_zone.go:1083 lxc/network_zone.go:1172
+#: lxc/network_zone.go:1219 lxc/network_zone.go:1349 lxc/network_zone.go:1410
+#: lxc/network_zone.go:1425 lxc/network_zone.go:1483 lxc/operation.go:25
+#: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
+#: lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180 lxc/profile.go:271
+#: lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493 lxc/profile.go:629
+#: lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860 lxc/profile.go:920
+#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31 lxc/project.go:95
+#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
+#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
+#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:648
+#: lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853 lxc/remote.go:917
+#: lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
+#: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
+#: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:459
+#: lxc/storage_bucket.go:536 lxc/storage_bucket.go:630
+#: lxc/storage_bucket.go:699 lxc/storage_bucket.go:733
+#: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
+#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:283
 #: lxc/storage_volume.go:390 lxc/storage_volume.go:605
 #: lxc/storage_volume.go:714 lxc/storage_volume.go:801
 #: lxc/storage_volume.go:899 lxc/storage_volume.go:996
@@ -1829,7 +1839,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:995
+#: lxc/file.go:1184
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1895,7 +1905,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:75
+#: lxc/file.go:79
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1913,7 +1923,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:172 lxc/file.go:173
+#: lxc/file.go:361 lxc/file.go:362
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2183,12 +2193,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1238
+#: lxc/file.go:1427
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1261
+#: lxc/file.go:1450
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2203,12 +2213,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1288
+#: lxc/file.go:1477
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1073
+#: lxc/file.go:1262
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2238,7 +2248,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1194
+#: lxc/file.go:1383
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2253,7 +2263,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1199
+#: lxc/file.go:1388
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2263,12 +2273,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1099
+#: lxc/file.go:1288
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1226
+#: lxc/file.go:1415
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2307,7 +2317,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1400
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2322,7 +2332,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:821
+#: lxc/file.go:1010
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2348,6 +2358,10 @@ msgstr ""
 
 #: lxc/cluster.go:1302
 msgid "Force a particular evacuation action"
+msgstr ""
+
+#: lxc/file.go:144
+msgid "Force creating files or directories"
 msgstr ""
 
 #: lxc/cluster.go:1301
@@ -2644,22 +2658,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1311
+#: lxc/file.go:1500
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1300
+#: lxc/file.go:1489
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1312
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1133
+#: lxc/file.go:1322
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2852,11 +2866,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1125
+#: lxc/file.go:1314
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1302
+#: lxc/file.go:1491
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2874,7 +2888,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1045
+#: lxc/file.go:1234
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2926,7 +2940,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1040
+#: lxc/file.go:1229
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2968,7 +2982,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:148
+#: lxc/file.go:337
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2984,14 +2998,19 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:314
+#: lxc/file.go:503
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:496
+#: lxc/file.go:177 lxc/file.go:685
 #, c-format
 msgid "Invalid target %s"
+msgstr ""
+
+#: lxc/file.go:163
+#, c-format
+msgid "Invalid type %q"
 msgstr ""
 
 #: lxc/info.go:238
@@ -3496,7 +3515,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:83 lxc/file.go:84
+#: lxc/file.go:87 lxc/file.go:88
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3882,7 +3901,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:599
+#: lxc/file.go:788
 msgid "Missing target directory"
 msgstr ""
 
@@ -3920,11 +3939,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:286
+#: lxc/file.go:475
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:986 lxc/file.go:987
+#: lxc/file.go:1175 lxc/file.go:1176
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4376,7 +4395,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1103
+#: lxc/file.go:1292
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4610,20 +4629,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:242 lxc/file.go:243
+#: lxc/file.go:431 lxc/file.go:432
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:417 lxc/file.go:768
+#: lxc/file.go:606 lxc/file.go:957
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:467 lxc/file.go:468
+#: lxc/file.go:656 lxc/file.go:657
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:702 lxc/file.go:868
+#: lxc/file.go:891 lxc/file.go:1057
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4661,7 +4680,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:250 lxc/file.go:474
+#: lxc/file.go:439 lxc/file.go:663
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4990,12 +5009,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1231
+#: lxc/file.go:1420
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1232
+#: lxc/file.go:1421
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5071,7 +5090,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:996
+#: lxc/file.go:1185
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5265,15 +5284,27 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:477
+#: lxc/file.go:145
+msgid "Set the file's gid on create"
+msgstr ""
+
+#: lxc/file.go:666
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:478
+#: lxc/file.go:147
+msgid "Set the file's perms on create"
+msgstr ""
+
+#: lxc/file.go:667
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:476
+#: lxc/file.go:146
+msgid "Set the file's uid on create"
+msgstr ""
+
+#: lxc/file.go:665
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5333,7 +5364,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:994
+#: lxc/file.go:1183
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5708,6 +5739,10 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
+#: lxc/file.go:167
+msgid "Symlink target path can only be used for type \"symlink\""
+msgstr ""
+
 #: lxc/alias.go:140
 msgid "TARGET"
 msgstr ""
@@ -5727,11 +5762,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1033
+#: lxc/file.go:1222
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1027
+#: lxc/file.go:1216
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5900,6 +5935,10 @@ msgstr ""
 
 #: lxc/network.go:537 lxc/network.go:634
 msgid "The specified device doesn't match the network"
+msgstr ""
+
+#: lxc/file.go:148
+msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
 #: lxc/publish.go:97
@@ -6080,7 +6119,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:198
+#: lxc/file.go:387
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6094,7 +6133,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1254
+#: lxc/file.go:1443
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6110,7 +6149,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:808
+#: lxc/file.go:997
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6328,7 +6367,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:72
+#: lxc/file.go:76
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6677,20 +6716,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:171
+#: lxc/file.go:360
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:121
+#: lxc/file.go:133
+msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
+msgstr ""
+
+#: lxc/file.go:310
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:241
+#: lxc/file.go:430
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:985
+#: lxc/file.go:1174
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7199,20 +7242,28 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:989
+#: lxc/file.go:137
+msgid ""
+"lxc file create foo/bar\n"
+"\t   To create a file /bar in the foo instance.\n"
+"lxc file create --type=symlink foo/bar baz\n"
+"\t   To create a symlink /bar in instance foo whose target is baz."
+msgstr ""
+
+#: lxc/file.go:1178
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:245
+#: lxc/file.go:434
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:470
+#: lxc/file.go:659
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7561,16 +7612,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1143
+#: lxc/file.go:1332
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1102
+#: lxc/file.go:1291
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1055
+#: lxc/file.go:1244
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-30 13:36-0400\n"
+"POT-Creation-Date: 2024-10-01 10:45-0600\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/linux-containers/"
@@ -695,12 +695,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:936
+#: lxc/file.go:1125
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:826
+#: lxc/file.go:1015
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -789,7 +789,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:466
+#: lxc/file.go:655
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -1244,7 +1244,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:341
+#: lxc/file.go:530
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1273,7 +1273,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:547
+#: lxc/file.go:736
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1659,8 +1659,12 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:249 lxc/file.go:475
+#: lxc/file.go:143 lxc/file.go:438 lxc/file.go:664
 msgid "Create any directories necessary"
+msgstr ""
+
+#: lxc/file.go:134 lxc/file.go:135
+msgid "Create files and directories in instances"
 msgstr ""
 
 #: lxc/auth.go:98 lxc/auth.go:99
@@ -1757,6 +1761,11 @@ msgstr ""
 msgid "Creating %s"
 msgstr ""
 
+#: lxc/file.go:273
+#, c-format
+msgid "Creating %s: %%s"
+msgstr ""
+
 #: lxc/init.go:184
 msgid "Creating the instance"
 msgstr ""
@@ -1813,7 +1822,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:123 lxc/file.go:124
+#: lxc/file.go:312 lxc/file.go:313
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1930,70 +1939,71 @@ msgstr ""
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
-#: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
-#: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
-#: lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090 lxc/image.go:1417
-#: lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638 lxc/image.go:1701
-#: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
-#: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
-#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33
-#: lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405
-#: lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793
-#: lxc/network.go:874 lxc/network.go:1005 lxc/network.go:1106
-#: lxc/network.go:1185 lxc/network.go:1245 lxc/network.go:1341
-#: lxc/network.go:1413 lxc/network_acl.go:30 lxc/network_acl.go:95
-#: lxc/network_acl.go:174 lxc/network_acl.go:235 lxc/network_acl.go:291
-#: lxc/network_acl.go:364 lxc/network_acl.go:461 lxc/network_acl.go:549
-#: lxc/network_acl.go:592 lxc/network_acl.go:731 lxc/network_acl.go:788
-#: lxc/network_acl.go:845 lxc/network_acl.go:860 lxc/network_acl.go:997
-#: lxc/network_allocations.go:51 lxc/network_forward.go:33
-#: lxc/network_forward.go:90 lxc/network_forward.go:179
-#: lxc/network_forward.go:256 lxc/network_forward.go:404
-#: lxc/network_forward.go:489 lxc/network_forward.go:599
-#: lxc/network_forward.go:646 lxc/network_forward.go:800
-#: lxc/network_forward.go:874 lxc/network_forward.go:889
-#: lxc/network_forward.go:970 lxc/network_load_balancer.go:33
-#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:181
-#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:408
-#: lxc/network_load_balancer.go:476 lxc/network_load_balancer.go:586
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:771
-#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:859
-#: lxc/network_load_balancer.go:935 lxc/network_load_balancer.go:1033
-#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1121
-#: lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:167
-#: lxc/network_peer.go:236 lxc/network_peer.go:360 lxc/network_peer.go:445
-#: lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731
-#: lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:165
-#: lxc/network_zone.go:228 lxc/network_zone.go:301 lxc/network_zone.go:396
-#: lxc/network_zone.go:484 lxc/network_zone.go:527 lxc/network_zone.go:654
-#: lxc/network_zone.go:710 lxc/network_zone.go:767 lxc/network_zone.go:845
-#: lxc/network_zone.go:909 lxc/network_zone.go:985 lxc/network_zone.go:1083
-#: lxc/network_zone.go:1172 lxc/network_zone.go:1219 lxc/network_zone.go:1349
-#: lxc/network_zone.go:1410 lxc/network_zone.go:1425 lxc/network_zone.go:1483
-#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
-#: lxc/operation.go:194 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
-#: lxc/profile.go:271 lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493
-#: lxc/profile.go:629 lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860
-#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31
-#: lxc/project.go:95 lxc/project.go:191 lxc/project.go:262 lxc/project.go:398
-#: lxc/project.go:472 lxc/project.go:592 lxc/project.go:657 lxc/project.go:745
-#: lxc/project.go:789 lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34
-#: lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91
-#: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853
-#: lxc/remote.go:917 lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24
-#: lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203
-#: lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655
-#: lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940
-#: lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189
-#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:383
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:536
-#: lxc/storage_bucket.go:630 lxc/storage_bucket.go:699
-#: lxc/storage_bucket.go:733 lxc/storage_bucket.go:774
-#: lxc/storage_bucket.go:853 lxc/storage_bucket.go:959
-#: lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158
-#: lxc/storage_volume.go:58 lxc/storage_volume.go:169 lxc/storage_volume.go:283
+#: lxc/export.go:32 lxc/file.go:88 lxc/file.go:135 lxc/file.go:313
+#: lxc/file.go:362 lxc/file.go:432 lxc/file.go:657 lxc/file.go:1176
+#: lxc/image.go:38 lxc/image.go:159 lxc/image.go:337 lxc/image.go:396
+#: lxc/image.go:525 lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090
+#: lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638
+#: lxc/image.go:1701 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255
+#: lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34
+#: lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233
+#: lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560
+#: lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1005
+#: lxc/network.go:1106 lxc/network.go:1185 lxc/network.go:1245
+#: lxc/network.go:1341 lxc/network.go:1413 lxc/network_acl.go:30
+#: lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235
+#: lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461
+#: lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731
+#: lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860
+#: lxc/network_acl.go:997 lxc/network_allocations.go:51
+#: lxc/network_forward.go:33 lxc/network_forward.go:90
+#: lxc/network_forward.go:179 lxc/network_forward.go:256
+#: lxc/network_forward.go:404 lxc/network_forward.go:489
+#: lxc/network_forward.go:599 lxc/network_forward.go:646
+#: lxc/network_forward.go:800 lxc/network_forward.go:874
+#: lxc/network_forward.go:889 lxc/network_forward.go:970
+#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
+#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844
+#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1121 lxc/network_peer.go:29
+#: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
+#: lxc/network_peer.go:360 lxc/network_peer.go:445 lxc/network_peer.go:547
+#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:29
+#: lxc/network_zone.go:86 lxc/network_zone.go:165 lxc/network_zone.go:228
+#: lxc/network_zone.go:301 lxc/network_zone.go:396 lxc/network_zone.go:484
+#: lxc/network_zone.go:527 lxc/network_zone.go:654 lxc/network_zone.go:710
+#: lxc/network_zone.go:767 lxc/network_zone.go:845 lxc/network_zone.go:909
+#: lxc/network_zone.go:985 lxc/network_zone.go:1083 lxc/network_zone.go:1172
+#: lxc/network_zone.go:1219 lxc/network_zone.go:1349 lxc/network_zone.go:1410
+#: lxc/network_zone.go:1425 lxc/network_zone.go:1483 lxc/operation.go:25
+#: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
+#: lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180 lxc/profile.go:271
+#: lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493 lxc/profile.go:629
+#: lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860 lxc/profile.go:920
+#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31 lxc/project.go:95
+#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
+#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
+#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:648
+#: lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853 lxc/remote.go:917
+#: lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
+#: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
+#: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:459
+#: lxc/storage_bucket.go:536 lxc/storage_bucket.go:630
+#: lxc/storage_bucket.go:699 lxc/storage_bucket.go:733
+#: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
+#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:283
 #: lxc/storage_volume.go:390 lxc/storage_volume.go:605
 #: lxc/storage_volume.go:714 lxc/storage_volume.go:801
 #: lxc/storage_volume.go:899 lxc/storage_volume.go:996
@@ -2091,7 +2101,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:995
+#: lxc/file.go:1184
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2157,7 +2167,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:75
+#: lxc/file.go:79
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -2175,7 +2185,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:172 lxc/file.go:173
+#: lxc/file.go:361 lxc/file.go:362
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2445,12 +2455,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1238
+#: lxc/file.go:1427
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1261
+#: lxc/file.go:1450
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2465,12 +2475,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1288
+#: lxc/file.go:1477
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1073
+#: lxc/file.go:1262
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2500,7 +2510,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1194
+#: lxc/file.go:1383
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2515,7 +2525,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1199
+#: lxc/file.go:1388
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2525,12 +2535,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1099
+#: lxc/file.go:1288
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1226
+#: lxc/file.go:1415
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2569,7 +2579,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1400
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2584,7 +2594,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:821
+#: lxc/file.go:1010
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2610,6 +2620,10 @@ msgstr ""
 
 #: lxc/cluster.go:1302
 msgid "Force a particular evacuation action"
+msgstr ""
+
+#: lxc/file.go:144
+msgid "Force creating files or directories"
 msgstr ""
 
 #: lxc/cluster.go:1301
@@ -2906,22 +2920,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1311
+#: lxc/file.go:1500
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1300
+#: lxc/file.go:1489
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1312
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1133
+#: lxc/file.go:1322
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -3114,11 +3128,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1125
+#: lxc/file.go:1314
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1302
+#: lxc/file.go:1491
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3136,7 +3150,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1045
+#: lxc/file.go:1234
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3188,7 +3202,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1040
+#: lxc/file.go:1229
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3230,7 +3244,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:148
+#: lxc/file.go:337
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -3246,14 +3260,19 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:314
+#: lxc/file.go:503
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:496
+#: lxc/file.go:177 lxc/file.go:685
 #, c-format
 msgid "Invalid target %s"
+msgstr ""
+
+#: lxc/file.go:163
+#, c-format
+msgid "Invalid type %q"
 msgstr ""
 
 #: lxc/info.go:238
@@ -3758,7 +3777,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:83 lxc/file.go:84
+#: lxc/file.go:87 lxc/file.go:88
 msgid "Manage files in instances"
 msgstr ""
 
@@ -4144,7 +4163,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:599
+#: lxc/file.go:788
 msgid "Missing target directory"
 msgstr ""
 
@@ -4182,11 +4201,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:286
+#: lxc/file.go:475
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:986 lxc/file.go:987
+#: lxc/file.go:1175 lxc/file.go:1176
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4638,7 +4657,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1103
+#: lxc/file.go:1292
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4872,20 +4891,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:242 lxc/file.go:243
+#: lxc/file.go:431 lxc/file.go:432
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:417 lxc/file.go:768
+#: lxc/file.go:606 lxc/file.go:957
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:467 lxc/file.go:468
+#: lxc/file.go:656 lxc/file.go:657
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:702 lxc/file.go:868
+#: lxc/file.go:891 lxc/file.go:1057
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4923,7 +4942,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:250 lxc/file.go:474
+#: lxc/file.go:439 lxc/file.go:663
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -5252,12 +5271,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1231
+#: lxc/file.go:1420
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1232
+#: lxc/file.go:1421
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5333,7 +5352,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:996
+#: lxc/file.go:1185
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5527,15 +5546,27 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:477
+#: lxc/file.go:145
+msgid "Set the file's gid on create"
+msgstr ""
+
+#: lxc/file.go:666
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:478
+#: lxc/file.go:147
+msgid "Set the file's perms on create"
+msgstr ""
+
+#: lxc/file.go:667
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:476
+#: lxc/file.go:146
+msgid "Set the file's uid on create"
+msgstr ""
+
+#: lxc/file.go:665
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5595,7 +5626,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:994
+#: lxc/file.go:1183
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5970,6 +6001,10 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
+#: lxc/file.go:167
+msgid "Symlink target path can only be used for type \"symlink\""
+msgstr ""
+
 #: lxc/alias.go:140
 msgid "TARGET"
 msgstr ""
@@ -5989,11 +6024,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1033
+#: lxc/file.go:1222
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1027
+#: lxc/file.go:1216
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -6162,6 +6197,10 @@ msgstr ""
 
 #: lxc/network.go:537 lxc/network.go:634
 msgid "The specified device doesn't match the network"
+msgstr ""
+
+#: lxc/file.go:148
+msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
 #: lxc/publish.go:97
@@ -6342,7 +6381,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:198
+#: lxc/file.go:387
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6356,7 +6395,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1254
+#: lxc/file.go:1443
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6372,7 +6411,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:808
+#: lxc/file.go:997
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6590,7 +6629,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:72
+#: lxc/file.go:76
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6939,20 +6978,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:171
+#: lxc/file.go:360
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:121
+#: lxc/file.go:133
+msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
+msgstr ""
+
+#: lxc/file.go:310
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:241
+#: lxc/file.go:430
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:985
+#: lxc/file.go:1174
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7461,20 +7504,28 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:989
+#: lxc/file.go:137
+msgid ""
+"lxc file create foo/bar\n"
+"\t   To create a file /bar in the foo instance.\n"
+"lxc file create --type=symlink foo/bar baz\n"
+"\t   To create a symlink /bar in instance foo whose target is baz."
+msgstr ""
+
+#: lxc/file.go:1178
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:245
+#: lxc/file.go:434
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:470
+#: lxc/file.go:659
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7823,16 +7874,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1143
+#: lxc/file.go:1332
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1102
+#: lxc/file.go:1291
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1055
+#: lxc/file.go:1244
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/pt.po
+++ b/po/pt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-30 13:36-0400\n"
+"POT-Creation-Date: 2024-10-01 10:45-0600\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -430,12 +430,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:936
+#: lxc/file.go:1125
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:826
+#: lxc/file.go:1015
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -524,7 +524,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:466
+#: lxc/file.go:655
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -979,7 +979,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:341
+#: lxc/file.go:530
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1008,7 +1008,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:547
+#: lxc/file.go:736
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1394,8 +1394,12 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:249 lxc/file.go:475
+#: lxc/file.go:143 lxc/file.go:438 lxc/file.go:664
 msgid "Create any directories necessary"
+msgstr ""
+
+#: lxc/file.go:134 lxc/file.go:135
+msgid "Create files and directories in instances"
 msgstr ""
 
 #: lxc/auth.go:98 lxc/auth.go:99
@@ -1492,6 +1496,11 @@ msgstr ""
 msgid "Creating %s"
 msgstr ""
 
+#: lxc/file.go:273
+#, c-format
+msgid "Creating %s: %%s"
+msgstr ""
+
 #: lxc/init.go:184
 msgid "Creating the instance"
 msgstr ""
@@ -1548,7 +1557,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:123 lxc/file.go:124
+#: lxc/file.go:312 lxc/file.go:313
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1665,70 +1674,71 @@ msgstr ""
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
-#: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
-#: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
-#: lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090 lxc/image.go:1417
-#: lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638 lxc/image.go:1701
-#: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
-#: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
-#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33
-#: lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405
-#: lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793
-#: lxc/network.go:874 lxc/network.go:1005 lxc/network.go:1106
-#: lxc/network.go:1185 lxc/network.go:1245 lxc/network.go:1341
-#: lxc/network.go:1413 lxc/network_acl.go:30 lxc/network_acl.go:95
-#: lxc/network_acl.go:174 lxc/network_acl.go:235 lxc/network_acl.go:291
-#: lxc/network_acl.go:364 lxc/network_acl.go:461 lxc/network_acl.go:549
-#: lxc/network_acl.go:592 lxc/network_acl.go:731 lxc/network_acl.go:788
-#: lxc/network_acl.go:845 lxc/network_acl.go:860 lxc/network_acl.go:997
-#: lxc/network_allocations.go:51 lxc/network_forward.go:33
-#: lxc/network_forward.go:90 lxc/network_forward.go:179
-#: lxc/network_forward.go:256 lxc/network_forward.go:404
-#: lxc/network_forward.go:489 lxc/network_forward.go:599
-#: lxc/network_forward.go:646 lxc/network_forward.go:800
-#: lxc/network_forward.go:874 lxc/network_forward.go:889
-#: lxc/network_forward.go:970 lxc/network_load_balancer.go:33
-#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:181
-#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:408
-#: lxc/network_load_balancer.go:476 lxc/network_load_balancer.go:586
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:771
-#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:859
-#: lxc/network_load_balancer.go:935 lxc/network_load_balancer.go:1033
-#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1121
-#: lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:167
-#: lxc/network_peer.go:236 lxc/network_peer.go:360 lxc/network_peer.go:445
-#: lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731
-#: lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:165
-#: lxc/network_zone.go:228 lxc/network_zone.go:301 lxc/network_zone.go:396
-#: lxc/network_zone.go:484 lxc/network_zone.go:527 lxc/network_zone.go:654
-#: lxc/network_zone.go:710 lxc/network_zone.go:767 lxc/network_zone.go:845
-#: lxc/network_zone.go:909 lxc/network_zone.go:985 lxc/network_zone.go:1083
-#: lxc/network_zone.go:1172 lxc/network_zone.go:1219 lxc/network_zone.go:1349
-#: lxc/network_zone.go:1410 lxc/network_zone.go:1425 lxc/network_zone.go:1483
-#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
-#: lxc/operation.go:194 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
-#: lxc/profile.go:271 lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493
-#: lxc/profile.go:629 lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860
-#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31
-#: lxc/project.go:95 lxc/project.go:191 lxc/project.go:262 lxc/project.go:398
-#: lxc/project.go:472 lxc/project.go:592 lxc/project.go:657 lxc/project.go:745
-#: lxc/project.go:789 lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34
-#: lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91
-#: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853
-#: lxc/remote.go:917 lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24
-#: lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203
-#: lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655
-#: lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940
-#: lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189
-#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:383
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:536
-#: lxc/storage_bucket.go:630 lxc/storage_bucket.go:699
-#: lxc/storage_bucket.go:733 lxc/storage_bucket.go:774
-#: lxc/storage_bucket.go:853 lxc/storage_bucket.go:959
-#: lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158
-#: lxc/storage_volume.go:58 lxc/storage_volume.go:169 lxc/storage_volume.go:283
+#: lxc/export.go:32 lxc/file.go:88 lxc/file.go:135 lxc/file.go:313
+#: lxc/file.go:362 lxc/file.go:432 lxc/file.go:657 lxc/file.go:1176
+#: lxc/image.go:38 lxc/image.go:159 lxc/image.go:337 lxc/image.go:396
+#: lxc/image.go:525 lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090
+#: lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638
+#: lxc/image.go:1701 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255
+#: lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34
+#: lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233
+#: lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560
+#: lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1005
+#: lxc/network.go:1106 lxc/network.go:1185 lxc/network.go:1245
+#: lxc/network.go:1341 lxc/network.go:1413 lxc/network_acl.go:30
+#: lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235
+#: lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461
+#: lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731
+#: lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860
+#: lxc/network_acl.go:997 lxc/network_allocations.go:51
+#: lxc/network_forward.go:33 lxc/network_forward.go:90
+#: lxc/network_forward.go:179 lxc/network_forward.go:256
+#: lxc/network_forward.go:404 lxc/network_forward.go:489
+#: lxc/network_forward.go:599 lxc/network_forward.go:646
+#: lxc/network_forward.go:800 lxc/network_forward.go:874
+#: lxc/network_forward.go:889 lxc/network_forward.go:970
+#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
+#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844
+#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1121 lxc/network_peer.go:29
+#: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
+#: lxc/network_peer.go:360 lxc/network_peer.go:445 lxc/network_peer.go:547
+#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:29
+#: lxc/network_zone.go:86 lxc/network_zone.go:165 lxc/network_zone.go:228
+#: lxc/network_zone.go:301 lxc/network_zone.go:396 lxc/network_zone.go:484
+#: lxc/network_zone.go:527 lxc/network_zone.go:654 lxc/network_zone.go:710
+#: lxc/network_zone.go:767 lxc/network_zone.go:845 lxc/network_zone.go:909
+#: lxc/network_zone.go:985 lxc/network_zone.go:1083 lxc/network_zone.go:1172
+#: lxc/network_zone.go:1219 lxc/network_zone.go:1349 lxc/network_zone.go:1410
+#: lxc/network_zone.go:1425 lxc/network_zone.go:1483 lxc/operation.go:25
+#: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
+#: lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180 lxc/profile.go:271
+#: lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493 lxc/profile.go:629
+#: lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860 lxc/profile.go:920
+#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31 lxc/project.go:95
+#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
+#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
+#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:648
+#: lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853 lxc/remote.go:917
+#: lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
+#: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
+#: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:459
+#: lxc/storage_bucket.go:536 lxc/storage_bucket.go:630
+#: lxc/storage_bucket.go:699 lxc/storage_bucket.go:733
+#: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
+#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:283
 #: lxc/storage_volume.go:390 lxc/storage_volume.go:605
 #: lxc/storage_volume.go:714 lxc/storage_volume.go:801
 #: lxc/storage_volume.go:899 lxc/storage_volume.go:996
@@ -1826,7 +1836,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:995
+#: lxc/file.go:1184
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1892,7 +1902,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:75
+#: lxc/file.go:79
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1910,7 +1920,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:172 lxc/file.go:173
+#: lxc/file.go:361 lxc/file.go:362
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2180,12 +2190,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1238
+#: lxc/file.go:1427
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1261
+#: lxc/file.go:1450
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2200,12 +2210,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1288
+#: lxc/file.go:1477
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1073
+#: lxc/file.go:1262
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2235,7 +2245,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1194
+#: lxc/file.go:1383
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2250,7 +2260,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1199
+#: lxc/file.go:1388
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2260,12 +2270,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1099
+#: lxc/file.go:1288
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1226
+#: lxc/file.go:1415
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2304,7 +2314,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1400
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2319,7 +2329,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:821
+#: lxc/file.go:1010
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2345,6 +2355,10 @@ msgstr ""
 
 #: lxc/cluster.go:1302
 msgid "Force a particular evacuation action"
+msgstr ""
+
+#: lxc/file.go:144
+msgid "Force creating files or directories"
 msgstr ""
 
 #: lxc/cluster.go:1301
@@ -2641,22 +2655,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1311
+#: lxc/file.go:1500
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1300
+#: lxc/file.go:1489
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1312
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1133
+#: lxc/file.go:1322
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2849,11 +2863,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1125
+#: lxc/file.go:1314
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1302
+#: lxc/file.go:1491
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2871,7 +2885,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1045
+#: lxc/file.go:1234
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2923,7 +2937,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1040
+#: lxc/file.go:1229
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2965,7 +2979,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:148
+#: lxc/file.go:337
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2981,14 +2995,19 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:314
+#: lxc/file.go:503
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:496
+#: lxc/file.go:177 lxc/file.go:685
 #, c-format
 msgid "Invalid target %s"
+msgstr ""
+
+#: lxc/file.go:163
+#, c-format
+msgid "Invalid type %q"
 msgstr ""
 
 #: lxc/info.go:238
@@ -3493,7 +3512,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:83 lxc/file.go:84
+#: lxc/file.go:87 lxc/file.go:88
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3879,7 +3898,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:599
+#: lxc/file.go:788
 msgid "Missing target directory"
 msgstr ""
 
@@ -3917,11 +3936,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:286
+#: lxc/file.go:475
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:986 lxc/file.go:987
+#: lxc/file.go:1175 lxc/file.go:1176
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4373,7 +4392,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1103
+#: lxc/file.go:1292
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4607,20 +4626,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:242 lxc/file.go:243
+#: lxc/file.go:431 lxc/file.go:432
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:417 lxc/file.go:768
+#: lxc/file.go:606 lxc/file.go:957
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:467 lxc/file.go:468
+#: lxc/file.go:656 lxc/file.go:657
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:702 lxc/file.go:868
+#: lxc/file.go:891 lxc/file.go:1057
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4658,7 +4677,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:250 lxc/file.go:474
+#: lxc/file.go:439 lxc/file.go:663
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4987,12 +5006,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1231
+#: lxc/file.go:1420
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1232
+#: lxc/file.go:1421
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5068,7 +5087,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:996
+#: lxc/file.go:1185
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5262,15 +5281,27 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:477
+#: lxc/file.go:145
+msgid "Set the file's gid on create"
+msgstr ""
+
+#: lxc/file.go:666
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:478
+#: lxc/file.go:147
+msgid "Set the file's perms on create"
+msgstr ""
+
+#: lxc/file.go:667
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:476
+#: lxc/file.go:146
+msgid "Set the file's uid on create"
+msgstr ""
+
+#: lxc/file.go:665
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5330,7 +5361,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:994
+#: lxc/file.go:1183
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5705,6 +5736,10 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
+#: lxc/file.go:167
+msgid "Symlink target path can only be used for type \"symlink\""
+msgstr ""
+
 #: lxc/alias.go:140
 msgid "TARGET"
 msgstr ""
@@ -5724,11 +5759,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1033
+#: lxc/file.go:1222
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1027
+#: lxc/file.go:1216
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5897,6 +5932,10 @@ msgstr ""
 
 #: lxc/network.go:537 lxc/network.go:634
 msgid "The specified device doesn't match the network"
+msgstr ""
+
+#: lxc/file.go:148
+msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
 #: lxc/publish.go:97
@@ -6077,7 +6116,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:198
+#: lxc/file.go:387
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6091,7 +6130,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1254
+#: lxc/file.go:1443
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6107,7 +6146,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:808
+#: lxc/file.go:997
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6325,7 +6364,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:72
+#: lxc/file.go:76
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6674,20 +6713,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:171
+#: lxc/file.go:360
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:121
+#: lxc/file.go:133
+msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
+msgstr ""
+
+#: lxc/file.go:310
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:241
+#: lxc/file.go:430
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:985
+#: lxc/file.go:1174
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7196,20 +7239,28 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:989
+#: lxc/file.go:137
+msgid ""
+"lxc file create foo/bar\n"
+"\t   To create a file /bar in the foo instance.\n"
+"lxc file create --type=symlink foo/bar baz\n"
+"\t   To create a symlink /bar in instance foo whose target is baz."
+msgstr ""
+
+#: lxc/file.go:1178
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:245
+#: lxc/file.go:434
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:470
+#: lxc/file.go:659
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7558,16 +7609,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1143
+#: lxc/file.go:1332
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1102
+#: lxc/file.go:1291
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1055
+#: lxc/file.go:1244
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-30 13:36-0400\n"
+"POT-Creation-Date: 2024-10-01 10:45-0600\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Renato dos Santos <renato.santos@wplex.com.br>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -681,12 +681,12 @@ msgstr "%s (%d mais)"
 msgid "%s (%s) (%d available)"
 msgstr "%s (%d mais)"
 
-#: lxc/file.go:936
+#: lxc/file.go:1125
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s não é um diretório"
 
-#: lxc/file.go:826
+#: lxc/file.go:1015
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' não é um tipo de arquivo suportado"
@@ -785,7 +785,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:466
+#: lxc/file.go:655
 #, fuzzy
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr "Editar templates de arquivo do container"
@@ -1259,7 +1259,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr "Não pode fornecer um nome para a imagem de destino"
 
-#: lxc/file.go:341
+#: lxc/file.go:530
 msgid "Can't pull a directory without --recursive"
 msgstr "Não pode pegar um diretório sem --recursive"
 
@@ -1289,7 +1289,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr "Não pode especificar a coluna L, quando não em cluster"
 
-#: lxc/file.go:547
+#: lxc/file.go:736
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr "Não é possível fornecer o uid/gid/modo no modo recursivo"
 
@@ -1689,9 +1689,14 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:249 lxc/file.go:475
+#: lxc/file.go:143 lxc/file.go:438 lxc/file.go:664
 msgid "Create any directories necessary"
 msgstr ""
+
+#: lxc/file.go:134 lxc/file.go:135
+#, fuzzy
+msgid "Create files and directories in instances"
+msgstr "Editar arquivos no container"
 
 #: lxc/auth.go:98 lxc/auth.go:99
 #, fuzzy
@@ -1802,6 +1807,11 @@ msgstr "Criado: %s"
 msgid "Creating %s"
 msgstr "Criando %s"
 
+#: lxc/file.go:273
+#, fuzzy, c-format
+msgid "Creating %s: %%s"
+msgstr "Criando %s"
+
 #: lxc/init.go:184
 #, fuzzy
 msgid "Creating the instance"
@@ -1861,7 +1871,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr "Apagar nomes alternativos da imagem"
 
-#: lxc/file.go:123 lxc/file.go:124
+#: lxc/file.go:312 lxc/file.go:313
 #, fuzzy
 msgid "Delete files in instances"
 msgstr "Editar arquivos no container"
@@ -1989,70 +1999,71 @@ msgstr ""
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
-#: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
-#: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
-#: lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090 lxc/image.go:1417
-#: lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638 lxc/image.go:1701
-#: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
-#: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
-#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33
-#: lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405
-#: lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793
-#: lxc/network.go:874 lxc/network.go:1005 lxc/network.go:1106
-#: lxc/network.go:1185 lxc/network.go:1245 lxc/network.go:1341
-#: lxc/network.go:1413 lxc/network_acl.go:30 lxc/network_acl.go:95
-#: lxc/network_acl.go:174 lxc/network_acl.go:235 lxc/network_acl.go:291
-#: lxc/network_acl.go:364 lxc/network_acl.go:461 lxc/network_acl.go:549
-#: lxc/network_acl.go:592 lxc/network_acl.go:731 lxc/network_acl.go:788
-#: lxc/network_acl.go:845 lxc/network_acl.go:860 lxc/network_acl.go:997
-#: lxc/network_allocations.go:51 lxc/network_forward.go:33
-#: lxc/network_forward.go:90 lxc/network_forward.go:179
-#: lxc/network_forward.go:256 lxc/network_forward.go:404
-#: lxc/network_forward.go:489 lxc/network_forward.go:599
-#: lxc/network_forward.go:646 lxc/network_forward.go:800
-#: lxc/network_forward.go:874 lxc/network_forward.go:889
-#: lxc/network_forward.go:970 lxc/network_load_balancer.go:33
-#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:181
-#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:408
-#: lxc/network_load_balancer.go:476 lxc/network_load_balancer.go:586
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:771
-#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:859
-#: lxc/network_load_balancer.go:935 lxc/network_load_balancer.go:1033
-#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1121
-#: lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:167
-#: lxc/network_peer.go:236 lxc/network_peer.go:360 lxc/network_peer.go:445
-#: lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731
-#: lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:165
-#: lxc/network_zone.go:228 lxc/network_zone.go:301 lxc/network_zone.go:396
-#: lxc/network_zone.go:484 lxc/network_zone.go:527 lxc/network_zone.go:654
-#: lxc/network_zone.go:710 lxc/network_zone.go:767 lxc/network_zone.go:845
-#: lxc/network_zone.go:909 lxc/network_zone.go:985 lxc/network_zone.go:1083
-#: lxc/network_zone.go:1172 lxc/network_zone.go:1219 lxc/network_zone.go:1349
-#: lxc/network_zone.go:1410 lxc/network_zone.go:1425 lxc/network_zone.go:1483
-#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
-#: lxc/operation.go:194 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
-#: lxc/profile.go:271 lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493
-#: lxc/profile.go:629 lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860
-#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31
-#: lxc/project.go:95 lxc/project.go:191 lxc/project.go:262 lxc/project.go:398
-#: lxc/project.go:472 lxc/project.go:592 lxc/project.go:657 lxc/project.go:745
-#: lxc/project.go:789 lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34
-#: lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91
-#: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853
-#: lxc/remote.go:917 lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24
-#: lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203
-#: lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655
-#: lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940
-#: lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189
-#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:383
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:536
-#: lxc/storage_bucket.go:630 lxc/storage_bucket.go:699
-#: lxc/storage_bucket.go:733 lxc/storage_bucket.go:774
-#: lxc/storage_bucket.go:853 lxc/storage_bucket.go:959
-#: lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158
-#: lxc/storage_volume.go:58 lxc/storage_volume.go:169 lxc/storage_volume.go:283
+#: lxc/export.go:32 lxc/file.go:88 lxc/file.go:135 lxc/file.go:313
+#: lxc/file.go:362 lxc/file.go:432 lxc/file.go:657 lxc/file.go:1176
+#: lxc/image.go:38 lxc/image.go:159 lxc/image.go:337 lxc/image.go:396
+#: lxc/image.go:525 lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090
+#: lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638
+#: lxc/image.go:1701 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255
+#: lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34
+#: lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233
+#: lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560
+#: lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1005
+#: lxc/network.go:1106 lxc/network.go:1185 lxc/network.go:1245
+#: lxc/network.go:1341 lxc/network.go:1413 lxc/network_acl.go:30
+#: lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235
+#: lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461
+#: lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731
+#: lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860
+#: lxc/network_acl.go:997 lxc/network_allocations.go:51
+#: lxc/network_forward.go:33 lxc/network_forward.go:90
+#: lxc/network_forward.go:179 lxc/network_forward.go:256
+#: lxc/network_forward.go:404 lxc/network_forward.go:489
+#: lxc/network_forward.go:599 lxc/network_forward.go:646
+#: lxc/network_forward.go:800 lxc/network_forward.go:874
+#: lxc/network_forward.go:889 lxc/network_forward.go:970
+#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
+#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844
+#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1121 lxc/network_peer.go:29
+#: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
+#: lxc/network_peer.go:360 lxc/network_peer.go:445 lxc/network_peer.go:547
+#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:29
+#: lxc/network_zone.go:86 lxc/network_zone.go:165 lxc/network_zone.go:228
+#: lxc/network_zone.go:301 lxc/network_zone.go:396 lxc/network_zone.go:484
+#: lxc/network_zone.go:527 lxc/network_zone.go:654 lxc/network_zone.go:710
+#: lxc/network_zone.go:767 lxc/network_zone.go:845 lxc/network_zone.go:909
+#: lxc/network_zone.go:985 lxc/network_zone.go:1083 lxc/network_zone.go:1172
+#: lxc/network_zone.go:1219 lxc/network_zone.go:1349 lxc/network_zone.go:1410
+#: lxc/network_zone.go:1425 lxc/network_zone.go:1483 lxc/operation.go:25
+#: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
+#: lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180 lxc/profile.go:271
+#: lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493 lxc/profile.go:629
+#: lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860 lxc/profile.go:920
+#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31 lxc/project.go:95
+#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
+#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
+#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:648
+#: lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853 lxc/remote.go:917
+#: lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
+#: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
+#: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:459
+#: lxc/storage_bucket.go:536 lxc/storage_bucket.go:630
+#: lxc/storage_bucket.go:699 lxc/storage_bucket.go:733
+#: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
+#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:283
 #: lxc/storage_volume.go:390 lxc/storage_volume.go:605
 #: lxc/storage_volume.go:714 lxc/storage_volume.go:801
 #: lxc/storage_volume.go:899 lxc/storage_volume.go:996
@@ -2154,7 +2165,7 @@ msgstr "A importação de diretório não está disponível nessa plataforma"
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:995
+#: lxc/file.go:1184
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2223,7 +2234,7 @@ msgstr "DATA DE VALIDADE"
 msgid "EXPIRY DATE"
 msgstr "DATA DE VALIDADE"
 
-#: lxc/file.go:75
+#: lxc/file.go:79
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -2243,7 +2254,7 @@ msgstr "Editar configurações de rede como YAML"
 msgid "Edit cluster member configurations as YAML"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: lxc/file.go:172 lxc/file.go:173
+#: lxc/file.go:361 lxc/file.go:362
 #, fuzzy
 msgid "Edit files in instances"
 msgstr "Editar arquivos no container"
@@ -2530,12 +2541,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1238
+#: lxc/file.go:1427
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1261
+#: lxc/file.go:1450
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2550,12 +2561,12 @@ msgstr "Nome de membro do cluster"
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "Nome de membro do cluster"
 
-#: lxc/file.go:1288
+#: lxc/file.go:1477
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1073
+#: lxc/file.go:1262
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "Nome de membro do cluster"
@@ -2585,7 +2596,7 @@ msgstr "Nome de membro do cluster"
 msgid "Failed fetching fingerprint %q: %w"
 msgstr "Nome de membro do cluster"
 
-#: lxc/file.go:1194
+#: lxc/file.go:1383
 #, fuzzy, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "Aceitar certificado"
@@ -2600,7 +2611,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr "Nome de membro do cluster"
 
-#: lxc/file.go:1199
+#: lxc/file.go:1388
 #, fuzzy, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "Aceitar certificado"
@@ -2610,12 +2621,12 @@ msgstr "Aceitar certificado"
 msgid "Failed starting command: %w"
 msgstr "Aceitar certificado"
 
-#: lxc/file.go:1099
+#: lxc/file.go:1288
 #, fuzzy, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "Aceitar certificado"
 
-#: lxc/file.go:1226
+#: lxc/file.go:1415
 #, fuzzy, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "Aceitar certificado"
@@ -2654,7 +2665,7 @@ msgstr "Aceitar certificado"
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1400
 #, fuzzy, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "Aceitar certificado"
@@ -2669,7 +2680,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr "Aceitar certificado"
 
-#: lxc/file.go:821
+#: lxc/file.go:1010
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2695,6 +2706,10 @@ msgstr ""
 
 #: lxc/cluster.go:1302
 msgid "Force a particular evacuation action"
+msgstr ""
+
+#: lxc/file.go:144
+msgid "Force creating files or directories"
 msgstr ""
 
 #: lxc/cluster.go:1301
@@ -3012,22 +3027,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1311
+#: lxc/file.go:1500
 #, fuzzy, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "Copiar a imagem: %s"
 
-#: lxc/file.go:1300
+#: lxc/file.go:1489
 #, fuzzy, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "Copiar a imagem: %s"
 
-#: lxc/file.go:1123
+#: lxc/file.go:1312
 #, fuzzy, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "Dispositivo %s adicionado a %s"
 
-#: lxc/file.go:1133
+#: lxc/file.go:1322
 #, fuzzy, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "Copiar a imagem: %s"
@@ -3222,11 +3237,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1125
+#: lxc/file.go:1314
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1302
+#: lxc/file.go:1491
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3244,7 +3259,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1045
+#: lxc/file.go:1234
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3296,7 +3311,7 @@ msgstr "Editar arquivos no container"
 msgid "Invalid instance name: %s"
 msgstr "Editar arquivos no container"
 
-#: lxc/file.go:1040
+#: lxc/file.go:1229
 #, fuzzy, c-format
 msgid "Invalid instance path: %q"
 msgstr "Editar arquivos no container"
@@ -3339,7 +3354,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:148
+#: lxc/file.go:337
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -3356,15 +3371,20 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr "Editar arquivos no container"
 
-#: lxc/file.go:314
+#: lxc/file.go:503
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:496
+#: lxc/file.go:177 lxc/file.go:685
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
+
+#: lxc/file.go:163
+#, fuzzy, c-format
+msgid "Invalid type %q"
+msgstr "Editar arquivos no container"
 
 #: lxc/info.go:238
 #, fuzzy, c-format
@@ -3881,7 +3901,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr "Editar arquivos no container"
 
-#: lxc/file.go:83 lxc/file.go:84
+#: lxc/file.go:87 lxc/file.go:88
 #, fuzzy
 msgid "Manage files in instances"
 msgstr "Editar arquivos no container"
@@ -4306,7 +4326,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr "Nome de membro do cluster"
 
-#: lxc/file.go:599
+#: lxc/file.go:788
 msgid "Missing target directory"
 msgstr ""
 
@@ -4345,11 +4365,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:286
+#: lxc/file.go:475
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:986 lxc/file.go:987
+#: lxc/file.go:1175 lxc/file.go:1176
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "Adicionar perfis aos containers"
@@ -4803,7 +4823,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1103
+#: lxc/file.go:1292
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -5042,21 +5062,21 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr "Editar arquivos no container"
 
-#: lxc/file.go:242 lxc/file.go:243
+#: lxc/file.go:431 lxc/file.go:432
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:417 lxc/file.go:768
+#: lxc/file.go:606 lxc/file.go:957
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:467 lxc/file.go:468
+#: lxc/file.go:656 lxc/file.go:657
 #, fuzzy
 msgid "Push files into instances"
 msgstr "Editar arquivos no container"
 
-#: lxc/file.go:702 lxc/file.go:868
+#: lxc/file.go:891 lxc/file.go:1057
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -5096,7 +5116,7 @@ msgstr "Editar arquivos no container"
 msgid "Rebuild instances"
 msgstr "Editar arquivos no container"
 
-#: lxc/file.go:250 lxc/file.go:474
+#: lxc/file.go:439 lxc/file.go:663
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -5452,12 +5472,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1231
+#: lxc/file.go:1420
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1232
+#: lxc/file.go:1421
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5535,7 +5555,7 @@ msgstr "Adicionar perfis aos containers"
 msgid "Set a cluster member's configuration keys"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: lxc/file.go:996
+#: lxc/file.go:1185
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5740,15 +5760,27 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:477
+#: lxc/file.go:145
+msgid "Set the file's gid on create"
+msgstr ""
+
+#: lxc/file.go:666
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:478
+#: lxc/file.go:147
+msgid "Set the file's perms on create"
+msgstr ""
+
+#: lxc/file.go:667
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:476
+#: lxc/file.go:146
+msgid "Set the file's uid on create"
+msgstr ""
+
+#: lxc/file.go:665
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5815,7 +5847,7 @@ msgstr "Desconectar volumes de armazenamento dos perfis"
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:994
+#: lxc/file.go:1183
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -6212,6 +6244,10 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
+#: lxc/file.go:167
+msgid "Symlink target path can only be used for type \"symlink\""
+msgstr ""
+
 #: lxc/alias.go:140
 msgid "TARGET"
 msgstr ""
@@ -6231,12 +6267,12 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1033
+#: lxc/file.go:1222
 #, fuzzy
 msgid "Target path and --listen flag cannot be used together"
 msgstr "--refresh só pode ser usado com containers"
 
-#: lxc/file.go:1027
+#: lxc/file.go:1216
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -6408,6 +6444,10 @@ msgstr ""
 
 #: lxc/network.go:537 lxc/network.go:634
 msgid "The specified device doesn't match the network"
+msgstr ""
+
+#: lxc/file.go:148
+msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
 #: lxc/publish.go:97
@@ -6591,7 +6631,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:198
+#: lxc/file.go:387
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6606,7 +6646,7 @@ msgstr "Adicionar novos servidores remoto"
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1254
+#: lxc/file.go:1443
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6622,7 +6662,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:808
+#: lxc/file.go:997
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6866,7 +6906,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:72
+#: lxc/file.go:76
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -7244,20 +7284,25 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:171
+#: lxc/file.go:360
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:121
+#: lxc/file.go:133
+#, fuzzy
+msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
+msgstr "Editar templates de arquivo do container"
+
+#: lxc/file.go:310
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:241
+#: lxc/file.go:430
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:985
+#: lxc/file.go:1174
 #, fuzzy
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr "Editar templates de arquivo do container"
@@ -7810,20 +7855,28 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:989
+#: lxc/file.go:137
+msgid ""
+"lxc file create foo/bar\n"
+"\t   To create a file /bar in the foo instance.\n"
+"lxc file create --type=symlink foo/bar baz\n"
+"\t   To create a symlink /bar in instance foo whose target is baz."
+msgstr ""
+
+#: lxc/file.go:1178
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:245
+#: lxc/file.go:434
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:470
+#: lxc/file.go:659
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -8172,16 +8225,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1143
+#: lxc/file.go:1332
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1102
+#: lxc/file.go:1291
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1055
+#: lxc/file.go:1244
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-30 13:36-0400\n"
+"POT-Creation-Date: 2024-10-01 10:45-0600\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Александр Киль <shorrey@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -690,12 +690,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:936
+#: lxc/file.go:1125
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:826
+#: lxc/file.go:1015
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -785,7 +785,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:466
+#: lxc/file.go:655
 #, fuzzy
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
@@ -1257,7 +1257,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:341
+#: lxc/file.go:530
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1286,7 +1286,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:547
+#: lxc/file.go:736
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1681,9 +1681,14 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:249 lxc/file.go:475
+#: lxc/file.go:143 lxc/file.go:438 lxc/file.go:664
 msgid "Create any directories necessary"
 msgstr ""
+
+#: lxc/file.go:134 lxc/file.go:135
+#, fuzzy
+msgid "Create files and directories in instances"
+msgstr "Невозможно добавить имя контейнера в список"
 
 #: lxc/auth.go:98 lxc/auth.go:99
 #, fuzzy
@@ -1794,6 +1799,11 @@ msgstr ""
 msgid "Creating %s"
 msgstr ""
 
+#: lxc/file.go:273
+#, c-format
+msgid "Creating %s: %%s"
+msgstr ""
+
 #: lxc/init.go:184
 #, fuzzy
 msgid "Creating the instance"
@@ -1851,7 +1861,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:123 lxc/file.go:124
+#: lxc/file.go:312 lxc/file.go:313
 #, fuzzy
 msgid "Delete files in instances"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -1978,70 +1988,71 @@ msgstr ""
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
-#: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
-#: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
-#: lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090 lxc/image.go:1417
-#: lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638 lxc/image.go:1701
-#: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
-#: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
-#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33
-#: lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405
-#: lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793
-#: lxc/network.go:874 lxc/network.go:1005 lxc/network.go:1106
-#: lxc/network.go:1185 lxc/network.go:1245 lxc/network.go:1341
-#: lxc/network.go:1413 lxc/network_acl.go:30 lxc/network_acl.go:95
-#: lxc/network_acl.go:174 lxc/network_acl.go:235 lxc/network_acl.go:291
-#: lxc/network_acl.go:364 lxc/network_acl.go:461 lxc/network_acl.go:549
-#: lxc/network_acl.go:592 lxc/network_acl.go:731 lxc/network_acl.go:788
-#: lxc/network_acl.go:845 lxc/network_acl.go:860 lxc/network_acl.go:997
-#: lxc/network_allocations.go:51 lxc/network_forward.go:33
-#: lxc/network_forward.go:90 lxc/network_forward.go:179
-#: lxc/network_forward.go:256 lxc/network_forward.go:404
-#: lxc/network_forward.go:489 lxc/network_forward.go:599
-#: lxc/network_forward.go:646 lxc/network_forward.go:800
-#: lxc/network_forward.go:874 lxc/network_forward.go:889
-#: lxc/network_forward.go:970 lxc/network_load_balancer.go:33
-#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:181
-#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:408
-#: lxc/network_load_balancer.go:476 lxc/network_load_balancer.go:586
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:771
-#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:859
-#: lxc/network_load_balancer.go:935 lxc/network_load_balancer.go:1033
-#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1121
-#: lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:167
-#: lxc/network_peer.go:236 lxc/network_peer.go:360 lxc/network_peer.go:445
-#: lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731
-#: lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:165
-#: lxc/network_zone.go:228 lxc/network_zone.go:301 lxc/network_zone.go:396
-#: lxc/network_zone.go:484 lxc/network_zone.go:527 lxc/network_zone.go:654
-#: lxc/network_zone.go:710 lxc/network_zone.go:767 lxc/network_zone.go:845
-#: lxc/network_zone.go:909 lxc/network_zone.go:985 lxc/network_zone.go:1083
-#: lxc/network_zone.go:1172 lxc/network_zone.go:1219 lxc/network_zone.go:1349
-#: lxc/network_zone.go:1410 lxc/network_zone.go:1425 lxc/network_zone.go:1483
-#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
-#: lxc/operation.go:194 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
-#: lxc/profile.go:271 lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493
-#: lxc/profile.go:629 lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860
-#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31
-#: lxc/project.go:95 lxc/project.go:191 lxc/project.go:262 lxc/project.go:398
-#: lxc/project.go:472 lxc/project.go:592 lxc/project.go:657 lxc/project.go:745
-#: lxc/project.go:789 lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34
-#: lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91
-#: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853
-#: lxc/remote.go:917 lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24
-#: lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203
-#: lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655
-#: lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940
-#: lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189
-#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:383
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:536
-#: lxc/storage_bucket.go:630 lxc/storage_bucket.go:699
-#: lxc/storage_bucket.go:733 lxc/storage_bucket.go:774
-#: lxc/storage_bucket.go:853 lxc/storage_bucket.go:959
-#: lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158
-#: lxc/storage_volume.go:58 lxc/storage_volume.go:169 lxc/storage_volume.go:283
+#: lxc/export.go:32 lxc/file.go:88 lxc/file.go:135 lxc/file.go:313
+#: lxc/file.go:362 lxc/file.go:432 lxc/file.go:657 lxc/file.go:1176
+#: lxc/image.go:38 lxc/image.go:159 lxc/image.go:337 lxc/image.go:396
+#: lxc/image.go:525 lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090
+#: lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638
+#: lxc/image.go:1701 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255
+#: lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34
+#: lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233
+#: lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560
+#: lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1005
+#: lxc/network.go:1106 lxc/network.go:1185 lxc/network.go:1245
+#: lxc/network.go:1341 lxc/network.go:1413 lxc/network_acl.go:30
+#: lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235
+#: lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461
+#: lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731
+#: lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860
+#: lxc/network_acl.go:997 lxc/network_allocations.go:51
+#: lxc/network_forward.go:33 lxc/network_forward.go:90
+#: lxc/network_forward.go:179 lxc/network_forward.go:256
+#: lxc/network_forward.go:404 lxc/network_forward.go:489
+#: lxc/network_forward.go:599 lxc/network_forward.go:646
+#: lxc/network_forward.go:800 lxc/network_forward.go:874
+#: lxc/network_forward.go:889 lxc/network_forward.go:970
+#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
+#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844
+#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1121 lxc/network_peer.go:29
+#: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
+#: lxc/network_peer.go:360 lxc/network_peer.go:445 lxc/network_peer.go:547
+#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:29
+#: lxc/network_zone.go:86 lxc/network_zone.go:165 lxc/network_zone.go:228
+#: lxc/network_zone.go:301 lxc/network_zone.go:396 lxc/network_zone.go:484
+#: lxc/network_zone.go:527 lxc/network_zone.go:654 lxc/network_zone.go:710
+#: lxc/network_zone.go:767 lxc/network_zone.go:845 lxc/network_zone.go:909
+#: lxc/network_zone.go:985 lxc/network_zone.go:1083 lxc/network_zone.go:1172
+#: lxc/network_zone.go:1219 lxc/network_zone.go:1349 lxc/network_zone.go:1410
+#: lxc/network_zone.go:1425 lxc/network_zone.go:1483 lxc/operation.go:25
+#: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
+#: lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180 lxc/profile.go:271
+#: lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493 lxc/profile.go:629
+#: lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860 lxc/profile.go:920
+#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31 lxc/project.go:95
+#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
+#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
+#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:648
+#: lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853 lxc/remote.go:917
+#: lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
+#: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
+#: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:459
+#: lxc/storage_bucket.go:536 lxc/storage_bucket.go:630
+#: lxc/storage_bucket.go:699 lxc/storage_bucket.go:733
+#: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
+#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:283
 #: lxc/storage_volume.go:390 lxc/storage_volume.go:605
 #: lxc/storage_volume.go:714 lxc/storage_volume.go:801
 #: lxc/storage_volume.go:899 lxc/storage_volume.go:996
@@ -2141,7 +2152,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:995
+#: lxc/file.go:1184
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2211,7 +2222,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:75
+#: lxc/file.go:79
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -2229,7 +2240,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:172 lxc/file.go:173
+#: lxc/file.go:361 lxc/file.go:362
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2517,12 +2528,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1238
+#: lxc/file.go:1427
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1261
+#: lxc/file.go:1450
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2537,12 +2548,12 @@ msgstr "Копирование образа: %s"
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "Копирование образа: %s"
 
-#: lxc/file.go:1288
+#: lxc/file.go:1477
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1073
+#: lxc/file.go:1262
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "Копирование образа: %s"
@@ -2572,7 +2583,7 @@ msgstr "Копирование образа: %s"
 msgid "Failed fetching fingerprint %q: %w"
 msgstr "Копирование образа: %s"
 
-#: lxc/file.go:1194
+#: lxc/file.go:1383
 #, fuzzy, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "Принять сертификат"
@@ -2587,7 +2598,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr "Копирование образа: %s"
 
-#: lxc/file.go:1199
+#: lxc/file.go:1388
 #, fuzzy, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "Принять сертификат"
@@ -2597,12 +2608,12 @@ msgstr "Принять сертификат"
 msgid "Failed starting command: %w"
 msgstr "Принять сертификат"
 
-#: lxc/file.go:1099
+#: lxc/file.go:1288
 #, fuzzy, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "Принять сертификат"
 
-#: lxc/file.go:1226
+#: lxc/file.go:1415
 #, fuzzy, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "Принять сертификат"
@@ -2641,7 +2652,7 @@ msgstr "Принять сертификат"
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1400
 #, fuzzy, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "Принять сертификат"
@@ -2656,7 +2667,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr "Принять сертификат"
 
-#: lxc/file.go:821
+#: lxc/file.go:1010
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2682,6 +2693,10 @@ msgstr ""
 
 #: lxc/cluster.go:1302
 msgid "Force a particular evacuation action"
+msgstr ""
+
+#: lxc/file.go:144
+msgid "Force creating files or directories"
 msgstr ""
 
 #: lxc/cluster.go:1301
@@ -2996,22 +3011,22 @@ msgstr "Псевдонимы:"
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1311
+#: lxc/file.go:1500
 #, fuzzy, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/file.go:1300
+#: lxc/file.go:1489
 #, fuzzy, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/file.go:1123
+#: lxc/file.go:1312
 #, fuzzy, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/file.go:1133
+#: lxc/file.go:1322
 #, fuzzy, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -3209,11 +3224,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr "Имя контейнера: %s"
 
-#: lxc/file.go:1125
+#: lxc/file.go:1314
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1302
+#: lxc/file.go:1491
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3233,7 +3248,7 @@ msgstr "Имя контейнера: %s"
 msgid "Instance name must be specified"
 msgstr "Имя контейнера: %s"
 
-#: lxc/file.go:1045
+#: lxc/file.go:1234
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3285,7 +3300,7 @@ msgstr "Имя контейнера: %s"
 msgid "Invalid instance name: %s"
 msgstr "Имя контейнера: %s"
 
-#: lxc/file.go:1040
+#: lxc/file.go:1229
 #, fuzzy, c-format
 msgid "Invalid instance path: %q"
 msgstr "Имя контейнера: %s"
@@ -3328,7 +3343,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:148
+#: lxc/file.go:337
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -3345,15 +3360,20 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr "Имя контейнера: %s"
 
-#: lxc/file.go:314
+#: lxc/file.go:503
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:496
+#: lxc/file.go:177 lxc/file.go:685
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
+
+#: lxc/file.go:163
+#, fuzzy, c-format
+msgid "Invalid type %q"
+msgstr "Имя контейнера: %s"
 
 #: lxc/info.go:238
 #, c-format
@@ -3880,7 +3900,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr "Копирование образа: %s"
 
-#: lxc/file.go:83 lxc/file.go:84
+#: lxc/file.go:87 lxc/file.go:88
 msgid "Manage files in instances"
 msgstr ""
 
@@ -4309,7 +4329,7 @@ msgstr "Копирование образа: %s"
 msgid "Missing storage pool name"
 msgstr "Копирование образа: %s"
 
-#: lxc/file.go:599
+#: lxc/file.go:788
 msgid "Missing target directory"
 msgstr ""
 
@@ -4348,11 +4368,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:286
+#: lxc/file.go:475
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:986 lxc/file.go:987
+#: lxc/file.go:1175 lxc/file.go:1176
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -4811,7 +4831,7 @@ msgstr "Авто-обновление: %s"
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1103
+#: lxc/file.go:1292
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -5045,20 +5065,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/file.go:242 lxc/file.go:243
+#: lxc/file.go:431 lxc/file.go:432
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:417 lxc/file.go:768
+#: lxc/file.go:606 lxc/file.go:957
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:467 lxc/file.go:468
+#: lxc/file.go:656 lxc/file.go:657
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:702 lxc/file.go:868
+#: lxc/file.go:891 lxc/file.go:1057
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -5098,7 +5118,7 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Rebuild instances"
 msgstr "Псевдонимы:"
 
-#: lxc/file.go:250 lxc/file.go:474
+#: lxc/file.go:439 lxc/file.go:663
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -5449,12 +5469,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1231
+#: lxc/file.go:1420
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1232
+#: lxc/file.go:1421
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5532,7 +5552,7 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Set a cluster member's configuration keys"
 msgstr "Копирование образа: %s"
 
-#: lxc/file.go:996
+#: lxc/file.go:1185
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5732,15 +5752,27 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:477
+#: lxc/file.go:145
+msgid "Set the file's gid on create"
+msgstr ""
+
+#: lxc/file.go:666
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:478
+#: lxc/file.go:147
+msgid "Set the file's perms on create"
+msgstr ""
+
+#: lxc/file.go:667
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:476
+#: lxc/file.go:146
+msgid "Set the file's uid on create"
+msgstr ""
+
+#: lxc/file.go:665
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5808,7 +5840,7 @@ msgstr "Копирование образа: %s"
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:994
+#: lxc/file.go:1183
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -6205,6 +6237,10 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
+#: lxc/file.go:167
+msgid "Symlink target path can only be used for type \"symlink\""
+msgstr ""
+
 #: lxc/alias.go:140
 msgid "TARGET"
 msgstr ""
@@ -6224,11 +6260,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1033
+#: lxc/file.go:1222
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1027
+#: lxc/file.go:1216
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -6397,6 +6433,10 @@ msgstr ""
 
 #: lxc/network.go:537 lxc/network.go:634
 msgid "The specified device doesn't match the network"
+msgstr ""
+
+#: lxc/file.go:148
+msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
 #: lxc/publish.go:97
@@ -6579,7 +6619,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:198
+#: lxc/file.go:387
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6593,7 +6633,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1254
+#: lxc/file.go:1443
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6609,7 +6649,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:808
+#: lxc/file.go:997
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6849,7 +6889,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:72
+#: lxc/file.go:76
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -7418,7 +7458,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/file.go:171
+#: lxc/file.go:360
 #, fuzzy
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
@@ -7426,7 +7466,15 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/file.go:121
+#: lxc/file.go:133
+#, fuzzy
+msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
+msgstr ""
+"Изменение состояния одного или нескольких контейнеров %s.\n"
+"\n"
+"lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
+
+#: lxc/file.go:310
 #, fuzzy
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
@@ -7434,7 +7482,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/file.go:241
+#: lxc/file.go:430
 #, fuzzy
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
@@ -7443,7 +7491,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/file.go:985
+#: lxc/file.go:1174
 #, fuzzy
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
@@ -8296,20 +8344,28 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:989
+#: lxc/file.go:137
+msgid ""
+"lxc file create foo/bar\n"
+"\t   To create a file /bar in the foo instance.\n"
+"lxc file create --type=symlink foo/bar baz\n"
+"\t   To create a symlink /bar in instance foo whose target is baz."
+msgstr ""
+
+#: lxc/file.go:1178
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:245
+#: lxc/file.go:434
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:470
+#: lxc/file.go:659
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -8658,16 +8714,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1143
+#: lxc/file.go:1332
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1102
+#: lxc/file.go:1291
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1055
+#: lxc/file.go:1244
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/si.po
+++ b/po/si.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-30 13:36-0400\n"
+"POT-Creation-Date: 2024-10-01 10:45-0600\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Sinhala <https://hosted.weblate.org/projects/linux-containers/"
@@ -433,12 +433,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:936
+#: lxc/file.go:1125
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:826
+#: lxc/file.go:1015
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -527,7 +527,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:466
+#: lxc/file.go:655
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -982,7 +982,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:341
+#: lxc/file.go:530
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1011,7 +1011,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:547
+#: lxc/file.go:736
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1397,8 +1397,12 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:249 lxc/file.go:475
+#: lxc/file.go:143 lxc/file.go:438 lxc/file.go:664
 msgid "Create any directories necessary"
+msgstr ""
+
+#: lxc/file.go:134 lxc/file.go:135
+msgid "Create files and directories in instances"
 msgstr ""
 
 #: lxc/auth.go:98 lxc/auth.go:99
@@ -1495,6 +1499,11 @@ msgstr ""
 msgid "Creating %s"
 msgstr ""
 
+#: lxc/file.go:273
+#, c-format
+msgid "Creating %s: %%s"
+msgstr ""
+
 #: lxc/init.go:184
 msgid "Creating the instance"
 msgstr ""
@@ -1551,7 +1560,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:123 lxc/file.go:124
+#: lxc/file.go:312 lxc/file.go:313
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1668,70 +1677,71 @@ msgstr ""
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
-#: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
-#: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
-#: lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090 lxc/image.go:1417
-#: lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638 lxc/image.go:1701
-#: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
-#: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
-#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33
-#: lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405
-#: lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793
-#: lxc/network.go:874 lxc/network.go:1005 lxc/network.go:1106
-#: lxc/network.go:1185 lxc/network.go:1245 lxc/network.go:1341
-#: lxc/network.go:1413 lxc/network_acl.go:30 lxc/network_acl.go:95
-#: lxc/network_acl.go:174 lxc/network_acl.go:235 lxc/network_acl.go:291
-#: lxc/network_acl.go:364 lxc/network_acl.go:461 lxc/network_acl.go:549
-#: lxc/network_acl.go:592 lxc/network_acl.go:731 lxc/network_acl.go:788
-#: lxc/network_acl.go:845 lxc/network_acl.go:860 lxc/network_acl.go:997
-#: lxc/network_allocations.go:51 lxc/network_forward.go:33
-#: lxc/network_forward.go:90 lxc/network_forward.go:179
-#: lxc/network_forward.go:256 lxc/network_forward.go:404
-#: lxc/network_forward.go:489 lxc/network_forward.go:599
-#: lxc/network_forward.go:646 lxc/network_forward.go:800
-#: lxc/network_forward.go:874 lxc/network_forward.go:889
-#: lxc/network_forward.go:970 lxc/network_load_balancer.go:33
-#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:181
-#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:408
-#: lxc/network_load_balancer.go:476 lxc/network_load_balancer.go:586
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:771
-#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:859
-#: lxc/network_load_balancer.go:935 lxc/network_load_balancer.go:1033
-#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1121
-#: lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:167
-#: lxc/network_peer.go:236 lxc/network_peer.go:360 lxc/network_peer.go:445
-#: lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731
-#: lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:165
-#: lxc/network_zone.go:228 lxc/network_zone.go:301 lxc/network_zone.go:396
-#: lxc/network_zone.go:484 lxc/network_zone.go:527 lxc/network_zone.go:654
-#: lxc/network_zone.go:710 lxc/network_zone.go:767 lxc/network_zone.go:845
-#: lxc/network_zone.go:909 lxc/network_zone.go:985 lxc/network_zone.go:1083
-#: lxc/network_zone.go:1172 lxc/network_zone.go:1219 lxc/network_zone.go:1349
-#: lxc/network_zone.go:1410 lxc/network_zone.go:1425 lxc/network_zone.go:1483
-#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
-#: lxc/operation.go:194 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
-#: lxc/profile.go:271 lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493
-#: lxc/profile.go:629 lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860
-#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31
-#: lxc/project.go:95 lxc/project.go:191 lxc/project.go:262 lxc/project.go:398
-#: lxc/project.go:472 lxc/project.go:592 lxc/project.go:657 lxc/project.go:745
-#: lxc/project.go:789 lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34
-#: lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91
-#: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853
-#: lxc/remote.go:917 lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24
-#: lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203
-#: lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655
-#: lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940
-#: lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189
-#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:383
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:536
-#: lxc/storage_bucket.go:630 lxc/storage_bucket.go:699
-#: lxc/storage_bucket.go:733 lxc/storage_bucket.go:774
-#: lxc/storage_bucket.go:853 lxc/storage_bucket.go:959
-#: lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158
-#: lxc/storage_volume.go:58 lxc/storage_volume.go:169 lxc/storage_volume.go:283
+#: lxc/export.go:32 lxc/file.go:88 lxc/file.go:135 lxc/file.go:313
+#: lxc/file.go:362 lxc/file.go:432 lxc/file.go:657 lxc/file.go:1176
+#: lxc/image.go:38 lxc/image.go:159 lxc/image.go:337 lxc/image.go:396
+#: lxc/image.go:525 lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090
+#: lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638
+#: lxc/image.go:1701 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255
+#: lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34
+#: lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233
+#: lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560
+#: lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1005
+#: lxc/network.go:1106 lxc/network.go:1185 lxc/network.go:1245
+#: lxc/network.go:1341 lxc/network.go:1413 lxc/network_acl.go:30
+#: lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235
+#: lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461
+#: lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731
+#: lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860
+#: lxc/network_acl.go:997 lxc/network_allocations.go:51
+#: lxc/network_forward.go:33 lxc/network_forward.go:90
+#: lxc/network_forward.go:179 lxc/network_forward.go:256
+#: lxc/network_forward.go:404 lxc/network_forward.go:489
+#: lxc/network_forward.go:599 lxc/network_forward.go:646
+#: lxc/network_forward.go:800 lxc/network_forward.go:874
+#: lxc/network_forward.go:889 lxc/network_forward.go:970
+#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
+#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844
+#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1121 lxc/network_peer.go:29
+#: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
+#: lxc/network_peer.go:360 lxc/network_peer.go:445 lxc/network_peer.go:547
+#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:29
+#: lxc/network_zone.go:86 lxc/network_zone.go:165 lxc/network_zone.go:228
+#: lxc/network_zone.go:301 lxc/network_zone.go:396 lxc/network_zone.go:484
+#: lxc/network_zone.go:527 lxc/network_zone.go:654 lxc/network_zone.go:710
+#: lxc/network_zone.go:767 lxc/network_zone.go:845 lxc/network_zone.go:909
+#: lxc/network_zone.go:985 lxc/network_zone.go:1083 lxc/network_zone.go:1172
+#: lxc/network_zone.go:1219 lxc/network_zone.go:1349 lxc/network_zone.go:1410
+#: lxc/network_zone.go:1425 lxc/network_zone.go:1483 lxc/operation.go:25
+#: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
+#: lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180 lxc/profile.go:271
+#: lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493 lxc/profile.go:629
+#: lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860 lxc/profile.go:920
+#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31 lxc/project.go:95
+#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
+#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
+#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:648
+#: lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853 lxc/remote.go:917
+#: lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
+#: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
+#: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:459
+#: lxc/storage_bucket.go:536 lxc/storage_bucket.go:630
+#: lxc/storage_bucket.go:699 lxc/storage_bucket.go:733
+#: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
+#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:283
 #: lxc/storage_volume.go:390 lxc/storage_volume.go:605
 #: lxc/storage_volume.go:714 lxc/storage_volume.go:801
 #: lxc/storage_volume.go:899 lxc/storage_volume.go:996
@@ -1829,7 +1839,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:995
+#: lxc/file.go:1184
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1895,7 +1905,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:75
+#: lxc/file.go:79
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1913,7 +1923,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:172 lxc/file.go:173
+#: lxc/file.go:361 lxc/file.go:362
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2183,12 +2193,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1238
+#: lxc/file.go:1427
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1261
+#: lxc/file.go:1450
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2203,12 +2213,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1288
+#: lxc/file.go:1477
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1073
+#: lxc/file.go:1262
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2238,7 +2248,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1194
+#: lxc/file.go:1383
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2253,7 +2263,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1199
+#: lxc/file.go:1388
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2263,12 +2273,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1099
+#: lxc/file.go:1288
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1226
+#: lxc/file.go:1415
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2307,7 +2317,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1400
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2322,7 +2332,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:821
+#: lxc/file.go:1010
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2348,6 +2358,10 @@ msgstr ""
 
 #: lxc/cluster.go:1302
 msgid "Force a particular evacuation action"
+msgstr ""
+
+#: lxc/file.go:144
+msgid "Force creating files or directories"
 msgstr ""
 
 #: lxc/cluster.go:1301
@@ -2644,22 +2658,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1311
+#: lxc/file.go:1500
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1300
+#: lxc/file.go:1489
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1312
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1133
+#: lxc/file.go:1322
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2852,11 +2866,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1125
+#: lxc/file.go:1314
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1302
+#: lxc/file.go:1491
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2874,7 +2888,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1045
+#: lxc/file.go:1234
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2926,7 +2940,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1040
+#: lxc/file.go:1229
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2968,7 +2982,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:148
+#: lxc/file.go:337
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2984,14 +2998,19 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:314
+#: lxc/file.go:503
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:496
+#: lxc/file.go:177 lxc/file.go:685
 #, c-format
 msgid "Invalid target %s"
+msgstr ""
+
+#: lxc/file.go:163
+#, c-format
+msgid "Invalid type %q"
 msgstr ""
 
 #: lxc/info.go:238
@@ -3496,7 +3515,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:83 lxc/file.go:84
+#: lxc/file.go:87 lxc/file.go:88
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3882,7 +3901,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:599
+#: lxc/file.go:788
 msgid "Missing target directory"
 msgstr ""
 
@@ -3920,11 +3939,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:286
+#: lxc/file.go:475
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:986 lxc/file.go:987
+#: lxc/file.go:1175 lxc/file.go:1176
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4376,7 +4395,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1103
+#: lxc/file.go:1292
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4610,20 +4629,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:242 lxc/file.go:243
+#: lxc/file.go:431 lxc/file.go:432
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:417 lxc/file.go:768
+#: lxc/file.go:606 lxc/file.go:957
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:467 lxc/file.go:468
+#: lxc/file.go:656 lxc/file.go:657
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:702 lxc/file.go:868
+#: lxc/file.go:891 lxc/file.go:1057
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4661,7 +4680,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:250 lxc/file.go:474
+#: lxc/file.go:439 lxc/file.go:663
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4990,12 +5009,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1231
+#: lxc/file.go:1420
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1232
+#: lxc/file.go:1421
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5071,7 +5090,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:996
+#: lxc/file.go:1185
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5265,15 +5284,27 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:477
+#: lxc/file.go:145
+msgid "Set the file's gid on create"
+msgstr ""
+
+#: lxc/file.go:666
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:478
+#: lxc/file.go:147
+msgid "Set the file's perms on create"
+msgstr ""
+
+#: lxc/file.go:667
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:476
+#: lxc/file.go:146
+msgid "Set the file's uid on create"
+msgstr ""
+
+#: lxc/file.go:665
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5333,7 +5364,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:994
+#: lxc/file.go:1183
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5708,6 +5739,10 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
+#: lxc/file.go:167
+msgid "Symlink target path can only be used for type \"symlink\""
+msgstr ""
+
 #: lxc/alias.go:140
 msgid "TARGET"
 msgstr ""
@@ -5727,11 +5762,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1033
+#: lxc/file.go:1222
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1027
+#: lxc/file.go:1216
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5900,6 +5935,10 @@ msgstr ""
 
 #: lxc/network.go:537 lxc/network.go:634
 msgid "The specified device doesn't match the network"
+msgstr ""
+
+#: lxc/file.go:148
+msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
 #: lxc/publish.go:97
@@ -6080,7 +6119,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:198
+#: lxc/file.go:387
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6094,7 +6133,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1254
+#: lxc/file.go:1443
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6110,7 +6149,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:808
+#: lxc/file.go:997
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6328,7 +6367,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:72
+#: lxc/file.go:76
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6677,20 +6716,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:171
+#: lxc/file.go:360
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:121
+#: lxc/file.go:133
+msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
+msgstr ""
+
+#: lxc/file.go:310
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:241
+#: lxc/file.go:430
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:985
+#: lxc/file.go:1174
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7199,20 +7242,28 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:989
+#: lxc/file.go:137
+msgid ""
+"lxc file create foo/bar\n"
+"\t   To create a file /bar in the foo instance.\n"
+"lxc file create --type=symlink foo/bar baz\n"
+"\t   To create a symlink /bar in instance foo whose target is baz."
+msgstr ""
+
+#: lxc/file.go:1178
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:245
+#: lxc/file.go:434
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:470
+#: lxc/file.go:659
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7561,16 +7612,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1143
+#: lxc/file.go:1332
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1102
+#: lxc/file.go:1291
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1055
+#: lxc/file.go:1244
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/sl.po
+++ b/po/sl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-30 13:36-0400\n"
+"POT-Creation-Date: 2024-10-01 10:45-0600\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Slovenian <https://hosted.weblate.org/projects/linux-"
@@ -434,12 +434,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:936
+#: lxc/file.go:1125
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:826
+#: lxc/file.go:1015
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -528,7 +528,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:466
+#: lxc/file.go:655
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -983,7 +983,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:341
+#: lxc/file.go:530
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1012,7 +1012,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:547
+#: lxc/file.go:736
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1398,8 +1398,12 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:249 lxc/file.go:475
+#: lxc/file.go:143 lxc/file.go:438 lxc/file.go:664
 msgid "Create any directories necessary"
+msgstr ""
+
+#: lxc/file.go:134 lxc/file.go:135
+msgid "Create files and directories in instances"
 msgstr ""
 
 #: lxc/auth.go:98 lxc/auth.go:99
@@ -1496,6 +1500,11 @@ msgstr ""
 msgid "Creating %s"
 msgstr ""
 
+#: lxc/file.go:273
+#, c-format
+msgid "Creating %s: %%s"
+msgstr ""
+
 #: lxc/init.go:184
 msgid "Creating the instance"
 msgstr ""
@@ -1552,7 +1561,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:123 lxc/file.go:124
+#: lxc/file.go:312 lxc/file.go:313
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1669,70 +1678,71 @@ msgstr ""
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
-#: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
-#: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
-#: lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090 lxc/image.go:1417
-#: lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638 lxc/image.go:1701
-#: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
-#: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
-#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33
-#: lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405
-#: lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793
-#: lxc/network.go:874 lxc/network.go:1005 lxc/network.go:1106
-#: lxc/network.go:1185 lxc/network.go:1245 lxc/network.go:1341
-#: lxc/network.go:1413 lxc/network_acl.go:30 lxc/network_acl.go:95
-#: lxc/network_acl.go:174 lxc/network_acl.go:235 lxc/network_acl.go:291
-#: lxc/network_acl.go:364 lxc/network_acl.go:461 lxc/network_acl.go:549
-#: lxc/network_acl.go:592 lxc/network_acl.go:731 lxc/network_acl.go:788
-#: lxc/network_acl.go:845 lxc/network_acl.go:860 lxc/network_acl.go:997
-#: lxc/network_allocations.go:51 lxc/network_forward.go:33
-#: lxc/network_forward.go:90 lxc/network_forward.go:179
-#: lxc/network_forward.go:256 lxc/network_forward.go:404
-#: lxc/network_forward.go:489 lxc/network_forward.go:599
-#: lxc/network_forward.go:646 lxc/network_forward.go:800
-#: lxc/network_forward.go:874 lxc/network_forward.go:889
-#: lxc/network_forward.go:970 lxc/network_load_balancer.go:33
-#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:181
-#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:408
-#: lxc/network_load_balancer.go:476 lxc/network_load_balancer.go:586
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:771
-#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:859
-#: lxc/network_load_balancer.go:935 lxc/network_load_balancer.go:1033
-#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1121
-#: lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:167
-#: lxc/network_peer.go:236 lxc/network_peer.go:360 lxc/network_peer.go:445
-#: lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731
-#: lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:165
-#: lxc/network_zone.go:228 lxc/network_zone.go:301 lxc/network_zone.go:396
-#: lxc/network_zone.go:484 lxc/network_zone.go:527 lxc/network_zone.go:654
-#: lxc/network_zone.go:710 lxc/network_zone.go:767 lxc/network_zone.go:845
-#: lxc/network_zone.go:909 lxc/network_zone.go:985 lxc/network_zone.go:1083
-#: lxc/network_zone.go:1172 lxc/network_zone.go:1219 lxc/network_zone.go:1349
-#: lxc/network_zone.go:1410 lxc/network_zone.go:1425 lxc/network_zone.go:1483
-#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
-#: lxc/operation.go:194 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
-#: lxc/profile.go:271 lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493
-#: lxc/profile.go:629 lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860
-#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31
-#: lxc/project.go:95 lxc/project.go:191 lxc/project.go:262 lxc/project.go:398
-#: lxc/project.go:472 lxc/project.go:592 lxc/project.go:657 lxc/project.go:745
-#: lxc/project.go:789 lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34
-#: lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91
-#: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853
-#: lxc/remote.go:917 lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24
-#: lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203
-#: lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655
-#: lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940
-#: lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189
-#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:383
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:536
-#: lxc/storage_bucket.go:630 lxc/storage_bucket.go:699
-#: lxc/storage_bucket.go:733 lxc/storage_bucket.go:774
-#: lxc/storage_bucket.go:853 lxc/storage_bucket.go:959
-#: lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158
-#: lxc/storage_volume.go:58 lxc/storage_volume.go:169 lxc/storage_volume.go:283
+#: lxc/export.go:32 lxc/file.go:88 lxc/file.go:135 lxc/file.go:313
+#: lxc/file.go:362 lxc/file.go:432 lxc/file.go:657 lxc/file.go:1176
+#: lxc/image.go:38 lxc/image.go:159 lxc/image.go:337 lxc/image.go:396
+#: lxc/image.go:525 lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090
+#: lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638
+#: lxc/image.go:1701 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255
+#: lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34
+#: lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233
+#: lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560
+#: lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1005
+#: lxc/network.go:1106 lxc/network.go:1185 lxc/network.go:1245
+#: lxc/network.go:1341 lxc/network.go:1413 lxc/network_acl.go:30
+#: lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235
+#: lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461
+#: lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731
+#: lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860
+#: lxc/network_acl.go:997 lxc/network_allocations.go:51
+#: lxc/network_forward.go:33 lxc/network_forward.go:90
+#: lxc/network_forward.go:179 lxc/network_forward.go:256
+#: lxc/network_forward.go:404 lxc/network_forward.go:489
+#: lxc/network_forward.go:599 lxc/network_forward.go:646
+#: lxc/network_forward.go:800 lxc/network_forward.go:874
+#: lxc/network_forward.go:889 lxc/network_forward.go:970
+#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
+#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844
+#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1121 lxc/network_peer.go:29
+#: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
+#: lxc/network_peer.go:360 lxc/network_peer.go:445 lxc/network_peer.go:547
+#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:29
+#: lxc/network_zone.go:86 lxc/network_zone.go:165 lxc/network_zone.go:228
+#: lxc/network_zone.go:301 lxc/network_zone.go:396 lxc/network_zone.go:484
+#: lxc/network_zone.go:527 lxc/network_zone.go:654 lxc/network_zone.go:710
+#: lxc/network_zone.go:767 lxc/network_zone.go:845 lxc/network_zone.go:909
+#: lxc/network_zone.go:985 lxc/network_zone.go:1083 lxc/network_zone.go:1172
+#: lxc/network_zone.go:1219 lxc/network_zone.go:1349 lxc/network_zone.go:1410
+#: lxc/network_zone.go:1425 lxc/network_zone.go:1483 lxc/operation.go:25
+#: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
+#: lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180 lxc/profile.go:271
+#: lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493 lxc/profile.go:629
+#: lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860 lxc/profile.go:920
+#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31 lxc/project.go:95
+#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
+#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
+#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:648
+#: lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853 lxc/remote.go:917
+#: lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
+#: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
+#: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:459
+#: lxc/storage_bucket.go:536 lxc/storage_bucket.go:630
+#: lxc/storage_bucket.go:699 lxc/storage_bucket.go:733
+#: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
+#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:283
 #: lxc/storage_volume.go:390 lxc/storage_volume.go:605
 #: lxc/storage_volume.go:714 lxc/storage_volume.go:801
 #: lxc/storage_volume.go:899 lxc/storage_volume.go:996
@@ -1830,7 +1840,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:995
+#: lxc/file.go:1184
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1896,7 +1906,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:75
+#: lxc/file.go:79
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1914,7 +1924,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:172 lxc/file.go:173
+#: lxc/file.go:361 lxc/file.go:362
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2184,12 +2194,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1238
+#: lxc/file.go:1427
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1261
+#: lxc/file.go:1450
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2204,12 +2214,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1288
+#: lxc/file.go:1477
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1073
+#: lxc/file.go:1262
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2239,7 +2249,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1194
+#: lxc/file.go:1383
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2254,7 +2264,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1199
+#: lxc/file.go:1388
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2264,12 +2274,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1099
+#: lxc/file.go:1288
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1226
+#: lxc/file.go:1415
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2308,7 +2318,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1400
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2323,7 +2333,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:821
+#: lxc/file.go:1010
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2349,6 +2359,10 @@ msgstr ""
 
 #: lxc/cluster.go:1302
 msgid "Force a particular evacuation action"
+msgstr ""
+
+#: lxc/file.go:144
+msgid "Force creating files or directories"
 msgstr ""
 
 #: lxc/cluster.go:1301
@@ -2645,22 +2659,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1311
+#: lxc/file.go:1500
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1300
+#: lxc/file.go:1489
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1312
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1133
+#: lxc/file.go:1322
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2853,11 +2867,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1125
+#: lxc/file.go:1314
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1302
+#: lxc/file.go:1491
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2875,7 +2889,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1045
+#: lxc/file.go:1234
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2927,7 +2941,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1040
+#: lxc/file.go:1229
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2969,7 +2983,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:148
+#: lxc/file.go:337
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2985,14 +2999,19 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:314
+#: lxc/file.go:503
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:496
+#: lxc/file.go:177 lxc/file.go:685
 #, c-format
 msgid "Invalid target %s"
+msgstr ""
+
+#: lxc/file.go:163
+#, c-format
+msgid "Invalid type %q"
 msgstr ""
 
 #: lxc/info.go:238
@@ -3497,7 +3516,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:83 lxc/file.go:84
+#: lxc/file.go:87 lxc/file.go:88
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3883,7 +3902,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:599
+#: lxc/file.go:788
 msgid "Missing target directory"
 msgstr ""
 
@@ -3921,11 +3940,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:286
+#: lxc/file.go:475
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:986 lxc/file.go:987
+#: lxc/file.go:1175 lxc/file.go:1176
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4377,7 +4396,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1103
+#: lxc/file.go:1292
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4611,20 +4630,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:242 lxc/file.go:243
+#: lxc/file.go:431 lxc/file.go:432
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:417 lxc/file.go:768
+#: lxc/file.go:606 lxc/file.go:957
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:467 lxc/file.go:468
+#: lxc/file.go:656 lxc/file.go:657
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:702 lxc/file.go:868
+#: lxc/file.go:891 lxc/file.go:1057
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4662,7 +4681,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:250 lxc/file.go:474
+#: lxc/file.go:439 lxc/file.go:663
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4991,12 +5010,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1231
+#: lxc/file.go:1420
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1232
+#: lxc/file.go:1421
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5072,7 +5091,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:996
+#: lxc/file.go:1185
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5266,15 +5285,27 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:477
+#: lxc/file.go:145
+msgid "Set the file's gid on create"
+msgstr ""
+
+#: lxc/file.go:666
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:478
+#: lxc/file.go:147
+msgid "Set the file's perms on create"
+msgstr ""
+
+#: lxc/file.go:667
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:476
+#: lxc/file.go:146
+msgid "Set the file's uid on create"
+msgstr ""
+
+#: lxc/file.go:665
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5334,7 +5365,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:994
+#: lxc/file.go:1183
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5709,6 +5740,10 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
+#: lxc/file.go:167
+msgid "Symlink target path can only be used for type \"symlink\""
+msgstr ""
+
 #: lxc/alias.go:140
 msgid "TARGET"
 msgstr ""
@@ -5728,11 +5763,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1033
+#: lxc/file.go:1222
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1027
+#: lxc/file.go:1216
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5901,6 +5936,10 @@ msgstr ""
 
 #: lxc/network.go:537 lxc/network.go:634
 msgid "The specified device doesn't match the network"
+msgstr ""
+
+#: lxc/file.go:148
+msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
 #: lxc/publish.go:97
@@ -6081,7 +6120,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:198
+#: lxc/file.go:387
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6095,7 +6134,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1254
+#: lxc/file.go:1443
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6111,7 +6150,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:808
+#: lxc/file.go:997
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6329,7 +6368,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:72
+#: lxc/file.go:76
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6678,20 +6717,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:171
+#: lxc/file.go:360
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:121
+#: lxc/file.go:133
+msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
+msgstr ""
+
+#: lxc/file.go:310
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:241
+#: lxc/file.go:430
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:985
+#: lxc/file.go:1174
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7200,20 +7243,28 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:989
+#: lxc/file.go:137
+msgid ""
+"lxc file create foo/bar\n"
+"\t   To create a file /bar in the foo instance.\n"
+"lxc file create --type=symlink foo/bar baz\n"
+"\t   To create a symlink /bar in instance foo whose target is baz."
+msgstr ""
+
+#: lxc/file.go:1178
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:245
+#: lxc/file.go:434
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:470
+#: lxc/file.go:659
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7562,16 +7613,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1143
+#: lxc/file.go:1332
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1102
+#: lxc/file.go:1291
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1055
+#: lxc/file.go:1244
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-30 13:36-0400\n"
+"POT-Creation-Date: 2024-10-01 10:45-0600\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Serbian <https://hosted.weblate.org/projects/linux-containers/"
@@ -434,12 +434,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:936
+#: lxc/file.go:1125
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:826
+#: lxc/file.go:1015
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -528,7 +528,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:466
+#: lxc/file.go:655
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -983,7 +983,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:341
+#: lxc/file.go:530
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1012,7 +1012,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:547
+#: lxc/file.go:736
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1398,8 +1398,12 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:249 lxc/file.go:475
+#: lxc/file.go:143 lxc/file.go:438 lxc/file.go:664
 msgid "Create any directories necessary"
+msgstr ""
+
+#: lxc/file.go:134 lxc/file.go:135
+msgid "Create files and directories in instances"
 msgstr ""
 
 #: lxc/auth.go:98 lxc/auth.go:99
@@ -1496,6 +1500,11 @@ msgstr ""
 msgid "Creating %s"
 msgstr ""
 
+#: lxc/file.go:273
+#, c-format
+msgid "Creating %s: %%s"
+msgstr ""
+
 #: lxc/init.go:184
 msgid "Creating the instance"
 msgstr ""
@@ -1552,7 +1561,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:123 lxc/file.go:124
+#: lxc/file.go:312 lxc/file.go:313
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1669,70 +1678,71 @@ msgstr ""
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
-#: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
-#: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
-#: lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090 lxc/image.go:1417
-#: lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638 lxc/image.go:1701
-#: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
-#: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
-#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33
-#: lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405
-#: lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793
-#: lxc/network.go:874 lxc/network.go:1005 lxc/network.go:1106
-#: lxc/network.go:1185 lxc/network.go:1245 lxc/network.go:1341
-#: lxc/network.go:1413 lxc/network_acl.go:30 lxc/network_acl.go:95
-#: lxc/network_acl.go:174 lxc/network_acl.go:235 lxc/network_acl.go:291
-#: lxc/network_acl.go:364 lxc/network_acl.go:461 lxc/network_acl.go:549
-#: lxc/network_acl.go:592 lxc/network_acl.go:731 lxc/network_acl.go:788
-#: lxc/network_acl.go:845 lxc/network_acl.go:860 lxc/network_acl.go:997
-#: lxc/network_allocations.go:51 lxc/network_forward.go:33
-#: lxc/network_forward.go:90 lxc/network_forward.go:179
-#: lxc/network_forward.go:256 lxc/network_forward.go:404
-#: lxc/network_forward.go:489 lxc/network_forward.go:599
-#: lxc/network_forward.go:646 lxc/network_forward.go:800
-#: lxc/network_forward.go:874 lxc/network_forward.go:889
-#: lxc/network_forward.go:970 lxc/network_load_balancer.go:33
-#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:181
-#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:408
-#: lxc/network_load_balancer.go:476 lxc/network_load_balancer.go:586
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:771
-#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:859
-#: lxc/network_load_balancer.go:935 lxc/network_load_balancer.go:1033
-#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1121
-#: lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:167
-#: lxc/network_peer.go:236 lxc/network_peer.go:360 lxc/network_peer.go:445
-#: lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731
-#: lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:165
-#: lxc/network_zone.go:228 lxc/network_zone.go:301 lxc/network_zone.go:396
-#: lxc/network_zone.go:484 lxc/network_zone.go:527 lxc/network_zone.go:654
-#: lxc/network_zone.go:710 lxc/network_zone.go:767 lxc/network_zone.go:845
-#: lxc/network_zone.go:909 lxc/network_zone.go:985 lxc/network_zone.go:1083
-#: lxc/network_zone.go:1172 lxc/network_zone.go:1219 lxc/network_zone.go:1349
-#: lxc/network_zone.go:1410 lxc/network_zone.go:1425 lxc/network_zone.go:1483
-#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
-#: lxc/operation.go:194 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
-#: lxc/profile.go:271 lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493
-#: lxc/profile.go:629 lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860
-#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31
-#: lxc/project.go:95 lxc/project.go:191 lxc/project.go:262 lxc/project.go:398
-#: lxc/project.go:472 lxc/project.go:592 lxc/project.go:657 lxc/project.go:745
-#: lxc/project.go:789 lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34
-#: lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91
-#: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853
-#: lxc/remote.go:917 lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24
-#: lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203
-#: lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655
-#: lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940
-#: lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189
-#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:383
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:536
-#: lxc/storage_bucket.go:630 lxc/storage_bucket.go:699
-#: lxc/storage_bucket.go:733 lxc/storage_bucket.go:774
-#: lxc/storage_bucket.go:853 lxc/storage_bucket.go:959
-#: lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158
-#: lxc/storage_volume.go:58 lxc/storage_volume.go:169 lxc/storage_volume.go:283
+#: lxc/export.go:32 lxc/file.go:88 lxc/file.go:135 lxc/file.go:313
+#: lxc/file.go:362 lxc/file.go:432 lxc/file.go:657 lxc/file.go:1176
+#: lxc/image.go:38 lxc/image.go:159 lxc/image.go:337 lxc/image.go:396
+#: lxc/image.go:525 lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090
+#: lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638
+#: lxc/image.go:1701 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255
+#: lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34
+#: lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233
+#: lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560
+#: lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1005
+#: lxc/network.go:1106 lxc/network.go:1185 lxc/network.go:1245
+#: lxc/network.go:1341 lxc/network.go:1413 lxc/network_acl.go:30
+#: lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235
+#: lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461
+#: lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731
+#: lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860
+#: lxc/network_acl.go:997 lxc/network_allocations.go:51
+#: lxc/network_forward.go:33 lxc/network_forward.go:90
+#: lxc/network_forward.go:179 lxc/network_forward.go:256
+#: lxc/network_forward.go:404 lxc/network_forward.go:489
+#: lxc/network_forward.go:599 lxc/network_forward.go:646
+#: lxc/network_forward.go:800 lxc/network_forward.go:874
+#: lxc/network_forward.go:889 lxc/network_forward.go:970
+#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
+#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844
+#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1121 lxc/network_peer.go:29
+#: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
+#: lxc/network_peer.go:360 lxc/network_peer.go:445 lxc/network_peer.go:547
+#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:29
+#: lxc/network_zone.go:86 lxc/network_zone.go:165 lxc/network_zone.go:228
+#: lxc/network_zone.go:301 lxc/network_zone.go:396 lxc/network_zone.go:484
+#: lxc/network_zone.go:527 lxc/network_zone.go:654 lxc/network_zone.go:710
+#: lxc/network_zone.go:767 lxc/network_zone.go:845 lxc/network_zone.go:909
+#: lxc/network_zone.go:985 lxc/network_zone.go:1083 lxc/network_zone.go:1172
+#: lxc/network_zone.go:1219 lxc/network_zone.go:1349 lxc/network_zone.go:1410
+#: lxc/network_zone.go:1425 lxc/network_zone.go:1483 lxc/operation.go:25
+#: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
+#: lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180 lxc/profile.go:271
+#: lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493 lxc/profile.go:629
+#: lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860 lxc/profile.go:920
+#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31 lxc/project.go:95
+#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
+#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
+#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:648
+#: lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853 lxc/remote.go:917
+#: lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
+#: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
+#: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:459
+#: lxc/storage_bucket.go:536 lxc/storage_bucket.go:630
+#: lxc/storage_bucket.go:699 lxc/storage_bucket.go:733
+#: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
+#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:283
 #: lxc/storage_volume.go:390 lxc/storage_volume.go:605
 #: lxc/storage_volume.go:714 lxc/storage_volume.go:801
 #: lxc/storage_volume.go:899 lxc/storage_volume.go:996
@@ -1830,7 +1840,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:995
+#: lxc/file.go:1184
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1896,7 +1906,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:75
+#: lxc/file.go:79
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1914,7 +1924,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:172 lxc/file.go:173
+#: lxc/file.go:361 lxc/file.go:362
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2184,12 +2194,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1238
+#: lxc/file.go:1427
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1261
+#: lxc/file.go:1450
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2204,12 +2214,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1288
+#: lxc/file.go:1477
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1073
+#: lxc/file.go:1262
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2239,7 +2249,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1194
+#: lxc/file.go:1383
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2254,7 +2264,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1199
+#: lxc/file.go:1388
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2264,12 +2274,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1099
+#: lxc/file.go:1288
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1226
+#: lxc/file.go:1415
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2308,7 +2318,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1400
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2323,7 +2333,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:821
+#: lxc/file.go:1010
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2349,6 +2359,10 @@ msgstr ""
 
 #: lxc/cluster.go:1302
 msgid "Force a particular evacuation action"
+msgstr ""
+
+#: lxc/file.go:144
+msgid "Force creating files or directories"
 msgstr ""
 
 #: lxc/cluster.go:1301
@@ -2645,22 +2659,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1311
+#: lxc/file.go:1500
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1300
+#: lxc/file.go:1489
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1312
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1133
+#: lxc/file.go:1322
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2853,11 +2867,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1125
+#: lxc/file.go:1314
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1302
+#: lxc/file.go:1491
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2875,7 +2889,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1045
+#: lxc/file.go:1234
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2927,7 +2941,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1040
+#: lxc/file.go:1229
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2969,7 +2983,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:148
+#: lxc/file.go:337
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2985,14 +2999,19 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:314
+#: lxc/file.go:503
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:496
+#: lxc/file.go:177 lxc/file.go:685
 #, c-format
 msgid "Invalid target %s"
+msgstr ""
+
+#: lxc/file.go:163
+#, c-format
+msgid "Invalid type %q"
 msgstr ""
 
 #: lxc/info.go:238
@@ -3497,7 +3516,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:83 lxc/file.go:84
+#: lxc/file.go:87 lxc/file.go:88
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3883,7 +3902,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:599
+#: lxc/file.go:788
 msgid "Missing target directory"
 msgstr ""
 
@@ -3921,11 +3940,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:286
+#: lxc/file.go:475
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:986 lxc/file.go:987
+#: lxc/file.go:1175 lxc/file.go:1176
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4377,7 +4396,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1103
+#: lxc/file.go:1292
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4611,20 +4630,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:242 lxc/file.go:243
+#: lxc/file.go:431 lxc/file.go:432
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:417 lxc/file.go:768
+#: lxc/file.go:606 lxc/file.go:957
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:467 lxc/file.go:468
+#: lxc/file.go:656 lxc/file.go:657
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:702 lxc/file.go:868
+#: lxc/file.go:891 lxc/file.go:1057
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4662,7 +4681,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:250 lxc/file.go:474
+#: lxc/file.go:439 lxc/file.go:663
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4991,12 +5010,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1231
+#: lxc/file.go:1420
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1232
+#: lxc/file.go:1421
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5072,7 +5091,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:996
+#: lxc/file.go:1185
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5266,15 +5285,27 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:477
+#: lxc/file.go:145
+msgid "Set the file's gid on create"
+msgstr ""
+
+#: lxc/file.go:666
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:478
+#: lxc/file.go:147
+msgid "Set the file's perms on create"
+msgstr ""
+
+#: lxc/file.go:667
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:476
+#: lxc/file.go:146
+msgid "Set the file's uid on create"
+msgstr ""
+
+#: lxc/file.go:665
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5334,7 +5365,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:994
+#: lxc/file.go:1183
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5709,6 +5740,10 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
+#: lxc/file.go:167
+msgid "Symlink target path can only be used for type \"symlink\""
+msgstr ""
+
 #: lxc/alias.go:140
 msgid "TARGET"
 msgstr ""
@@ -5728,11 +5763,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1033
+#: lxc/file.go:1222
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1027
+#: lxc/file.go:1216
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5901,6 +5936,10 @@ msgstr ""
 
 #: lxc/network.go:537 lxc/network.go:634
 msgid "The specified device doesn't match the network"
+msgstr ""
+
+#: lxc/file.go:148
+msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
 #: lxc/publish.go:97
@@ -6081,7 +6120,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:198
+#: lxc/file.go:387
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6095,7 +6134,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1254
+#: lxc/file.go:1443
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6111,7 +6150,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:808
+#: lxc/file.go:997
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6329,7 +6368,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:72
+#: lxc/file.go:76
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6678,20 +6717,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:171
+#: lxc/file.go:360
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:121
+#: lxc/file.go:133
+msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
+msgstr ""
+
+#: lxc/file.go:310
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:241
+#: lxc/file.go:430
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:985
+#: lxc/file.go:1174
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7200,20 +7243,28 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:989
+#: lxc/file.go:137
+msgid ""
+"lxc file create foo/bar\n"
+"\t   To create a file /bar in the foo instance.\n"
+"lxc file create --type=symlink foo/bar baz\n"
+"\t   To create a symlink /bar in instance foo whose target is baz."
+msgstr ""
+
+#: lxc/file.go:1178
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:245
+#: lxc/file.go:434
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:470
+#: lxc/file.go:659
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7562,16 +7613,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1143
+#: lxc/file.go:1332
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1102
+#: lxc/file.go:1291
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1055
+#: lxc/file.go:1244
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-30 13:36-0400\n"
+"POT-Creation-Date: 2024-10-01 10:45-0600\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Swedish <https://hosted.weblate.org/projects/linux-containers/"
@@ -433,12 +433,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:936
+#: lxc/file.go:1125
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:826
+#: lxc/file.go:1015
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -527,7 +527,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:466
+#: lxc/file.go:655
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -982,7 +982,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:341
+#: lxc/file.go:530
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1011,7 +1011,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:547
+#: lxc/file.go:736
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1397,8 +1397,12 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:249 lxc/file.go:475
+#: lxc/file.go:143 lxc/file.go:438 lxc/file.go:664
 msgid "Create any directories necessary"
+msgstr ""
+
+#: lxc/file.go:134 lxc/file.go:135
+msgid "Create files and directories in instances"
 msgstr ""
 
 #: lxc/auth.go:98 lxc/auth.go:99
@@ -1495,6 +1499,11 @@ msgstr ""
 msgid "Creating %s"
 msgstr ""
 
+#: lxc/file.go:273
+#, c-format
+msgid "Creating %s: %%s"
+msgstr ""
+
 #: lxc/init.go:184
 msgid "Creating the instance"
 msgstr ""
@@ -1551,7 +1560,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:123 lxc/file.go:124
+#: lxc/file.go:312 lxc/file.go:313
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1668,70 +1677,71 @@ msgstr ""
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
-#: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
-#: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
-#: lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090 lxc/image.go:1417
-#: lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638 lxc/image.go:1701
-#: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
-#: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
-#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33
-#: lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405
-#: lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793
-#: lxc/network.go:874 lxc/network.go:1005 lxc/network.go:1106
-#: lxc/network.go:1185 lxc/network.go:1245 lxc/network.go:1341
-#: lxc/network.go:1413 lxc/network_acl.go:30 lxc/network_acl.go:95
-#: lxc/network_acl.go:174 lxc/network_acl.go:235 lxc/network_acl.go:291
-#: lxc/network_acl.go:364 lxc/network_acl.go:461 lxc/network_acl.go:549
-#: lxc/network_acl.go:592 lxc/network_acl.go:731 lxc/network_acl.go:788
-#: lxc/network_acl.go:845 lxc/network_acl.go:860 lxc/network_acl.go:997
-#: lxc/network_allocations.go:51 lxc/network_forward.go:33
-#: lxc/network_forward.go:90 lxc/network_forward.go:179
-#: lxc/network_forward.go:256 lxc/network_forward.go:404
-#: lxc/network_forward.go:489 lxc/network_forward.go:599
-#: lxc/network_forward.go:646 lxc/network_forward.go:800
-#: lxc/network_forward.go:874 lxc/network_forward.go:889
-#: lxc/network_forward.go:970 lxc/network_load_balancer.go:33
-#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:181
-#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:408
-#: lxc/network_load_balancer.go:476 lxc/network_load_balancer.go:586
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:771
-#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:859
-#: lxc/network_load_balancer.go:935 lxc/network_load_balancer.go:1033
-#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1121
-#: lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:167
-#: lxc/network_peer.go:236 lxc/network_peer.go:360 lxc/network_peer.go:445
-#: lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731
-#: lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:165
-#: lxc/network_zone.go:228 lxc/network_zone.go:301 lxc/network_zone.go:396
-#: lxc/network_zone.go:484 lxc/network_zone.go:527 lxc/network_zone.go:654
-#: lxc/network_zone.go:710 lxc/network_zone.go:767 lxc/network_zone.go:845
-#: lxc/network_zone.go:909 lxc/network_zone.go:985 lxc/network_zone.go:1083
-#: lxc/network_zone.go:1172 lxc/network_zone.go:1219 lxc/network_zone.go:1349
-#: lxc/network_zone.go:1410 lxc/network_zone.go:1425 lxc/network_zone.go:1483
-#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
-#: lxc/operation.go:194 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
-#: lxc/profile.go:271 lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493
-#: lxc/profile.go:629 lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860
-#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31
-#: lxc/project.go:95 lxc/project.go:191 lxc/project.go:262 lxc/project.go:398
-#: lxc/project.go:472 lxc/project.go:592 lxc/project.go:657 lxc/project.go:745
-#: lxc/project.go:789 lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34
-#: lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91
-#: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853
-#: lxc/remote.go:917 lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24
-#: lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203
-#: lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655
-#: lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940
-#: lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189
-#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:383
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:536
-#: lxc/storage_bucket.go:630 lxc/storage_bucket.go:699
-#: lxc/storage_bucket.go:733 lxc/storage_bucket.go:774
-#: lxc/storage_bucket.go:853 lxc/storage_bucket.go:959
-#: lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158
-#: lxc/storage_volume.go:58 lxc/storage_volume.go:169 lxc/storage_volume.go:283
+#: lxc/export.go:32 lxc/file.go:88 lxc/file.go:135 lxc/file.go:313
+#: lxc/file.go:362 lxc/file.go:432 lxc/file.go:657 lxc/file.go:1176
+#: lxc/image.go:38 lxc/image.go:159 lxc/image.go:337 lxc/image.go:396
+#: lxc/image.go:525 lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090
+#: lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638
+#: lxc/image.go:1701 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255
+#: lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34
+#: lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233
+#: lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560
+#: lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1005
+#: lxc/network.go:1106 lxc/network.go:1185 lxc/network.go:1245
+#: lxc/network.go:1341 lxc/network.go:1413 lxc/network_acl.go:30
+#: lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235
+#: lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461
+#: lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731
+#: lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860
+#: lxc/network_acl.go:997 lxc/network_allocations.go:51
+#: lxc/network_forward.go:33 lxc/network_forward.go:90
+#: lxc/network_forward.go:179 lxc/network_forward.go:256
+#: lxc/network_forward.go:404 lxc/network_forward.go:489
+#: lxc/network_forward.go:599 lxc/network_forward.go:646
+#: lxc/network_forward.go:800 lxc/network_forward.go:874
+#: lxc/network_forward.go:889 lxc/network_forward.go:970
+#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
+#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844
+#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1121 lxc/network_peer.go:29
+#: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
+#: lxc/network_peer.go:360 lxc/network_peer.go:445 lxc/network_peer.go:547
+#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:29
+#: lxc/network_zone.go:86 lxc/network_zone.go:165 lxc/network_zone.go:228
+#: lxc/network_zone.go:301 lxc/network_zone.go:396 lxc/network_zone.go:484
+#: lxc/network_zone.go:527 lxc/network_zone.go:654 lxc/network_zone.go:710
+#: lxc/network_zone.go:767 lxc/network_zone.go:845 lxc/network_zone.go:909
+#: lxc/network_zone.go:985 lxc/network_zone.go:1083 lxc/network_zone.go:1172
+#: lxc/network_zone.go:1219 lxc/network_zone.go:1349 lxc/network_zone.go:1410
+#: lxc/network_zone.go:1425 lxc/network_zone.go:1483 lxc/operation.go:25
+#: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
+#: lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180 lxc/profile.go:271
+#: lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493 lxc/profile.go:629
+#: lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860 lxc/profile.go:920
+#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31 lxc/project.go:95
+#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
+#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
+#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:648
+#: lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853 lxc/remote.go:917
+#: lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
+#: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
+#: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:459
+#: lxc/storage_bucket.go:536 lxc/storage_bucket.go:630
+#: lxc/storage_bucket.go:699 lxc/storage_bucket.go:733
+#: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
+#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:283
 #: lxc/storage_volume.go:390 lxc/storage_volume.go:605
 #: lxc/storage_volume.go:714 lxc/storage_volume.go:801
 #: lxc/storage_volume.go:899 lxc/storage_volume.go:996
@@ -1829,7 +1839,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:995
+#: lxc/file.go:1184
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1895,7 +1905,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:75
+#: lxc/file.go:79
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1913,7 +1923,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:172 lxc/file.go:173
+#: lxc/file.go:361 lxc/file.go:362
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2183,12 +2193,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1238
+#: lxc/file.go:1427
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1261
+#: lxc/file.go:1450
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2203,12 +2213,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1288
+#: lxc/file.go:1477
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1073
+#: lxc/file.go:1262
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2238,7 +2248,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1194
+#: lxc/file.go:1383
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2253,7 +2263,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1199
+#: lxc/file.go:1388
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2263,12 +2273,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1099
+#: lxc/file.go:1288
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1226
+#: lxc/file.go:1415
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2307,7 +2317,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1400
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2322,7 +2332,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:821
+#: lxc/file.go:1010
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2348,6 +2358,10 @@ msgstr ""
 
 #: lxc/cluster.go:1302
 msgid "Force a particular evacuation action"
+msgstr ""
+
+#: lxc/file.go:144
+msgid "Force creating files or directories"
 msgstr ""
 
 #: lxc/cluster.go:1301
@@ -2644,22 +2658,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1311
+#: lxc/file.go:1500
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1300
+#: lxc/file.go:1489
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1312
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1133
+#: lxc/file.go:1322
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2852,11 +2866,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1125
+#: lxc/file.go:1314
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1302
+#: lxc/file.go:1491
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2874,7 +2888,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1045
+#: lxc/file.go:1234
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2926,7 +2940,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1040
+#: lxc/file.go:1229
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2968,7 +2982,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:148
+#: lxc/file.go:337
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2984,14 +2998,19 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:314
+#: lxc/file.go:503
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:496
+#: lxc/file.go:177 lxc/file.go:685
 #, c-format
 msgid "Invalid target %s"
+msgstr ""
+
+#: lxc/file.go:163
+#, c-format
+msgid "Invalid type %q"
 msgstr ""
 
 #: lxc/info.go:238
@@ -3496,7 +3515,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:83 lxc/file.go:84
+#: lxc/file.go:87 lxc/file.go:88
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3882,7 +3901,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:599
+#: lxc/file.go:788
 msgid "Missing target directory"
 msgstr ""
 
@@ -3920,11 +3939,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:286
+#: lxc/file.go:475
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:986 lxc/file.go:987
+#: lxc/file.go:1175 lxc/file.go:1176
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4376,7 +4395,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1103
+#: lxc/file.go:1292
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4610,20 +4629,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:242 lxc/file.go:243
+#: lxc/file.go:431 lxc/file.go:432
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:417 lxc/file.go:768
+#: lxc/file.go:606 lxc/file.go:957
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:467 lxc/file.go:468
+#: lxc/file.go:656 lxc/file.go:657
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:702 lxc/file.go:868
+#: lxc/file.go:891 lxc/file.go:1057
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4661,7 +4680,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:250 lxc/file.go:474
+#: lxc/file.go:439 lxc/file.go:663
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4990,12 +5009,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1231
+#: lxc/file.go:1420
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1232
+#: lxc/file.go:1421
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5071,7 +5090,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:996
+#: lxc/file.go:1185
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5265,15 +5284,27 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:477
+#: lxc/file.go:145
+msgid "Set the file's gid on create"
+msgstr ""
+
+#: lxc/file.go:666
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:478
+#: lxc/file.go:147
+msgid "Set the file's perms on create"
+msgstr ""
+
+#: lxc/file.go:667
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:476
+#: lxc/file.go:146
+msgid "Set the file's uid on create"
+msgstr ""
+
+#: lxc/file.go:665
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5333,7 +5364,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:994
+#: lxc/file.go:1183
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5708,6 +5739,10 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
+#: lxc/file.go:167
+msgid "Symlink target path can only be used for type \"symlink\""
+msgstr ""
+
 #: lxc/alias.go:140
 msgid "TARGET"
 msgstr ""
@@ -5727,11 +5762,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1033
+#: lxc/file.go:1222
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1027
+#: lxc/file.go:1216
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5900,6 +5935,10 @@ msgstr ""
 
 #: lxc/network.go:537 lxc/network.go:634
 msgid "The specified device doesn't match the network"
+msgstr ""
+
+#: lxc/file.go:148
+msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
 #: lxc/publish.go:97
@@ -6080,7 +6119,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:198
+#: lxc/file.go:387
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6094,7 +6133,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1254
+#: lxc/file.go:1443
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6110,7 +6149,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:808
+#: lxc/file.go:997
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6328,7 +6367,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:72
+#: lxc/file.go:76
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6677,20 +6716,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:171
+#: lxc/file.go:360
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:121
+#: lxc/file.go:133
+msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
+msgstr ""
+
+#: lxc/file.go:310
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:241
+#: lxc/file.go:430
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:985
+#: lxc/file.go:1174
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7199,20 +7242,28 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:989
+#: lxc/file.go:137
+msgid ""
+"lxc file create foo/bar\n"
+"\t   To create a file /bar in the foo instance.\n"
+"lxc file create --type=symlink foo/bar baz\n"
+"\t   To create a symlink /bar in instance foo whose target is baz."
+msgstr ""
+
+#: lxc/file.go:1178
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:245
+#: lxc/file.go:434
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:470
+#: lxc/file.go:659
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7561,16 +7612,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1143
+#: lxc/file.go:1332
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1102
+#: lxc/file.go:1291
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1055
+#: lxc/file.go:1244
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/te.po
+++ b/po/te.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-30 13:36-0400\n"
+"POT-Creation-Date: 2024-10-01 10:45-0600\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Telugu <https://hosted.weblate.org/projects/linux-containers/"
@@ -433,12 +433,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:936
+#: lxc/file.go:1125
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:826
+#: lxc/file.go:1015
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -527,7 +527,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:466
+#: lxc/file.go:655
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -982,7 +982,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:341
+#: lxc/file.go:530
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1011,7 +1011,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:547
+#: lxc/file.go:736
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1397,8 +1397,12 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:249 lxc/file.go:475
+#: lxc/file.go:143 lxc/file.go:438 lxc/file.go:664
 msgid "Create any directories necessary"
+msgstr ""
+
+#: lxc/file.go:134 lxc/file.go:135
+msgid "Create files and directories in instances"
 msgstr ""
 
 #: lxc/auth.go:98 lxc/auth.go:99
@@ -1495,6 +1499,11 @@ msgstr ""
 msgid "Creating %s"
 msgstr ""
 
+#: lxc/file.go:273
+#, c-format
+msgid "Creating %s: %%s"
+msgstr ""
+
 #: lxc/init.go:184
 msgid "Creating the instance"
 msgstr ""
@@ -1551,7 +1560,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:123 lxc/file.go:124
+#: lxc/file.go:312 lxc/file.go:313
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1668,70 +1677,71 @@ msgstr ""
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
-#: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
-#: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
-#: lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090 lxc/image.go:1417
-#: lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638 lxc/image.go:1701
-#: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
-#: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
-#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33
-#: lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405
-#: lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793
-#: lxc/network.go:874 lxc/network.go:1005 lxc/network.go:1106
-#: lxc/network.go:1185 lxc/network.go:1245 lxc/network.go:1341
-#: lxc/network.go:1413 lxc/network_acl.go:30 lxc/network_acl.go:95
-#: lxc/network_acl.go:174 lxc/network_acl.go:235 lxc/network_acl.go:291
-#: lxc/network_acl.go:364 lxc/network_acl.go:461 lxc/network_acl.go:549
-#: lxc/network_acl.go:592 lxc/network_acl.go:731 lxc/network_acl.go:788
-#: lxc/network_acl.go:845 lxc/network_acl.go:860 lxc/network_acl.go:997
-#: lxc/network_allocations.go:51 lxc/network_forward.go:33
-#: lxc/network_forward.go:90 lxc/network_forward.go:179
-#: lxc/network_forward.go:256 lxc/network_forward.go:404
-#: lxc/network_forward.go:489 lxc/network_forward.go:599
-#: lxc/network_forward.go:646 lxc/network_forward.go:800
-#: lxc/network_forward.go:874 lxc/network_forward.go:889
-#: lxc/network_forward.go:970 lxc/network_load_balancer.go:33
-#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:181
-#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:408
-#: lxc/network_load_balancer.go:476 lxc/network_load_balancer.go:586
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:771
-#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:859
-#: lxc/network_load_balancer.go:935 lxc/network_load_balancer.go:1033
-#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1121
-#: lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:167
-#: lxc/network_peer.go:236 lxc/network_peer.go:360 lxc/network_peer.go:445
-#: lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731
-#: lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:165
-#: lxc/network_zone.go:228 lxc/network_zone.go:301 lxc/network_zone.go:396
-#: lxc/network_zone.go:484 lxc/network_zone.go:527 lxc/network_zone.go:654
-#: lxc/network_zone.go:710 lxc/network_zone.go:767 lxc/network_zone.go:845
-#: lxc/network_zone.go:909 lxc/network_zone.go:985 lxc/network_zone.go:1083
-#: lxc/network_zone.go:1172 lxc/network_zone.go:1219 lxc/network_zone.go:1349
-#: lxc/network_zone.go:1410 lxc/network_zone.go:1425 lxc/network_zone.go:1483
-#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
-#: lxc/operation.go:194 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
-#: lxc/profile.go:271 lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493
-#: lxc/profile.go:629 lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860
-#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31
-#: lxc/project.go:95 lxc/project.go:191 lxc/project.go:262 lxc/project.go:398
-#: lxc/project.go:472 lxc/project.go:592 lxc/project.go:657 lxc/project.go:745
-#: lxc/project.go:789 lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34
-#: lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91
-#: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853
-#: lxc/remote.go:917 lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24
-#: lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203
-#: lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655
-#: lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940
-#: lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189
-#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:383
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:536
-#: lxc/storage_bucket.go:630 lxc/storage_bucket.go:699
-#: lxc/storage_bucket.go:733 lxc/storage_bucket.go:774
-#: lxc/storage_bucket.go:853 lxc/storage_bucket.go:959
-#: lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158
-#: lxc/storage_volume.go:58 lxc/storage_volume.go:169 lxc/storage_volume.go:283
+#: lxc/export.go:32 lxc/file.go:88 lxc/file.go:135 lxc/file.go:313
+#: lxc/file.go:362 lxc/file.go:432 lxc/file.go:657 lxc/file.go:1176
+#: lxc/image.go:38 lxc/image.go:159 lxc/image.go:337 lxc/image.go:396
+#: lxc/image.go:525 lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090
+#: lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638
+#: lxc/image.go:1701 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255
+#: lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34
+#: lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233
+#: lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560
+#: lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1005
+#: lxc/network.go:1106 lxc/network.go:1185 lxc/network.go:1245
+#: lxc/network.go:1341 lxc/network.go:1413 lxc/network_acl.go:30
+#: lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235
+#: lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461
+#: lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731
+#: lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860
+#: lxc/network_acl.go:997 lxc/network_allocations.go:51
+#: lxc/network_forward.go:33 lxc/network_forward.go:90
+#: lxc/network_forward.go:179 lxc/network_forward.go:256
+#: lxc/network_forward.go:404 lxc/network_forward.go:489
+#: lxc/network_forward.go:599 lxc/network_forward.go:646
+#: lxc/network_forward.go:800 lxc/network_forward.go:874
+#: lxc/network_forward.go:889 lxc/network_forward.go:970
+#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
+#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844
+#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1121 lxc/network_peer.go:29
+#: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
+#: lxc/network_peer.go:360 lxc/network_peer.go:445 lxc/network_peer.go:547
+#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:29
+#: lxc/network_zone.go:86 lxc/network_zone.go:165 lxc/network_zone.go:228
+#: lxc/network_zone.go:301 lxc/network_zone.go:396 lxc/network_zone.go:484
+#: lxc/network_zone.go:527 lxc/network_zone.go:654 lxc/network_zone.go:710
+#: lxc/network_zone.go:767 lxc/network_zone.go:845 lxc/network_zone.go:909
+#: lxc/network_zone.go:985 lxc/network_zone.go:1083 lxc/network_zone.go:1172
+#: lxc/network_zone.go:1219 lxc/network_zone.go:1349 lxc/network_zone.go:1410
+#: lxc/network_zone.go:1425 lxc/network_zone.go:1483 lxc/operation.go:25
+#: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
+#: lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180 lxc/profile.go:271
+#: lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493 lxc/profile.go:629
+#: lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860 lxc/profile.go:920
+#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31 lxc/project.go:95
+#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
+#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
+#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:648
+#: lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853 lxc/remote.go:917
+#: lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
+#: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
+#: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:459
+#: lxc/storage_bucket.go:536 lxc/storage_bucket.go:630
+#: lxc/storage_bucket.go:699 lxc/storage_bucket.go:733
+#: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
+#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:283
 #: lxc/storage_volume.go:390 lxc/storage_volume.go:605
 #: lxc/storage_volume.go:714 lxc/storage_volume.go:801
 #: lxc/storage_volume.go:899 lxc/storage_volume.go:996
@@ -1829,7 +1839,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:995
+#: lxc/file.go:1184
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1895,7 +1905,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:75
+#: lxc/file.go:79
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1913,7 +1923,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:172 lxc/file.go:173
+#: lxc/file.go:361 lxc/file.go:362
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2183,12 +2193,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1238
+#: lxc/file.go:1427
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1261
+#: lxc/file.go:1450
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2203,12 +2213,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1288
+#: lxc/file.go:1477
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1073
+#: lxc/file.go:1262
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2238,7 +2248,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1194
+#: lxc/file.go:1383
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2253,7 +2263,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1199
+#: lxc/file.go:1388
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2263,12 +2273,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1099
+#: lxc/file.go:1288
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1226
+#: lxc/file.go:1415
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2307,7 +2317,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1400
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2322,7 +2332,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:821
+#: lxc/file.go:1010
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2348,6 +2358,10 @@ msgstr ""
 
 #: lxc/cluster.go:1302
 msgid "Force a particular evacuation action"
+msgstr ""
+
+#: lxc/file.go:144
+msgid "Force creating files or directories"
 msgstr ""
 
 #: lxc/cluster.go:1301
@@ -2644,22 +2658,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1311
+#: lxc/file.go:1500
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1300
+#: lxc/file.go:1489
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1312
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1133
+#: lxc/file.go:1322
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2852,11 +2866,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1125
+#: lxc/file.go:1314
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1302
+#: lxc/file.go:1491
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2874,7 +2888,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1045
+#: lxc/file.go:1234
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2926,7 +2940,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1040
+#: lxc/file.go:1229
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2968,7 +2982,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:148
+#: lxc/file.go:337
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2984,14 +2998,19 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:314
+#: lxc/file.go:503
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:496
+#: lxc/file.go:177 lxc/file.go:685
 #, c-format
 msgid "Invalid target %s"
+msgstr ""
+
+#: lxc/file.go:163
+#, c-format
+msgid "Invalid type %q"
 msgstr ""
 
 #: lxc/info.go:238
@@ -3496,7 +3515,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:83 lxc/file.go:84
+#: lxc/file.go:87 lxc/file.go:88
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3882,7 +3901,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:599
+#: lxc/file.go:788
 msgid "Missing target directory"
 msgstr ""
 
@@ -3920,11 +3939,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:286
+#: lxc/file.go:475
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:986 lxc/file.go:987
+#: lxc/file.go:1175 lxc/file.go:1176
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4376,7 +4395,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1103
+#: lxc/file.go:1292
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4610,20 +4629,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:242 lxc/file.go:243
+#: lxc/file.go:431 lxc/file.go:432
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:417 lxc/file.go:768
+#: lxc/file.go:606 lxc/file.go:957
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:467 lxc/file.go:468
+#: lxc/file.go:656 lxc/file.go:657
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:702 lxc/file.go:868
+#: lxc/file.go:891 lxc/file.go:1057
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4661,7 +4680,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:250 lxc/file.go:474
+#: lxc/file.go:439 lxc/file.go:663
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4990,12 +5009,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1231
+#: lxc/file.go:1420
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1232
+#: lxc/file.go:1421
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5071,7 +5090,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:996
+#: lxc/file.go:1185
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5265,15 +5284,27 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:477
+#: lxc/file.go:145
+msgid "Set the file's gid on create"
+msgstr ""
+
+#: lxc/file.go:666
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:478
+#: lxc/file.go:147
+msgid "Set the file's perms on create"
+msgstr ""
+
+#: lxc/file.go:667
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:476
+#: lxc/file.go:146
+msgid "Set the file's uid on create"
+msgstr ""
+
+#: lxc/file.go:665
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5333,7 +5364,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:994
+#: lxc/file.go:1183
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5708,6 +5739,10 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
+#: lxc/file.go:167
+msgid "Symlink target path can only be used for type \"symlink\""
+msgstr ""
+
 #: lxc/alias.go:140
 msgid "TARGET"
 msgstr ""
@@ -5727,11 +5762,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1033
+#: lxc/file.go:1222
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1027
+#: lxc/file.go:1216
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5900,6 +5935,10 @@ msgstr ""
 
 #: lxc/network.go:537 lxc/network.go:634
 msgid "The specified device doesn't match the network"
+msgstr ""
+
+#: lxc/file.go:148
+msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
 #: lxc/publish.go:97
@@ -6080,7 +6119,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:198
+#: lxc/file.go:387
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6094,7 +6133,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1254
+#: lxc/file.go:1443
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6110,7 +6149,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:808
+#: lxc/file.go:997
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6328,7 +6367,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:72
+#: lxc/file.go:76
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6677,20 +6716,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:171
+#: lxc/file.go:360
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:121
+#: lxc/file.go:133
+msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
+msgstr ""
+
+#: lxc/file.go:310
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:241
+#: lxc/file.go:430
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:985
+#: lxc/file.go:1174
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7199,20 +7242,28 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:989
+#: lxc/file.go:137
+msgid ""
+"lxc file create foo/bar\n"
+"\t   To create a file /bar in the foo instance.\n"
+"lxc file create --type=symlink foo/bar baz\n"
+"\t   To create a symlink /bar in instance foo whose target is baz."
+msgstr ""
+
+#: lxc/file.go:1178
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:245
+#: lxc/file.go:434
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:470
+#: lxc/file.go:659
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7561,16 +7612,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1143
+#: lxc/file.go:1332
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1102
+#: lxc/file.go:1291
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1055
+#: lxc/file.go:1244
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/th.po
+++ b/po/th.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-30 13:36-0400\n"
+"POT-Creation-Date: 2024-10-01 10:45-0600\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -430,12 +430,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:936
+#: lxc/file.go:1125
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:826
+#: lxc/file.go:1015
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -524,7 +524,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:466
+#: lxc/file.go:655
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -979,7 +979,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:341
+#: lxc/file.go:530
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1008,7 +1008,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:547
+#: lxc/file.go:736
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1394,8 +1394,12 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:249 lxc/file.go:475
+#: lxc/file.go:143 lxc/file.go:438 lxc/file.go:664
 msgid "Create any directories necessary"
+msgstr ""
+
+#: lxc/file.go:134 lxc/file.go:135
+msgid "Create files and directories in instances"
 msgstr ""
 
 #: lxc/auth.go:98 lxc/auth.go:99
@@ -1492,6 +1496,11 @@ msgstr ""
 msgid "Creating %s"
 msgstr ""
 
+#: lxc/file.go:273
+#, c-format
+msgid "Creating %s: %%s"
+msgstr ""
+
 #: lxc/init.go:184
 msgid "Creating the instance"
 msgstr ""
@@ -1548,7 +1557,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:123 lxc/file.go:124
+#: lxc/file.go:312 lxc/file.go:313
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1665,70 +1674,71 @@ msgstr ""
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
-#: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
-#: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
-#: lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090 lxc/image.go:1417
-#: lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638 lxc/image.go:1701
-#: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
-#: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
-#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33
-#: lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405
-#: lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793
-#: lxc/network.go:874 lxc/network.go:1005 lxc/network.go:1106
-#: lxc/network.go:1185 lxc/network.go:1245 lxc/network.go:1341
-#: lxc/network.go:1413 lxc/network_acl.go:30 lxc/network_acl.go:95
-#: lxc/network_acl.go:174 lxc/network_acl.go:235 lxc/network_acl.go:291
-#: lxc/network_acl.go:364 lxc/network_acl.go:461 lxc/network_acl.go:549
-#: lxc/network_acl.go:592 lxc/network_acl.go:731 lxc/network_acl.go:788
-#: lxc/network_acl.go:845 lxc/network_acl.go:860 lxc/network_acl.go:997
-#: lxc/network_allocations.go:51 lxc/network_forward.go:33
-#: lxc/network_forward.go:90 lxc/network_forward.go:179
-#: lxc/network_forward.go:256 lxc/network_forward.go:404
-#: lxc/network_forward.go:489 lxc/network_forward.go:599
-#: lxc/network_forward.go:646 lxc/network_forward.go:800
-#: lxc/network_forward.go:874 lxc/network_forward.go:889
-#: lxc/network_forward.go:970 lxc/network_load_balancer.go:33
-#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:181
-#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:408
-#: lxc/network_load_balancer.go:476 lxc/network_load_balancer.go:586
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:771
-#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:859
-#: lxc/network_load_balancer.go:935 lxc/network_load_balancer.go:1033
-#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1121
-#: lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:167
-#: lxc/network_peer.go:236 lxc/network_peer.go:360 lxc/network_peer.go:445
-#: lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731
-#: lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:165
-#: lxc/network_zone.go:228 lxc/network_zone.go:301 lxc/network_zone.go:396
-#: lxc/network_zone.go:484 lxc/network_zone.go:527 lxc/network_zone.go:654
-#: lxc/network_zone.go:710 lxc/network_zone.go:767 lxc/network_zone.go:845
-#: lxc/network_zone.go:909 lxc/network_zone.go:985 lxc/network_zone.go:1083
-#: lxc/network_zone.go:1172 lxc/network_zone.go:1219 lxc/network_zone.go:1349
-#: lxc/network_zone.go:1410 lxc/network_zone.go:1425 lxc/network_zone.go:1483
-#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
-#: lxc/operation.go:194 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
-#: lxc/profile.go:271 lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493
-#: lxc/profile.go:629 lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860
-#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31
-#: lxc/project.go:95 lxc/project.go:191 lxc/project.go:262 lxc/project.go:398
-#: lxc/project.go:472 lxc/project.go:592 lxc/project.go:657 lxc/project.go:745
-#: lxc/project.go:789 lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34
-#: lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91
-#: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853
-#: lxc/remote.go:917 lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24
-#: lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203
-#: lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655
-#: lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940
-#: lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189
-#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:383
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:536
-#: lxc/storage_bucket.go:630 lxc/storage_bucket.go:699
-#: lxc/storage_bucket.go:733 lxc/storage_bucket.go:774
-#: lxc/storage_bucket.go:853 lxc/storage_bucket.go:959
-#: lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158
-#: lxc/storage_volume.go:58 lxc/storage_volume.go:169 lxc/storage_volume.go:283
+#: lxc/export.go:32 lxc/file.go:88 lxc/file.go:135 lxc/file.go:313
+#: lxc/file.go:362 lxc/file.go:432 lxc/file.go:657 lxc/file.go:1176
+#: lxc/image.go:38 lxc/image.go:159 lxc/image.go:337 lxc/image.go:396
+#: lxc/image.go:525 lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090
+#: lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638
+#: lxc/image.go:1701 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255
+#: lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34
+#: lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233
+#: lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560
+#: lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1005
+#: lxc/network.go:1106 lxc/network.go:1185 lxc/network.go:1245
+#: lxc/network.go:1341 lxc/network.go:1413 lxc/network_acl.go:30
+#: lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235
+#: lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461
+#: lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731
+#: lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860
+#: lxc/network_acl.go:997 lxc/network_allocations.go:51
+#: lxc/network_forward.go:33 lxc/network_forward.go:90
+#: lxc/network_forward.go:179 lxc/network_forward.go:256
+#: lxc/network_forward.go:404 lxc/network_forward.go:489
+#: lxc/network_forward.go:599 lxc/network_forward.go:646
+#: lxc/network_forward.go:800 lxc/network_forward.go:874
+#: lxc/network_forward.go:889 lxc/network_forward.go:970
+#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
+#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844
+#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1121 lxc/network_peer.go:29
+#: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
+#: lxc/network_peer.go:360 lxc/network_peer.go:445 lxc/network_peer.go:547
+#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:29
+#: lxc/network_zone.go:86 lxc/network_zone.go:165 lxc/network_zone.go:228
+#: lxc/network_zone.go:301 lxc/network_zone.go:396 lxc/network_zone.go:484
+#: lxc/network_zone.go:527 lxc/network_zone.go:654 lxc/network_zone.go:710
+#: lxc/network_zone.go:767 lxc/network_zone.go:845 lxc/network_zone.go:909
+#: lxc/network_zone.go:985 lxc/network_zone.go:1083 lxc/network_zone.go:1172
+#: lxc/network_zone.go:1219 lxc/network_zone.go:1349 lxc/network_zone.go:1410
+#: lxc/network_zone.go:1425 lxc/network_zone.go:1483 lxc/operation.go:25
+#: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
+#: lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180 lxc/profile.go:271
+#: lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493 lxc/profile.go:629
+#: lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860 lxc/profile.go:920
+#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31 lxc/project.go:95
+#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
+#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
+#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:648
+#: lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853 lxc/remote.go:917
+#: lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
+#: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
+#: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:459
+#: lxc/storage_bucket.go:536 lxc/storage_bucket.go:630
+#: lxc/storage_bucket.go:699 lxc/storage_bucket.go:733
+#: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
+#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:283
 #: lxc/storage_volume.go:390 lxc/storage_volume.go:605
 #: lxc/storage_volume.go:714 lxc/storage_volume.go:801
 #: lxc/storage_volume.go:899 lxc/storage_volume.go:996
@@ -1826,7 +1836,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:995
+#: lxc/file.go:1184
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1892,7 +1902,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:75
+#: lxc/file.go:79
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1910,7 +1920,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:172 lxc/file.go:173
+#: lxc/file.go:361 lxc/file.go:362
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2180,12 +2190,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1238
+#: lxc/file.go:1427
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1261
+#: lxc/file.go:1450
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2200,12 +2210,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1288
+#: lxc/file.go:1477
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1073
+#: lxc/file.go:1262
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2235,7 +2245,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1194
+#: lxc/file.go:1383
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2250,7 +2260,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1199
+#: lxc/file.go:1388
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2260,12 +2270,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1099
+#: lxc/file.go:1288
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1226
+#: lxc/file.go:1415
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2304,7 +2314,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1400
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2319,7 +2329,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:821
+#: lxc/file.go:1010
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2345,6 +2355,10 @@ msgstr ""
 
 #: lxc/cluster.go:1302
 msgid "Force a particular evacuation action"
+msgstr ""
+
+#: lxc/file.go:144
+msgid "Force creating files or directories"
 msgstr ""
 
 #: lxc/cluster.go:1301
@@ -2641,22 +2655,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1311
+#: lxc/file.go:1500
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1300
+#: lxc/file.go:1489
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1312
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1133
+#: lxc/file.go:1322
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2849,11 +2863,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1125
+#: lxc/file.go:1314
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1302
+#: lxc/file.go:1491
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2871,7 +2885,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1045
+#: lxc/file.go:1234
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2923,7 +2937,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1040
+#: lxc/file.go:1229
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2965,7 +2979,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:148
+#: lxc/file.go:337
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2981,14 +2995,19 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:314
+#: lxc/file.go:503
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:496
+#: lxc/file.go:177 lxc/file.go:685
 #, c-format
 msgid "Invalid target %s"
+msgstr ""
+
+#: lxc/file.go:163
+#, c-format
+msgid "Invalid type %q"
 msgstr ""
 
 #: lxc/info.go:238
@@ -3493,7 +3512,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:83 lxc/file.go:84
+#: lxc/file.go:87 lxc/file.go:88
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3879,7 +3898,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:599
+#: lxc/file.go:788
 msgid "Missing target directory"
 msgstr ""
 
@@ -3917,11 +3936,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:286
+#: lxc/file.go:475
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:986 lxc/file.go:987
+#: lxc/file.go:1175 lxc/file.go:1176
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4373,7 +4392,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1103
+#: lxc/file.go:1292
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4607,20 +4626,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:242 lxc/file.go:243
+#: lxc/file.go:431 lxc/file.go:432
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:417 lxc/file.go:768
+#: lxc/file.go:606 lxc/file.go:957
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:467 lxc/file.go:468
+#: lxc/file.go:656 lxc/file.go:657
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:702 lxc/file.go:868
+#: lxc/file.go:891 lxc/file.go:1057
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4658,7 +4677,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:250 lxc/file.go:474
+#: lxc/file.go:439 lxc/file.go:663
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4987,12 +5006,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1231
+#: lxc/file.go:1420
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1232
+#: lxc/file.go:1421
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5068,7 +5087,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:996
+#: lxc/file.go:1185
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5262,15 +5281,27 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:477
+#: lxc/file.go:145
+msgid "Set the file's gid on create"
+msgstr ""
+
+#: lxc/file.go:666
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:478
+#: lxc/file.go:147
+msgid "Set the file's perms on create"
+msgstr ""
+
+#: lxc/file.go:667
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:476
+#: lxc/file.go:146
+msgid "Set the file's uid on create"
+msgstr ""
+
+#: lxc/file.go:665
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5330,7 +5361,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:994
+#: lxc/file.go:1183
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5705,6 +5736,10 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
+#: lxc/file.go:167
+msgid "Symlink target path can only be used for type \"symlink\""
+msgstr ""
+
 #: lxc/alias.go:140
 msgid "TARGET"
 msgstr ""
@@ -5724,11 +5759,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1033
+#: lxc/file.go:1222
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1027
+#: lxc/file.go:1216
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5897,6 +5932,10 @@ msgstr ""
 
 #: lxc/network.go:537 lxc/network.go:634
 msgid "The specified device doesn't match the network"
+msgstr ""
+
+#: lxc/file.go:148
+msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
 #: lxc/publish.go:97
@@ -6077,7 +6116,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:198
+#: lxc/file.go:387
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6091,7 +6130,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1254
+#: lxc/file.go:1443
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6107,7 +6146,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:808
+#: lxc/file.go:997
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6325,7 +6364,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:72
+#: lxc/file.go:76
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6674,20 +6713,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:171
+#: lxc/file.go:360
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:121
+#: lxc/file.go:133
+msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
+msgstr ""
+
+#: lxc/file.go:310
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:241
+#: lxc/file.go:430
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:985
+#: lxc/file.go:1174
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7196,20 +7239,28 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:989
+#: lxc/file.go:137
+msgid ""
+"lxc file create foo/bar\n"
+"\t   To create a file /bar in the foo instance.\n"
+"lxc file create --type=symlink foo/bar baz\n"
+"\t   To create a symlink /bar in instance foo whose target is baz."
+msgstr ""
+
+#: lxc/file.go:1178
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:245
+#: lxc/file.go:434
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:470
+#: lxc/file.go:659
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7558,16 +7609,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1143
+#: lxc/file.go:1332
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1102
+#: lxc/file.go:1291
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1055
+#: lxc/file.go:1244
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-30 13:36-0400\n"
+"POT-Creation-Date: 2024-10-01 10:45-0600\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Turkish <https://hosted.weblate.org/projects/linux-containers/"
@@ -433,12 +433,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:936
+#: lxc/file.go:1125
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:826
+#: lxc/file.go:1015
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -527,7 +527,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:466
+#: lxc/file.go:655
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -982,7 +982,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:341
+#: lxc/file.go:530
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1011,7 +1011,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:547
+#: lxc/file.go:736
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1397,8 +1397,12 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:249 lxc/file.go:475
+#: lxc/file.go:143 lxc/file.go:438 lxc/file.go:664
 msgid "Create any directories necessary"
+msgstr ""
+
+#: lxc/file.go:134 lxc/file.go:135
+msgid "Create files and directories in instances"
 msgstr ""
 
 #: lxc/auth.go:98 lxc/auth.go:99
@@ -1495,6 +1499,11 @@ msgstr ""
 msgid "Creating %s"
 msgstr ""
 
+#: lxc/file.go:273
+#, c-format
+msgid "Creating %s: %%s"
+msgstr ""
+
 #: lxc/init.go:184
 msgid "Creating the instance"
 msgstr ""
@@ -1551,7 +1560,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:123 lxc/file.go:124
+#: lxc/file.go:312 lxc/file.go:313
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1668,70 +1677,71 @@ msgstr ""
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
-#: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
-#: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
-#: lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090 lxc/image.go:1417
-#: lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638 lxc/image.go:1701
-#: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
-#: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
-#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33
-#: lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405
-#: lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793
-#: lxc/network.go:874 lxc/network.go:1005 lxc/network.go:1106
-#: lxc/network.go:1185 lxc/network.go:1245 lxc/network.go:1341
-#: lxc/network.go:1413 lxc/network_acl.go:30 lxc/network_acl.go:95
-#: lxc/network_acl.go:174 lxc/network_acl.go:235 lxc/network_acl.go:291
-#: lxc/network_acl.go:364 lxc/network_acl.go:461 lxc/network_acl.go:549
-#: lxc/network_acl.go:592 lxc/network_acl.go:731 lxc/network_acl.go:788
-#: lxc/network_acl.go:845 lxc/network_acl.go:860 lxc/network_acl.go:997
-#: lxc/network_allocations.go:51 lxc/network_forward.go:33
-#: lxc/network_forward.go:90 lxc/network_forward.go:179
-#: lxc/network_forward.go:256 lxc/network_forward.go:404
-#: lxc/network_forward.go:489 lxc/network_forward.go:599
-#: lxc/network_forward.go:646 lxc/network_forward.go:800
-#: lxc/network_forward.go:874 lxc/network_forward.go:889
-#: lxc/network_forward.go:970 lxc/network_load_balancer.go:33
-#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:181
-#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:408
-#: lxc/network_load_balancer.go:476 lxc/network_load_balancer.go:586
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:771
-#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:859
-#: lxc/network_load_balancer.go:935 lxc/network_load_balancer.go:1033
-#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1121
-#: lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:167
-#: lxc/network_peer.go:236 lxc/network_peer.go:360 lxc/network_peer.go:445
-#: lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731
-#: lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:165
-#: lxc/network_zone.go:228 lxc/network_zone.go:301 lxc/network_zone.go:396
-#: lxc/network_zone.go:484 lxc/network_zone.go:527 lxc/network_zone.go:654
-#: lxc/network_zone.go:710 lxc/network_zone.go:767 lxc/network_zone.go:845
-#: lxc/network_zone.go:909 lxc/network_zone.go:985 lxc/network_zone.go:1083
-#: lxc/network_zone.go:1172 lxc/network_zone.go:1219 lxc/network_zone.go:1349
-#: lxc/network_zone.go:1410 lxc/network_zone.go:1425 lxc/network_zone.go:1483
-#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
-#: lxc/operation.go:194 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
-#: lxc/profile.go:271 lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493
-#: lxc/profile.go:629 lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860
-#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31
-#: lxc/project.go:95 lxc/project.go:191 lxc/project.go:262 lxc/project.go:398
-#: lxc/project.go:472 lxc/project.go:592 lxc/project.go:657 lxc/project.go:745
-#: lxc/project.go:789 lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34
-#: lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91
-#: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853
-#: lxc/remote.go:917 lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24
-#: lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203
-#: lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655
-#: lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940
-#: lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189
-#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:383
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:536
-#: lxc/storage_bucket.go:630 lxc/storage_bucket.go:699
-#: lxc/storage_bucket.go:733 lxc/storage_bucket.go:774
-#: lxc/storage_bucket.go:853 lxc/storage_bucket.go:959
-#: lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158
-#: lxc/storage_volume.go:58 lxc/storage_volume.go:169 lxc/storage_volume.go:283
+#: lxc/export.go:32 lxc/file.go:88 lxc/file.go:135 lxc/file.go:313
+#: lxc/file.go:362 lxc/file.go:432 lxc/file.go:657 lxc/file.go:1176
+#: lxc/image.go:38 lxc/image.go:159 lxc/image.go:337 lxc/image.go:396
+#: lxc/image.go:525 lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090
+#: lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638
+#: lxc/image.go:1701 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255
+#: lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34
+#: lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233
+#: lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560
+#: lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1005
+#: lxc/network.go:1106 lxc/network.go:1185 lxc/network.go:1245
+#: lxc/network.go:1341 lxc/network.go:1413 lxc/network_acl.go:30
+#: lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235
+#: lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461
+#: lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731
+#: lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860
+#: lxc/network_acl.go:997 lxc/network_allocations.go:51
+#: lxc/network_forward.go:33 lxc/network_forward.go:90
+#: lxc/network_forward.go:179 lxc/network_forward.go:256
+#: lxc/network_forward.go:404 lxc/network_forward.go:489
+#: lxc/network_forward.go:599 lxc/network_forward.go:646
+#: lxc/network_forward.go:800 lxc/network_forward.go:874
+#: lxc/network_forward.go:889 lxc/network_forward.go:970
+#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
+#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844
+#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1121 lxc/network_peer.go:29
+#: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
+#: lxc/network_peer.go:360 lxc/network_peer.go:445 lxc/network_peer.go:547
+#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:29
+#: lxc/network_zone.go:86 lxc/network_zone.go:165 lxc/network_zone.go:228
+#: lxc/network_zone.go:301 lxc/network_zone.go:396 lxc/network_zone.go:484
+#: lxc/network_zone.go:527 lxc/network_zone.go:654 lxc/network_zone.go:710
+#: lxc/network_zone.go:767 lxc/network_zone.go:845 lxc/network_zone.go:909
+#: lxc/network_zone.go:985 lxc/network_zone.go:1083 lxc/network_zone.go:1172
+#: lxc/network_zone.go:1219 lxc/network_zone.go:1349 lxc/network_zone.go:1410
+#: lxc/network_zone.go:1425 lxc/network_zone.go:1483 lxc/operation.go:25
+#: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
+#: lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180 lxc/profile.go:271
+#: lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493 lxc/profile.go:629
+#: lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860 lxc/profile.go:920
+#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31 lxc/project.go:95
+#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
+#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
+#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:648
+#: lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853 lxc/remote.go:917
+#: lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
+#: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
+#: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:459
+#: lxc/storage_bucket.go:536 lxc/storage_bucket.go:630
+#: lxc/storage_bucket.go:699 lxc/storage_bucket.go:733
+#: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
+#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:283
 #: lxc/storage_volume.go:390 lxc/storage_volume.go:605
 #: lxc/storage_volume.go:714 lxc/storage_volume.go:801
 #: lxc/storage_volume.go:899 lxc/storage_volume.go:996
@@ -1829,7 +1839,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:995
+#: lxc/file.go:1184
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1895,7 +1905,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:75
+#: lxc/file.go:79
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1913,7 +1923,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:172 lxc/file.go:173
+#: lxc/file.go:361 lxc/file.go:362
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2183,12 +2193,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1238
+#: lxc/file.go:1427
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1261
+#: lxc/file.go:1450
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2203,12 +2213,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1288
+#: lxc/file.go:1477
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1073
+#: lxc/file.go:1262
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2238,7 +2248,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1194
+#: lxc/file.go:1383
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2253,7 +2263,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1199
+#: lxc/file.go:1388
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2263,12 +2273,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1099
+#: lxc/file.go:1288
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1226
+#: lxc/file.go:1415
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2307,7 +2317,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1400
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2322,7 +2332,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:821
+#: lxc/file.go:1010
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2348,6 +2358,10 @@ msgstr ""
 
 #: lxc/cluster.go:1302
 msgid "Force a particular evacuation action"
+msgstr ""
+
+#: lxc/file.go:144
+msgid "Force creating files or directories"
 msgstr ""
 
 #: lxc/cluster.go:1301
@@ -2644,22 +2658,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1311
+#: lxc/file.go:1500
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1300
+#: lxc/file.go:1489
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1312
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1133
+#: lxc/file.go:1322
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2852,11 +2866,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1125
+#: lxc/file.go:1314
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1302
+#: lxc/file.go:1491
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2874,7 +2888,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1045
+#: lxc/file.go:1234
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2926,7 +2940,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1040
+#: lxc/file.go:1229
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2968,7 +2982,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:148
+#: lxc/file.go:337
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2984,14 +2998,19 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:314
+#: lxc/file.go:503
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:496
+#: lxc/file.go:177 lxc/file.go:685
 #, c-format
 msgid "Invalid target %s"
+msgstr ""
+
+#: lxc/file.go:163
+#, c-format
+msgid "Invalid type %q"
 msgstr ""
 
 #: lxc/info.go:238
@@ -3496,7 +3515,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:83 lxc/file.go:84
+#: lxc/file.go:87 lxc/file.go:88
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3882,7 +3901,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:599
+#: lxc/file.go:788
 msgid "Missing target directory"
 msgstr ""
 
@@ -3920,11 +3939,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:286
+#: lxc/file.go:475
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:986 lxc/file.go:987
+#: lxc/file.go:1175 lxc/file.go:1176
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4376,7 +4395,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1103
+#: lxc/file.go:1292
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4610,20 +4629,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:242 lxc/file.go:243
+#: lxc/file.go:431 lxc/file.go:432
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:417 lxc/file.go:768
+#: lxc/file.go:606 lxc/file.go:957
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:467 lxc/file.go:468
+#: lxc/file.go:656 lxc/file.go:657
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:702 lxc/file.go:868
+#: lxc/file.go:891 lxc/file.go:1057
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4661,7 +4680,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:250 lxc/file.go:474
+#: lxc/file.go:439 lxc/file.go:663
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4990,12 +5009,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1231
+#: lxc/file.go:1420
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1232
+#: lxc/file.go:1421
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5071,7 +5090,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:996
+#: lxc/file.go:1185
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5265,15 +5284,27 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:477
+#: lxc/file.go:145
+msgid "Set the file's gid on create"
+msgstr ""
+
+#: lxc/file.go:666
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:478
+#: lxc/file.go:147
+msgid "Set the file's perms on create"
+msgstr ""
+
+#: lxc/file.go:667
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:476
+#: lxc/file.go:146
+msgid "Set the file's uid on create"
+msgstr ""
+
+#: lxc/file.go:665
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5333,7 +5364,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:994
+#: lxc/file.go:1183
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5708,6 +5739,10 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
+#: lxc/file.go:167
+msgid "Symlink target path can only be used for type \"symlink\""
+msgstr ""
+
 #: lxc/alias.go:140
 msgid "TARGET"
 msgstr ""
@@ -5727,11 +5762,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1033
+#: lxc/file.go:1222
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1027
+#: lxc/file.go:1216
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5900,6 +5935,10 @@ msgstr ""
 
 #: lxc/network.go:537 lxc/network.go:634
 msgid "The specified device doesn't match the network"
+msgstr ""
+
+#: lxc/file.go:148
+msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
 #: lxc/publish.go:97
@@ -6080,7 +6119,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:198
+#: lxc/file.go:387
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6094,7 +6133,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1254
+#: lxc/file.go:1443
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6110,7 +6149,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:808
+#: lxc/file.go:997
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6328,7 +6367,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:72
+#: lxc/file.go:76
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6677,20 +6716,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:171
+#: lxc/file.go:360
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:121
+#: lxc/file.go:133
+msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
+msgstr ""
+
+#: lxc/file.go:310
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:241
+#: lxc/file.go:430
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:985
+#: lxc/file.go:1174
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7199,20 +7242,28 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:989
+#: lxc/file.go:137
+msgid ""
+"lxc file create foo/bar\n"
+"\t   To create a file /bar in the foo instance.\n"
+"lxc file create --type=symlink foo/bar baz\n"
+"\t   To create a symlink /bar in instance foo whose target is baz."
+msgstr ""
+
+#: lxc/file.go:1178
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:245
+#: lxc/file.go:434
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:470
+#: lxc/file.go:659
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7561,16 +7612,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1143
+#: lxc/file.go:1332
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1102
+#: lxc/file.go:1291
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1055
+#: lxc/file.go:1244
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/tzm.po
+++ b/po/tzm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-30 13:36-0400\n"
+"POT-Creation-Date: 2024-10-01 10:45-0600\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Tamazight (Central Atlas) <https://hosted.weblate.org/"
@@ -433,12 +433,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:936
+#: lxc/file.go:1125
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:826
+#: lxc/file.go:1015
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -527,7 +527,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:466
+#: lxc/file.go:655
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -982,7 +982,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:341
+#: lxc/file.go:530
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1011,7 +1011,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:547
+#: lxc/file.go:736
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1397,8 +1397,12 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:249 lxc/file.go:475
+#: lxc/file.go:143 lxc/file.go:438 lxc/file.go:664
 msgid "Create any directories necessary"
+msgstr ""
+
+#: lxc/file.go:134 lxc/file.go:135
+msgid "Create files and directories in instances"
 msgstr ""
 
 #: lxc/auth.go:98 lxc/auth.go:99
@@ -1495,6 +1499,11 @@ msgstr ""
 msgid "Creating %s"
 msgstr ""
 
+#: lxc/file.go:273
+#, c-format
+msgid "Creating %s: %%s"
+msgstr ""
+
 #: lxc/init.go:184
 msgid "Creating the instance"
 msgstr ""
@@ -1551,7 +1560,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:123 lxc/file.go:124
+#: lxc/file.go:312 lxc/file.go:313
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1668,70 +1677,71 @@ msgstr ""
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
-#: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
-#: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
-#: lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090 lxc/image.go:1417
-#: lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638 lxc/image.go:1701
-#: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
-#: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
-#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33
-#: lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405
-#: lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793
-#: lxc/network.go:874 lxc/network.go:1005 lxc/network.go:1106
-#: lxc/network.go:1185 lxc/network.go:1245 lxc/network.go:1341
-#: lxc/network.go:1413 lxc/network_acl.go:30 lxc/network_acl.go:95
-#: lxc/network_acl.go:174 lxc/network_acl.go:235 lxc/network_acl.go:291
-#: lxc/network_acl.go:364 lxc/network_acl.go:461 lxc/network_acl.go:549
-#: lxc/network_acl.go:592 lxc/network_acl.go:731 lxc/network_acl.go:788
-#: lxc/network_acl.go:845 lxc/network_acl.go:860 lxc/network_acl.go:997
-#: lxc/network_allocations.go:51 lxc/network_forward.go:33
-#: lxc/network_forward.go:90 lxc/network_forward.go:179
-#: lxc/network_forward.go:256 lxc/network_forward.go:404
-#: lxc/network_forward.go:489 lxc/network_forward.go:599
-#: lxc/network_forward.go:646 lxc/network_forward.go:800
-#: lxc/network_forward.go:874 lxc/network_forward.go:889
-#: lxc/network_forward.go:970 lxc/network_load_balancer.go:33
-#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:181
-#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:408
-#: lxc/network_load_balancer.go:476 lxc/network_load_balancer.go:586
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:771
-#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:859
-#: lxc/network_load_balancer.go:935 lxc/network_load_balancer.go:1033
-#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1121
-#: lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:167
-#: lxc/network_peer.go:236 lxc/network_peer.go:360 lxc/network_peer.go:445
-#: lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731
-#: lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:165
-#: lxc/network_zone.go:228 lxc/network_zone.go:301 lxc/network_zone.go:396
-#: lxc/network_zone.go:484 lxc/network_zone.go:527 lxc/network_zone.go:654
-#: lxc/network_zone.go:710 lxc/network_zone.go:767 lxc/network_zone.go:845
-#: lxc/network_zone.go:909 lxc/network_zone.go:985 lxc/network_zone.go:1083
-#: lxc/network_zone.go:1172 lxc/network_zone.go:1219 lxc/network_zone.go:1349
-#: lxc/network_zone.go:1410 lxc/network_zone.go:1425 lxc/network_zone.go:1483
-#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
-#: lxc/operation.go:194 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
-#: lxc/profile.go:271 lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493
-#: lxc/profile.go:629 lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860
-#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31
-#: lxc/project.go:95 lxc/project.go:191 lxc/project.go:262 lxc/project.go:398
-#: lxc/project.go:472 lxc/project.go:592 lxc/project.go:657 lxc/project.go:745
-#: lxc/project.go:789 lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34
-#: lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91
-#: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853
-#: lxc/remote.go:917 lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24
-#: lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203
-#: lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655
-#: lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940
-#: lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189
-#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:383
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:536
-#: lxc/storage_bucket.go:630 lxc/storage_bucket.go:699
-#: lxc/storage_bucket.go:733 lxc/storage_bucket.go:774
-#: lxc/storage_bucket.go:853 lxc/storage_bucket.go:959
-#: lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158
-#: lxc/storage_volume.go:58 lxc/storage_volume.go:169 lxc/storage_volume.go:283
+#: lxc/export.go:32 lxc/file.go:88 lxc/file.go:135 lxc/file.go:313
+#: lxc/file.go:362 lxc/file.go:432 lxc/file.go:657 lxc/file.go:1176
+#: lxc/image.go:38 lxc/image.go:159 lxc/image.go:337 lxc/image.go:396
+#: lxc/image.go:525 lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090
+#: lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638
+#: lxc/image.go:1701 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255
+#: lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34
+#: lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233
+#: lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560
+#: lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1005
+#: lxc/network.go:1106 lxc/network.go:1185 lxc/network.go:1245
+#: lxc/network.go:1341 lxc/network.go:1413 lxc/network_acl.go:30
+#: lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235
+#: lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461
+#: lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731
+#: lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860
+#: lxc/network_acl.go:997 lxc/network_allocations.go:51
+#: lxc/network_forward.go:33 lxc/network_forward.go:90
+#: lxc/network_forward.go:179 lxc/network_forward.go:256
+#: lxc/network_forward.go:404 lxc/network_forward.go:489
+#: lxc/network_forward.go:599 lxc/network_forward.go:646
+#: lxc/network_forward.go:800 lxc/network_forward.go:874
+#: lxc/network_forward.go:889 lxc/network_forward.go:970
+#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
+#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844
+#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1121 lxc/network_peer.go:29
+#: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
+#: lxc/network_peer.go:360 lxc/network_peer.go:445 lxc/network_peer.go:547
+#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:29
+#: lxc/network_zone.go:86 lxc/network_zone.go:165 lxc/network_zone.go:228
+#: lxc/network_zone.go:301 lxc/network_zone.go:396 lxc/network_zone.go:484
+#: lxc/network_zone.go:527 lxc/network_zone.go:654 lxc/network_zone.go:710
+#: lxc/network_zone.go:767 lxc/network_zone.go:845 lxc/network_zone.go:909
+#: lxc/network_zone.go:985 lxc/network_zone.go:1083 lxc/network_zone.go:1172
+#: lxc/network_zone.go:1219 lxc/network_zone.go:1349 lxc/network_zone.go:1410
+#: lxc/network_zone.go:1425 lxc/network_zone.go:1483 lxc/operation.go:25
+#: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
+#: lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180 lxc/profile.go:271
+#: lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493 lxc/profile.go:629
+#: lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860 lxc/profile.go:920
+#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31 lxc/project.go:95
+#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
+#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
+#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:648
+#: lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853 lxc/remote.go:917
+#: lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
+#: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
+#: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:459
+#: lxc/storage_bucket.go:536 lxc/storage_bucket.go:630
+#: lxc/storage_bucket.go:699 lxc/storage_bucket.go:733
+#: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
+#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:283
 #: lxc/storage_volume.go:390 lxc/storage_volume.go:605
 #: lxc/storage_volume.go:714 lxc/storage_volume.go:801
 #: lxc/storage_volume.go:899 lxc/storage_volume.go:996
@@ -1829,7 +1839,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:995
+#: lxc/file.go:1184
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1895,7 +1905,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:75
+#: lxc/file.go:79
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1913,7 +1923,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:172 lxc/file.go:173
+#: lxc/file.go:361 lxc/file.go:362
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2183,12 +2193,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1238
+#: lxc/file.go:1427
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1261
+#: lxc/file.go:1450
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2203,12 +2213,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1288
+#: lxc/file.go:1477
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1073
+#: lxc/file.go:1262
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2238,7 +2248,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1194
+#: lxc/file.go:1383
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2253,7 +2263,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1199
+#: lxc/file.go:1388
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2263,12 +2273,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1099
+#: lxc/file.go:1288
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1226
+#: lxc/file.go:1415
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2307,7 +2317,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1400
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2322,7 +2332,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:821
+#: lxc/file.go:1010
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2348,6 +2358,10 @@ msgstr ""
 
 #: lxc/cluster.go:1302
 msgid "Force a particular evacuation action"
+msgstr ""
+
+#: lxc/file.go:144
+msgid "Force creating files or directories"
 msgstr ""
 
 #: lxc/cluster.go:1301
@@ -2644,22 +2658,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1311
+#: lxc/file.go:1500
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1300
+#: lxc/file.go:1489
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1312
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1133
+#: lxc/file.go:1322
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2852,11 +2866,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1125
+#: lxc/file.go:1314
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1302
+#: lxc/file.go:1491
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2874,7 +2888,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1045
+#: lxc/file.go:1234
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2926,7 +2940,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1040
+#: lxc/file.go:1229
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2968,7 +2982,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:148
+#: lxc/file.go:337
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2984,14 +2998,19 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:314
+#: lxc/file.go:503
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:496
+#: lxc/file.go:177 lxc/file.go:685
 #, c-format
 msgid "Invalid target %s"
+msgstr ""
+
+#: lxc/file.go:163
+#, c-format
+msgid "Invalid type %q"
 msgstr ""
 
 #: lxc/info.go:238
@@ -3496,7 +3515,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:83 lxc/file.go:84
+#: lxc/file.go:87 lxc/file.go:88
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3882,7 +3901,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:599
+#: lxc/file.go:788
 msgid "Missing target directory"
 msgstr ""
 
@@ -3920,11 +3939,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:286
+#: lxc/file.go:475
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:986 lxc/file.go:987
+#: lxc/file.go:1175 lxc/file.go:1176
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4376,7 +4395,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1103
+#: lxc/file.go:1292
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4610,20 +4629,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:242 lxc/file.go:243
+#: lxc/file.go:431 lxc/file.go:432
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:417 lxc/file.go:768
+#: lxc/file.go:606 lxc/file.go:957
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:467 lxc/file.go:468
+#: lxc/file.go:656 lxc/file.go:657
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:702 lxc/file.go:868
+#: lxc/file.go:891 lxc/file.go:1057
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4661,7 +4680,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:250 lxc/file.go:474
+#: lxc/file.go:439 lxc/file.go:663
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4990,12 +5009,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1231
+#: lxc/file.go:1420
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1232
+#: lxc/file.go:1421
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5071,7 +5090,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:996
+#: lxc/file.go:1185
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5265,15 +5284,27 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:477
+#: lxc/file.go:145
+msgid "Set the file's gid on create"
+msgstr ""
+
+#: lxc/file.go:666
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:478
+#: lxc/file.go:147
+msgid "Set the file's perms on create"
+msgstr ""
+
+#: lxc/file.go:667
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:476
+#: lxc/file.go:146
+msgid "Set the file's uid on create"
+msgstr ""
+
+#: lxc/file.go:665
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5333,7 +5364,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:994
+#: lxc/file.go:1183
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5708,6 +5739,10 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
+#: lxc/file.go:167
+msgid "Symlink target path can only be used for type \"symlink\""
+msgstr ""
+
 #: lxc/alias.go:140
 msgid "TARGET"
 msgstr ""
@@ -5727,11 +5762,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1033
+#: lxc/file.go:1222
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1027
+#: lxc/file.go:1216
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5900,6 +5935,10 @@ msgstr ""
 
 #: lxc/network.go:537 lxc/network.go:634
 msgid "The specified device doesn't match the network"
+msgstr ""
+
+#: lxc/file.go:148
+msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
 #: lxc/publish.go:97
@@ -6080,7 +6119,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:198
+#: lxc/file.go:387
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6094,7 +6133,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1254
+#: lxc/file.go:1443
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6110,7 +6149,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:808
+#: lxc/file.go:997
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6328,7 +6367,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:72
+#: lxc/file.go:76
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6677,20 +6716,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:171
+#: lxc/file.go:360
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:121
+#: lxc/file.go:133
+msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
+msgstr ""
+
+#: lxc/file.go:310
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:241
+#: lxc/file.go:430
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:985
+#: lxc/file.go:1174
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7199,20 +7242,28 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:989
+#: lxc/file.go:137
+msgid ""
+"lxc file create foo/bar\n"
+"\t   To create a file /bar in the foo instance.\n"
+"lxc file create --type=symlink foo/bar baz\n"
+"\t   To create a symlink /bar in instance foo whose target is baz."
+msgstr ""
+
+#: lxc/file.go:1178
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:245
+#: lxc/file.go:434
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:470
+#: lxc/file.go:659
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7561,16 +7612,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1143
+#: lxc/file.go:1332
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1102
+#: lxc/file.go:1291
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1055
+#: lxc/file.go:1244
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/ug.po
+++ b/po/ug.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-30 13:36-0400\n"
+"POT-Creation-Date: 2024-10-01 10:45-0600\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Uyghur <https://hosted.weblate.org/projects/linux-containers/"
@@ -433,12 +433,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:936
+#: lxc/file.go:1125
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:826
+#: lxc/file.go:1015
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -527,7 +527,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:466
+#: lxc/file.go:655
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -982,7 +982,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:341
+#: lxc/file.go:530
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1011,7 +1011,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:547
+#: lxc/file.go:736
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1397,8 +1397,12 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:249 lxc/file.go:475
+#: lxc/file.go:143 lxc/file.go:438 lxc/file.go:664
 msgid "Create any directories necessary"
+msgstr ""
+
+#: lxc/file.go:134 lxc/file.go:135
+msgid "Create files and directories in instances"
 msgstr ""
 
 #: lxc/auth.go:98 lxc/auth.go:99
@@ -1495,6 +1499,11 @@ msgstr ""
 msgid "Creating %s"
 msgstr ""
 
+#: lxc/file.go:273
+#, c-format
+msgid "Creating %s: %%s"
+msgstr ""
+
 #: lxc/init.go:184
 msgid "Creating the instance"
 msgstr ""
@@ -1551,7 +1560,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:123 lxc/file.go:124
+#: lxc/file.go:312 lxc/file.go:313
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1668,70 +1677,71 @@ msgstr ""
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
-#: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
-#: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
-#: lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090 lxc/image.go:1417
-#: lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638 lxc/image.go:1701
-#: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
-#: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
-#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33
-#: lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405
-#: lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793
-#: lxc/network.go:874 lxc/network.go:1005 lxc/network.go:1106
-#: lxc/network.go:1185 lxc/network.go:1245 lxc/network.go:1341
-#: lxc/network.go:1413 lxc/network_acl.go:30 lxc/network_acl.go:95
-#: lxc/network_acl.go:174 lxc/network_acl.go:235 lxc/network_acl.go:291
-#: lxc/network_acl.go:364 lxc/network_acl.go:461 lxc/network_acl.go:549
-#: lxc/network_acl.go:592 lxc/network_acl.go:731 lxc/network_acl.go:788
-#: lxc/network_acl.go:845 lxc/network_acl.go:860 lxc/network_acl.go:997
-#: lxc/network_allocations.go:51 lxc/network_forward.go:33
-#: lxc/network_forward.go:90 lxc/network_forward.go:179
-#: lxc/network_forward.go:256 lxc/network_forward.go:404
-#: lxc/network_forward.go:489 lxc/network_forward.go:599
-#: lxc/network_forward.go:646 lxc/network_forward.go:800
-#: lxc/network_forward.go:874 lxc/network_forward.go:889
-#: lxc/network_forward.go:970 lxc/network_load_balancer.go:33
-#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:181
-#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:408
-#: lxc/network_load_balancer.go:476 lxc/network_load_balancer.go:586
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:771
-#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:859
-#: lxc/network_load_balancer.go:935 lxc/network_load_balancer.go:1033
-#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1121
-#: lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:167
-#: lxc/network_peer.go:236 lxc/network_peer.go:360 lxc/network_peer.go:445
-#: lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731
-#: lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:165
-#: lxc/network_zone.go:228 lxc/network_zone.go:301 lxc/network_zone.go:396
-#: lxc/network_zone.go:484 lxc/network_zone.go:527 lxc/network_zone.go:654
-#: lxc/network_zone.go:710 lxc/network_zone.go:767 lxc/network_zone.go:845
-#: lxc/network_zone.go:909 lxc/network_zone.go:985 lxc/network_zone.go:1083
-#: lxc/network_zone.go:1172 lxc/network_zone.go:1219 lxc/network_zone.go:1349
-#: lxc/network_zone.go:1410 lxc/network_zone.go:1425 lxc/network_zone.go:1483
-#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
-#: lxc/operation.go:194 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
-#: lxc/profile.go:271 lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493
-#: lxc/profile.go:629 lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860
-#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31
-#: lxc/project.go:95 lxc/project.go:191 lxc/project.go:262 lxc/project.go:398
-#: lxc/project.go:472 lxc/project.go:592 lxc/project.go:657 lxc/project.go:745
-#: lxc/project.go:789 lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34
-#: lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91
-#: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853
-#: lxc/remote.go:917 lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24
-#: lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203
-#: lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655
-#: lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940
-#: lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189
-#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:383
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:536
-#: lxc/storage_bucket.go:630 lxc/storage_bucket.go:699
-#: lxc/storage_bucket.go:733 lxc/storage_bucket.go:774
-#: lxc/storage_bucket.go:853 lxc/storage_bucket.go:959
-#: lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158
-#: lxc/storage_volume.go:58 lxc/storage_volume.go:169 lxc/storage_volume.go:283
+#: lxc/export.go:32 lxc/file.go:88 lxc/file.go:135 lxc/file.go:313
+#: lxc/file.go:362 lxc/file.go:432 lxc/file.go:657 lxc/file.go:1176
+#: lxc/image.go:38 lxc/image.go:159 lxc/image.go:337 lxc/image.go:396
+#: lxc/image.go:525 lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090
+#: lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638
+#: lxc/image.go:1701 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255
+#: lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34
+#: lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233
+#: lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560
+#: lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1005
+#: lxc/network.go:1106 lxc/network.go:1185 lxc/network.go:1245
+#: lxc/network.go:1341 lxc/network.go:1413 lxc/network_acl.go:30
+#: lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235
+#: lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461
+#: lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731
+#: lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860
+#: lxc/network_acl.go:997 lxc/network_allocations.go:51
+#: lxc/network_forward.go:33 lxc/network_forward.go:90
+#: lxc/network_forward.go:179 lxc/network_forward.go:256
+#: lxc/network_forward.go:404 lxc/network_forward.go:489
+#: lxc/network_forward.go:599 lxc/network_forward.go:646
+#: lxc/network_forward.go:800 lxc/network_forward.go:874
+#: lxc/network_forward.go:889 lxc/network_forward.go:970
+#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
+#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844
+#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1121 lxc/network_peer.go:29
+#: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
+#: lxc/network_peer.go:360 lxc/network_peer.go:445 lxc/network_peer.go:547
+#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:29
+#: lxc/network_zone.go:86 lxc/network_zone.go:165 lxc/network_zone.go:228
+#: lxc/network_zone.go:301 lxc/network_zone.go:396 lxc/network_zone.go:484
+#: lxc/network_zone.go:527 lxc/network_zone.go:654 lxc/network_zone.go:710
+#: lxc/network_zone.go:767 lxc/network_zone.go:845 lxc/network_zone.go:909
+#: lxc/network_zone.go:985 lxc/network_zone.go:1083 lxc/network_zone.go:1172
+#: lxc/network_zone.go:1219 lxc/network_zone.go:1349 lxc/network_zone.go:1410
+#: lxc/network_zone.go:1425 lxc/network_zone.go:1483 lxc/operation.go:25
+#: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
+#: lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180 lxc/profile.go:271
+#: lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493 lxc/profile.go:629
+#: lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860 lxc/profile.go:920
+#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31 lxc/project.go:95
+#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
+#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
+#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:648
+#: lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853 lxc/remote.go:917
+#: lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
+#: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
+#: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:459
+#: lxc/storage_bucket.go:536 lxc/storage_bucket.go:630
+#: lxc/storage_bucket.go:699 lxc/storage_bucket.go:733
+#: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
+#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:283
 #: lxc/storage_volume.go:390 lxc/storage_volume.go:605
 #: lxc/storage_volume.go:714 lxc/storage_volume.go:801
 #: lxc/storage_volume.go:899 lxc/storage_volume.go:996
@@ -1829,7 +1839,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:995
+#: lxc/file.go:1184
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1895,7 +1905,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:75
+#: lxc/file.go:79
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1913,7 +1923,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:172 lxc/file.go:173
+#: lxc/file.go:361 lxc/file.go:362
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2183,12 +2193,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1238
+#: lxc/file.go:1427
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1261
+#: lxc/file.go:1450
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2203,12 +2213,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1288
+#: lxc/file.go:1477
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1073
+#: lxc/file.go:1262
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2238,7 +2248,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1194
+#: lxc/file.go:1383
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2253,7 +2263,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1199
+#: lxc/file.go:1388
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2263,12 +2273,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1099
+#: lxc/file.go:1288
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1226
+#: lxc/file.go:1415
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2307,7 +2317,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1400
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2322,7 +2332,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:821
+#: lxc/file.go:1010
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2348,6 +2358,10 @@ msgstr ""
 
 #: lxc/cluster.go:1302
 msgid "Force a particular evacuation action"
+msgstr ""
+
+#: lxc/file.go:144
+msgid "Force creating files or directories"
 msgstr ""
 
 #: lxc/cluster.go:1301
@@ -2644,22 +2658,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1311
+#: lxc/file.go:1500
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1300
+#: lxc/file.go:1489
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1312
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1133
+#: lxc/file.go:1322
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2852,11 +2866,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1125
+#: lxc/file.go:1314
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1302
+#: lxc/file.go:1491
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2874,7 +2888,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1045
+#: lxc/file.go:1234
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2926,7 +2940,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1040
+#: lxc/file.go:1229
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2968,7 +2982,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:148
+#: lxc/file.go:337
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2984,14 +2998,19 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:314
+#: lxc/file.go:503
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:496
+#: lxc/file.go:177 lxc/file.go:685
 #, c-format
 msgid "Invalid target %s"
+msgstr ""
+
+#: lxc/file.go:163
+#, c-format
+msgid "Invalid type %q"
 msgstr ""
 
 #: lxc/info.go:238
@@ -3496,7 +3515,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:83 lxc/file.go:84
+#: lxc/file.go:87 lxc/file.go:88
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3882,7 +3901,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:599
+#: lxc/file.go:788
 msgid "Missing target directory"
 msgstr ""
 
@@ -3920,11 +3939,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:286
+#: lxc/file.go:475
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:986 lxc/file.go:987
+#: lxc/file.go:1175 lxc/file.go:1176
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4376,7 +4395,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1103
+#: lxc/file.go:1292
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4610,20 +4629,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:242 lxc/file.go:243
+#: lxc/file.go:431 lxc/file.go:432
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:417 lxc/file.go:768
+#: lxc/file.go:606 lxc/file.go:957
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:467 lxc/file.go:468
+#: lxc/file.go:656 lxc/file.go:657
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:702 lxc/file.go:868
+#: lxc/file.go:891 lxc/file.go:1057
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4661,7 +4680,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:250 lxc/file.go:474
+#: lxc/file.go:439 lxc/file.go:663
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4990,12 +5009,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1231
+#: lxc/file.go:1420
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1232
+#: lxc/file.go:1421
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5071,7 +5090,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:996
+#: lxc/file.go:1185
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5265,15 +5284,27 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:477
+#: lxc/file.go:145
+msgid "Set the file's gid on create"
+msgstr ""
+
+#: lxc/file.go:666
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:478
+#: lxc/file.go:147
+msgid "Set the file's perms on create"
+msgstr ""
+
+#: lxc/file.go:667
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:476
+#: lxc/file.go:146
+msgid "Set the file's uid on create"
+msgstr ""
+
+#: lxc/file.go:665
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5333,7 +5364,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:994
+#: lxc/file.go:1183
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5708,6 +5739,10 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
+#: lxc/file.go:167
+msgid "Symlink target path can only be used for type \"symlink\""
+msgstr ""
+
 #: lxc/alias.go:140
 msgid "TARGET"
 msgstr ""
@@ -5727,11 +5762,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1033
+#: lxc/file.go:1222
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1027
+#: lxc/file.go:1216
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5900,6 +5935,10 @@ msgstr ""
 
 #: lxc/network.go:537 lxc/network.go:634
 msgid "The specified device doesn't match the network"
+msgstr ""
+
+#: lxc/file.go:148
+msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
 #: lxc/publish.go:97
@@ -6080,7 +6119,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:198
+#: lxc/file.go:387
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6094,7 +6133,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1254
+#: lxc/file.go:1443
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6110,7 +6149,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:808
+#: lxc/file.go:997
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6328,7 +6367,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:72
+#: lxc/file.go:76
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6677,20 +6716,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:171
+#: lxc/file.go:360
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:121
+#: lxc/file.go:133
+msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
+msgstr ""
+
+#: lxc/file.go:310
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:241
+#: lxc/file.go:430
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:985
+#: lxc/file.go:1174
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7199,20 +7242,28 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:989
+#: lxc/file.go:137
+msgid ""
+"lxc file create foo/bar\n"
+"\t   To create a file /bar in the foo instance.\n"
+"lxc file create --type=symlink foo/bar baz\n"
+"\t   To create a symlink /bar in instance foo whose target is baz."
+msgstr ""
+
+#: lxc/file.go:1178
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:245
+#: lxc/file.go:434
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:470
+#: lxc/file.go:659
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7561,16 +7612,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1143
+#: lxc/file.go:1332
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1102
+#: lxc/file.go:1291
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1055
+#: lxc/file.go:1244
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-30 13:36-0400\n"
+"POT-Creation-Date: 2024-10-01 10:45-0600\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Ukrainian <https://hosted.weblate.org/projects/linux-"
@@ -434,12 +434,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:936
+#: lxc/file.go:1125
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:826
+#: lxc/file.go:1015
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -528,7 +528,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:466
+#: lxc/file.go:655
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -983,7 +983,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:341
+#: lxc/file.go:530
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1012,7 +1012,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:547
+#: lxc/file.go:736
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1398,8 +1398,12 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:249 lxc/file.go:475
+#: lxc/file.go:143 lxc/file.go:438 lxc/file.go:664
 msgid "Create any directories necessary"
+msgstr ""
+
+#: lxc/file.go:134 lxc/file.go:135
+msgid "Create files and directories in instances"
 msgstr ""
 
 #: lxc/auth.go:98 lxc/auth.go:99
@@ -1496,6 +1500,11 @@ msgstr ""
 msgid "Creating %s"
 msgstr ""
 
+#: lxc/file.go:273
+#, c-format
+msgid "Creating %s: %%s"
+msgstr ""
+
 #: lxc/init.go:184
 msgid "Creating the instance"
 msgstr ""
@@ -1552,7 +1561,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:123 lxc/file.go:124
+#: lxc/file.go:312 lxc/file.go:313
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1669,70 +1678,71 @@ msgstr ""
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
-#: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
-#: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
-#: lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090 lxc/image.go:1417
-#: lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638 lxc/image.go:1701
-#: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
-#: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
-#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33
-#: lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405
-#: lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793
-#: lxc/network.go:874 lxc/network.go:1005 lxc/network.go:1106
-#: lxc/network.go:1185 lxc/network.go:1245 lxc/network.go:1341
-#: lxc/network.go:1413 lxc/network_acl.go:30 lxc/network_acl.go:95
-#: lxc/network_acl.go:174 lxc/network_acl.go:235 lxc/network_acl.go:291
-#: lxc/network_acl.go:364 lxc/network_acl.go:461 lxc/network_acl.go:549
-#: lxc/network_acl.go:592 lxc/network_acl.go:731 lxc/network_acl.go:788
-#: lxc/network_acl.go:845 lxc/network_acl.go:860 lxc/network_acl.go:997
-#: lxc/network_allocations.go:51 lxc/network_forward.go:33
-#: lxc/network_forward.go:90 lxc/network_forward.go:179
-#: lxc/network_forward.go:256 lxc/network_forward.go:404
-#: lxc/network_forward.go:489 lxc/network_forward.go:599
-#: lxc/network_forward.go:646 lxc/network_forward.go:800
-#: lxc/network_forward.go:874 lxc/network_forward.go:889
-#: lxc/network_forward.go:970 lxc/network_load_balancer.go:33
-#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:181
-#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:408
-#: lxc/network_load_balancer.go:476 lxc/network_load_balancer.go:586
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:771
-#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:859
-#: lxc/network_load_balancer.go:935 lxc/network_load_balancer.go:1033
-#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1121
-#: lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:167
-#: lxc/network_peer.go:236 lxc/network_peer.go:360 lxc/network_peer.go:445
-#: lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731
-#: lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:165
-#: lxc/network_zone.go:228 lxc/network_zone.go:301 lxc/network_zone.go:396
-#: lxc/network_zone.go:484 lxc/network_zone.go:527 lxc/network_zone.go:654
-#: lxc/network_zone.go:710 lxc/network_zone.go:767 lxc/network_zone.go:845
-#: lxc/network_zone.go:909 lxc/network_zone.go:985 lxc/network_zone.go:1083
-#: lxc/network_zone.go:1172 lxc/network_zone.go:1219 lxc/network_zone.go:1349
-#: lxc/network_zone.go:1410 lxc/network_zone.go:1425 lxc/network_zone.go:1483
-#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
-#: lxc/operation.go:194 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
-#: lxc/profile.go:271 lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493
-#: lxc/profile.go:629 lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860
-#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31
-#: lxc/project.go:95 lxc/project.go:191 lxc/project.go:262 lxc/project.go:398
-#: lxc/project.go:472 lxc/project.go:592 lxc/project.go:657 lxc/project.go:745
-#: lxc/project.go:789 lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34
-#: lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91
-#: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853
-#: lxc/remote.go:917 lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24
-#: lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203
-#: lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655
-#: lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940
-#: lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189
-#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:383
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:536
-#: lxc/storage_bucket.go:630 lxc/storage_bucket.go:699
-#: lxc/storage_bucket.go:733 lxc/storage_bucket.go:774
-#: lxc/storage_bucket.go:853 lxc/storage_bucket.go:959
-#: lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158
-#: lxc/storage_volume.go:58 lxc/storage_volume.go:169 lxc/storage_volume.go:283
+#: lxc/export.go:32 lxc/file.go:88 lxc/file.go:135 lxc/file.go:313
+#: lxc/file.go:362 lxc/file.go:432 lxc/file.go:657 lxc/file.go:1176
+#: lxc/image.go:38 lxc/image.go:159 lxc/image.go:337 lxc/image.go:396
+#: lxc/image.go:525 lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090
+#: lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638
+#: lxc/image.go:1701 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255
+#: lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34
+#: lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233
+#: lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560
+#: lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1005
+#: lxc/network.go:1106 lxc/network.go:1185 lxc/network.go:1245
+#: lxc/network.go:1341 lxc/network.go:1413 lxc/network_acl.go:30
+#: lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235
+#: lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461
+#: lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731
+#: lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860
+#: lxc/network_acl.go:997 lxc/network_allocations.go:51
+#: lxc/network_forward.go:33 lxc/network_forward.go:90
+#: lxc/network_forward.go:179 lxc/network_forward.go:256
+#: lxc/network_forward.go:404 lxc/network_forward.go:489
+#: lxc/network_forward.go:599 lxc/network_forward.go:646
+#: lxc/network_forward.go:800 lxc/network_forward.go:874
+#: lxc/network_forward.go:889 lxc/network_forward.go:970
+#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
+#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844
+#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1121 lxc/network_peer.go:29
+#: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
+#: lxc/network_peer.go:360 lxc/network_peer.go:445 lxc/network_peer.go:547
+#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:29
+#: lxc/network_zone.go:86 lxc/network_zone.go:165 lxc/network_zone.go:228
+#: lxc/network_zone.go:301 lxc/network_zone.go:396 lxc/network_zone.go:484
+#: lxc/network_zone.go:527 lxc/network_zone.go:654 lxc/network_zone.go:710
+#: lxc/network_zone.go:767 lxc/network_zone.go:845 lxc/network_zone.go:909
+#: lxc/network_zone.go:985 lxc/network_zone.go:1083 lxc/network_zone.go:1172
+#: lxc/network_zone.go:1219 lxc/network_zone.go:1349 lxc/network_zone.go:1410
+#: lxc/network_zone.go:1425 lxc/network_zone.go:1483 lxc/operation.go:25
+#: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
+#: lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180 lxc/profile.go:271
+#: lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493 lxc/profile.go:629
+#: lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860 lxc/profile.go:920
+#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31 lxc/project.go:95
+#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
+#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
+#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:648
+#: lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853 lxc/remote.go:917
+#: lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
+#: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
+#: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:459
+#: lxc/storage_bucket.go:536 lxc/storage_bucket.go:630
+#: lxc/storage_bucket.go:699 lxc/storage_bucket.go:733
+#: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
+#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:283
 #: lxc/storage_volume.go:390 lxc/storage_volume.go:605
 #: lxc/storage_volume.go:714 lxc/storage_volume.go:801
 #: lxc/storage_volume.go:899 lxc/storage_volume.go:996
@@ -1830,7 +1840,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:995
+#: lxc/file.go:1184
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1896,7 +1906,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:75
+#: lxc/file.go:79
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1914,7 +1924,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:172 lxc/file.go:173
+#: lxc/file.go:361 lxc/file.go:362
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2184,12 +2194,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1238
+#: lxc/file.go:1427
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1261
+#: lxc/file.go:1450
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2204,12 +2214,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1288
+#: lxc/file.go:1477
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1073
+#: lxc/file.go:1262
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2239,7 +2249,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1194
+#: lxc/file.go:1383
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2254,7 +2264,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1199
+#: lxc/file.go:1388
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2264,12 +2274,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1099
+#: lxc/file.go:1288
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1226
+#: lxc/file.go:1415
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2308,7 +2318,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1400
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2323,7 +2333,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:821
+#: lxc/file.go:1010
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2349,6 +2359,10 @@ msgstr ""
 
 #: lxc/cluster.go:1302
 msgid "Force a particular evacuation action"
+msgstr ""
+
+#: lxc/file.go:144
+msgid "Force creating files or directories"
 msgstr ""
 
 #: lxc/cluster.go:1301
@@ -2645,22 +2659,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1311
+#: lxc/file.go:1500
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1300
+#: lxc/file.go:1489
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1312
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1133
+#: lxc/file.go:1322
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2853,11 +2867,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1125
+#: lxc/file.go:1314
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1302
+#: lxc/file.go:1491
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2875,7 +2889,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1045
+#: lxc/file.go:1234
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2927,7 +2941,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1040
+#: lxc/file.go:1229
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2969,7 +2983,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:148
+#: lxc/file.go:337
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2985,14 +2999,19 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:314
+#: lxc/file.go:503
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:496
+#: lxc/file.go:177 lxc/file.go:685
 #, c-format
 msgid "Invalid target %s"
+msgstr ""
+
+#: lxc/file.go:163
+#, c-format
+msgid "Invalid type %q"
 msgstr ""
 
 #: lxc/info.go:238
@@ -3497,7 +3516,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:83 lxc/file.go:84
+#: lxc/file.go:87 lxc/file.go:88
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3883,7 +3902,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:599
+#: lxc/file.go:788
 msgid "Missing target directory"
 msgstr ""
 
@@ -3921,11 +3940,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:286
+#: lxc/file.go:475
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:986 lxc/file.go:987
+#: lxc/file.go:1175 lxc/file.go:1176
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4377,7 +4396,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1103
+#: lxc/file.go:1292
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4611,20 +4630,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:242 lxc/file.go:243
+#: lxc/file.go:431 lxc/file.go:432
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:417 lxc/file.go:768
+#: lxc/file.go:606 lxc/file.go:957
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:467 lxc/file.go:468
+#: lxc/file.go:656 lxc/file.go:657
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:702 lxc/file.go:868
+#: lxc/file.go:891 lxc/file.go:1057
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4662,7 +4681,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:250 lxc/file.go:474
+#: lxc/file.go:439 lxc/file.go:663
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4991,12 +5010,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1231
+#: lxc/file.go:1420
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1232
+#: lxc/file.go:1421
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5072,7 +5091,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:996
+#: lxc/file.go:1185
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5266,15 +5285,27 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:477
+#: lxc/file.go:145
+msgid "Set the file's gid on create"
+msgstr ""
+
+#: lxc/file.go:666
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:478
+#: lxc/file.go:147
+msgid "Set the file's perms on create"
+msgstr ""
+
+#: lxc/file.go:667
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:476
+#: lxc/file.go:146
+msgid "Set the file's uid on create"
+msgstr ""
+
+#: lxc/file.go:665
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5334,7 +5365,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:994
+#: lxc/file.go:1183
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5709,6 +5740,10 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
+#: lxc/file.go:167
+msgid "Symlink target path can only be used for type \"symlink\""
+msgstr ""
+
 #: lxc/alias.go:140
 msgid "TARGET"
 msgstr ""
@@ -5728,11 +5763,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1033
+#: lxc/file.go:1222
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1027
+#: lxc/file.go:1216
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5901,6 +5936,10 @@ msgstr ""
 
 #: lxc/network.go:537 lxc/network.go:634
 msgid "The specified device doesn't match the network"
+msgstr ""
+
+#: lxc/file.go:148
+msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
 #: lxc/publish.go:97
@@ -6081,7 +6120,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:198
+#: lxc/file.go:387
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6095,7 +6134,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1254
+#: lxc/file.go:1443
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6111,7 +6150,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:808
+#: lxc/file.go:997
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6329,7 +6368,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:72
+#: lxc/file.go:76
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6678,20 +6717,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:171
+#: lxc/file.go:360
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:121
+#: lxc/file.go:133
+msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
+msgstr ""
+
+#: lxc/file.go:310
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:241
+#: lxc/file.go:430
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:985
+#: lxc/file.go:1174
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7200,20 +7243,28 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:989
+#: lxc/file.go:137
+msgid ""
+"lxc file create foo/bar\n"
+"\t   To create a file /bar in the foo instance.\n"
+"lxc file create --type=symlink foo/bar baz\n"
+"\t   To create a symlink /bar in instance foo whose target is baz."
+msgstr ""
+
+#: lxc/file.go:1178
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:245
+#: lxc/file.go:434
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:470
+#: lxc/file.go:659
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7562,16 +7613,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1143
+#: lxc/file.go:1332
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1102
+#: lxc/file.go:1291
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1055
+#: lxc/file.go:1244
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-30 13:36-0400\n"
+"POT-Creation-Date: 2024-10-01 10:45-0600\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: 0x0916 <w@laoqinren.net>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -594,12 +594,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:936
+#: lxc/file.go:1125
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s 不是一个目录"
 
-#: lxc/file.go:826
+#: lxc/file.go:1015
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -688,7 +688,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:466
+#: lxc/file.go:655
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:341
+#: lxc/file.go:530
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1172,7 +1172,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:547
+#: lxc/file.go:736
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1558,8 +1558,12 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:249 lxc/file.go:475
+#: lxc/file.go:143 lxc/file.go:438 lxc/file.go:664
 msgid "Create any directories necessary"
+msgstr ""
+
+#: lxc/file.go:134 lxc/file.go:135
+msgid "Create files and directories in instances"
 msgstr ""
 
 #: lxc/auth.go:98 lxc/auth.go:99
@@ -1656,6 +1660,11 @@ msgstr ""
 msgid "Creating %s"
 msgstr ""
 
+#: lxc/file.go:273
+#, c-format
+msgid "Creating %s: %%s"
+msgstr ""
+
 #: lxc/init.go:184
 msgid "Creating the instance"
 msgstr ""
@@ -1712,7 +1721,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:123 lxc/file.go:124
+#: lxc/file.go:312 lxc/file.go:313
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1829,70 +1838,71 @@ msgstr ""
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
-#: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
-#: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
-#: lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090 lxc/image.go:1417
-#: lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638 lxc/image.go:1701
-#: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
-#: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
-#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33
-#: lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405
-#: lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793
-#: lxc/network.go:874 lxc/network.go:1005 lxc/network.go:1106
-#: lxc/network.go:1185 lxc/network.go:1245 lxc/network.go:1341
-#: lxc/network.go:1413 lxc/network_acl.go:30 lxc/network_acl.go:95
-#: lxc/network_acl.go:174 lxc/network_acl.go:235 lxc/network_acl.go:291
-#: lxc/network_acl.go:364 lxc/network_acl.go:461 lxc/network_acl.go:549
-#: lxc/network_acl.go:592 lxc/network_acl.go:731 lxc/network_acl.go:788
-#: lxc/network_acl.go:845 lxc/network_acl.go:860 lxc/network_acl.go:997
-#: lxc/network_allocations.go:51 lxc/network_forward.go:33
-#: lxc/network_forward.go:90 lxc/network_forward.go:179
-#: lxc/network_forward.go:256 lxc/network_forward.go:404
-#: lxc/network_forward.go:489 lxc/network_forward.go:599
-#: lxc/network_forward.go:646 lxc/network_forward.go:800
-#: lxc/network_forward.go:874 lxc/network_forward.go:889
-#: lxc/network_forward.go:970 lxc/network_load_balancer.go:33
-#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:181
-#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:408
-#: lxc/network_load_balancer.go:476 lxc/network_load_balancer.go:586
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:771
-#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:859
-#: lxc/network_load_balancer.go:935 lxc/network_load_balancer.go:1033
-#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1121
-#: lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:167
-#: lxc/network_peer.go:236 lxc/network_peer.go:360 lxc/network_peer.go:445
-#: lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731
-#: lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:165
-#: lxc/network_zone.go:228 lxc/network_zone.go:301 lxc/network_zone.go:396
-#: lxc/network_zone.go:484 lxc/network_zone.go:527 lxc/network_zone.go:654
-#: lxc/network_zone.go:710 lxc/network_zone.go:767 lxc/network_zone.go:845
-#: lxc/network_zone.go:909 lxc/network_zone.go:985 lxc/network_zone.go:1083
-#: lxc/network_zone.go:1172 lxc/network_zone.go:1219 lxc/network_zone.go:1349
-#: lxc/network_zone.go:1410 lxc/network_zone.go:1425 lxc/network_zone.go:1483
-#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
-#: lxc/operation.go:194 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
-#: lxc/profile.go:271 lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493
-#: lxc/profile.go:629 lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860
-#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31
-#: lxc/project.go:95 lxc/project.go:191 lxc/project.go:262 lxc/project.go:398
-#: lxc/project.go:472 lxc/project.go:592 lxc/project.go:657 lxc/project.go:745
-#: lxc/project.go:789 lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34
-#: lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91
-#: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853
-#: lxc/remote.go:917 lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24
-#: lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203
-#: lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655
-#: lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940
-#: lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189
-#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:383
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:536
-#: lxc/storage_bucket.go:630 lxc/storage_bucket.go:699
-#: lxc/storage_bucket.go:733 lxc/storage_bucket.go:774
-#: lxc/storage_bucket.go:853 lxc/storage_bucket.go:959
-#: lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158
-#: lxc/storage_volume.go:58 lxc/storage_volume.go:169 lxc/storage_volume.go:283
+#: lxc/export.go:32 lxc/file.go:88 lxc/file.go:135 lxc/file.go:313
+#: lxc/file.go:362 lxc/file.go:432 lxc/file.go:657 lxc/file.go:1176
+#: lxc/image.go:38 lxc/image.go:159 lxc/image.go:337 lxc/image.go:396
+#: lxc/image.go:525 lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090
+#: lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638
+#: lxc/image.go:1701 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255
+#: lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34
+#: lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233
+#: lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560
+#: lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1005
+#: lxc/network.go:1106 lxc/network.go:1185 lxc/network.go:1245
+#: lxc/network.go:1341 lxc/network.go:1413 lxc/network_acl.go:30
+#: lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235
+#: lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461
+#: lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731
+#: lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860
+#: lxc/network_acl.go:997 lxc/network_allocations.go:51
+#: lxc/network_forward.go:33 lxc/network_forward.go:90
+#: lxc/network_forward.go:179 lxc/network_forward.go:256
+#: lxc/network_forward.go:404 lxc/network_forward.go:489
+#: lxc/network_forward.go:599 lxc/network_forward.go:646
+#: lxc/network_forward.go:800 lxc/network_forward.go:874
+#: lxc/network_forward.go:889 lxc/network_forward.go:970
+#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
+#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844
+#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1121 lxc/network_peer.go:29
+#: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
+#: lxc/network_peer.go:360 lxc/network_peer.go:445 lxc/network_peer.go:547
+#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:29
+#: lxc/network_zone.go:86 lxc/network_zone.go:165 lxc/network_zone.go:228
+#: lxc/network_zone.go:301 lxc/network_zone.go:396 lxc/network_zone.go:484
+#: lxc/network_zone.go:527 lxc/network_zone.go:654 lxc/network_zone.go:710
+#: lxc/network_zone.go:767 lxc/network_zone.go:845 lxc/network_zone.go:909
+#: lxc/network_zone.go:985 lxc/network_zone.go:1083 lxc/network_zone.go:1172
+#: lxc/network_zone.go:1219 lxc/network_zone.go:1349 lxc/network_zone.go:1410
+#: lxc/network_zone.go:1425 lxc/network_zone.go:1483 lxc/operation.go:25
+#: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
+#: lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180 lxc/profile.go:271
+#: lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493 lxc/profile.go:629
+#: lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860 lxc/profile.go:920
+#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31 lxc/project.go:95
+#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
+#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
+#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:648
+#: lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853 lxc/remote.go:917
+#: lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
+#: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
+#: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:459
+#: lxc/storage_bucket.go:536 lxc/storage_bucket.go:630
+#: lxc/storage_bucket.go:699 lxc/storage_bucket.go:733
+#: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
+#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:283
 #: lxc/storage_volume.go:390 lxc/storage_volume.go:605
 #: lxc/storage_volume.go:714 lxc/storage_volume.go:801
 #: lxc/storage_volume.go:899 lxc/storage_volume.go:996
@@ -1990,7 +2000,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:995
+#: lxc/file.go:1184
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2056,7 +2066,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:75
+#: lxc/file.go:79
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -2074,7 +2084,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:172 lxc/file.go:173
+#: lxc/file.go:361 lxc/file.go:362
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2344,12 +2354,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1238
+#: lxc/file.go:1427
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1261
+#: lxc/file.go:1450
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2364,12 +2374,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1288
+#: lxc/file.go:1477
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1073
+#: lxc/file.go:1262
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2399,7 +2409,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1194
+#: lxc/file.go:1383
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2414,7 +2424,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1199
+#: lxc/file.go:1388
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2424,12 +2434,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1099
+#: lxc/file.go:1288
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1226
+#: lxc/file.go:1415
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2468,7 +2478,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1400
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2483,7 +2493,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:821
+#: lxc/file.go:1010
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2509,6 +2519,10 @@ msgstr ""
 
 #: lxc/cluster.go:1302
 msgid "Force a particular evacuation action"
+msgstr ""
+
+#: lxc/file.go:144
+msgid "Force creating files or directories"
 msgstr ""
 
 #: lxc/cluster.go:1301
@@ -2805,22 +2819,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1311
+#: lxc/file.go:1500
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1300
+#: lxc/file.go:1489
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1312
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1133
+#: lxc/file.go:1322
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -3013,11 +3027,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1125
+#: lxc/file.go:1314
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1302
+#: lxc/file.go:1491
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3035,7 +3049,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1045
+#: lxc/file.go:1234
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3087,7 +3101,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1040
+#: lxc/file.go:1229
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3129,7 +3143,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:148
+#: lxc/file.go:337
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -3145,14 +3159,19 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:314
+#: lxc/file.go:503
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:496
+#: lxc/file.go:177 lxc/file.go:685
 #, c-format
 msgid "Invalid target %s"
+msgstr ""
+
+#: lxc/file.go:163
+#, c-format
+msgid "Invalid type %q"
 msgstr ""
 
 #: lxc/info.go:238
@@ -3657,7 +3676,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:83 lxc/file.go:84
+#: lxc/file.go:87 lxc/file.go:88
 msgid "Manage files in instances"
 msgstr ""
 
@@ -4043,7 +4062,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:599
+#: lxc/file.go:788
 msgid "Missing target directory"
 msgstr ""
 
@@ -4081,11 +4100,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:286
+#: lxc/file.go:475
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:986 lxc/file.go:987
+#: lxc/file.go:1175 lxc/file.go:1176
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4537,7 +4556,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1103
+#: lxc/file.go:1292
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4771,20 +4790,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:242 lxc/file.go:243
+#: lxc/file.go:431 lxc/file.go:432
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:417 lxc/file.go:768
+#: lxc/file.go:606 lxc/file.go:957
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:467 lxc/file.go:468
+#: lxc/file.go:656 lxc/file.go:657
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:702 lxc/file.go:868
+#: lxc/file.go:891 lxc/file.go:1057
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4822,7 +4841,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:250 lxc/file.go:474
+#: lxc/file.go:439 lxc/file.go:663
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -5151,12 +5170,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1231
+#: lxc/file.go:1420
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1232
+#: lxc/file.go:1421
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5232,7 +5251,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:996
+#: lxc/file.go:1185
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5426,15 +5445,27 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:477
+#: lxc/file.go:145
+msgid "Set the file's gid on create"
+msgstr ""
+
+#: lxc/file.go:666
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:478
+#: lxc/file.go:147
+msgid "Set the file's perms on create"
+msgstr ""
+
+#: lxc/file.go:667
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:476
+#: lxc/file.go:146
+msgid "Set the file's uid on create"
+msgstr ""
+
+#: lxc/file.go:665
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5494,7 +5525,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:994
+#: lxc/file.go:1183
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5869,6 +5900,10 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
+#: lxc/file.go:167
+msgid "Symlink target path can only be used for type \"symlink\""
+msgstr ""
+
 #: lxc/alias.go:140
 msgid "TARGET"
 msgstr ""
@@ -5888,11 +5923,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1033
+#: lxc/file.go:1222
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1027
+#: lxc/file.go:1216
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -6061,6 +6096,10 @@ msgstr ""
 
 #: lxc/network.go:537 lxc/network.go:634
 msgid "The specified device doesn't match the network"
+msgstr ""
+
+#: lxc/file.go:148
+msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
 #: lxc/publish.go:97
@@ -6241,7 +6280,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:198
+#: lxc/file.go:387
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6255,7 +6294,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1254
+#: lxc/file.go:1443
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6271,7 +6310,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:808
+#: lxc/file.go:997
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6489,7 +6528,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:72
+#: lxc/file.go:76
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6838,20 +6877,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:171
+#: lxc/file.go:360
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:121
+#: lxc/file.go:133
+msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
+msgstr ""
+
+#: lxc/file.go:310
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:241
+#: lxc/file.go:430
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:985
+#: lxc/file.go:1174
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7360,20 +7403,28 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:989
+#: lxc/file.go:137
+msgid ""
+"lxc file create foo/bar\n"
+"\t   To create a file /bar in the foo instance.\n"
+"lxc file create --type=symlink foo/bar baz\n"
+"\t   To create a symlink /bar in instance foo whose target is baz."
+msgstr ""
+
+#: lxc/file.go:1178
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:245
+#: lxc/file.go:434
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:470
+#: lxc/file.go:659
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7722,16 +7773,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1143
+#: lxc/file.go:1332
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1102
+#: lxc/file.go:1291
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1055
+#: lxc/file.go:1244
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/zh_Hant.po
+++ b/po/zh_Hant.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-09-30 13:36-0400\n"
+"POT-Creation-Date: 2024-10-01 10:45-0600\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Chinese (Traditional) <https://hosted.weblate.org/projects/"
@@ -433,12 +433,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:936
+#: lxc/file.go:1125
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:826
+#: lxc/file.go:1015
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -527,7 +527,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:466
+#: lxc/file.go:655
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -982,7 +982,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:341
+#: lxc/file.go:530
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1011,7 +1011,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:547
+#: lxc/file.go:736
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1397,8 +1397,12 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:249 lxc/file.go:475
+#: lxc/file.go:143 lxc/file.go:438 lxc/file.go:664
 msgid "Create any directories necessary"
+msgstr ""
+
+#: lxc/file.go:134 lxc/file.go:135
+msgid "Create files and directories in instances"
 msgstr ""
 
 #: lxc/auth.go:98 lxc/auth.go:99
@@ -1495,6 +1499,11 @@ msgstr ""
 msgid "Creating %s"
 msgstr ""
 
+#: lxc/file.go:273
+#, c-format
+msgid "Creating %s: %%s"
+msgstr ""
+
 #: lxc/init.go:184
 msgid "Creating the instance"
 msgstr ""
@@ -1551,7 +1560,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/file.go:123 lxc/file.go:124
+#: lxc/file.go:312 lxc/file.go:313
 msgid "Delete files in instances"
 msgstr ""
 
@@ -1668,70 +1677,71 @@ msgstr ""
 #: lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432
 #: lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651
 #: lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:84 lxc/file.go:124 lxc/file.go:173
-#: lxc/file.go:243 lxc/file.go:468 lxc/file.go:987 lxc/image.go:38
-#: lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525
-#: lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090 lxc/image.go:1417
-#: lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638 lxc/image.go:1701
-#: lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107
-#: lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29
-#: lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83
-#: lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33
-#: lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405
-#: lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793
-#: lxc/network.go:874 lxc/network.go:1005 lxc/network.go:1106
-#: lxc/network.go:1185 lxc/network.go:1245 lxc/network.go:1341
-#: lxc/network.go:1413 lxc/network_acl.go:30 lxc/network_acl.go:95
-#: lxc/network_acl.go:174 lxc/network_acl.go:235 lxc/network_acl.go:291
-#: lxc/network_acl.go:364 lxc/network_acl.go:461 lxc/network_acl.go:549
-#: lxc/network_acl.go:592 lxc/network_acl.go:731 lxc/network_acl.go:788
-#: lxc/network_acl.go:845 lxc/network_acl.go:860 lxc/network_acl.go:997
-#: lxc/network_allocations.go:51 lxc/network_forward.go:33
-#: lxc/network_forward.go:90 lxc/network_forward.go:179
-#: lxc/network_forward.go:256 lxc/network_forward.go:404
-#: lxc/network_forward.go:489 lxc/network_forward.go:599
-#: lxc/network_forward.go:646 lxc/network_forward.go:800
-#: lxc/network_forward.go:874 lxc/network_forward.go:889
-#: lxc/network_forward.go:970 lxc/network_load_balancer.go:33
-#: lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:181
-#: lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:408
-#: lxc/network_load_balancer.go:476 lxc/network_load_balancer.go:586
-#: lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:771
-#: lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:859
-#: lxc/network_load_balancer.go:935 lxc/network_load_balancer.go:1033
-#: lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1121
-#: lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:167
-#: lxc/network_peer.go:236 lxc/network_peer.go:360 lxc/network_peer.go:445
-#: lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731
-#: lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:165
-#: lxc/network_zone.go:228 lxc/network_zone.go:301 lxc/network_zone.go:396
-#: lxc/network_zone.go:484 lxc/network_zone.go:527 lxc/network_zone.go:654
-#: lxc/network_zone.go:710 lxc/network_zone.go:767 lxc/network_zone.go:845
-#: lxc/network_zone.go:909 lxc/network_zone.go:985 lxc/network_zone.go:1083
-#: lxc/network_zone.go:1172 lxc/network_zone.go:1219 lxc/network_zone.go:1349
-#: lxc/network_zone.go:1410 lxc/network_zone.go:1425 lxc/network_zone.go:1483
-#: lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107
-#: lxc/operation.go:194 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180
-#: lxc/profile.go:271 lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493
-#: lxc/profile.go:629 lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860
-#: lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31
-#: lxc/project.go:95 lxc/project.go:191 lxc/project.go:262 lxc/project.go:398
-#: lxc/project.go:472 lxc/project.go:592 lxc/project.go:657 lxc/project.go:745
-#: lxc/project.go:789 lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34
-#: lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91
-#: lxc/remote.go:648 lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853
-#: lxc/remote.go:917 lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24
-#: lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203
-#: lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655
-#: lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940
-#: lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189
-#: lxc/storage_bucket.go:250 lxc/storage_bucket.go:383
-#: lxc/storage_bucket.go:459 lxc/storage_bucket.go:536
-#: lxc/storage_bucket.go:630 lxc/storage_bucket.go:699
-#: lxc/storage_bucket.go:733 lxc/storage_bucket.go:774
-#: lxc/storage_bucket.go:853 lxc/storage_bucket.go:959
-#: lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158
-#: lxc/storage_volume.go:58 lxc/storage_volume.go:169 lxc/storage_volume.go:283
+#: lxc/export.go:32 lxc/file.go:88 lxc/file.go:135 lxc/file.go:313
+#: lxc/file.go:362 lxc/file.go:432 lxc/file.go:657 lxc/file.go:1176
+#: lxc/image.go:38 lxc/image.go:159 lxc/image.go:337 lxc/image.go:396
+#: lxc/image.go:525 lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090
+#: lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638
+#: lxc/image.go:1701 lxc/image_alias.go:24 lxc/image_alias.go:60
+#: lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255
+#: lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24
+#: lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34
+#: lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233
+#: lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560
+#: lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1005
+#: lxc/network.go:1106 lxc/network.go:1185 lxc/network.go:1245
+#: lxc/network.go:1341 lxc/network.go:1413 lxc/network_acl.go:30
+#: lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235
+#: lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461
+#: lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731
+#: lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860
+#: lxc/network_acl.go:997 lxc/network_allocations.go:51
+#: lxc/network_forward.go:33 lxc/network_forward.go:90
+#: lxc/network_forward.go:179 lxc/network_forward.go:256
+#: lxc/network_forward.go:404 lxc/network_forward.go:489
+#: lxc/network_forward.go:599 lxc/network_forward.go:646
+#: lxc/network_forward.go:800 lxc/network_forward.go:874
+#: lxc/network_forward.go:889 lxc/network_forward.go:970
+#: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
+#: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
+#: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
+#: lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616
+#: lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844
+#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935
+#: lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048
+#: lxc/network_load_balancer.go:1121 lxc/network_peer.go:29
+#: lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236
+#: lxc/network_peer.go:360 lxc/network_peer.go:445 lxc/network_peer.go:547
+#: lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:29
+#: lxc/network_zone.go:86 lxc/network_zone.go:165 lxc/network_zone.go:228
+#: lxc/network_zone.go:301 lxc/network_zone.go:396 lxc/network_zone.go:484
+#: lxc/network_zone.go:527 lxc/network_zone.go:654 lxc/network_zone.go:710
+#: lxc/network_zone.go:767 lxc/network_zone.go:845 lxc/network_zone.go:909
+#: lxc/network_zone.go:985 lxc/network_zone.go:1083 lxc/network_zone.go:1172
+#: lxc/network_zone.go:1219 lxc/network_zone.go:1349 lxc/network_zone.go:1410
+#: lxc/network_zone.go:1425 lxc/network_zone.go:1483 lxc/operation.go:25
+#: lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194
+#: lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180 lxc/profile.go:271
+#: lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493 lxc/profile.go:629
+#: lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860 lxc/profile.go:920
+#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31 lxc/project.go:95
+#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
+#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
+#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:648
+#: lxc/remote.go:686 lxc/remote.go:772 lxc/remote.go:853 lxc/remote.go:917
+#: lxc/remote.go:965 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
+#: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
+#: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
+#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250
+#: lxc/storage_bucket.go:383 lxc/storage_bucket.go:459
+#: lxc/storage_bucket.go:536 lxc/storage_bucket.go:630
+#: lxc/storage_bucket.go:699 lxc/storage_bucket.go:733
+#: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
+#: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
+#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:283
 #: lxc/storage_volume.go:390 lxc/storage_volume.go:605
 #: lxc/storage_volume.go:714 lxc/storage_volume.go:801
 #: lxc/storage_volume.go:899 lxc/storage_volume.go:996
@@ -1829,7 +1839,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:995
+#: lxc/file.go:1184
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1895,7 +1905,7 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/file.go:75
+#: lxc/file.go:79
 msgid ""
 "Early server side processing of file transfer requests cannot be canceled "
 "(interrupt two more times to force)"
@@ -1913,7 +1923,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:172 lxc/file.go:173
+#: lxc/file.go:361 lxc/file.go:362
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2183,12 +2193,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1238
+#: lxc/file.go:1427
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1261
+#: lxc/file.go:1450
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2203,12 +2213,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1288
+#: lxc/file.go:1477
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1073
+#: lxc/file.go:1262
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2238,7 +2248,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1194
+#: lxc/file.go:1383
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2253,7 +2263,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1199
+#: lxc/file.go:1388
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2263,12 +2273,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1099
+#: lxc/file.go:1288
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1226
+#: lxc/file.go:1415
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2307,7 +2317,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1211
+#: lxc/file.go:1400
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2322,7 +2332,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:821
+#: lxc/file.go:1010
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2348,6 +2358,10 @@ msgstr ""
 
 #: lxc/cluster.go:1302
 msgid "Force a particular evacuation action"
+msgstr ""
+
+#: lxc/file.go:144
+msgid "Force creating files or directories"
 msgstr ""
 
 #: lxc/cluster.go:1301
@@ -2644,22 +2658,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1311
+#: lxc/file.go:1500
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1300
+#: lxc/file.go:1489
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1123
+#: lxc/file.go:1312
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1133
+#: lxc/file.go:1322
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2852,11 +2866,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1125
+#: lxc/file.go:1314
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1302
+#: lxc/file.go:1491
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2874,7 +2888,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1045
+#: lxc/file.go:1234
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2926,7 +2940,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1040
+#: lxc/file.go:1229
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2968,7 +2982,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:148
+#: lxc/file.go:337
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -2984,14 +2998,19 @@ msgstr ""
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:314
+#: lxc/file.go:503
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:496
+#: lxc/file.go:177 lxc/file.go:685
 #, c-format
 msgid "Invalid target %s"
+msgstr ""
+
+#: lxc/file.go:163
+#, c-format
+msgid "Invalid type %q"
 msgstr ""
 
 #: lxc/info.go:238
@@ -3496,7 +3515,7 @@ msgstr ""
 msgid "Manage devices"
 msgstr ""
 
-#: lxc/file.go:83 lxc/file.go:84
+#: lxc/file.go:87 lxc/file.go:88
 msgid "Manage files in instances"
 msgstr ""
 
@@ -3882,7 +3901,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:599
+#: lxc/file.go:788
 msgid "Missing target directory"
 msgstr ""
 
@@ -3920,11 +3939,11 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:286
+#: lxc/file.go:475
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:986 lxc/file.go:987
+#: lxc/file.go:1175 lxc/file.go:1176
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4376,7 +4395,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1103
+#: lxc/file.go:1292
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4610,20 +4629,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:242 lxc/file.go:243
+#: lxc/file.go:431 lxc/file.go:432
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:417 lxc/file.go:768
+#: lxc/file.go:606 lxc/file.go:957
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:467 lxc/file.go:468
+#: lxc/file.go:656 lxc/file.go:657
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:702 lxc/file.go:868
+#: lxc/file.go:891 lxc/file.go:1057
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4661,7 +4680,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:250 lxc/file.go:474
+#: lxc/file.go:439 lxc/file.go:663
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4990,12 +5009,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1231
+#: lxc/file.go:1420
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1232
+#: lxc/file.go:1421
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5071,7 +5090,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:996
+#: lxc/file.go:1185
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5265,15 +5284,27 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:477
+#: lxc/file.go:145
+msgid "Set the file's gid on create"
+msgstr ""
+
+#: lxc/file.go:666
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:478
+#: lxc/file.go:147
+msgid "Set the file's perms on create"
+msgstr ""
+
+#: lxc/file.go:667
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:476
+#: lxc/file.go:146
+msgid "Set the file's uid on create"
+msgstr ""
+
+#: lxc/file.go:665
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5333,7 +5364,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:994
+#: lxc/file.go:1183
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5708,6 +5739,10 @@ msgstr ""
 msgid "Switch the default remote"
 msgstr ""
 
+#: lxc/file.go:167
+msgid "Symlink target path can only be used for type \"symlink\""
+msgstr ""
+
 #: lxc/alias.go:140
 msgid "TARGET"
 msgstr ""
@@ -5727,11 +5762,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1033
+#: lxc/file.go:1222
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1027
+#: lxc/file.go:1216
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5900,6 +5935,10 @@ msgstr ""
 
 #: lxc/network.go:537 lxc/network.go:634
 msgid "The specified device doesn't match the network"
+msgstr ""
+
+#: lxc/file.go:148
+msgid "The type to create (file, symlink, or directory)"
 msgstr ""
 
 #: lxc/publish.go:97
@@ -6080,7 +6119,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:198
+#: lxc/file.go:387
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6094,7 +6133,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1254
+#: lxc/file.go:1443
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6110,7 +6149,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:808
+#: lxc/file.go:997
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6328,7 +6367,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/file.go:72
+#: lxc/file.go:76
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -6677,20 +6716,24 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:171
+#: lxc/file.go:360
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/file.go:121
+#: lxc/file.go:133
+msgid "[<remote>:]<instance>/<path> [<symlink target path>]"
+msgstr ""
+
+#: lxc/file.go:310
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:241
+#: lxc/file.go:430
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:985
+#: lxc/file.go:1174
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7199,20 +7242,28 @@ msgid ""
 "    Download a backup tarball of the u1 instance."
 msgstr ""
 
-#: lxc/file.go:989
+#: lxc/file.go:137
+msgid ""
+"lxc file create foo/bar\n"
+"\t   To create a file /bar in the foo instance.\n"
+"lxc file create --type=symlink foo/bar baz\n"
+"\t   To create a symlink /bar in instance foo whose target is baz."
+msgstr ""
+
+#: lxc/file.go:1178
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:245
+#: lxc/file.go:434
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:470
+#: lxc/file.go:659
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7561,16 +7612,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1143
+#: lxc/file.go:1332
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1102
+#: lxc/file.go:1291
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1055
+#: lxc/file.go:1244
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/test/suites/filemanip.sh
+++ b/test/suites/filemanip.sh
@@ -127,6 +127,31 @@ test_filemanip() {
     lxc delete idmap --force
   fi
 
+  # Test lxc file create.
+
+  # Create a new empty file.
+  lxc file create filemanip/tmp/create-test
+  [ -z "$(lxc exec filemanip --project=test -- cat /tmp/create-test)" ]
+
+  # This fails because the parent directory doesn't exist.
+  ! lxc file create filemanip/tmp/create-test-dir/foo || false
+
+  # Create foo along with the parent directory.
+  lxc file create --create-dirs filemanip/tmp/create-test-dir/foo
+  [ -z "$(lxc exec filemanip --project=test -- cat /tmp/create-test-dir/foo)" ]
+
+  # Create directory using --type flag.
+  lxc file create --type=directory filemanip/tmp/create-test-dir/sub-dir
+  lxc exec filemanip --project=test -- test -d /tmp/create-test-dir/sub-dir
+
+  # Create directory using trailing "/".
+  lxc file create filemanip/tmp/create-test-dir/sub-dir-1/
+  lxc exec filemanip --project=test -- test -d /tmp/create-test-dir/sub-dir-1
+
+  # Create symlink.
+  lxc file create --type=symlink filemanip/tmp/create-symlink foo
+  [ "$(lxc exec filemanip --project=test -- readlink /tmp/create-symlink)" = "foo" ]
+
   # Test SFTP functionality.
   cmd=$(unset -f lxc; command -v lxc)
   $cmd file mount filemanip --listen=127.0.0.1:2022 --no-auth &


### PR DESCRIPTION
Cherry-picked from https://github.com/lxc/incus/pull/408. I've also added instance shell completions for `lxc file` subcommands.

Signed-off-by: Kadin Sayani <kadin.sayani@canonical.com>