### PR TITLE
Add shell completions for `lxc config device`

### DIFF
--- a/lxc/completion.go
+++ b/lxc/completion.go
@@ -366,6 +366,37 @@ func (g *cmdGlobal) cmpInstanceAllDevices(instanceName string) ([]string, cobra.
 	return devices, cobra.ShellCompDirectiveNoFileComp
 }
 
+func (g *cmdGlobal) cmpInstanceAllDeviceOptions(instanceName string, deviceName string) ([]string, cobra.ShellCompDirective) {
+	resources, err := g.ParseServers(instanceName)
+	if err != nil || len(resources) == 0 {
+		return nil, cobra.ShellCompDirectiveError
+	}
+
+	resource := resources[0]
+	client := resource.server
+
+	metadataConfiguration, err := client.GetMetadataConfiguration()
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveError
+	}
+
+	deviceOptions := make([]string, 0, len(metadataConfiguration.Configs))
+
+	for key, device := range metadataConfiguration.Configs {
+		parts := strings.Split(key, "-")
+		if strings.HasPrefix(key, "device-") && parts[1] == deviceName {
+			conf := device["device-conf"]
+			for _, keyMap := range conf.Keys {
+				for option := range keyMap {
+					deviceOptions = append(deviceOptions, option)
+				}
+			}
+		}
+	}
+
+	return deviceOptions, cobra.ShellCompDirectiveNoFileComp
+}
+
 func (g *cmdGlobal) cmpInstances(toComplete string) ([]string, cobra.ShellCompDirective) {
 	var results []string
 	cmpDirectives := cobra.ShellCompDirectiveNoFileComp

--- a/lxc/completion.go
+++ b/lxc/completion.go
@@ -339,6 +339,33 @@ func (g *cmdGlobal) cmpInstanceDeviceNames(instanceName string) ([]string, cobra
 	return results, cobra.ShellCompDirectiveNoFileComp
 }
 
+func (g *cmdGlobal) cmpInstanceAllDevices(instanceName string) ([]string, cobra.ShellCompDirective) {
+	resources, err := g.ParseServers(instanceName)
+	if err != nil || len(resources) == 0 {
+		return nil, cobra.ShellCompDirectiveError
+	}
+
+	resource := resources[0]
+	client := resource.server
+
+	metadataConfiguration, err := client.GetMetadataConfiguration()
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveError
+	}
+
+	devices := make([]string, 0, len(metadataConfiguration.Configs))
+
+	for key := range metadataConfiguration.Configs {
+		if strings.HasPrefix(key, "device-") {
+			parts := strings.Split(key, "-")
+			deviceName := parts[1]
+			devices = append(devices, deviceName)
+		}
+	}
+
+	return devices, cobra.ShellCompDirectiveNoFileComp
+}
+
 func (g *cmdGlobal) cmpInstances(toComplete string) ([]string, cobra.ShellCompDirective) {
 	var results []string
 	cmpDirectives := cobra.ShellCompDirectiveNoFileComp

--- a/lxc/config_device.go
+++ b/lxc/config_device.go
@@ -107,6 +107,10 @@ lxc profile device add [<remote>:]profile1 <device-name> disk pool=some-pool sou
 			}
 		}
 
+		if len(args) == 1 {
+			return c.global.cmpInstanceAllDevices(toComplete)
+		}
+
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 

--- a/lxc/config_device.go
+++ b/lxc/config_device.go
@@ -111,6 +111,10 @@ lxc profile device add [<remote>:]profile1 <device-name> disk pool=some-pool sou
 			return c.global.cmpInstanceAllDevices(toComplete)
 		}
 
+		if len(args) == 2 {
+			return c.global.cmpInstanceAllDeviceOptions(args[0], args[1])
+		}
+
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 


### PR DESCRIPTION
Fixes https://github.com/canonical/lxd/issues/14138

Adds shell completions for `lxc config device add`:

- `lxc config device add [TAB]` shows all possible devices; and
- `lxc config device add <device> [TAB]` shows all possible device options.

Shell completions for `lxc config device get/set/unset` are unchanged, as they currently return set config options from either the config or profile (whichever exists), and I think it makes sense to keep it this way. Please let me know if you have any suggestions 😄 