### PR TITLE
fix:fix slice init length

### DIFF
--- a/lxd/storage/drivers/driver_ceph_volumes.go
+++ b/lxd/storage/drivers/driver_ceph_volumes.go
@@ -1513,7 +1513,7 @@ func (d *ceph) ListVolumes() ([]Volume, error) {
 		return nil, fmt.Errorf("Failed getting volume list: %v: %w", strings.TrimSpace(string(errMsg)), err)
 	}
 
-	volList := make([]Volume, len(vols))
+	volList := make([]Volume, 0, len(vols))
 	for _, v := range vols {
 		volList = append(volList, v)
 	}


### PR DESCRIPTION
The intention here should be to initialize a slice with a capacity of len(vols) rather than initializing the length of this slice.

The online demo:  https://go.dev/play/p/q1BcVCmvidW
