### PR TITLE
lxc/completions: Improvements to completions for `lxc action`, `lxc delete` and `lxc exec`

### DIFF
--- a/lxc/action.go
+++ b/lxc/action.go
@@ -34,7 +34,7 @@ func (c *cmdStart) command() *cobra.Command {
 		`Start instances`))
 
 	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return c.global.cmpInstances(toComplete)
+		return c.global.cmpInstancesAction(toComplete, "start", c.action.flagForce)
 	}
 
 	return cmd
@@ -60,7 +60,7 @@ func (c *cmdPause) command() *cobra.Command {
 	cmd.Aliases = []string{"freeze"}
 
 	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return c.global.cmpInstances(toComplete)
+		return c.global.cmpInstancesAction(toComplete, "pause", c.action.flagForce)
 	}
 
 	return cmd
@@ -87,7 +87,7 @@ func (c *cmdRestart) command() *cobra.Command {
 The opposite of "lxc pause" is "lxc start".`))
 
 	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return c.global.cmpInstances(toComplete)
+		return c.global.cmpInstancesAction(toComplete, "restart", c.action.flagForce)
 	}
 
 	return cmd
@@ -112,7 +112,7 @@ func (c *cmdStop) command() *cobra.Command {
 		`Stop instances`))
 
 	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return c.global.cmpInstances(toComplete)
+		return c.global.cmpInstancesAction(toComplete, "stop", c.action.flagForce)
 	}
 
 	return cmd

--- a/lxc/delete.go
+++ b/lxc/delete.go
@@ -37,7 +37,7 @@ func (c *cmdDelete) command() *cobra.Command {
 	cmd.Flags().BoolVarP(&c.flagInteractive, "interactive", "i", false, i18n.G("Require user confirmation"))
 
 	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return c.global.cmpInstances(toComplete)
+		return c.global.cmpInstancesAction(toComplete, "delete", c.flagForce)
 	}
 
 	return cmd

--- a/lxc/exec.go
+++ b/lxc/exec.go
@@ -62,7 +62,7 @@ Mode defaults to non-interactive, interactive mode is selected if both stdin AND
 
 	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
-			return c.global.cmpInstances(toComplete)
+			return c.global.cmpInstancesAction(toComplete, "exec", false)
 		}
 
 		return nil, cobra.ShellCompDirectiveNoFileComp

--- a/shared/api/status_code.go
+++ b/shared/api/status_code.go
@@ -67,3 +67,13 @@ func StatusCodeFromString(status string) StatusCode {
 
 	return -1
 }
+
+// GetAllStatusCodeStrings returns a slice of all status code strings.
+func GetAllStatusCodeStrings() []string {
+	var statusStrings []string
+	for _, code := range StatusCodeNames {
+		statusStrings = append(statusStrings, code)
+	}
+
+	return statusStrings
+}


### PR DESCRIPTION
This PR includes improvements to `cmpInstances()`:

lxc pause|stop|exec <tab> completes RUNNING instances
lxc stop --force <tab> completes RUNNING|FROZEN instances
lxc start <tab> completes STOPPED|FROZEN instances
lxc delete <tab> completes STOPPED instances
lxc delete --force <tab> completes ALL instances

Resolves https://github.com/canonical/lxd/issues/14198