### PR TITLE
test/suites/backup: ignore time discrepancies when untar'ing

### DIFF
--- a/test/suites/backup.sh
+++ b/test/suites/backup.sh
@@ -575,7 +575,7 @@ _backup_export_with_project() {
 
   if storage_backend_optimized_backup "$lxd_backend"; then
     lxc export c1 "${LXD_DIR}/c1-optimized.tar.gz" --optimized-storage --instance-only
-    tar -xzf "${LXD_DIR}/c1-optimized.tar.gz" -C "${LXD_DIR}/optimized"
+    tar --warning=no-timestamp -xzf "${LXD_DIR}/c1-optimized.tar.gz" -C "${LXD_DIR}/optimized"
 
     ls -l "${LXD_DIR}/optimized/backup/"
     [ -f "${LXD_DIR}/optimized/backup/index.yaml" ]
@@ -584,7 +584,7 @@ _backup_export_with_project() {
   fi
 
   lxc export c1 "${LXD_DIR}/c1.tar.gz" --instance-only
-  tar -xzf "${LXD_DIR}/c1.tar.gz" -C "${LXD_DIR}/non-optimized"
+  tar --warning=no-timestamp -xzf "${LXD_DIR}/c1.tar.gz" -C "${LXD_DIR}/non-optimized"
 
   # check tarball content
   ls -l "${LXD_DIR}/non-optimized/backup/"
@@ -597,7 +597,7 @@ _backup_export_with_project() {
   # with snapshots
   if storage_backend_optimized_backup "$lxd_backend"; then
     lxc export c1 "${LXD_DIR}/c1-optimized.tar.gz" --optimized-storage
-    tar -xzf "${LXD_DIR}/c1-optimized.tar.gz" -C "${LXD_DIR}/optimized"
+    tar --warning=no-timestamp -xzf "${LXD_DIR}/c1-optimized.tar.gz" -C "${LXD_DIR}/optimized"
 
     ls -l "${LXD_DIR}/optimized/backup/"
     [ -f "${LXD_DIR}/optimized/backup/index.yaml" ]
@@ -606,7 +606,7 @@ _backup_export_with_project() {
   fi
 
   lxc export c1 "${LXD_DIR}/c1.tar.gz"
-  tar -xzf "${LXD_DIR}/c1.tar.gz" -C "${LXD_DIR}/non-optimized"
+  tar --warning=no-timestamp -xzf "${LXD_DIR}/c1.tar.gz" -C "${LXD_DIR}/non-optimized"
 
   # check tarball content
   ls -l "${LXD_DIR}/non-optimized/backup/"
@@ -745,7 +745,7 @@ _backup_volume_export_with_project() {
     [ -f "${LXD_DIR}/testvol-optimized.tar.gz" ]
 
     # Extract backup tarball.
-    tar -xzf "${LXD_DIR}/testvol-optimized.tar.gz" -C "${LXD_DIR}/optimized"
+    tar --warning=no-timestamp -xzf "${LXD_DIR}/testvol-optimized.tar.gz" -C "${LXD_DIR}/optimized"
 
     ls -l "${LXD_DIR}/optimized/backup/"
     [ -f "${LXD_DIR}/optimized/backup/index.yaml" ]
@@ -759,7 +759,7 @@ _backup_volume_export_with_project() {
   [ -f "${LXD_DIR}/testvol.tar.gz" ]
 
   # Extract non-optimized backup tarball.
-  tar -xzf "${LXD_DIR}/testvol.tar.gz" -C "${LXD_DIR}/non-optimized"
+  tar --warning=no-timestamp -xzf "${LXD_DIR}/testvol.tar.gz" -C "${LXD_DIR}/non-optimized"
 
   # Check tarball content.
   ls -l "${LXD_DIR}/non-optimized/backup/"
@@ -780,7 +780,7 @@ _backup_volume_export_with_project() {
     [ -f "${LXD_DIR}/testvol-optimized.tar.gz" ]
 
     # Extract backup tarball.
-    tar -xzf "${LXD_DIR}/testvol-optimized.tar.gz" -C "${LXD_DIR}/optimized"
+    tar --warning=no-timestamp -xzf "${LXD_DIR}/testvol-optimized.tar.gz" -C "${LXD_DIR}/optimized"
 
     ls -l "${LXD_DIR}/optimized/backup/"
     [ -f "${LXD_DIR}/optimized/backup/index.yaml" ]
@@ -794,7 +794,7 @@ _backup_volume_export_with_project() {
   [ -f "${LXD_DIR}/testvol.tar.gz" ]
 
   # Extract backup tarball.
-  tar -xzf "${LXD_DIR}/testvol.tar.gz" -C "${LXD_DIR}/non-optimized"
+  tar --warning=no-timestamp -xzf "${LXD_DIR}/testvol.tar.gz" -C "${LXD_DIR}/non-optimized"
 
   # Check tarball content.
   ls -l "${LXD_DIR}/non-optimized/backup/"


### PR DESCRIPTION
In CI, untar'ing backups lead to those warnings about time discrepancies:

```
+ tar -xzf /home/runner/work/lxd/lxd/test/tmp.yy0/T5U/testvol.tar.gz -C /home/runner/work/lxd/lxd/test/tmp.yy0/T5U/non-optimized
tar: backup/index.yaml: time stamp 2024-10-04 13:47:24 is 0.053552327 s in the future
tar: backup/volume-snapshots/test-snap0/test: time stamp 2024-10-04 13:47:24 is 0.053404079 s in the future
tar: backup/volume-snapshots/test-snap0: time stamp 2024-10-04 13:47:24 is 0.053373382 s in the future
tar: backup/volume-snapshots/test-snap1/test: time stamp 2024-10-04 13:47:24 is 0.053263225 s in the future
tar: backup/volume-snapshots/test-snap1: time stamp 2024-10-04 13:47:24 is 0.053238839 s in the future
tar: backup/volume/test: time stamp 2024-10-04 13:47:24 is 0.053151806 s in the future
tar: backup/volume: time stamp 2024-10-04 13:47:24 is 0.053119726 s in the future
```

According to `man 1 tar`, `--warning=no-timestamp` would ignore the following warnings:

```
  timestamp
         "%s: implausibly old time stamp %s"
         "%s: time stamp %s is %s s in the future"
```