### PR TITLE
Auth: Creation of fine-grained TLS identites

### DIFF
--- a/client/interfaces.go
+++ b/client/interfaces.go
@@ -446,6 +446,8 @@ type InstanceServer interface {
 	GetCurrentIdentityInfo() (identityInfo *api.IdentityInfo, ETag string, err error)
 	UpdateIdentity(authenticationMethod string, nameOrIdentifier string, identityPut api.IdentityPut, ETag string) error
 	DeleteIdentity(authenticationMethod string, nameOrIdentifier string) error
+	CreateIdentityTLS(identitiesTLSPost api.IdentitiesTLSPost) error
+	CreateIdentityTLSToken(identitiesTLSPost api.IdentitiesTLSPost) (*api.CertificateAddToken, error)
 	GetIdentityProviderGroupNames() (identityProviderGroupNames []string, err error)
 	GetIdentityProviderGroups() (identityProviderGroups []api.IdentityProviderGroup, err error)
 	GetIdentityProviderGroup(identityProviderGroupName string) (identityProviderGroup *api.IdentityProviderGroup, ETag string, err error)

--- a/client/lxd_auth.go
+++ b/client/lxd_auth.go
@@ -276,6 +276,41 @@ func (r *ProtocolLXD) DeleteIdentity(authenticationMethod string, nameOrIdentifi
 	return nil
 }
 
+// CreateIdentityTLS creates a TLS identity.
+func (r *ProtocolLXD) CreateIdentityTLS(tlsIdentitiesPost api.IdentitiesTLSPost) error {
+	err := r.CheckExtension("access_management_tls")
+	if err != nil {
+		return err
+	}
+
+	_, _, err = r.query(http.MethodPost, api.NewURL().Path("auth", "identities", api.AuthenticationMethodTLS).String(), tlsIdentitiesPost, "")
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// CreateIdentityTLSToken creates a pending TLS identity and returns a token that can be used by an untrusted client to set up authentication with LXD.
+func (r *ProtocolLXD) CreateIdentityTLSToken(tlsIdentitiesPost api.IdentitiesTLSPost) (*api.CertificateAddToken, error) {
+	err := r.CheckExtension("access_management_tls")
+	if err != nil {
+		return nil, err
+	}
+
+	if !tlsIdentitiesPost.Token {
+		return nil, fmt.Errorf("Token needs to be true when requesting a token")
+	}
+
+	var token api.CertificateAddToken
+	_, err = r.queryStruct(http.MethodPost, api.NewURL().Path("auth", "identities", api.AuthenticationMethodTLS).String(), tlsIdentitiesPost, "", &token)
+	if err != nil {
+		return nil, err
+	}
+
+	return &token, nil
+}
+
 // GetIdentityProviderGroupNames returns a list of identity provider group names.
 func (r *ProtocolLXD) GetIdentityProviderGroupNames() ([]string, error) {
 	err := r.CheckExtension("access_management")

--- a/doc/authentication.md
+++ b/doc/authentication.md
@@ -46,13 +46,6 @@ any backward compatibility to broken protocol or ciphers.
 (authentication-trusted-clients)=
 ### Trusted TLS clients
 
-You can obtain the list of TLS certificates trusted by a LXD server with [`lxc config trust list`](lxc_config_trust_list.md).
-
-Trusted clients can be added in either of the following ways:
-
-- {ref}`authentication-add-certs`
-- {ref}`authentication-token`
-
 The workflow to authenticate with the server is similar to that of SSH, where an initial connection to an unknown server triggers a prompt:
 
 1. When the user adds a server with [`lxc remote add`](lxc_remote_add.md), the server is contacted over HTTPS, its certificate is downloaded and the fingerprint is shown to the user.
@@ -64,44 +57,7 @@ The workflow to authenticate with the server is similar to that of SSH, where an
      If the provided token matches, the client certificate is added to the server's trust store and the connection is granted.
      Otherwise, the connection is rejected.
 
-To revoke trust to a client, remove its certificate from the server with [`lxc config trust remove <fingerprint>`](lxc_config_trust_remove.md).
-
-TLS clients can be restricted to a subset of projects, see {ref}`restricted-tls-certs` for more information.
-
-(authentication-add-certs)=
-#### Adding trusted certificates to the server
-
-The preferred way to add trusted clients is to directly add their certificates to the trust store on the server.
-To do so, copy the client certificate to the server and register it using [`lxc config trust add <file>`](lxc_config_trust_add.md).
-
-(authentication-token)=
-#### Adding client certificates using tokens
-
-You can also add new clients by using tokens. These tokens expire after a configurable time ({config:option}`server-core:core.remote_token_expiry`) or once they've been used.
-
-To use this method, generate a token for each client by calling [`lxc config trust add`](lxc_config_trust_add.md), which will prompt for the client name.
-The clients can then add their certificates to the server's trust store by providing the generated token.
-
-<!-- Include start NAT authentication -->
-
-```{note}
-If your LXD server is behind NAT, you must specify its external public address when adding it as a remote for a client:
-
-    lxc remote add <name> <IP_address>
-
-When you are prompted for the token, specify the generated token from the previous step.
-Alternatively, use the `--token` flag:
-
-    lxc remote add <name> <IP_address> --token <token>
-
-When generating the token on the server, LXD includes a list of IP addresses that the client can use to access the server.
-However, if the server is behind NAT, these addresses might be local addresses that the client cannot connect to.
-In this case, you must specify the external address manually.
-```
-
-<!-- Include end NAT authentication -->
-
-Alternatively, the clients can provide the token directly when adding the remote: [`lxc remote add <name> <token>`](lxc_remote_add.md).
+See {ref}`server-expose` and {ref}`server-authenticate` for instructions on how to configure TLS authentication and add trusted clients.
 
 (authentication-pki)=
 ### Using a PKI system

--- a/doc/explanation/authorization.md
+++ b/doc/explanation/authorization.md
@@ -23,7 +23,7 @@ If the list of projects is empty, the client will not be allowed access to any o
 (fine-grained-authorization)=
 ## Fine-grained authorization
 
-It is possible to restrict {ref}`OIDC clients <authentication-openid>` to granular actions on specific LXD resources.
+It is possible to restrict {ref}`OIDC clients <authentication-openid>` and fine-grained TLS identities to granular actions on specific LXD resources.
 For example, one could restrict a user to be able to view, but not edit, a single instance.
 
 There are four key concepts that LXD uses to manage these fine-grained permissions:

--- a/doc/explanation/projects.md
+++ b/doc/explanation/projects.md
@@ -67,24 +67,19 @@ In addition, this method allows users to work with LXD without being a member of
 Members of the `lxd` group have full access to LXD, including permission to attach file system paths and tweak the security features of an instance, which makes it possible to gain root access to the host system.
 Using confined projects limits what users can do in LXD, but it also prevents users from gaining root access.
 
-### Authentication methods for projects
+When LXD is accessible over the HTTPS API, both {ref}`authentication-tls-certs` and {ref}`OIDC clients <authentication-openid>` can be restricted to allow access to specific projects only.
+This is managed via {ref}`fine-grained-authorization`.
+See {ref}`projects-confine-https` for instructions.
 
-There are different ways of authentication that you can use to confine projects to specific users:
+### Multi-user LXD daemon
+The LXD snap contains a multi-user LXD daemon that allows dynamic project creation on a per-user basis.
+You can configure a specific user group other than the `lxd` group to give restricted LXD access to every user in the group.
 
-Client certificates
-: You can restrict the {ref}`authentication-tls-certs` to allow access to specific projects only.
-  The projects must exist before you can restrict access to them.
-  A client that connects using a restricted certificate can see only the project or projects that the client has been granted access to.
+When a user that is a member of this group starts using LXD, the multi-user daemon automatically creates a confined project for this user.
 
-Multi-user LXD daemon
-: The LXD snap contains a multi-user LXD daemon that allows dynamic project creation on a per-user basis.
-  You can configure a specific user group other than the `lxd` group to give restricted LXD access to every user in the group.
+If you're not using the snap, you can still use this feature if your distribution supports it.
 
-  When a user that is a member of this group starts using LXD, LXD automatically creates a confined project for this user.
-
-  If you're not using the snap, you can still use this feature if your distribution supports it.
-
-See {ref}`projects-confine` for instructions on how to enable and configure the different authentication methods.
+See {ref}`projects-confine-users` for instructions on configuring the multi-user daemon.
 
 ## Related topics
 

--- a/doc/howto/cluster_form.md
+++ b/doc/howto/cluster_form.md
@@ -97,7 +97,7 @@ Basically, the initialization process consists of the following steps:
 
 1. Authenticate with the cluster.
 
-   Generate a {ref}`join token <authentication-token>` for each new member.
+   Generate a cluster join token for each new member.
    To do so, run the following command on an existing cluster member (for example, the bootstrap server):
 
        lxc cluster add <new_member_name>

--- a/doc/howto/projects_confine.md
+++ b/doc/howto/projects_confine.md
@@ -1,13 +1,14 @@
 (projects-confine)=
-# How to confine projects to specific users
+# How to confine users to specific projects
 
-You can use projects to confine the activities of different users or clients.
-See {ref}`projects-confined` for more information.
+You restrict users or clients to specific projects.
+Projects can be configured with features, limits, and restrictions to prevent misuse.
+See {ref}`exp-projects` for more information.
 
-How to confine a project to a specific user depends on the authentication method you choose.
+How to confine users to specific projects depends on whether LXD is accessible via the {ref}`HTTPS API <projects-confine-https>`, or via the {ref}`Unix socket <projects-confine-users>`.
 
-## Confine projects to specific TLS clients
-
+(projects-confine-https)=
+## Confine users to specific projects on the HTTPS API
 ```{youtube} https://www.youtube.com/watch?v=4iNpiL-lrXU&t=525s
 ```
 
@@ -103,7 +104,7 @@ Send the following request:
 Make sure that `restricted` is set to `true` and specify the projects that the certificate should give access to under `projects`.
 
 (projects-confine-users)=
-## Confine projects to specific LXD users
+## Confine users to specific LXD projects via Unix socket
 
 ```{youtube} https://www.youtube.com/watch?v=6O0q3rSWr8A
 ```

--- a/doc/projects.md
+++ b/doc/projects.md
@@ -14,7 +14,7 @@ The following how-to guides cover common operations related to projects:
 
 :diataxis:Create and configure </howto/projects_create>
 :diataxis:Work with projects </howto/projects_work>
-:diataxis:Confine projects to users </howto/projects_confine>
+:diataxis:Confine users to projects </howto/projects_confine>
 ```
 
 ## Related topics
@@ -31,6 +31,6 @@ The following how-to guides cover common operations related to projects:
 :topical:/explanation/projects
 :topical:Create and configure projects </howto/projects_create>
 :topical:Work with different projects </howto/projects_work>
-:topical:Confine projects to users </howto/projects_confine>
+:topical:Confine users to projects </howto/projects_confine>
 :topical:/reference/projects
 ```

--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -158,6 +158,11 @@ definitions:
                 example: 2b2284d44db32675923fe0d2020477e0e9be11801ff70c435e032b97028c35cd
                 type: string
                 x-go-name: Secret
+            type:
+                description: Type is an indicator for which API (certificates or identities) to send the token.
+                example: Client certificate
+                type: string
+                x-go-name: Type
         title: CertificateAddToken represents the fields contained within an encoded certificate add token.
         type: object
         x-go-package: github.com/canonical/lxd/shared/api
@@ -711,6 +716,39 @@ definitions:
                 example: lifecycle
                 type: string
                 x-go-name: Type
+        type: object
+        x-go-package: github.com/canonical/lxd/shared/api
+    IdentitiesTLSPost:
+        properties:
+            certificate:
+                description: The PEM encoded x509 certificate of the identity
+                type: string
+                x-go-name: Certificate
+            groups:
+                description: Groups is the list of groups for which the identity is a member.
+                example:
+                    - foo
+                    - bar
+                items:
+                    type: string
+                type: array
+                x-go-name: Groups
+            name:
+                description: Name associated with the identity
+                example: foo
+                type: string
+                x-go-name: Name
+            token:
+                description: Whether to create a certificate add token
+                example: true
+                type: boolean
+                x-go-name: Token
+            trust_token:
+                description: Trust token (used to add an untrusted client)
+                example: blah
+                type: string
+                x-go-name: TrustToken
+        title: IdentitiesTLSPost contains required information for the creation of a TLS identity.
         type: object
         x-go-package: github.com/canonical/lxd/shared/api
     Identity:
@@ -7448,6 +7486,34 @@ paths:
             summary: Get the TLS identities
             tags:
                 - identities
+        post:
+            consumes:
+                - application/json
+            description: |-
+                Adds a TLS identity as a trusted client, or creates a pending TLS identity and returns a token
+                for use by an untrusted client. One of `token` or `certificate` must be set.
+            operationId: identities_post_tls
+            parameters:
+                - description: TLS Identity
+                  in: body
+                  name: TLS identity
+                  required: true
+                  schema:
+                    $ref: '#/definitions/IdentitiesPostTLS'
+            produces:
+                - application/json
+            responses:
+                "201":
+                    description: ""
+                "400":
+                    $ref: '#/responses/BadRequest'
+                "403":
+                    $ref: '#/responses/Forbidden'
+                "500":
+                    $ref: '#/responses/InternalServerError'
+            summary: Add a TLS identity.
+            tags:
+                - identities
     /1.0/auth/identities/tls/{nameOrIdentifier}:
         delete:
             description: Removes the TLS identity and revokes trust.
@@ -7557,6 +7623,40 @@ paths:
                 "501":
                     $ref: '#/responses/NotImplemented'
             summary: Update the TLS identity
+            tags:
+                - identities
+    /1.0/auth/identities/tls?public:
+        post:
+            consumes:
+                - application/json
+            description: |-
+                Adds a TLS identity as a trusted client.
+                In this mode, the `token` property must be set to the correct value.
+                The certificate that the client sent during the TLS handshake will be added.
+                The `certificate` field must be omitted.
+
+                The `?public` part of the URL isn't required, it's simply used to
+                separate the two behaviors of this endpoint.
+            operationId: identities_post_tls_untrusted
+            parameters:
+                - description: TLS Identity
+                  in: body
+                  name: TLS identity
+                  required: true
+                  schema:
+                    $ref: '#/definitions/IdentitiesPostTLS'
+            produces:
+                - application/json
+            responses:
+                "201":
+                    $ref: '#/responses/EmptySyncResponse'
+                "400":
+                    $ref: '#/responses/BadRequest'
+                "403":
+                    $ref: '#/responses/Forbidden'
+                "500":
+                    $ref: '#/responses/InternalServerError'
+            summary: Add a TLS identity
             tags:
                 - identities
     /1.0/auth/identities/tls?recursion=1:

--- a/lxc/remote.go
+++ b/lxc/remote.go
@@ -171,14 +171,14 @@ func (c *cmdRemoteAdd) runToken(addr string, server string, token string, rawTok
 
 	// If address is provided, use token on that specific address.
 	if addr != "" {
-		return c.addRemoteFromToken(addr, server, token, rawToken.Fingerprint)
+		return c.addRemoteFromToken(addr, server, token, *rawToken)
 	}
 
 	// Otherwise, iterate over all addresses within the token.
 	for _, addr := range rawToken.Addresses {
 		addr = fmt.Sprintf("https://%s", addr)
 
-		err := c.addRemoteFromToken(addr, server, token, rawToken.Fingerprint)
+		err := c.addRemoteFromToken(addr, server, token, *rawToken)
 		if err != nil {
 			if api.StatusErrorCheck(err, http.StatusServiceUnavailable) {
 				continue
@@ -203,7 +203,7 @@ func (c *cmdRemoteAdd) runToken(addr string, server string, token string, rawTok
 		return errors.New(i18n.G("Failed to add remote"))
 	}
 
-	err = c.addRemoteFromToken(string(line), server, token, rawToken.Fingerprint)
+	err = c.addRemoteFromToken(string(line), server, token, *rawToken)
 	if err != nil {
 		return err
 	}
@@ -211,7 +211,7 @@ func (c *cmdRemoteAdd) runToken(addr string, server string, token string, rawTok
 	return nil
 }
 
-func (c *cmdRemoteAdd) addRemoteFromToken(addr string, server string, token string, fingerprint string) error {
+func (c *cmdRemoteAdd) addRemoteFromToken(addr string, server string, token string, rawToken api.CertificateAddToken) error {
 	conf := c.global.conf
 
 	var certificate *x509.Certificate
@@ -227,7 +227,7 @@ func (c *cmdRemoteAdd) addRemoteFromToken(addr string, server string, token stri
 		}
 
 		certDigest := shared.CertFingerprint(certificate)
-		if fingerprint != certDigest {
+		if rawToken.Fingerprint != certDigest {
 			return fmt.Errorf(i18n.G("Certificate fingerprint mismatch between certificate token and server %q"), addr)
 		}
 
@@ -260,19 +260,33 @@ func (c *cmdRemoteAdd) addRemoteFromToken(addr string, server string, token stri
 		return api.StatusErrorf(http.StatusServiceUnavailable, "%s: %w", i18n.G("Unavailable remote server"), err)
 	}
 
-	req := api.CertificatesPost{}
-	if d.HasExtension("explicit_trust_token") {
-		req.TrustToken = token
-	} else {
-		req.Password = token
-	}
-
 	// Add client certificate to trust store. Even if we are already trusted (src.Auth == "trusted"),
 	// we want to send the token to invalidate it. Therefore, we can ignore the conflict error, which
 	// is thrown if we are trying to add a client cert that is already trusted by LXD remote.
-	err = d.CreateCertificate(req)
-	if err != nil && !api.StatusErrorCheck(err, http.StatusConflict) {
-		return err
+	//
+	// If "type" is not set on the token, the token was issued by the certificates API and CreateCertificate should be
+	// called. If "type" is set, the token was issued by the auth API and CreateIdentityTLS should be called.
+	if rawToken.Type == "" {
+		req := api.CertificatesPost{}
+		if d.HasExtension("explicit_trust_token") {
+			req.TrustToken = token
+		} else {
+			req.Password = token
+		}
+
+		err = d.CreateCertificate(req)
+		if err != nil && !api.StatusErrorCheck(err, http.StatusConflict) {
+			return err
+		}
+	} else {
+		req := api.IdentitiesTLSPost{
+			TrustToken: token,
+		}
+
+		err = d.CreateIdentityTLS(req)
+		if err != nil && !api.StatusErrorCheck(err, http.StatusConflict) {
+			return err
+		}
 	}
 
 	// And check if trusted now.
@@ -630,18 +644,36 @@ func (c *cmdRemoteAdd) run(cmd *cobra.Command, args []string) error {
 	// Check if additional authentication is required.
 	if srv.Auth != "trusted" {
 		if c.flagAuthType == api.AuthenticationMethodTLS {
-			req := api.CertificatesPost{}
+			var gainTrust func() error
 
 			// If the password flag isn't provided and the server supports the explicit_trust_token extension,
 			// use the token instead and prompt for it if not present.
 			if d.(lxd.InstanceServer).HasExtension("explicit_trust_token") && c.flagPassword == "" {
 				// Prompt for trust token.
-				c.flagToken, err = c.global.asker.AskString(fmt.Sprintf(i18n.G("Trust token for %s: "), server), "", nil)
+				token, err := c.global.asker.AskString(fmt.Sprintf(i18n.G("Trust token for %s: "), server), "", nil)
 				if err != nil {
 					return err
 				}
 
-				req.TrustToken = c.flagToken
+				// Decode the token.
+				certificateAddToken, err := shared.CertificateTokenDecode(token)
+				if err != nil {
+					return err
+				}
+
+				// If the type field is set it's for use with the auth API. Otherwise it's for use with the certificates API.
+				if certificateAddToken.Type == "" {
+					gainTrust = func() error {
+						return d.(lxd.InstanceServer).CreateCertificate(api.CertificatesPost{
+							Type:       api.CertificateTypeClient,
+							TrustToken: token,
+						})
+					}
+				} else {
+					gainTrust = func() error {
+						return d.(lxd.InstanceServer).CreateIdentityTLS(api.IdentitiesTLSPost{TrustToken: token})
+					}
+				}
 			} else {
 				// Prompt for trust password if token is not supported by the server.
 				if c.flagPassword == "" {
@@ -656,16 +688,18 @@ func (c *cmdRemoteAdd) run(cmd *cobra.Command, args []string) error {
 					}
 
 					fmt.Println("")
-					req.Password = string(pwd)
-				} else {
-					req.Password = c.flagPassword
+					c.flagPassword = string(pwd)
+				}
+
+				gainTrust = func() error {
+					return d.(lxd.InstanceServer).CreateCertificate(api.CertificatesPost{
+						Type:     api.CertificateTypeClient,
+						Password: c.flagPassword,
+					})
 				}
 			}
 
-			req.Type = api.CertificateTypeClient
-
-			// Add client certificate to trust store.
-			err = d.(lxd.InstanceServer).CreateCertificate(req)
+			err = gainTrust()
 			if err != nil {
 				return err
 			}

--- a/lxd/auth/drivers/openfga.go
+++ b/lxd/auth/drivers/openfga.go
@@ -167,8 +167,8 @@ func (e *embeddedOpenFGA) CheckPermission(ctx context.Context, entityURL *api.UR
 	logCtx["protocol"] = id.AuthenticationMethod
 	l := e.logger.AddContext(logCtx)
 
-	// If the authentication method was TLS, use the TLS driver instead.
-	if id.AuthenticationMethod == api.AuthenticationMethodTLS {
+	// If the identity type does not use fine-grained auth use the TLS driver instead.
+	if !identity.IsFineGrainedIdentityType(id.IdentityType) {
 		return e.tlsAuthorizer.CheckPermission(ctx, entityURL, entitlement)
 	}
 
@@ -365,8 +365,8 @@ func (e *embeddedOpenFGA) GetPermissionChecker(ctx context.Context, entitlement 
 	logCtx["protocol"] = id.AuthenticationMethod
 	l := e.logger.AddContext(logCtx)
 
-	// If the authentication method was TLS, use the TLS driver instead.
-	if id.AuthenticationMethod == api.AuthenticationMethodTLS {
+	// If the identity type does not use fine-grained auth, use the TLS driver instead.
+	if !identity.IsFineGrainedIdentityType(id.IdentityType) {
 		return e.tlsAuthorizer.GetPermissionChecker(ctx, entitlement, entityType)
 	}
 

--- a/lxd/certificates.go
+++ b/lxd/certificates.go
@@ -292,6 +292,15 @@ func certificateTokenValid(s *state.State, r *http.Request, addToken *api.Certif
 	}
 
 	if foundOp == nil {
+		err := s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
+			var err error
+			_, err = dbCluster.GetPendingTLSIdentityByTokenSecret(ctx, tx.Tx(), addToken.Secret)
+			return err
+		})
+		if err == nil {
+			return nil, api.NewStatusError(http.StatusBadRequest, "TLS Identity token detected (you must update your client)")
+		}
+
 		// No operation found.
 		return nil, nil
 	}
@@ -538,7 +547,7 @@ func certificatesPost(d *Daemon, r *http.Request) response.Response {
 			// If so then check there is a matching join operation.
 			tokenReq, err := certificateTokenValid(s, r, joinToken)
 			if err != nil {
-				return response.InternalError(fmt.Errorf("Failed during search for certificate add token operation: %w", err))
+				return response.SmartError(fmt.Errorf("Failed during search for certificate add token operation: %w", err))
 			}
 
 			if tokenReq == nil {

--- a/lxd/certificates.go
+++ b/lxd/certificates.go
@@ -636,20 +636,13 @@ func certificatesPost(d *Daemon, r *http.Request) response.Response {
 		}
 
 		cert = r.TLS.PeerCertificates[len(r.TLS.PeerCertificates)-1]
-		networkCert := s.Endpoints.NetworkCert()
-		if networkCert.CA() != nil {
-			// If we are in CA mode, we only allow adding certificates that are signed by the CA.
-			trusted, _, _ := util.CheckCASignature(*cert, networkCert)
-			if !trusted {
-				return response.Forbidden(fmt.Errorf("The certificate is not trusted by the CA or has been revoked"))
-			}
-		}
 	} else {
 		return response.BadRequest(fmt.Errorf("Can't use TLS data on non-TLS link"))
 	}
 
 	// Check validity.
-	err = certificateValidate(cert)
+	networkCert := d.endpoints.NetworkCert()
+	err = certificateValidate(networkCert, cert)
 	if err != nil {
 		return response.BadRequest(err)
 	}
@@ -697,7 +690,7 @@ func certificatesPost(d *Daemon, r *http.Request) response.Response {
 	}
 
 	// Send a notification to other cluster members to refresh their identity cache.
-	notifier, err := cluster.NewNotifier(s, s.Endpoints.NetworkCert(), s.ServerCert(), cluster.NotifyAlive)
+	notifier, err := cluster.NewNotifier(s, networkCert, s.ServerCert(), cluster.NotifyAlive)
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -1005,6 +998,7 @@ func doCertificateUpdate(ctx context.Context, d *Daemon, dbInfo api.Certificate,
 		}
 	}
 
+	networkCert := d.endpoints.NetworkCert()
 	if req.Certificate != "" && dbInfo.Certificate != req.Certificate {
 		// Add supplied certificate.
 		block, _ := pem.Decode([]byte(req.Certificate))
@@ -1018,7 +1012,7 @@ func doCertificateUpdate(ctx context.Context, d *Daemon, dbInfo api.Certificate,
 		dbCert.Fingerprint = shared.CertFingerprint(cert)
 
 		// Check validity.
-		err = certificateValidate(cert)
+		err = certificateValidate(networkCert, cert)
 		if err != nil {
 			return response.BadRequest(err)
 		}
@@ -1043,7 +1037,7 @@ func doCertificateUpdate(ctx context.Context, d *Daemon, dbInfo api.Certificate,
 	}
 
 	// Notify other cluster members to update their identity cache.
-	notifier, err := cluster.NewNotifier(s, s.Endpoints.NetworkCert(), s.ServerCert(), cluster.NotifyAlive)
+	notifier, err := cluster.NewNotifier(s, networkCert, s.ServerCert(), cluster.NotifyAlive)
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -1175,13 +1169,21 @@ func certificateDelete(d *Daemon, r *http.Request) response.Response {
 	return response.EmptySyncResponse
 }
 
-func certificateValidate(cert *x509.Certificate) error {
+func certificateValidate(networkCert *shared.CertInfo, cert *x509.Certificate) error {
 	if time.Now().Before(cert.NotBefore) {
 		return fmt.Errorf("The provided certificate isn't valid yet")
 	}
 
 	if time.Now().After(cert.NotAfter) {
 		return fmt.Errorf("The provided certificate is expired")
+	}
+
+	if networkCert != nil && networkCert.CA() != nil {
+		// If we are in CA mode, we only allow adding certificates that are signed by the CA.
+		trusted, _, _ := util.CheckCASignature(*cert, networkCert)
+		if !trusted {
+			return api.NewStatusError(http.StatusForbidden, "The certificate is not trusted by the CA or has been revoked")
+		}
 	}
 
 	if cert.PublicKeyAlgorithm == x509.RSA {

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -336,6 +336,9 @@ func allowProjectResourceList(d *Daemon, r *http.Request) response.Response {
 	case api.IdentityTypeOIDCClient:
 		// OIDC authenticated clients are governed by fine-grained auth. They can call the endpoint but may see an empty list.
 		return response.EmptySyncResponse
+	case api.IdentityTypeCertificateClient:
+		// Fine-grained TLS identities can list resources in any project. They may see an empty list.
+		return response.EmptySyncResponse
 	case api.IdentityTypeCertificateClientRestricted:
 		// A restricted client may be able to call the endpoint, continue.
 	default:

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -424,7 +424,7 @@ func (d *Daemon) Authenticate(w http.ResponseWriter, r *http.Request) (trusted b
 
 	// List of candidate identity types for this request. We have already checked server certificates at the beginning of this method
 	// so we only need to consider client and metrics certificates. (OIDC auth was completed above).
-	candidateIdentityTypes := []string{api.IdentityTypeCertificateClientUnrestricted, api.IdentityTypeCertificateClientRestricted}
+	candidateIdentityTypes := []string{api.IdentityTypeCertificateClientUnrestricted, api.IdentityTypeCertificateClientRestricted, api.IdentityTypeCertificateClient}
 	if isMetricsRequest(*r.URL) {
 		// Metrics certificates can only authenticate when calling metrics related endpoints.
 		candidateIdentityTypes = append(candidateIdentityTypes, api.IdentityTypeCertificateMetricsUnrestricted, api.IdentityTypeCertificateMetricsRestricted)

--- a/lxd/db/cluster/entity_type_identity.go
+++ b/lxd/db/cluster/entity_type_identity.go
@@ -28,12 +28,12 @@ SELECT
 		identities.identifier
 	) 
 FROM identities
-WHERE type IN (%d)
+WHERE type IN (%d, %d, %d)
 `,
 		e.code(),
 		authMethodTLS, api.AuthenticationMethodTLS,
 		authMethodOIDC, api.AuthenticationMethodOIDC,
-		identityTypeOIDCClient,
+		identityTypeOIDCClient, identityTypeCertificateClient, identityTypeCertificateClientPending,
 	)
 }
 

--- a/lxd/db/cluster/identities.go
+++ b/lxd/db/cluster/identities.go
@@ -12,6 +12,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/canonical/lxd/lxd/auth"
 	"github.com/canonical/lxd/lxd/certificate"
@@ -313,6 +314,27 @@ func (i Identity) Subject() (string, error) {
 	}
 
 	return metadata.Subject, nil
+}
+
+// PendingTLSMetadata contains metadata for the pending TLS certificate identity type.
+type PendingTLSMetadata struct {
+	Secret string    `json:"secret"`
+	Expiry time.Time `json:"expiry"`
+}
+
+// PendingTLSMetadata returns the pending TLS identity metadata.
+func (i Identity) PendingTLSMetadata() (*PendingTLSMetadata, error) {
+	if i.Type != api.IdentityTypeCertificateClientPending {
+		return nil, fmt.Errorf("Cannot extract pending TLS identity secret: Identity is not pending")
+	}
+
+	var metadata PendingTLSMetadata
+	err := json.Unmarshal([]byte(i.Metadata), &metadata)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to unmarshal pending TLS identity metadata: %w", err)
+	}
+
+	return &metadata, nil
 }
 
 // ToAPI converts an Identity to an api.Identity, executing database queries as necessary.

--- a/lxd/db/cluster/identities.go
+++ b/lxd/db/cluster/identities.go
@@ -117,6 +117,8 @@ const (
 	identityTypeCertificateMetricsRestricted   int64 = 4
 	identityTypeOIDCClient                     int64 = 5
 	identityTypeCertificateMetricsUnrestricted int64 = 6
+	identityTypeCertificateClient              int64 = 7
+	identityTypeCertificateClientPending       int64 = 8
 )
 
 // Scan implements sql.Scanner for IdentityType. This converts the integer value back into the correct API constant or
@@ -149,6 +151,10 @@ func (i *IdentityType) Scan(value any) error {
 		*i = api.IdentityTypeCertificateMetricsUnrestricted
 	case identityTypeOIDCClient:
 		*i = api.IdentityTypeOIDCClient
+	case identityTypeCertificateClient:
+		*i = api.IdentityTypeCertificateClient
+	case identityTypeCertificateClientPending:
+		*i = api.IdentityTypeCertificateClientPending
 	default:
 		return fmt.Errorf("Unknown identity type `%d`", identityTypeInt)
 	}
@@ -171,6 +177,10 @@ func (i IdentityType) Value() (driver.Value, error) {
 		return identityTypeCertificateMetricsUnrestricted, nil
 	case api.IdentityTypeOIDCClient:
 		return identityTypeOIDCClient, nil
+	case api.IdentityTypeCertificateClient:
+		return identityTypeCertificateClient, nil
+	case api.IdentityTypeCertificateClientPending:
+		return identityTypeCertificateClientPending, nil
 	}
 
 	return nil, fmt.Errorf("Invalid identity type %q", i)

--- a/lxd/db/cluster/identities.go
+++ b/lxd/db/cluster/identities.go
@@ -14,10 +14,13 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/google/uuid"
+
 	"github.com/canonical/lxd/lxd/auth"
 	"github.com/canonical/lxd/lxd/certificate"
 	"github.com/canonical/lxd/lxd/db/query"
 	"github.com/canonical/lxd/lxd/identity"
+	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/api"
 	"github.com/canonical/lxd/shared/entity"
 )
@@ -358,6 +361,41 @@ func (i *Identity) ToAPI(ctx context.Context, tx *sql.Tx, canViewGroup auth.Perm
 		Name:                 i.Name,
 		Groups:               groupNames,
 	}, nil
+}
+
+// ActivateTLSIdentity updates a TLS identity to make it valid by adding the fingerprint, PEM encoded certificate, and setting
+// the type to api.IdentityTypeCertificateClient.
+func ActivateTLSIdentity(ctx context.Context, tx *sql.Tx, identifier uuid.UUID, cert *x509.Certificate) error {
+	fingerprint := shared.CertFingerprint(cert)
+	_, err := GetIdentityID(ctx, tx, api.AuthenticationMethodTLS, fingerprint)
+	if err == nil {
+		return api.StatusErrorf(http.StatusConflict, "Identity already exists")
+	}
+
+	metadata := CertificateMetadata{Certificate: string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw}))}
+	b, err := json.Marshal(metadata)
+	if err != nil {
+		return fmt.Errorf("Failed to encode certificate metadata: %w", err)
+	}
+
+	stmt := `UPDATE identities SET type = ?, identifier = ?, metadata = ? WHERE identifier = ? AND auth_method = ?`
+	res, err := tx.ExecContext(ctx, stmt, identityTypeCertificateClient, fingerprint, string(b), identifier.String(), authMethodTLS)
+	if err != nil {
+		return fmt.Errorf("Failed to activate TLS identity: %w", err)
+	}
+
+	n, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("Failed to check for activated TLS identity: %w", err)
+	}
+
+	if n == 0 {
+		return api.StatusErrorf(http.StatusNotFound, "No pending TLS identity found with identifier %q", identifier)
+	} else if n > 1 {
+		return fmt.Errorf("Unknown error occurred when activating a TLS identity: %w", err)
+	}
+
+	return nil
 }
 
 // GetAuthGroupsByIdentityID returns a slice of groups that the identity with the given ID is a member of.

--- a/lxd/identities.go
+++ b/lxd/identities.go
@@ -1503,9 +1503,23 @@ func updateIdentityCache(d *Daemon) {
 		return
 	}
 
+	cacheableIdentityTypes := []string{
+		api.IdentityTypeCertificateClientRestricted,
+		api.IdentityTypeCertificateClientUnrestricted,
+		api.IdentityTypeCertificateClient,
+		api.IdentityTypeCertificateServer,
+		api.IdentityTypeCertificateMetricsRestricted,
+		api.IdentityTypeCertificateMetricsUnrestricted,
+		api.IdentityTypeOIDCClient,
+	}
+
 	identityCacheEntries := make([]identity.CacheEntry, 0, len(identities))
 	var localServerCerts []dbCluster.Certificate
 	for _, id := range identities {
+		if !shared.ValueInSlice(string(id.Type), cacheableIdentityTypes) {
+			continue
+		}
+
 		cacheEntry := identity.CacheEntry{
 			Identifier:           id.Identifier,
 			Name:                 id.Name,

--- a/lxd/identities.go
+++ b/lxd/identities.go
@@ -5,10 +5,13 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
+	"time"
 
+	"github.com/google/uuid"
 	"github.com/gorilla/mux"
 
 	"github.com/canonical/lxd/client"
@@ -59,6 +62,10 @@ var tlsIdentitiesCmd = APIEndpoint{
 	Get: APIEndpointAction{
 		Handler:       getIdentities(api.AuthenticationMethodTLS),
 		AccessHandler: allowAuthenticated,
+	},
+	Post: APIEndpointAction{
+		Handler:        createIdentityTLS,
+		AllowUntrusted: true,
 	},
 }
 
@@ -169,6 +176,361 @@ func identityAccessHandler(authenticationMethod string, entitlement auth.Entitle
 		request.SetCtxValue(r, ctxClusterDBIdentity, id)
 		return response.EmptySyncResponse
 	}
+}
+
+// swagger:operation POST /1.0/auth/identities/tls?public identities identities_post_tls_untrusted
+//
+//  Add a TLS identity
+//
+//  Adds a TLS identity as a trusted client.
+//  In this mode, the `token` property must be set to the correct value.
+//  The certificate that the client sent during the TLS handshake will be added.
+//  The `certificate` field must be omitted.
+//
+//  The `?public` part of the URL isn't required, it's simply used to
+//  separate the two behaviors of this endpoint.
+//
+//  ---
+//  consumes:
+//    - application/json
+//  produces:
+//    - application/json
+//  parameters:
+//    - in: body
+//      name: TLS identity
+//      description: TLS Identity
+//      required: true
+//      schema:
+//        $ref: "#/definitions/IdentitiesPostTLS"
+//  responses:
+//    "201":
+//      $ref: "#/responses/EmptySyncResponse"
+//    "400":
+//      $ref: "#/responses/BadRequest"
+//    "403":
+//      $ref: "#/responses/Forbidden"
+//    "500":
+//      $ref: "#/responses/InternalServerError"
+
+// swagger:operation POST /1.0/auth/identities/tls identities identities_post_tls
+//
+//	Add a TLS identity.
+//
+//	Adds a TLS identity as a trusted client, or creates a pending TLS identity and returns a token
+//	for use by an untrusted client. One of `token` or `certificate` must be set.
+//
+//	---
+//	consumes:
+//	  - application/json
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: body
+//	    name: TLS identity
+//	    description: TLS Identity
+//	    required: true
+//	    schema:
+//	      $ref: "#/definitions/IdentitiesPostTLS"
+//	responses:
+//	  "201":
+//	    oneOf:
+//	      - $ref: "#/responses/CertificateAddToken"
+//	      - $ref: "#/responses/EmptySyncResponse"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
+func createIdentityTLS(d *Daemon, r *http.Request) response.Response {
+	s := d.State()
+
+	// Parse the request.
+	req := api.IdentitiesTLSPost{}
+	err := json.NewDecoder(r.Body).Decode(&req)
+	if err != nil {
+		return response.BadRequest(err)
+	}
+
+	networkCert := s.Endpoints.NetworkCert()
+	serverCert := s.ServerCert()
+	notify := newIdentityNotificationFunc(s, r, networkCert, serverCert)
+
+	if !auth.IsTrusted(r.Context()) {
+		return createIdentityTLSUntrusted(r.Context(), s, r.TLS.PeerCertificates, networkCert, req, notify)
+	}
+
+	return createIdentityTLSTrusted(r.Context(), s, networkCert, req, notify)
+}
+
+// createIdentityTLSUntrusted handles requests to create an identity when the caller is not trusted.
+func createIdentityTLSUntrusted(ctx context.Context, s *state.State, peerCertificates []*x509.Certificate, networkCert *shared.CertInfo, req api.IdentitiesTLSPost, notify identityNotificationFunc) response.Response {
+	// If not trusted a token must be provided.
+	if req.TrustToken == "" {
+		return response.Forbidden(errors.New("Trust token required"))
+	}
+
+	// If not trusted other fields must not be populated.
+	if req.Token || req.Certificate != "" || req.Name != "" || len(req.Groups) > 0 {
+		return response.Forbidden(errors.New("Only trust token must be provided"))
+	}
+
+	// If not trusted get the certificate from the request TLS config.
+	if len(peerCertificates) < 1 {
+		return response.BadRequest(fmt.Errorf("No client certificate provided"))
+	}
+
+	cert := peerCertificates[len(peerCertificates)-1]
+
+	// Validate certificate.
+	err := certificateValidate(networkCert, cert)
+	if err != nil {
+		return response.BadRequest(err)
+	}
+
+	// Check if certificate add token is valid.
+	joinToken, err := shared.CertificateTokenDecode(req.TrustToken)
+	if err != nil {
+		return response.Forbidden(nil)
+	}
+
+	// If so then check there is a matching pending TLS identity.
+	identifier, err := tlsIdentityTokenValidate(ctx, s, *joinToken)
+	if err != nil {
+		return response.InternalError(fmt.Errorf("Failed during search for pending TLS identity: %w", err))
+	}
+
+	// Activate the pending identity with the certificate.
+	err = s.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
+		return dbCluster.ActivateTLSIdentity(ctx, tx.Tx(), identifier, cert)
+	})
+	if err != nil {
+		return response.SmartError(err)
+	}
+
+	// Notify other members, update the cache, and send a lifecycle event.
+	lc, err := notify(lifecycle.IdentityUpdated, api.AuthenticationMethodTLS, identifier.String(), true)
+	if err != nil {
+		return response.SmartError(err)
+	}
+
+	return response.SyncResponseLocation(true, nil, lc.Source)
+}
+
+// createIdentityTLSTrusted handles requests to create an identity when the caller is trusted.
+func createIdentityTLSTrusted(ctx context.Context, s *state.State, networkCert *shared.CertInfo, req api.IdentitiesTLSPost, notify identityNotificationFunc) response.Response {
+	// Check if the caller has permission to create identities.
+	err := s.Authorizer.CheckPermission(ctx, entity.ServerURL(), auth.EntitlementCanCreateIdentities)
+	if err != nil {
+		return response.SmartError(err)
+	}
+
+	// A name is required whether getting a token or directly creating the identity with a certificate.
+	if req.Name == "" {
+		return response.BadRequest(fmt.Errorf("Identity name must be provided"))
+	}
+
+	// If the caller is trusted, they should not be providing a trust token
+	if req.TrustToken != "" {
+		return response.Conflict(fmt.Errorf("Client already trusted"))
+	}
+
+	// Can't request a token if a certificate is provided.
+	if req.Token && req.Certificate != "" {
+		return response.BadRequest(fmt.Errorf("Can't use certificate if token is requested"))
+	}
+
+	// If a token is requested, create a pending TLS identity and return an api.CertificateAddToken.
+	if req.Token {
+		return createIdentityTLSPending(ctx, s, req, notify)
+	}
+
+	// If a token is not requested, the caller must provide a certificate.
+	if req.Certificate == "" {
+		return response.BadRequest(fmt.Errorf("Must provide a certificate"))
+	}
+
+	// Parse the certificate.
+	cert, err := shared.ParseCert([]byte(req.Certificate))
+	if err != nil {
+		return response.BadRequest(fmt.Errorf("Invalid certificate material: %w", err))
+	}
+
+	// Validate the certificate.
+	err = certificateValidate(networkCert, cert)
+	if err != nil {
+		return response.BadRequest(err)
+	}
+
+	// Calculate the fingerprint and certificate metadata.
+	fingerprint := shared.CertFingerprint(cert)
+	metadata := dbCluster.CertificateMetadata{Certificate: string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw}))}
+	metadataJSON, err := json.Marshal(metadata)
+	if err != nil {
+		return response.InternalError(fmt.Errorf("Failed to encode certificate metadata: %w", err))
+	}
+
+	err = s.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
+		// Check if we already have the certificate.
+		_, err := dbCluster.GetIdentityID(ctx, tx.Tx(), api.AuthenticationMethodTLS, fingerprint)
+		if err == nil {
+			return api.StatusErrorf(http.StatusConflict, "Identity already exists")
+		}
+
+		// Create the identity.
+		id, err := dbCluster.CreateIdentity(ctx, tx.Tx(), dbCluster.Identity{
+			AuthMethod: api.AuthenticationMethodTLS,
+			Type:       api.IdentityTypeCertificateClient,
+			Identifier: fingerprint,
+			Name:       req.Name,
+			Metadata:   string(metadataJSON),
+		})
+		if err != nil {
+			return err
+		}
+
+		if len(req.Groups) > 0 {
+			return dbCluster.SetIdentityAuthGroups(ctx, tx.Tx(), int(id), req.Groups)
+		}
+
+		return nil
+	})
+	if err != nil {
+		return response.SmartError(err)
+	}
+
+	// Notify other members, update the cache, and send a lifecycle event.
+	lc, err := notify(lifecycle.IdentityCreated, api.AuthenticationMethodTLS, fingerprint, true)
+	if err != nil {
+		return response.SmartError(err)
+	}
+
+	return response.SyncResponseLocation(true, nil, lc.Source)
+}
+
+func createIdentityTLSPending(ctx context.Context, s *state.State, req api.IdentitiesTLSPost, notify identityNotificationFunc) response.Response {
+	localHTTPSAddress := s.LocalConfig.HTTPSAddress()
+
+	// Tokens are useless if the server isn't listening (how will the untrusted client contact the server?)
+	if localHTTPSAddress == "" {
+		return response.BadRequest(fmt.Errorf("Can't issue token when server isn't listening on network"))
+	}
+
+	// Get all addresses the server is listening on. This is encoded in the certificate token,
+	// so that the client will not have to specify a server address. The client will iterate
+	// through all these addresses until it can connect to one of them.
+	addresses, err := util.ListenAddresses(localHTTPSAddress)
+	if err != nil {
+		return response.InternalError(err)
+	}
+
+	// Generate join secret for new client. This will be stored inside the join token operation and will be
+	// supplied by the joining client (encoded inside the join token) which will allow us to lookup the correct
+	// operation in order to validate the requested joining client name is correct and authorised.
+	joinSecret, err := shared.RandomCryptoString()
+	if err != nil {
+		return response.InternalError(err)
+	}
+
+	// Generate fingerprint of network certificate so joining member can automatically trust the correct
+	// certificate when it is presented during the join process.
+	fingerprint, err := shared.CertFingerprintStr(string(s.Endpoints.NetworkPublicKey()))
+	if err != nil {
+		return response.InternalError(err)
+	}
+
+	// Calculate an expiry for the pending TLS identity.
+	expiry := s.GlobalConfig.RemoteTokenExpiry()
+	var expiresAt time.Time
+	if expiry != "" {
+		expiresAt, err = shared.GetExpiry(time.Now(), expiry)
+		if err != nil {
+			return response.InternalError(err)
+		}
+	}
+
+	// Generate an identifier for the identity and calculate its metadata.
+	identifier := uuid.New()
+	metadata := dbCluster.PendingTLSMetadata{
+		Secret: joinSecret,
+		Expiry: expiresAt,
+	}
+
+	metadataJSON, err := json.Marshal(metadata)
+	if err != nil {
+		return response.InternalError(fmt.Errorf("Failed to encode pending TLS identity metadata: %w", err))
+	}
+
+	// Create the identity.
+	err = s.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
+		id, err := dbCluster.CreateIdentity(ctx, tx.Tx(), dbCluster.Identity{
+			AuthMethod: api.AuthenticationMethodTLS,
+			Type:       api.IdentityTypeCertificateClientPending,
+			Identifier: identifier.String(),
+			Name:       req.Name,
+			Metadata:   string(metadataJSON),
+		})
+		if err != nil {
+			return err
+		}
+
+		if len(req.Groups) > 0 {
+			return dbCluster.SetIdentityAuthGroups(ctx, tx.Tx(), int(id), req.Groups)
+		}
+
+		return nil
+	})
+	if err != nil {
+		return response.InternalError(fmt.Errorf("Failed to create pending TLS identity: %w", err))
+	}
+
+	// Return the CertificateAddToken.
+	token := api.CertificateAddToken{
+		ClientName:  req.Name,
+		Fingerprint: fingerprint,
+		Addresses:   addresses,
+		Secret:      joinSecret,
+		ExpiresAt:   expiresAt,
+		// Set the Type field so that the client can differentiate
+		// between tokens meant for the certificates API and the auth API.
+		Type: api.IdentityTypeCertificateClient,
+	}
+
+	// Notify other members, update the cache, and send a lifecycle event.
+	lc, err := notify(lifecycle.IdentityCreated, api.AuthenticationMethodTLS, identifier.String(), false)
+	if err != nil {
+		return response.SmartError(err)
+	}
+
+	return response.SyncResponseLocation(true, token, lc.Source)
+}
+
+func tlsIdentityTokenValidate(ctx context.Context, s *state.State, token api.CertificateAddToken) (uuid.UUID, error) {
+	var id *dbCluster.Identity
+	err := s.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
+		var err error
+		id, err = dbCluster.GetPendingTLSIdentityByTokenSecret(ctx, tx.Tx(), token.Secret)
+		return err
+	})
+	if err != nil {
+		return uuid.UUID{}, fmt.Errorf("Failed to find a matching pending identity: %w", err)
+	}
+
+	metadata, err := id.PendingTLSMetadata()
+	if err != nil {
+		return uuid.UUID{}, fmt.Errorf("Failed extracting pending TLS identity metadata: %w", err)
+	}
+
+	if !metadata.Expiry.IsZero() && metadata.Expiry.Before(time.Now()) {
+		return uuid.UUID{}, api.StatusErrorf(http.StatusForbidden, "Token has expired")
+	}
+
+	uid, err := uuid.Parse(id.Identifier)
+	if err != nil {
+		return uuid.UUID{}, fmt.Errorf("Unexpected identifier format for pending TLS identity: %w", err)
+	}
+
+	return uid, nil
 }
 
 // swagger:operation GET /1.0/auth/identities identities identities_get

--- a/lxd/identity/util.go
+++ b/lxd/identity/util.go
@@ -10,7 +10,7 @@ import (
 
 // IsFineGrainedIdentityType returns true if permissions of the identity type are managed via group membership.
 func IsFineGrainedIdentityType(identityType string) bool {
-	return shared.ValueInSlice(identityType, []string{api.IdentityTypeOIDCClient})
+	return shared.ValueInSlice(identityType, []string{api.IdentityTypeOIDCClient, api.IdentityTypeCertificateClient, api.IdentityTypeCertificateClientPending})
 }
 
 // IsRestrictedIdentityType returns whether the given identity is restricted or not. Identity types that are not

--- a/lxd/identity/util.go
+++ b/lxd/identity/util.go
@@ -28,7 +28,7 @@ func IsRestrictedIdentityType(identityType string) (bool, error) {
 // identity types must correspond to an authentication method. An error is returned if the identity type is not recognised.
 func AuthenticationMethodFromIdentityType(identityType string) (string, error) {
 	switch identityType {
-	case api.IdentityTypeCertificateClientRestricted, api.IdentityTypeCertificateClientUnrestricted, api.IdentityTypeCertificateServer, api.IdentityTypeCertificateMetricsRestricted, api.IdentityTypeCertificateMetricsUnrestricted:
+	case api.IdentityTypeCertificateClientRestricted, api.IdentityTypeCertificateClientUnrestricted, api.IdentityTypeCertificateServer, api.IdentityTypeCertificateMetricsRestricted, api.IdentityTypeCertificateMetricsUnrestricted, api.IdentityTypeCertificateClient:
 		return api.AuthenticationMethodTLS, nil
 	case api.IdentityTypeOIDCClient:
 		return api.AuthenticationMethodOIDC, nil

--- a/po/ar.po
+++ b/po/ar.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-14 13:30+0000\n"
+"POT-Creation-Date: 2024-10-15 14:52+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -130,7 +130,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:214
+#: lxc/auth.go:219
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -157,7 +157,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:972
+#: lxc/auth.go:1121
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -178,7 +178,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1644
+#: lxc/auth.go:1793
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -512,15 +512,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:917 lxc/remote.go:982
+#: lxc/remote.go:951 lxc/remote.go:1016
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1030
+#: lxc/remote.go:1064
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:836
+#: lxc/remote.go:870
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -553,11 +553,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:818
+#: lxc/remote.go:852
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:817
+#: lxc/auth.go:966
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -595,11 +595,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1165 lxc/auth.go:1166
+#: lxc/auth.go:1314 lxc/auth.go:1315
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1933 lxc/auth.go:1934
+#: lxc/auth.go:2082 lxc/auth.go:2083
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -668,7 +668,7 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:516 lxc/auth.go:517
+#: lxc/auth.go:521 lxc/auth.go:522
 msgid "Add permissions to groups"
 msgstr ""
 
@@ -702,7 +702,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:648
+#: lxc/remote.go:680
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -810,7 +810,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:621
+#: lxc/remote.go:635
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -988,7 +988,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:961
+#: lxc/remote.go:995
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1054,7 +1054,7 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:509
+#: lxc/remote.go:523
 msgid "Certificate fingerprint"
 msgstr ""
 
@@ -1073,7 +1073,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:687
+#: lxc/remote.go:721
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1321,12 +1321,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:559
+#: lxc/remote.go:573
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:237 lxc/remote.go:543
+#: lxc/remote.go:237 lxc/remote.go:557
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1340,12 +1340,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:1719
+#: lxc/auth.go:306 lxc/auth.go:1868
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1058
+#: lxc/auth.go:1207
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1365,13 +1365,17 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:554
+#: lxc/remote.go:568
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
 #: lxc/network_zone.go:1536
 msgid "Couldn't find a matching entry"
+msgstr ""
+
+#: lxc/auth.go:776
+msgid "Create a TLS identity"
 msgstr ""
 
 #: lxc/cluster_group.go:169 lxc/cluster_group.go:170
@@ -1390,6 +1394,10 @@ msgstr ""
 msgid "Create an empty instance"
 msgstr ""
 
+#: lxc/auth.go:775
+msgid "Create an identity"
+msgstr ""
+
 #: lxc/launch.go:23 lxc/launch.go:24
 msgid "Create and start instances from images"
 msgstr ""
@@ -1402,11 +1410,11 @@ msgstr ""
 msgid "Create files and directories in instances"
 msgstr ""
 
-#: lxc/auth.go:98 lxc/auth.go:99
+#: lxc/auth.go:103 lxc/auth.go:104
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1530 lxc/auth.go:1531
+#: lxc/auth.go:1679 lxc/auth.go:1680
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1514,7 +1522,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
@@ -1557,7 +1565,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/auth.go:1088 lxc/auth.go:1089
+#: lxc/auth.go:1237 lxc/auth.go:1238
 msgid "Delete an identity"
 msgstr ""
 
@@ -1565,11 +1573,11 @@ msgstr ""
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/auth.go:152 lxc/auth.go:153
+#: lxc/auth.go:157 lxc/auth.go:158
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1582 lxc/auth.go:1583
+#: lxc/auth.go:1731 lxc/auth.go:1732
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1647,18 +1655,18 @@ msgstr ""
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:31 lxc/auth.go:60 lxc/auth.go:99
-#: lxc/auth.go:153 lxc/auth.go:202 lxc/auth.go:333 lxc/auth.go:393
-#: lxc/auth.go:442 lxc/auth.go:494 lxc/auth.go:517 lxc/auth.go:576
-#: lxc/auth.go:732 lxc/auth.go:769 lxc/auth.go:836 lxc/auth.go:899
-#: lxc/auth.go:960 lxc/auth.go:1089 lxc/auth.go:1143 lxc/auth.go:1166
-#: lxc/auth.go:1224 lxc/auth.go:1293 lxc/auth.go:1315 lxc/auth.go:1493
-#: lxc/auth.go:1531 lxc/auth.go:1583 lxc/auth.go:1632 lxc/auth.go:1751
-#: lxc/auth.go:1811 lxc/auth.go:1860 lxc/auth.go:1911 lxc/auth.go:1934
-#: lxc/auth.go:1987 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215
-#: lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:484
-#: lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677 lxc/cluster.go:770
-#: lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
+#: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
+#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:338 lxc/auth.go:398
+#: lxc/auth.go:447 lxc/auth.go:499 lxc/auth.go:522 lxc/auth.go:581
+#: lxc/auth.go:737 lxc/auth.go:776 lxc/auth.go:918 lxc/auth.go:985
+#: lxc/auth.go:1048 lxc/auth.go:1109 lxc/auth.go:1238 lxc/auth.go:1292
+#: lxc/auth.go:1315 lxc/auth.go:1373 lxc/auth.go:1442 lxc/auth.go:1464
+#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
+#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
+#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
+#: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
+#: lxc/cluster.go:770 lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
 #: lxc/cluster.go:1175 lxc/cluster.go:1299 lxc/cluster.go:1329
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
@@ -1729,9 +1737,9 @@ msgstr ""
 #: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
 #: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
 #: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:715
-#: lxc/remote.go:753 lxc/remote.go:839 lxc/remote.go:920 lxc/remote.go:984
-#: lxc/remote.go:1032 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
+#: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
+#: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1916,7 +1924,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:959 lxc/auth.go:960
+#: lxc/auth.go:1108 lxc/auth.go:1109
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1928,11 +1936,11 @@ msgstr ""
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/auth.go:201 lxc/auth.go:202
+#: lxc/auth.go:206 lxc/auth.go:207
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1631 lxc/auth.go:1632
+#: lxc/auth.go:1780 lxc/auth.go:1781
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2308,12 +2316,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:486
+#: lxc/remote.go:500
 #, c-format
 msgid "Failed to decode trust token: %w"
 msgstr ""
 
-#: lxc/remote.go:292
+#: lxc/remote.go:306
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2417,7 +2425,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:773 lxc/auth.go:1755
+#: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
@@ -2425,7 +2433,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:757 lxc/storage.go:657
+#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2463,7 +2471,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:821
+#: lxc/remote.go:855
 msgid "GLOBAL"
 msgstr ""
 
@@ -2475,7 +2483,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:821 lxc/auth.go:1795
+#: lxc/auth.go:970 lxc/auth.go:1944
 msgid "GROUPS"
 msgstr ""
 
@@ -2483,7 +2491,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:165 lxc/remote.go:443
+#: lxc/remote.go:165 lxc/remote.go:457
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2624,17 +2632,17 @@ msgstr ""
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: lxc/auth.go:137
+#: lxc/auth.go:142
 #, c-format
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:187
+#: lxc/auth.go:192
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:427 lxc/auth.go:1845
+#: lxc/auth.go:432 lxc/auth.go:1994
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2693,7 +2701,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:820
+#: lxc/auth.go:969
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -2725,12 +2733,16 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1567
+#: lxc/auth.go:829
+msgid "Identity creation only supported for TLS identities"
+msgstr ""
+
+#: lxc/auth.go:1716
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1617
+#: lxc/auth.go:1766
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2859,7 +2871,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1292 lxc/auth.go:1293
+#: lxc/auth.go:1441 lxc/auth.go:1442
 msgid "Inspect permissions"
 msgstr ""
 
@@ -2907,7 +2919,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:395
+#: lxc/remote.go:409
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2988,7 +3000,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:384
+#: lxc/remote.go:398
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3163,15 +3175,15 @@ msgstr ""
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:332 lxc/auth.go:333
+#: lxc/auth.go:337 lxc/auth.go:338
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:768 lxc/auth.go:769
+#: lxc/auth.go:917 lxc/auth.go:918
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1750 lxc/auth.go:1751
+#: lxc/auth.go:1899 lxc/auth.go:1900
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3324,7 +3336,7 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1314 lxc/auth.go:1315
+#: lxc/auth.go:1463 lxc/auth.go:1464
 msgid "List permissions"
 msgstr ""
 
@@ -3368,7 +3380,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:752 lxc/remote.go:753
+#: lxc/remote.go:786 lxc/remote.go:787
 msgid "List the available remotes"
 msgstr ""
 
@@ -3492,6 +3504,12 @@ msgstr ""
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
+#: lxc/auth.go:825
+msgid ""
+"Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
+"got "
+msgstr ""
+
 #: lxc/network.go:32 lxc/network.go:33
 msgid "Manage and attach instances to networks"
 msgstr ""
@@ -3520,19 +3538,19 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:59 lxc/auth.go:60 lxc/auth.go:1492 lxc/auth.go:1493
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1142 lxc/auth.go:1143
+#: lxc/auth.go:1291 lxc/auth.go:1292
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:731 lxc/auth.go:732
+#: lxc/auth.go:736 lxc/auth.go:737
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1910 lxc/auth.go:1911
+#: lxc/auth.go:2059 lxc/auth.go:2060
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3623,7 +3641,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:493 lxc/auth.go:494
+#: lxc/auth.go:498 lxc/auth.go:499
 msgid "Manage permissions"
 msgstr ""
 
@@ -3675,7 +3693,7 @@ msgstr ""
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/auth.go:30 lxc/auth.go:31
+#: lxc/auth.go:35 lxc/auth.go:36
 msgid "Manage user authorization"
 msgstr ""
 
@@ -3772,21 +3790,21 @@ msgstr ""
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:123 lxc/auth.go:177 lxc/auth.go:255 lxc/auth.go:417
-#: lxc/auth.go:466 lxc/auth.go:541 lxc/auth.go:600 lxc/auth.go:1884
+#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:260 lxc/auth.go:422
+#: lxc/auth.go:471 lxc/auth.go:546 lxc/auth.go:605 lxc/auth.go:2033
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:866 lxc/auth.go:1007 lxc/auth.go:1124 lxc/auth.go:1190
-#: lxc/auth.go:1248
+#: lxc/auth.go:820 lxc/auth.go:1015 lxc/auth.go:1156 lxc/auth.go:1273
+#: lxc/auth.go:1339 lxc/auth.go:1397
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1554 lxc/auth.go:1607 lxc/auth.go:1673 lxc/auth.go:1835
+#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1958 lxc/auth.go:2011
+#: lxc/auth.go:2107 lxc/auth.go:2160
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -4007,12 +4025,12 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:376 lxc/auth.go:819 lxc/auth.go:1794 lxc/cluster.go:192
+#: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
-#: lxc/remote.go:815 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
 msgstr ""
@@ -4039,7 +4057,7 @@ msgstr ""
 
 #: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:775 lxc/remote.go:780 lxc/remote.go:785
+#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr ""
 
@@ -4268,7 +4286,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:378
+#: lxc/remote.go:392
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4339,11 +4357,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:817
+#: lxc/remote.go:851
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:819
+#: lxc/image.go:1136 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4384,7 +4402,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:536
+#: lxc/remote.go:550
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
@@ -4401,7 +4419,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:302 lxc/auth.go:1059 lxc/auth.go:1720 lxc/cluster.go:860
+#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -4704,33 +4722,33 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:877
+#: lxc/remote.go:911
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:868 lxc/remote.go:949 lxc/remote.go:1013
-#: lxc/remote.go:1061
+#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/remote.go:1095
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:345
+#: lxc/remote.go:359
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:957
+#: lxc/remote.go:991
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:872 lxc/remote.go:953 lxc/remote.go:1065
+#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1099
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:319
+#: lxc/remote.go:333
 msgid "Remote address must not be empty"
 msgstr ""
 
@@ -4738,7 +4756,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:339
+#: lxc/remote.go:353
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4760,7 +4778,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1223 lxc/auth.go:1224
+#: lxc/auth.go:1372 lxc/auth.go:1373
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4796,7 +4814,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1986 lxc/auth.go:1987
+#: lxc/auth.go:2135 lxc/auth.go:2136
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4808,7 +4826,7 @@ msgstr ""
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:575 lxc/auth.go:576
+#: lxc/auth.go:580 lxc/auth.go:581
 msgid "Remove permissions from groups"
 msgstr ""
 
@@ -4824,7 +4842,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:919 lxc/remote.go:920
+#: lxc/remote.go:953 lxc/remote.go:954
 msgid "Remove remotes"
 msgstr ""
 
@@ -4853,11 +4871,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:392 lxc/auth.go:393
+#: lxc/auth.go:397 lxc/auth.go:398
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1810 lxc/auth.go:1811
+#: lxc/auth.go:1959 lxc/auth.go:1960
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -4881,7 +4899,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:838 lxc/remote.go:839
+#: lxc/remote.go:872 lxc/remote.go:873
 msgid "Rename remotes"
 msgstr ""
 
@@ -5026,7 +5044,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:820
+#: lxc/remote.go:854
 msgid "STATIC"
 msgstr ""
 
@@ -5067,11 +5085,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:532
+#: lxc/remote.go:546
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:285 lxc/remote.go:683
+#: lxc/remote.go:299 lxc/remote.go:717
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5282,7 +5300,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1031 lxc/remote.go:1032
+#: lxc/remote.go:1065 lxc/remote.go:1066
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5378,7 +5396,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1859 lxc/auth.go:1860
+#: lxc/auth.go:2008 lxc/auth.go:2009
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5406,11 +5424,11 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:441 lxc/auth.go:442
+#: lxc/auth.go:446 lxc/auth.go:447
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:836
+#: lxc/auth.go:985
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5515,7 +5533,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:899
+#: lxc/auth.go:1048
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5525,7 +5543,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:714 lxc/remote.go:715
+#: lxc/remote.go:748 lxc/remote.go:749
 msgid "Show the default remote"
 msgstr ""
 
@@ -5737,7 +5755,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:983 lxc/remote.go:984
+#: lxc/remote.go:1017 lxc/remote.go:1018
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5749,11 +5767,21 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
+#: lxc/auth.go:876
+#, c-format
+msgid "TLS identity %q (%s) pending identity token:"
+msgstr ""
+
+#: lxc/auth.go:902
+#, c-format
+msgid "TLS identity %q created with fingerprint %q"
+msgstr ""
+
 #: lxc/cluster.go:1070 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:818 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
 #: lxc/storage_volume.go:1736 lxc/warning.go:216
@@ -5772,7 +5800,7 @@ msgstr ""
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/remote.go:161 lxc/remote.go:334
+#: lxc/remote.go:161 lxc/remote.go:348
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
@@ -5928,7 +5956,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:527
+#: lxc/remote.go:541
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
@@ -6066,15 +6094,15 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:329
+#: lxc/remote.go:343
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:324
+#: lxc/remote.go:338
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr ""
 
-#: lxc/remote.go:639
+#: lxc/remote.go:653
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6117,7 +6145,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:193 lxc/remote.go:816
+#: lxc/cluster.go:193 lxc/remote.go:850
 msgid "URL"
 msgstr ""
 
@@ -6425,11 +6453,11 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:835
+#: lxc/auth.go:984
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:898
+#: lxc/auth.go:1047
 msgid "View the current identity"
 msgstr ""
 
@@ -6468,7 +6496,7 @@ msgstr ""
 
 #: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:777 lxc/remote.go:782 lxc/remote.go:787
+#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr ""
 
@@ -6500,7 +6528,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:330 lxc/auth.go:766 lxc/auth.go:897 lxc/auth.go:1748
+#: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
@@ -6533,7 +6561,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1313
+#: lxc/auth.go:1462
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6594,11 +6622,17 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:834 lxc/auth.go:1086
+#: lxc/auth.go:774
+msgid ""
+"[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
+"certificate>] [[--group <group_name>]]"
+msgstr ""
+
+#: lxc/auth.go:983 lxc/auth.go:1235
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1164 lxc/auth.go:1222 lxc/auth.go:1985
+#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:2134
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6606,13 +6640,13 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:97 lxc/auth.go:150 lxc/auth.go:200 lxc/auth.go:440
-#: lxc/auth.go:958 lxc/auth.go:1529 lxc/cluster_group.go:168
+#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:445
+#: lxc/auth.go:1107 lxc/auth.go:1678 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:515 lxc/auth.go:573
+#: lxc/auth.go:520 lxc/auth.go:578
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
@@ -6622,19 +6656,19 @@ msgstr ""
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:390
+#: lxc/auth.go:395
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1580 lxc/auth.go:1630 lxc/auth.go:1858
+#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1932
+#: lxc/auth.go:2081
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1808
+#: lxc/auth.go:1957
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -7125,7 +7159,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:806
+#: lxc/project.go:557 lxc/remote.go:840
 msgid "current"
 msgstr ""
 
@@ -7172,20 +7206,20 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/auth.go:204
+#: lxc/auth.go:209
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:962
+#: lxc/auth.go:1111
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1634
+#: lxc/auth.go:1783
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7609,7 +7643,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:531
+#: lxc/remote.go:545
 msgid "n"
 msgstr ""
 
@@ -7621,7 +7655,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:510
+#: lxc/remote.go:524
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7658,7 +7692,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:519
+#: lxc/remote.go:533
 msgid "y"
 msgstr ""
 

--- a/po/ber.po
+++ b/po/ber.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-14 13:30+0000\n"
+"POT-Creation-Date: 2024-10-15 14:52+0100\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Berber <https://hosted.weblate.org/projects/linux-containers/"
@@ -133,7 +133,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:214
+#: lxc/auth.go:219
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -160,7 +160,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:972
+#: lxc/auth.go:1121
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -181,7 +181,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1644
+#: lxc/auth.go:1793
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -515,15 +515,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:917 lxc/remote.go:982
+#: lxc/remote.go:951 lxc/remote.go:1016
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1030
+#: lxc/remote.go:1064
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:836
+#: lxc/remote.go:870
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -556,11 +556,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:818
+#: lxc/remote.go:852
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:817
+#: lxc/auth.go:966
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -598,11 +598,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1165 lxc/auth.go:1166
+#: lxc/auth.go:1314 lxc/auth.go:1315
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1933 lxc/auth.go:1934
+#: lxc/auth.go:2082 lxc/auth.go:2083
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -671,7 +671,7 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:516 lxc/auth.go:517
+#: lxc/auth.go:521 lxc/auth.go:522
 msgid "Add permissions to groups"
 msgstr ""
 
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:648
+#: lxc/remote.go:680
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -813,7 +813,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:621
+#: lxc/remote.go:635
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -991,7 +991,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:961
+#: lxc/remote.go:995
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1057,7 +1057,7 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:509
+#: lxc/remote.go:523
 msgid "Certificate fingerprint"
 msgstr ""
 
@@ -1076,7 +1076,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:687
+#: lxc/remote.go:721
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1324,12 +1324,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:559
+#: lxc/remote.go:573
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:237 lxc/remote.go:543
+#: lxc/remote.go:237 lxc/remote.go:557
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1343,12 +1343,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:1719
+#: lxc/auth.go:306 lxc/auth.go:1868
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1058
+#: lxc/auth.go:1207
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1368,13 +1368,17 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:554
+#: lxc/remote.go:568
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
 #: lxc/network_zone.go:1536
 msgid "Couldn't find a matching entry"
+msgstr ""
+
+#: lxc/auth.go:776
+msgid "Create a TLS identity"
 msgstr ""
 
 #: lxc/cluster_group.go:169 lxc/cluster_group.go:170
@@ -1393,6 +1397,10 @@ msgstr ""
 msgid "Create an empty instance"
 msgstr ""
 
+#: lxc/auth.go:775
+msgid "Create an identity"
+msgstr ""
+
 #: lxc/launch.go:23 lxc/launch.go:24
 msgid "Create and start instances from images"
 msgstr ""
@@ -1405,11 +1413,11 @@ msgstr ""
 msgid "Create files and directories in instances"
 msgstr ""
 
-#: lxc/auth.go:98 lxc/auth.go:99
+#: lxc/auth.go:103 lxc/auth.go:104
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1530 lxc/auth.go:1531
+#: lxc/auth.go:1679 lxc/auth.go:1680
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1517,7 +1525,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
@@ -1560,7 +1568,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/auth.go:1088 lxc/auth.go:1089
+#: lxc/auth.go:1237 lxc/auth.go:1238
 msgid "Delete an identity"
 msgstr ""
 
@@ -1568,11 +1576,11 @@ msgstr ""
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/auth.go:152 lxc/auth.go:153
+#: lxc/auth.go:157 lxc/auth.go:158
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1582 lxc/auth.go:1583
+#: lxc/auth.go:1731 lxc/auth.go:1732
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1650,18 +1658,18 @@ msgstr ""
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:31 lxc/auth.go:60 lxc/auth.go:99
-#: lxc/auth.go:153 lxc/auth.go:202 lxc/auth.go:333 lxc/auth.go:393
-#: lxc/auth.go:442 lxc/auth.go:494 lxc/auth.go:517 lxc/auth.go:576
-#: lxc/auth.go:732 lxc/auth.go:769 lxc/auth.go:836 lxc/auth.go:899
-#: lxc/auth.go:960 lxc/auth.go:1089 lxc/auth.go:1143 lxc/auth.go:1166
-#: lxc/auth.go:1224 lxc/auth.go:1293 lxc/auth.go:1315 lxc/auth.go:1493
-#: lxc/auth.go:1531 lxc/auth.go:1583 lxc/auth.go:1632 lxc/auth.go:1751
-#: lxc/auth.go:1811 lxc/auth.go:1860 lxc/auth.go:1911 lxc/auth.go:1934
-#: lxc/auth.go:1987 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215
-#: lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:484
-#: lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677 lxc/cluster.go:770
-#: lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
+#: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
+#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:338 lxc/auth.go:398
+#: lxc/auth.go:447 lxc/auth.go:499 lxc/auth.go:522 lxc/auth.go:581
+#: lxc/auth.go:737 lxc/auth.go:776 lxc/auth.go:918 lxc/auth.go:985
+#: lxc/auth.go:1048 lxc/auth.go:1109 lxc/auth.go:1238 lxc/auth.go:1292
+#: lxc/auth.go:1315 lxc/auth.go:1373 lxc/auth.go:1442 lxc/auth.go:1464
+#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
+#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
+#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
+#: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
+#: lxc/cluster.go:770 lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
 #: lxc/cluster.go:1175 lxc/cluster.go:1299 lxc/cluster.go:1329
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
@@ -1732,9 +1740,9 @@ msgstr ""
 #: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
 #: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
 #: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:715
-#: lxc/remote.go:753 lxc/remote.go:839 lxc/remote.go:920 lxc/remote.go:984
-#: lxc/remote.go:1032 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
+#: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
+#: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1919,7 +1927,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:959 lxc/auth.go:960
+#: lxc/auth.go:1108 lxc/auth.go:1109
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1931,11 +1939,11 @@ msgstr ""
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/auth.go:201 lxc/auth.go:202
+#: lxc/auth.go:206 lxc/auth.go:207
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1631 lxc/auth.go:1632
+#: lxc/auth.go:1780 lxc/auth.go:1781
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2311,12 +2319,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:486
+#: lxc/remote.go:500
 #, c-format
 msgid "Failed to decode trust token: %w"
 msgstr ""
 
-#: lxc/remote.go:292
+#: lxc/remote.go:306
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2420,7 +2428,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:773 lxc/auth.go:1755
+#: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
@@ -2428,7 +2436,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:757 lxc/storage.go:657
+#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2466,7 +2474,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:821
+#: lxc/remote.go:855
 msgid "GLOBAL"
 msgstr ""
 
@@ -2478,7 +2486,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:821 lxc/auth.go:1795
+#: lxc/auth.go:970 lxc/auth.go:1944
 msgid "GROUPS"
 msgstr ""
 
@@ -2486,7 +2494,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:165 lxc/remote.go:443
+#: lxc/remote.go:165 lxc/remote.go:457
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2627,17 +2635,17 @@ msgstr ""
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: lxc/auth.go:137
+#: lxc/auth.go:142
 #, c-format
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:187
+#: lxc/auth.go:192
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:427 lxc/auth.go:1845
+#: lxc/auth.go:432 lxc/auth.go:1994
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2696,7 +2704,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:820
+#: lxc/auth.go:969
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -2728,12 +2736,16 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1567
+#: lxc/auth.go:829
+msgid "Identity creation only supported for TLS identities"
+msgstr ""
+
+#: lxc/auth.go:1716
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1617
+#: lxc/auth.go:1766
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2862,7 +2874,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1292 lxc/auth.go:1293
+#: lxc/auth.go:1441 lxc/auth.go:1442
 msgid "Inspect permissions"
 msgstr ""
 
@@ -2910,7 +2922,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:395
+#: lxc/remote.go:409
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2991,7 +3003,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:384
+#: lxc/remote.go:398
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3166,15 +3178,15 @@ msgstr ""
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:332 lxc/auth.go:333
+#: lxc/auth.go:337 lxc/auth.go:338
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:768 lxc/auth.go:769
+#: lxc/auth.go:917 lxc/auth.go:918
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1750 lxc/auth.go:1751
+#: lxc/auth.go:1899 lxc/auth.go:1900
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3327,7 +3339,7 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1314 lxc/auth.go:1315
+#: lxc/auth.go:1463 lxc/auth.go:1464
 msgid "List permissions"
 msgstr ""
 
@@ -3371,7 +3383,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:752 lxc/remote.go:753
+#: lxc/remote.go:786 lxc/remote.go:787
 msgid "List the available remotes"
 msgstr ""
 
@@ -3495,6 +3507,12 @@ msgstr ""
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
+#: lxc/auth.go:825
+msgid ""
+"Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
+"got "
+msgstr ""
+
 #: lxc/network.go:32 lxc/network.go:33
 msgid "Manage and attach instances to networks"
 msgstr ""
@@ -3523,19 +3541,19 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:59 lxc/auth.go:60 lxc/auth.go:1492 lxc/auth.go:1493
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1142 lxc/auth.go:1143
+#: lxc/auth.go:1291 lxc/auth.go:1292
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:731 lxc/auth.go:732
+#: lxc/auth.go:736 lxc/auth.go:737
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1910 lxc/auth.go:1911
+#: lxc/auth.go:2059 lxc/auth.go:2060
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3626,7 +3644,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:493 lxc/auth.go:494
+#: lxc/auth.go:498 lxc/auth.go:499
 msgid "Manage permissions"
 msgstr ""
 
@@ -3678,7 +3696,7 @@ msgstr ""
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/auth.go:30 lxc/auth.go:31
+#: lxc/auth.go:35 lxc/auth.go:36
 msgid "Manage user authorization"
 msgstr ""
 
@@ -3775,21 +3793,21 @@ msgstr ""
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:123 lxc/auth.go:177 lxc/auth.go:255 lxc/auth.go:417
-#: lxc/auth.go:466 lxc/auth.go:541 lxc/auth.go:600 lxc/auth.go:1884
+#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:260 lxc/auth.go:422
+#: lxc/auth.go:471 lxc/auth.go:546 lxc/auth.go:605 lxc/auth.go:2033
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:866 lxc/auth.go:1007 lxc/auth.go:1124 lxc/auth.go:1190
-#: lxc/auth.go:1248
+#: lxc/auth.go:820 lxc/auth.go:1015 lxc/auth.go:1156 lxc/auth.go:1273
+#: lxc/auth.go:1339 lxc/auth.go:1397
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1554 lxc/auth.go:1607 lxc/auth.go:1673 lxc/auth.go:1835
+#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1958 lxc/auth.go:2011
+#: lxc/auth.go:2107 lxc/auth.go:2160
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -4010,12 +4028,12 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:376 lxc/auth.go:819 lxc/auth.go:1794 lxc/cluster.go:192
+#: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
-#: lxc/remote.go:815 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
 msgstr ""
@@ -4042,7 +4060,7 @@ msgstr ""
 
 #: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:775 lxc/remote.go:780 lxc/remote.go:785
+#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr ""
 
@@ -4271,7 +4289,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:378
+#: lxc/remote.go:392
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4342,11 +4360,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:817
+#: lxc/remote.go:851
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:819
+#: lxc/image.go:1136 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4387,7 +4405,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:536
+#: lxc/remote.go:550
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
@@ -4404,7 +4422,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:302 lxc/auth.go:1059 lxc/auth.go:1720 lxc/cluster.go:860
+#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -4707,33 +4725,33 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:877
+#: lxc/remote.go:911
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:868 lxc/remote.go:949 lxc/remote.go:1013
-#: lxc/remote.go:1061
+#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/remote.go:1095
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:345
+#: lxc/remote.go:359
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:957
+#: lxc/remote.go:991
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:872 lxc/remote.go:953 lxc/remote.go:1065
+#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1099
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:319
+#: lxc/remote.go:333
 msgid "Remote address must not be empty"
 msgstr ""
 
@@ -4741,7 +4759,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:339
+#: lxc/remote.go:353
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4763,7 +4781,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1223 lxc/auth.go:1224
+#: lxc/auth.go:1372 lxc/auth.go:1373
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4799,7 +4817,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1986 lxc/auth.go:1987
+#: lxc/auth.go:2135 lxc/auth.go:2136
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4811,7 +4829,7 @@ msgstr ""
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:575 lxc/auth.go:576
+#: lxc/auth.go:580 lxc/auth.go:581
 msgid "Remove permissions from groups"
 msgstr ""
 
@@ -4827,7 +4845,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:919 lxc/remote.go:920
+#: lxc/remote.go:953 lxc/remote.go:954
 msgid "Remove remotes"
 msgstr ""
 
@@ -4856,11 +4874,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:392 lxc/auth.go:393
+#: lxc/auth.go:397 lxc/auth.go:398
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1810 lxc/auth.go:1811
+#: lxc/auth.go:1959 lxc/auth.go:1960
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -4884,7 +4902,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:838 lxc/remote.go:839
+#: lxc/remote.go:872 lxc/remote.go:873
 msgid "Rename remotes"
 msgstr ""
 
@@ -5029,7 +5047,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:820
+#: lxc/remote.go:854
 msgid "STATIC"
 msgstr ""
 
@@ -5070,11 +5088,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:532
+#: lxc/remote.go:546
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:285 lxc/remote.go:683
+#: lxc/remote.go:299 lxc/remote.go:717
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5285,7 +5303,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1031 lxc/remote.go:1032
+#: lxc/remote.go:1065 lxc/remote.go:1066
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5381,7 +5399,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1859 lxc/auth.go:1860
+#: lxc/auth.go:2008 lxc/auth.go:2009
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5409,11 +5427,11 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:441 lxc/auth.go:442
+#: lxc/auth.go:446 lxc/auth.go:447
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:836
+#: lxc/auth.go:985
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5518,7 +5536,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:899
+#: lxc/auth.go:1048
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5528,7 +5546,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:714 lxc/remote.go:715
+#: lxc/remote.go:748 lxc/remote.go:749
 msgid "Show the default remote"
 msgstr ""
 
@@ -5740,7 +5758,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:983 lxc/remote.go:984
+#: lxc/remote.go:1017 lxc/remote.go:1018
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5752,11 +5770,21 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
+#: lxc/auth.go:876
+#, c-format
+msgid "TLS identity %q (%s) pending identity token:"
+msgstr ""
+
+#: lxc/auth.go:902
+#, c-format
+msgid "TLS identity %q created with fingerprint %q"
+msgstr ""
+
 #: lxc/cluster.go:1070 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:818 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
 #: lxc/storage_volume.go:1736 lxc/warning.go:216
@@ -5775,7 +5803,7 @@ msgstr ""
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/remote.go:161 lxc/remote.go:334
+#: lxc/remote.go:161 lxc/remote.go:348
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
@@ -5931,7 +5959,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:527
+#: lxc/remote.go:541
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
@@ -6069,15 +6097,15 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:329
+#: lxc/remote.go:343
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:324
+#: lxc/remote.go:338
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr ""
 
-#: lxc/remote.go:639
+#: lxc/remote.go:653
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6120,7 +6148,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:193 lxc/remote.go:816
+#: lxc/cluster.go:193 lxc/remote.go:850
 msgid "URL"
 msgstr ""
 
@@ -6428,11 +6456,11 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:835
+#: lxc/auth.go:984
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:898
+#: lxc/auth.go:1047
 msgid "View the current identity"
 msgstr ""
 
@@ -6471,7 +6499,7 @@ msgstr ""
 
 #: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:777 lxc/remote.go:782 lxc/remote.go:787
+#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr ""
 
@@ -6503,7 +6531,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:330 lxc/auth.go:766 lxc/auth.go:897 lxc/auth.go:1748
+#: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
@@ -6536,7 +6564,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1313
+#: lxc/auth.go:1462
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6597,11 +6625,17 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:834 lxc/auth.go:1086
+#: lxc/auth.go:774
+msgid ""
+"[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
+"certificate>] [[--group <group_name>]]"
+msgstr ""
+
+#: lxc/auth.go:983 lxc/auth.go:1235
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1164 lxc/auth.go:1222 lxc/auth.go:1985
+#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:2134
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6609,13 +6643,13 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:97 lxc/auth.go:150 lxc/auth.go:200 lxc/auth.go:440
-#: lxc/auth.go:958 lxc/auth.go:1529 lxc/cluster_group.go:168
+#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:445
+#: lxc/auth.go:1107 lxc/auth.go:1678 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:515 lxc/auth.go:573
+#: lxc/auth.go:520 lxc/auth.go:578
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
@@ -6625,19 +6659,19 @@ msgstr ""
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:390
+#: lxc/auth.go:395
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1580 lxc/auth.go:1630 lxc/auth.go:1858
+#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1932
+#: lxc/auth.go:2081
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1808
+#: lxc/auth.go:1957
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -7128,7 +7162,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:806
+#: lxc/project.go:557 lxc/remote.go:840
 msgid "current"
 msgstr ""
 
@@ -7175,20 +7209,20 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/auth.go:204
+#: lxc/auth.go:209
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:962
+#: lxc/auth.go:1111
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1634
+#: lxc/auth.go:1783
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7612,7 +7646,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:531
+#: lxc/remote.go:545
 msgid "n"
 msgstr ""
 
@@ -7624,7 +7658,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:510
+#: lxc/remote.go:524
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7661,7 +7695,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:519
+#: lxc/remote.go:533
 msgid "y"
 msgstr ""
 

--- a/po/bg.po
+++ b/po/bg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-14 13:30+0000\n"
+"POT-Creation-Date: 2024-10-15 14:52+0100\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Bulgarian <https://hosted.weblate.org/projects/linux-"
@@ -133,7 +133,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:214
+#: lxc/auth.go:219
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -160,7 +160,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:972
+#: lxc/auth.go:1121
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -181,7 +181,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1644
+#: lxc/auth.go:1793
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -515,15 +515,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:917 lxc/remote.go:982
+#: lxc/remote.go:951 lxc/remote.go:1016
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1030
+#: lxc/remote.go:1064
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:836
+#: lxc/remote.go:870
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -556,11 +556,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:818
+#: lxc/remote.go:852
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:817
+#: lxc/auth.go:966
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -598,11 +598,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1165 lxc/auth.go:1166
+#: lxc/auth.go:1314 lxc/auth.go:1315
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1933 lxc/auth.go:1934
+#: lxc/auth.go:2082 lxc/auth.go:2083
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -671,7 +671,7 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:516 lxc/auth.go:517
+#: lxc/auth.go:521 lxc/auth.go:522
 msgid "Add permissions to groups"
 msgstr ""
 
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:648
+#: lxc/remote.go:680
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -813,7 +813,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:621
+#: lxc/remote.go:635
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -991,7 +991,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:961
+#: lxc/remote.go:995
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1057,7 +1057,7 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:509
+#: lxc/remote.go:523
 msgid "Certificate fingerprint"
 msgstr ""
 
@@ -1076,7 +1076,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:687
+#: lxc/remote.go:721
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1324,12 +1324,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:559
+#: lxc/remote.go:573
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:237 lxc/remote.go:543
+#: lxc/remote.go:237 lxc/remote.go:557
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1343,12 +1343,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:1719
+#: lxc/auth.go:306 lxc/auth.go:1868
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1058
+#: lxc/auth.go:1207
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1368,13 +1368,17 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:554
+#: lxc/remote.go:568
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
 #: lxc/network_zone.go:1536
 msgid "Couldn't find a matching entry"
+msgstr ""
+
+#: lxc/auth.go:776
+msgid "Create a TLS identity"
 msgstr ""
 
 #: lxc/cluster_group.go:169 lxc/cluster_group.go:170
@@ -1393,6 +1397,10 @@ msgstr ""
 msgid "Create an empty instance"
 msgstr ""
 
+#: lxc/auth.go:775
+msgid "Create an identity"
+msgstr ""
+
 #: lxc/launch.go:23 lxc/launch.go:24
 msgid "Create and start instances from images"
 msgstr ""
@@ -1405,11 +1413,11 @@ msgstr ""
 msgid "Create files and directories in instances"
 msgstr ""
 
-#: lxc/auth.go:98 lxc/auth.go:99
+#: lxc/auth.go:103 lxc/auth.go:104
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1530 lxc/auth.go:1531
+#: lxc/auth.go:1679 lxc/auth.go:1680
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1517,7 +1525,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
@@ -1560,7 +1568,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/auth.go:1088 lxc/auth.go:1089
+#: lxc/auth.go:1237 lxc/auth.go:1238
 msgid "Delete an identity"
 msgstr ""
 
@@ -1568,11 +1576,11 @@ msgstr ""
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/auth.go:152 lxc/auth.go:153
+#: lxc/auth.go:157 lxc/auth.go:158
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1582 lxc/auth.go:1583
+#: lxc/auth.go:1731 lxc/auth.go:1732
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1650,18 +1658,18 @@ msgstr ""
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:31 lxc/auth.go:60 lxc/auth.go:99
-#: lxc/auth.go:153 lxc/auth.go:202 lxc/auth.go:333 lxc/auth.go:393
-#: lxc/auth.go:442 lxc/auth.go:494 lxc/auth.go:517 lxc/auth.go:576
-#: lxc/auth.go:732 lxc/auth.go:769 lxc/auth.go:836 lxc/auth.go:899
-#: lxc/auth.go:960 lxc/auth.go:1089 lxc/auth.go:1143 lxc/auth.go:1166
-#: lxc/auth.go:1224 lxc/auth.go:1293 lxc/auth.go:1315 lxc/auth.go:1493
-#: lxc/auth.go:1531 lxc/auth.go:1583 lxc/auth.go:1632 lxc/auth.go:1751
-#: lxc/auth.go:1811 lxc/auth.go:1860 lxc/auth.go:1911 lxc/auth.go:1934
-#: lxc/auth.go:1987 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215
-#: lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:484
-#: lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677 lxc/cluster.go:770
-#: lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
+#: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
+#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:338 lxc/auth.go:398
+#: lxc/auth.go:447 lxc/auth.go:499 lxc/auth.go:522 lxc/auth.go:581
+#: lxc/auth.go:737 lxc/auth.go:776 lxc/auth.go:918 lxc/auth.go:985
+#: lxc/auth.go:1048 lxc/auth.go:1109 lxc/auth.go:1238 lxc/auth.go:1292
+#: lxc/auth.go:1315 lxc/auth.go:1373 lxc/auth.go:1442 lxc/auth.go:1464
+#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
+#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
+#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
+#: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
+#: lxc/cluster.go:770 lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
 #: lxc/cluster.go:1175 lxc/cluster.go:1299 lxc/cluster.go:1329
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
@@ -1732,9 +1740,9 @@ msgstr ""
 #: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
 #: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
 #: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:715
-#: lxc/remote.go:753 lxc/remote.go:839 lxc/remote.go:920 lxc/remote.go:984
-#: lxc/remote.go:1032 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
+#: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
+#: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1919,7 +1927,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:959 lxc/auth.go:960
+#: lxc/auth.go:1108 lxc/auth.go:1109
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1931,11 +1939,11 @@ msgstr ""
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/auth.go:201 lxc/auth.go:202
+#: lxc/auth.go:206 lxc/auth.go:207
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1631 lxc/auth.go:1632
+#: lxc/auth.go:1780 lxc/auth.go:1781
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2311,12 +2319,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:486
+#: lxc/remote.go:500
 #, c-format
 msgid "Failed to decode trust token: %w"
 msgstr ""
 
-#: lxc/remote.go:292
+#: lxc/remote.go:306
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2420,7 +2428,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:773 lxc/auth.go:1755
+#: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
@@ -2428,7 +2436,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:757 lxc/storage.go:657
+#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2466,7 +2474,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:821
+#: lxc/remote.go:855
 msgid "GLOBAL"
 msgstr ""
 
@@ -2478,7 +2486,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:821 lxc/auth.go:1795
+#: lxc/auth.go:970 lxc/auth.go:1944
 msgid "GROUPS"
 msgstr ""
 
@@ -2486,7 +2494,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:165 lxc/remote.go:443
+#: lxc/remote.go:165 lxc/remote.go:457
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2627,17 +2635,17 @@ msgstr ""
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: lxc/auth.go:137
+#: lxc/auth.go:142
 #, c-format
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:187
+#: lxc/auth.go:192
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:427 lxc/auth.go:1845
+#: lxc/auth.go:432 lxc/auth.go:1994
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2696,7 +2704,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:820
+#: lxc/auth.go:969
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -2728,12 +2736,16 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1567
+#: lxc/auth.go:829
+msgid "Identity creation only supported for TLS identities"
+msgstr ""
+
+#: lxc/auth.go:1716
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1617
+#: lxc/auth.go:1766
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2862,7 +2874,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1292 lxc/auth.go:1293
+#: lxc/auth.go:1441 lxc/auth.go:1442
 msgid "Inspect permissions"
 msgstr ""
 
@@ -2910,7 +2922,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:395
+#: lxc/remote.go:409
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2991,7 +3003,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:384
+#: lxc/remote.go:398
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3166,15 +3178,15 @@ msgstr ""
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:332 lxc/auth.go:333
+#: lxc/auth.go:337 lxc/auth.go:338
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:768 lxc/auth.go:769
+#: lxc/auth.go:917 lxc/auth.go:918
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1750 lxc/auth.go:1751
+#: lxc/auth.go:1899 lxc/auth.go:1900
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3327,7 +3339,7 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1314 lxc/auth.go:1315
+#: lxc/auth.go:1463 lxc/auth.go:1464
 msgid "List permissions"
 msgstr ""
 
@@ -3371,7 +3383,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:752 lxc/remote.go:753
+#: lxc/remote.go:786 lxc/remote.go:787
 msgid "List the available remotes"
 msgstr ""
 
@@ -3495,6 +3507,12 @@ msgstr ""
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
+#: lxc/auth.go:825
+msgid ""
+"Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
+"got "
+msgstr ""
+
 #: lxc/network.go:32 lxc/network.go:33
 msgid "Manage and attach instances to networks"
 msgstr ""
@@ -3523,19 +3541,19 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:59 lxc/auth.go:60 lxc/auth.go:1492 lxc/auth.go:1493
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1142 lxc/auth.go:1143
+#: lxc/auth.go:1291 lxc/auth.go:1292
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:731 lxc/auth.go:732
+#: lxc/auth.go:736 lxc/auth.go:737
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1910 lxc/auth.go:1911
+#: lxc/auth.go:2059 lxc/auth.go:2060
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3626,7 +3644,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:493 lxc/auth.go:494
+#: lxc/auth.go:498 lxc/auth.go:499
 msgid "Manage permissions"
 msgstr ""
 
@@ -3678,7 +3696,7 @@ msgstr ""
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/auth.go:30 lxc/auth.go:31
+#: lxc/auth.go:35 lxc/auth.go:36
 msgid "Manage user authorization"
 msgstr ""
 
@@ -3775,21 +3793,21 @@ msgstr ""
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:123 lxc/auth.go:177 lxc/auth.go:255 lxc/auth.go:417
-#: lxc/auth.go:466 lxc/auth.go:541 lxc/auth.go:600 lxc/auth.go:1884
+#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:260 lxc/auth.go:422
+#: lxc/auth.go:471 lxc/auth.go:546 lxc/auth.go:605 lxc/auth.go:2033
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:866 lxc/auth.go:1007 lxc/auth.go:1124 lxc/auth.go:1190
-#: lxc/auth.go:1248
+#: lxc/auth.go:820 lxc/auth.go:1015 lxc/auth.go:1156 lxc/auth.go:1273
+#: lxc/auth.go:1339 lxc/auth.go:1397
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1554 lxc/auth.go:1607 lxc/auth.go:1673 lxc/auth.go:1835
+#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1958 lxc/auth.go:2011
+#: lxc/auth.go:2107 lxc/auth.go:2160
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -4010,12 +4028,12 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:376 lxc/auth.go:819 lxc/auth.go:1794 lxc/cluster.go:192
+#: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
-#: lxc/remote.go:815 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
 msgstr ""
@@ -4042,7 +4060,7 @@ msgstr ""
 
 #: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:775 lxc/remote.go:780 lxc/remote.go:785
+#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr ""
 
@@ -4271,7 +4289,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:378
+#: lxc/remote.go:392
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4342,11 +4360,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:817
+#: lxc/remote.go:851
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:819
+#: lxc/image.go:1136 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4387,7 +4405,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:536
+#: lxc/remote.go:550
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
@@ -4404,7 +4422,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:302 lxc/auth.go:1059 lxc/auth.go:1720 lxc/cluster.go:860
+#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -4707,33 +4725,33 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:877
+#: lxc/remote.go:911
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:868 lxc/remote.go:949 lxc/remote.go:1013
-#: lxc/remote.go:1061
+#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/remote.go:1095
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:345
+#: lxc/remote.go:359
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:957
+#: lxc/remote.go:991
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:872 lxc/remote.go:953 lxc/remote.go:1065
+#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1099
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:319
+#: lxc/remote.go:333
 msgid "Remote address must not be empty"
 msgstr ""
 
@@ -4741,7 +4759,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:339
+#: lxc/remote.go:353
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4763,7 +4781,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1223 lxc/auth.go:1224
+#: lxc/auth.go:1372 lxc/auth.go:1373
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4799,7 +4817,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1986 lxc/auth.go:1987
+#: lxc/auth.go:2135 lxc/auth.go:2136
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4811,7 +4829,7 @@ msgstr ""
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:575 lxc/auth.go:576
+#: lxc/auth.go:580 lxc/auth.go:581
 msgid "Remove permissions from groups"
 msgstr ""
 
@@ -4827,7 +4845,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:919 lxc/remote.go:920
+#: lxc/remote.go:953 lxc/remote.go:954
 msgid "Remove remotes"
 msgstr ""
 
@@ -4856,11 +4874,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:392 lxc/auth.go:393
+#: lxc/auth.go:397 lxc/auth.go:398
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1810 lxc/auth.go:1811
+#: lxc/auth.go:1959 lxc/auth.go:1960
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -4884,7 +4902,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:838 lxc/remote.go:839
+#: lxc/remote.go:872 lxc/remote.go:873
 msgid "Rename remotes"
 msgstr ""
 
@@ -5029,7 +5047,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:820
+#: lxc/remote.go:854
 msgid "STATIC"
 msgstr ""
 
@@ -5070,11 +5088,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:532
+#: lxc/remote.go:546
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:285 lxc/remote.go:683
+#: lxc/remote.go:299 lxc/remote.go:717
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5285,7 +5303,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1031 lxc/remote.go:1032
+#: lxc/remote.go:1065 lxc/remote.go:1066
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5381,7 +5399,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1859 lxc/auth.go:1860
+#: lxc/auth.go:2008 lxc/auth.go:2009
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5409,11 +5427,11 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:441 lxc/auth.go:442
+#: lxc/auth.go:446 lxc/auth.go:447
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:836
+#: lxc/auth.go:985
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5518,7 +5536,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:899
+#: lxc/auth.go:1048
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5528,7 +5546,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:714 lxc/remote.go:715
+#: lxc/remote.go:748 lxc/remote.go:749
 msgid "Show the default remote"
 msgstr ""
 
@@ -5740,7 +5758,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:983 lxc/remote.go:984
+#: lxc/remote.go:1017 lxc/remote.go:1018
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5752,11 +5770,21 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
+#: lxc/auth.go:876
+#, c-format
+msgid "TLS identity %q (%s) pending identity token:"
+msgstr ""
+
+#: lxc/auth.go:902
+#, c-format
+msgid "TLS identity %q created with fingerprint %q"
+msgstr ""
+
 #: lxc/cluster.go:1070 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:818 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
 #: lxc/storage_volume.go:1736 lxc/warning.go:216
@@ -5775,7 +5803,7 @@ msgstr ""
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/remote.go:161 lxc/remote.go:334
+#: lxc/remote.go:161 lxc/remote.go:348
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
@@ -5931,7 +5959,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:527
+#: lxc/remote.go:541
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
@@ -6069,15 +6097,15 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:329
+#: lxc/remote.go:343
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:324
+#: lxc/remote.go:338
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr ""
 
-#: lxc/remote.go:639
+#: lxc/remote.go:653
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6120,7 +6148,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:193 lxc/remote.go:816
+#: lxc/cluster.go:193 lxc/remote.go:850
 msgid "URL"
 msgstr ""
 
@@ -6428,11 +6456,11 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:835
+#: lxc/auth.go:984
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:898
+#: lxc/auth.go:1047
 msgid "View the current identity"
 msgstr ""
 
@@ -6471,7 +6499,7 @@ msgstr ""
 
 #: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:777 lxc/remote.go:782 lxc/remote.go:787
+#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr ""
 
@@ -6503,7 +6531,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:330 lxc/auth.go:766 lxc/auth.go:897 lxc/auth.go:1748
+#: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
@@ -6536,7 +6564,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1313
+#: lxc/auth.go:1462
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6597,11 +6625,17 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:834 lxc/auth.go:1086
+#: lxc/auth.go:774
+msgid ""
+"[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
+"certificate>] [[--group <group_name>]]"
+msgstr ""
+
+#: lxc/auth.go:983 lxc/auth.go:1235
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1164 lxc/auth.go:1222 lxc/auth.go:1985
+#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:2134
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6609,13 +6643,13 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:97 lxc/auth.go:150 lxc/auth.go:200 lxc/auth.go:440
-#: lxc/auth.go:958 lxc/auth.go:1529 lxc/cluster_group.go:168
+#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:445
+#: lxc/auth.go:1107 lxc/auth.go:1678 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:515 lxc/auth.go:573
+#: lxc/auth.go:520 lxc/auth.go:578
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
@@ -6625,19 +6659,19 @@ msgstr ""
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:390
+#: lxc/auth.go:395
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1580 lxc/auth.go:1630 lxc/auth.go:1858
+#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1932
+#: lxc/auth.go:2081
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1808
+#: lxc/auth.go:1957
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -7128,7 +7162,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:806
+#: lxc/project.go:557 lxc/remote.go:840
 msgid "current"
 msgstr ""
 
@@ -7175,20 +7209,20 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/auth.go:204
+#: lxc/auth.go:209
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:962
+#: lxc/auth.go:1111
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1634
+#: lxc/auth.go:1783
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7612,7 +7646,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:531
+#: lxc/remote.go:545
 msgid "n"
 msgstr ""
 
@@ -7624,7 +7658,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:510
+#: lxc/remote.go:524
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7661,7 +7695,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:519
+#: lxc/remote.go:533
 msgid "y"
 msgstr ""
 

--- a/po/ca.po
+++ b/po/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-14 13:30+0000\n"
+"POT-Creation-Date: 2024-10-15 14:52+0100\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Catalan <https://hosted.weblate.org/projects/linux-containers/"
@@ -133,7 +133,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:214
+#: lxc/auth.go:219
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -160,7 +160,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:972
+#: lxc/auth.go:1121
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -181,7 +181,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1644
+#: lxc/auth.go:1793
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -515,15 +515,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:917 lxc/remote.go:982
+#: lxc/remote.go:951 lxc/remote.go:1016
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1030
+#: lxc/remote.go:1064
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:836
+#: lxc/remote.go:870
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -556,11 +556,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:818
+#: lxc/remote.go:852
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:817
+#: lxc/auth.go:966
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -598,11 +598,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1165 lxc/auth.go:1166
+#: lxc/auth.go:1314 lxc/auth.go:1315
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1933 lxc/auth.go:1934
+#: lxc/auth.go:2082 lxc/auth.go:2083
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -671,7 +671,7 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:516 lxc/auth.go:517
+#: lxc/auth.go:521 lxc/auth.go:522
 msgid "Add permissions to groups"
 msgstr ""
 
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:648
+#: lxc/remote.go:680
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -813,7 +813,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:621
+#: lxc/remote.go:635
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -991,7 +991,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:961
+#: lxc/remote.go:995
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1057,7 +1057,7 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:509
+#: lxc/remote.go:523
 msgid "Certificate fingerprint"
 msgstr ""
 
@@ -1076,7 +1076,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:687
+#: lxc/remote.go:721
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1324,12 +1324,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:559
+#: lxc/remote.go:573
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:237 lxc/remote.go:543
+#: lxc/remote.go:237 lxc/remote.go:557
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1343,12 +1343,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:1719
+#: lxc/auth.go:306 lxc/auth.go:1868
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1058
+#: lxc/auth.go:1207
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1368,13 +1368,17 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:554
+#: lxc/remote.go:568
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
 #: lxc/network_zone.go:1536
 msgid "Couldn't find a matching entry"
+msgstr ""
+
+#: lxc/auth.go:776
+msgid "Create a TLS identity"
 msgstr ""
 
 #: lxc/cluster_group.go:169 lxc/cluster_group.go:170
@@ -1393,6 +1397,10 @@ msgstr ""
 msgid "Create an empty instance"
 msgstr ""
 
+#: lxc/auth.go:775
+msgid "Create an identity"
+msgstr ""
+
 #: lxc/launch.go:23 lxc/launch.go:24
 msgid "Create and start instances from images"
 msgstr ""
@@ -1405,11 +1413,11 @@ msgstr ""
 msgid "Create files and directories in instances"
 msgstr ""
 
-#: lxc/auth.go:98 lxc/auth.go:99
+#: lxc/auth.go:103 lxc/auth.go:104
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1530 lxc/auth.go:1531
+#: lxc/auth.go:1679 lxc/auth.go:1680
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1517,7 +1525,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
@@ -1560,7 +1568,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/auth.go:1088 lxc/auth.go:1089
+#: lxc/auth.go:1237 lxc/auth.go:1238
 msgid "Delete an identity"
 msgstr ""
 
@@ -1568,11 +1576,11 @@ msgstr ""
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/auth.go:152 lxc/auth.go:153
+#: lxc/auth.go:157 lxc/auth.go:158
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1582 lxc/auth.go:1583
+#: lxc/auth.go:1731 lxc/auth.go:1732
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1650,18 +1658,18 @@ msgstr ""
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:31 lxc/auth.go:60 lxc/auth.go:99
-#: lxc/auth.go:153 lxc/auth.go:202 lxc/auth.go:333 lxc/auth.go:393
-#: lxc/auth.go:442 lxc/auth.go:494 lxc/auth.go:517 lxc/auth.go:576
-#: lxc/auth.go:732 lxc/auth.go:769 lxc/auth.go:836 lxc/auth.go:899
-#: lxc/auth.go:960 lxc/auth.go:1089 lxc/auth.go:1143 lxc/auth.go:1166
-#: lxc/auth.go:1224 lxc/auth.go:1293 lxc/auth.go:1315 lxc/auth.go:1493
-#: lxc/auth.go:1531 lxc/auth.go:1583 lxc/auth.go:1632 lxc/auth.go:1751
-#: lxc/auth.go:1811 lxc/auth.go:1860 lxc/auth.go:1911 lxc/auth.go:1934
-#: lxc/auth.go:1987 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215
-#: lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:484
-#: lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677 lxc/cluster.go:770
-#: lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
+#: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
+#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:338 lxc/auth.go:398
+#: lxc/auth.go:447 lxc/auth.go:499 lxc/auth.go:522 lxc/auth.go:581
+#: lxc/auth.go:737 lxc/auth.go:776 lxc/auth.go:918 lxc/auth.go:985
+#: lxc/auth.go:1048 lxc/auth.go:1109 lxc/auth.go:1238 lxc/auth.go:1292
+#: lxc/auth.go:1315 lxc/auth.go:1373 lxc/auth.go:1442 lxc/auth.go:1464
+#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
+#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
+#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
+#: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
+#: lxc/cluster.go:770 lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
 #: lxc/cluster.go:1175 lxc/cluster.go:1299 lxc/cluster.go:1329
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
@@ -1732,9 +1740,9 @@ msgstr ""
 #: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
 #: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
 #: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:715
-#: lxc/remote.go:753 lxc/remote.go:839 lxc/remote.go:920 lxc/remote.go:984
-#: lxc/remote.go:1032 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
+#: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
+#: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1919,7 +1927,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:959 lxc/auth.go:960
+#: lxc/auth.go:1108 lxc/auth.go:1109
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1931,11 +1939,11 @@ msgstr ""
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/auth.go:201 lxc/auth.go:202
+#: lxc/auth.go:206 lxc/auth.go:207
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1631 lxc/auth.go:1632
+#: lxc/auth.go:1780 lxc/auth.go:1781
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2311,12 +2319,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:486
+#: lxc/remote.go:500
 #, c-format
 msgid "Failed to decode trust token: %w"
 msgstr ""
 
-#: lxc/remote.go:292
+#: lxc/remote.go:306
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2420,7 +2428,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:773 lxc/auth.go:1755
+#: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
@@ -2428,7 +2436,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:757 lxc/storage.go:657
+#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2466,7 +2474,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:821
+#: lxc/remote.go:855
 msgid "GLOBAL"
 msgstr ""
 
@@ -2478,7 +2486,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:821 lxc/auth.go:1795
+#: lxc/auth.go:970 lxc/auth.go:1944
 msgid "GROUPS"
 msgstr ""
 
@@ -2486,7 +2494,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:165 lxc/remote.go:443
+#: lxc/remote.go:165 lxc/remote.go:457
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2627,17 +2635,17 @@ msgstr ""
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: lxc/auth.go:137
+#: lxc/auth.go:142
 #, c-format
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:187
+#: lxc/auth.go:192
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:427 lxc/auth.go:1845
+#: lxc/auth.go:432 lxc/auth.go:1994
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2696,7 +2704,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:820
+#: lxc/auth.go:969
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -2728,12 +2736,16 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1567
+#: lxc/auth.go:829
+msgid "Identity creation only supported for TLS identities"
+msgstr ""
+
+#: lxc/auth.go:1716
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1617
+#: lxc/auth.go:1766
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2862,7 +2874,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1292 lxc/auth.go:1293
+#: lxc/auth.go:1441 lxc/auth.go:1442
 msgid "Inspect permissions"
 msgstr ""
 
@@ -2910,7 +2922,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:395
+#: lxc/remote.go:409
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2991,7 +3003,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:384
+#: lxc/remote.go:398
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3166,15 +3178,15 @@ msgstr ""
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:332 lxc/auth.go:333
+#: lxc/auth.go:337 lxc/auth.go:338
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:768 lxc/auth.go:769
+#: lxc/auth.go:917 lxc/auth.go:918
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1750 lxc/auth.go:1751
+#: lxc/auth.go:1899 lxc/auth.go:1900
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3327,7 +3339,7 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1314 lxc/auth.go:1315
+#: lxc/auth.go:1463 lxc/auth.go:1464
 msgid "List permissions"
 msgstr ""
 
@@ -3371,7 +3383,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:752 lxc/remote.go:753
+#: lxc/remote.go:786 lxc/remote.go:787
 msgid "List the available remotes"
 msgstr ""
 
@@ -3495,6 +3507,12 @@ msgstr ""
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
+#: lxc/auth.go:825
+msgid ""
+"Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
+"got "
+msgstr ""
+
 #: lxc/network.go:32 lxc/network.go:33
 msgid "Manage and attach instances to networks"
 msgstr ""
@@ -3523,19 +3541,19 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:59 lxc/auth.go:60 lxc/auth.go:1492 lxc/auth.go:1493
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1142 lxc/auth.go:1143
+#: lxc/auth.go:1291 lxc/auth.go:1292
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:731 lxc/auth.go:732
+#: lxc/auth.go:736 lxc/auth.go:737
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1910 lxc/auth.go:1911
+#: lxc/auth.go:2059 lxc/auth.go:2060
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3626,7 +3644,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:493 lxc/auth.go:494
+#: lxc/auth.go:498 lxc/auth.go:499
 msgid "Manage permissions"
 msgstr ""
 
@@ -3678,7 +3696,7 @@ msgstr ""
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/auth.go:30 lxc/auth.go:31
+#: lxc/auth.go:35 lxc/auth.go:36
 msgid "Manage user authorization"
 msgstr ""
 
@@ -3775,21 +3793,21 @@ msgstr ""
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:123 lxc/auth.go:177 lxc/auth.go:255 lxc/auth.go:417
-#: lxc/auth.go:466 lxc/auth.go:541 lxc/auth.go:600 lxc/auth.go:1884
+#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:260 lxc/auth.go:422
+#: lxc/auth.go:471 lxc/auth.go:546 lxc/auth.go:605 lxc/auth.go:2033
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:866 lxc/auth.go:1007 lxc/auth.go:1124 lxc/auth.go:1190
-#: lxc/auth.go:1248
+#: lxc/auth.go:820 lxc/auth.go:1015 lxc/auth.go:1156 lxc/auth.go:1273
+#: lxc/auth.go:1339 lxc/auth.go:1397
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1554 lxc/auth.go:1607 lxc/auth.go:1673 lxc/auth.go:1835
+#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1958 lxc/auth.go:2011
+#: lxc/auth.go:2107 lxc/auth.go:2160
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -4010,12 +4028,12 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:376 lxc/auth.go:819 lxc/auth.go:1794 lxc/cluster.go:192
+#: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
-#: lxc/remote.go:815 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
 msgstr ""
@@ -4042,7 +4060,7 @@ msgstr ""
 
 #: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:775 lxc/remote.go:780 lxc/remote.go:785
+#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr ""
 
@@ -4271,7 +4289,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:378
+#: lxc/remote.go:392
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4342,11 +4360,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:817
+#: lxc/remote.go:851
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:819
+#: lxc/image.go:1136 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4387,7 +4405,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:536
+#: lxc/remote.go:550
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
@@ -4404,7 +4422,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:302 lxc/auth.go:1059 lxc/auth.go:1720 lxc/cluster.go:860
+#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -4707,33 +4725,33 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:877
+#: lxc/remote.go:911
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:868 lxc/remote.go:949 lxc/remote.go:1013
-#: lxc/remote.go:1061
+#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/remote.go:1095
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:345
+#: lxc/remote.go:359
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:957
+#: lxc/remote.go:991
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:872 lxc/remote.go:953 lxc/remote.go:1065
+#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1099
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:319
+#: lxc/remote.go:333
 msgid "Remote address must not be empty"
 msgstr ""
 
@@ -4741,7 +4759,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:339
+#: lxc/remote.go:353
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4763,7 +4781,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1223 lxc/auth.go:1224
+#: lxc/auth.go:1372 lxc/auth.go:1373
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4799,7 +4817,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1986 lxc/auth.go:1987
+#: lxc/auth.go:2135 lxc/auth.go:2136
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4811,7 +4829,7 @@ msgstr ""
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:575 lxc/auth.go:576
+#: lxc/auth.go:580 lxc/auth.go:581
 msgid "Remove permissions from groups"
 msgstr ""
 
@@ -4827,7 +4845,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:919 lxc/remote.go:920
+#: lxc/remote.go:953 lxc/remote.go:954
 msgid "Remove remotes"
 msgstr ""
 
@@ -4856,11 +4874,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:392 lxc/auth.go:393
+#: lxc/auth.go:397 lxc/auth.go:398
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1810 lxc/auth.go:1811
+#: lxc/auth.go:1959 lxc/auth.go:1960
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -4884,7 +4902,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:838 lxc/remote.go:839
+#: lxc/remote.go:872 lxc/remote.go:873
 msgid "Rename remotes"
 msgstr ""
 
@@ -5029,7 +5047,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:820
+#: lxc/remote.go:854
 msgid "STATIC"
 msgstr ""
 
@@ -5070,11 +5088,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:532
+#: lxc/remote.go:546
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:285 lxc/remote.go:683
+#: lxc/remote.go:299 lxc/remote.go:717
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5285,7 +5303,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1031 lxc/remote.go:1032
+#: lxc/remote.go:1065 lxc/remote.go:1066
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5381,7 +5399,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1859 lxc/auth.go:1860
+#: lxc/auth.go:2008 lxc/auth.go:2009
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5409,11 +5427,11 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:441 lxc/auth.go:442
+#: lxc/auth.go:446 lxc/auth.go:447
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:836
+#: lxc/auth.go:985
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5518,7 +5536,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:899
+#: lxc/auth.go:1048
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5528,7 +5546,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:714 lxc/remote.go:715
+#: lxc/remote.go:748 lxc/remote.go:749
 msgid "Show the default remote"
 msgstr ""
 
@@ -5740,7 +5758,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:983 lxc/remote.go:984
+#: lxc/remote.go:1017 lxc/remote.go:1018
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5752,11 +5770,21 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
+#: lxc/auth.go:876
+#, c-format
+msgid "TLS identity %q (%s) pending identity token:"
+msgstr ""
+
+#: lxc/auth.go:902
+#, c-format
+msgid "TLS identity %q created with fingerprint %q"
+msgstr ""
+
 #: lxc/cluster.go:1070 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:818 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
 #: lxc/storage_volume.go:1736 lxc/warning.go:216
@@ -5775,7 +5803,7 @@ msgstr ""
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/remote.go:161 lxc/remote.go:334
+#: lxc/remote.go:161 lxc/remote.go:348
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
@@ -5931,7 +5959,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:527
+#: lxc/remote.go:541
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
@@ -6069,15 +6097,15 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:329
+#: lxc/remote.go:343
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:324
+#: lxc/remote.go:338
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr ""
 
-#: lxc/remote.go:639
+#: lxc/remote.go:653
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6120,7 +6148,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:193 lxc/remote.go:816
+#: lxc/cluster.go:193 lxc/remote.go:850
 msgid "URL"
 msgstr ""
 
@@ -6428,11 +6456,11 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:835
+#: lxc/auth.go:984
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:898
+#: lxc/auth.go:1047
 msgid "View the current identity"
 msgstr ""
 
@@ -6471,7 +6499,7 @@ msgstr ""
 
 #: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:777 lxc/remote.go:782 lxc/remote.go:787
+#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr ""
 
@@ -6503,7 +6531,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:330 lxc/auth.go:766 lxc/auth.go:897 lxc/auth.go:1748
+#: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
@@ -6536,7 +6564,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1313
+#: lxc/auth.go:1462
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6597,11 +6625,17 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:834 lxc/auth.go:1086
+#: lxc/auth.go:774
+msgid ""
+"[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
+"certificate>] [[--group <group_name>]]"
+msgstr ""
+
+#: lxc/auth.go:983 lxc/auth.go:1235
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1164 lxc/auth.go:1222 lxc/auth.go:1985
+#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:2134
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6609,13 +6643,13 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:97 lxc/auth.go:150 lxc/auth.go:200 lxc/auth.go:440
-#: lxc/auth.go:958 lxc/auth.go:1529 lxc/cluster_group.go:168
+#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:445
+#: lxc/auth.go:1107 lxc/auth.go:1678 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:515 lxc/auth.go:573
+#: lxc/auth.go:520 lxc/auth.go:578
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
@@ -6625,19 +6659,19 @@ msgstr ""
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:390
+#: lxc/auth.go:395
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1580 lxc/auth.go:1630 lxc/auth.go:1858
+#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1932
+#: lxc/auth.go:2081
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1808
+#: lxc/auth.go:1957
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -7128,7 +7162,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:806
+#: lxc/project.go:557 lxc/remote.go:840
 msgid "current"
 msgstr ""
 
@@ -7175,20 +7209,20 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/auth.go:204
+#: lxc/auth.go:209
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:962
+#: lxc/auth.go:1111
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1634
+#: lxc/auth.go:1783
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7612,7 +7646,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:531
+#: lxc/remote.go:545
 msgid "n"
 msgstr ""
 
@@ -7624,7 +7658,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:510
+#: lxc/remote.go:524
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7661,7 +7695,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:519
+#: lxc/remote.go:533
 msgid "y"
 msgstr ""
 

--- a/po/cs.po
+++ b/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-14 13:30+0000\n"
+"POT-Creation-Date: 2024-10-15 14:52+0100\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Czech <https://hosted.weblate.org/projects/linux-containers/"
@@ -133,7 +133,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:214
+#: lxc/auth.go:219
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -160,7 +160,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:972
+#: lxc/auth.go:1121
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -181,7 +181,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1644
+#: lxc/auth.go:1793
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -515,15 +515,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:917 lxc/remote.go:982
+#: lxc/remote.go:951 lxc/remote.go:1016
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1030
+#: lxc/remote.go:1064
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:836
+#: lxc/remote.go:870
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -556,11 +556,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:818
+#: lxc/remote.go:852
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:817
+#: lxc/auth.go:966
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -598,11 +598,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1165 lxc/auth.go:1166
+#: lxc/auth.go:1314 lxc/auth.go:1315
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1933 lxc/auth.go:1934
+#: lxc/auth.go:2082 lxc/auth.go:2083
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -671,7 +671,7 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:516 lxc/auth.go:517
+#: lxc/auth.go:521 lxc/auth.go:522
 msgid "Add permissions to groups"
 msgstr ""
 
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:648
+#: lxc/remote.go:680
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -813,7 +813,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:621
+#: lxc/remote.go:635
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -991,7 +991,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:961
+#: lxc/remote.go:995
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1057,7 +1057,7 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:509
+#: lxc/remote.go:523
 msgid "Certificate fingerprint"
 msgstr ""
 
@@ -1076,7 +1076,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:687
+#: lxc/remote.go:721
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1324,12 +1324,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:559
+#: lxc/remote.go:573
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:237 lxc/remote.go:543
+#: lxc/remote.go:237 lxc/remote.go:557
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1343,12 +1343,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:1719
+#: lxc/auth.go:306 lxc/auth.go:1868
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1058
+#: lxc/auth.go:1207
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1368,13 +1368,17 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:554
+#: lxc/remote.go:568
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
 #: lxc/network_zone.go:1536
 msgid "Couldn't find a matching entry"
+msgstr ""
+
+#: lxc/auth.go:776
+msgid "Create a TLS identity"
 msgstr ""
 
 #: lxc/cluster_group.go:169 lxc/cluster_group.go:170
@@ -1393,6 +1397,10 @@ msgstr ""
 msgid "Create an empty instance"
 msgstr ""
 
+#: lxc/auth.go:775
+msgid "Create an identity"
+msgstr ""
+
 #: lxc/launch.go:23 lxc/launch.go:24
 msgid "Create and start instances from images"
 msgstr ""
@@ -1405,11 +1413,11 @@ msgstr ""
 msgid "Create files and directories in instances"
 msgstr ""
 
-#: lxc/auth.go:98 lxc/auth.go:99
+#: lxc/auth.go:103 lxc/auth.go:104
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1530 lxc/auth.go:1531
+#: lxc/auth.go:1679 lxc/auth.go:1680
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1517,7 +1525,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
@@ -1560,7 +1568,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/auth.go:1088 lxc/auth.go:1089
+#: lxc/auth.go:1237 lxc/auth.go:1238
 msgid "Delete an identity"
 msgstr ""
 
@@ -1568,11 +1576,11 @@ msgstr ""
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/auth.go:152 lxc/auth.go:153
+#: lxc/auth.go:157 lxc/auth.go:158
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1582 lxc/auth.go:1583
+#: lxc/auth.go:1731 lxc/auth.go:1732
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1650,18 +1658,18 @@ msgstr ""
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:31 lxc/auth.go:60 lxc/auth.go:99
-#: lxc/auth.go:153 lxc/auth.go:202 lxc/auth.go:333 lxc/auth.go:393
-#: lxc/auth.go:442 lxc/auth.go:494 lxc/auth.go:517 lxc/auth.go:576
-#: lxc/auth.go:732 lxc/auth.go:769 lxc/auth.go:836 lxc/auth.go:899
-#: lxc/auth.go:960 lxc/auth.go:1089 lxc/auth.go:1143 lxc/auth.go:1166
-#: lxc/auth.go:1224 lxc/auth.go:1293 lxc/auth.go:1315 lxc/auth.go:1493
-#: lxc/auth.go:1531 lxc/auth.go:1583 lxc/auth.go:1632 lxc/auth.go:1751
-#: lxc/auth.go:1811 lxc/auth.go:1860 lxc/auth.go:1911 lxc/auth.go:1934
-#: lxc/auth.go:1987 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215
-#: lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:484
-#: lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677 lxc/cluster.go:770
-#: lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
+#: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
+#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:338 lxc/auth.go:398
+#: lxc/auth.go:447 lxc/auth.go:499 lxc/auth.go:522 lxc/auth.go:581
+#: lxc/auth.go:737 lxc/auth.go:776 lxc/auth.go:918 lxc/auth.go:985
+#: lxc/auth.go:1048 lxc/auth.go:1109 lxc/auth.go:1238 lxc/auth.go:1292
+#: lxc/auth.go:1315 lxc/auth.go:1373 lxc/auth.go:1442 lxc/auth.go:1464
+#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
+#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
+#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
+#: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
+#: lxc/cluster.go:770 lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
 #: lxc/cluster.go:1175 lxc/cluster.go:1299 lxc/cluster.go:1329
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
@@ -1732,9 +1740,9 @@ msgstr ""
 #: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
 #: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
 #: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:715
-#: lxc/remote.go:753 lxc/remote.go:839 lxc/remote.go:920 lxc/remote.go:984
-#: lxc/remote.go:1032 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
+#: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
+#: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1919,7 +1927,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:959 lxc/auth.go:960
+#: lxc/auth.go:1108 lxc/auth.go:1109
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1931,11 +1939,11 @@ msgstr ""
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/auth.go:201 lxc/auth.go:202
+#: lxc/auth.go:206 lxc/auth.go:207
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1631 lxc/auth.go:1632
+#: lxc/auth.go:1780 lxc/auth.go:1781
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2311,12 +2319,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:486
+#: lxc/remote.go:500
 #, c-format
 msgid "Failed to decode trust token: %w"
 msgstr ""
 
-#: lxc/remote.go:292
+#: lxc/remote.go:306
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2420,7 +2428,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:773 lxc/auth.go:1755
+#: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
@@ -2428,7 +2436,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:757 lxc/storage.go:657
+#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2466,7 +2474,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:821
+#: lxc/remote.go:855
 msgid "GLOBAL"
 msgstr ""
 
@@ -2478,7 +2486,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:821 lxc/auth.go:1795
+#: lxc/auth.go:970 lxc/auth.go:1944
 msgid "GROUPS"
 msgstr ""
 
@@ -2486,7 +2494,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:165 lxc/remote.go:443
+#: lxc/remote.go:165 lxc/remote.go:457
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2627,17 +2635,17 @@ msgstr ""
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: lxc/auth.go:137
+#: lxc/auth.go:142
 #, c-format
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:187
+#: lxc/auth.go:192
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:427 lxc/auth.go:1845
+#: lxc/auth.go:432 lxc/auth.go:1994
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2696,7 +2704,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:820
+#: lxc/auth.go:969
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -2728,12 +2736,16 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1567
+#: lxc/auth.go:829
+msgid "Identity creation only supported for TLS identities"
+msgstr ""
+
+#: lxc/auth.go:1716
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1617
+#: lxc/auth.go:1766
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2862,7 +2874,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1292 lxc/auth.go:1293
+#: lxc/auth.go:1441 lxc/auth.go:1442
 msgid "Inspect permissions"
 msgstr ""
 
@@ -2910,7 +2922,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:395
+#: lxc/remote.go:409
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2991,7 +3003,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:384
+#: lxc/remote.go:398
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3166,15 +3178,15 @@ msgstr ""
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:332 lxc/auth.go:333
+#: lxc/auth.go:337 lxc/auth.go:338
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:768 lxc/auth.go:769
+#: lxc/auth.go:917 lxc/auth.go:918
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1750 lxc/auth.go:1751
+#: lxc/auth.go:1899 lxc/auth.go:1900
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3327,7 +3339,7 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1314 lxc/auth.go:1315
+#: lxc/auth.go:1463 lxc/auth.go:1464
 msgid "List permissions"
 msgstr ""
 
@@ -3371,7 +3383,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:752 lxc/remote.go:753
+#: lxc/remote.go:786 lxc/remote.go:787
 msgid "List the available remotes"
 msgstr ""
 
@@ -3495,6 +3507,12 @@ msgstr ""
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
+#: lxc/auth.go:825
+msgid ""
+"Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
+"got "
+msgstr ""
+
 #: lxc/network.go:32 lxc/network.go:33
 msgid "Manage and attach instances to networks"
 msgstr ""
@@ -3523,19 +3541,19 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:59 lxc/auth.go:60 lxc/auth.go:1492 lxc/auth.go:1493
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1142 lxc/auth.go:1143
+#: lxc/auth.go:1291 lxc/auth.go:1292
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:731 lxc/auth.go:732
+#: lxc/auth.go:736 lxc/auth.go:737
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1910 lxc/auth.go:1911
+#: lxc/auth.go:2059 lxc/auth.go:2060
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3626,7 +3644,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:493 lxc/auth.go:494
+#: lxc/auth.go:498 lxc/auth.go:499
 msgid "Manage permissions"
 msgstr ""
 
@@ -3678,7 +3696,7 @@ msgstr ""
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/auth.go:30 lxc/auth.go:31
+#: lxc/auth.go:35 lxc/auth.go:36
 msgid "Manage user authorization"
 msgstr ""
 
@@ -3775,21 +3793,21 @@ msgstr ""
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:123 lxc/auth.go:177 lxc/auth.go:255 lxc/auth.go:417
-#: lxc/auth.go:466 lxc/auth.go:541 lxc/auth.go:600 lxc/auth.go:1884
+#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:260 lxc/auth.go:422
+#: lxc/auth.go:471 lxc/auth.go:546 lxc/auth.go:605 lxc/auth.go:2033
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:866 lxc/auth.go:1007 lxc/auth.go:1124 lxc/auth.go:1190
-#: lxc/auth.go:1248
+#: lxc/auth.go:820 lxc/auth.go:1015 lxc/auth.go:1156 lxc/auth.go:1273
+#: lxc/auth.go:1339 lxc/auth.go:1397
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1554 lxc/auth.go:1607 lxc/auth.go:1673 lxc/auth.go:1835
+#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1958 lxc/auth.go:2011
+#: lxc/auth.go:2107 lxc/auth.go:2160
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -4010,12 +4028,12 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:376 lxc/auth.go:819 lxc/auth.go:1794 lxc/cluster.go:192
+#: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
-#: lxc/remote.go:815 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
 msgstr ""
@@ -4042,7 +4060,7 @@ msgstr ""
 
 #: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:775 lxc/remote.go:780 lxc/remote.go:785
+#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr ""
 
@@ -4271,7 +4289,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:378
+#: lxc/remote.go:392
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4342,11 +4360,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:817
+#: lxc/remote.go:851
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:819
+#: lxc/image.go:1136 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4387,7 +4405,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:536
+#: lxc/remote.go:550
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
@@ -4404,7 +4422,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:302 lxc/auth.go:1059 lxc/auth.go:1720 lxc/cluster.go:860
+#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -4707,33 +4725,33 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:877
+#: lxc/remote.go:911
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:868 lxc/remote.go:949 lxc/remote.go:1013
-#: lxc/remote.go:1061
+#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/remote.go:1095
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:345
+#: lxc/remote.go:359
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:957
+#: lxc/remote.go:991
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:872 lxc/remote.go:953 lxc/remote.go:1065
+#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1099
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:319
+#: lxc/remote.go:333
 msgid "Remote address must not be empty"
 msgstr ""
 
@@ -4741,7 +4759,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:339
+#: lxc/remote.go:353
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4763,7 +4781,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1223 lxc/auth.go:1224
+#: lxc/auth.go:1372 lxc/auth.go:1373
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4799,7 +4817,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1986 lxc/auth.go:1987
+#: lxc/auth.go:2135 lxc/auth.go:2136
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4811,7 +4829,7 @@ msgstr ""
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:575 lxc/auth.go:576
+#: lxc/auth.go:580 lxc/auth.go:581
 msgid "Remove permissions from groups"
 msgstr ""
 
@@ -4827,7 +4845,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:919 lxc/remote.go:920
+#: lxc/remote.go:953 lxc/remote.go:954
 msgid "Remove remotes"
 msgstr ""
 
@@ -4856,11 +4874,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:392 lxc/auth.go:393
+#: lxc/auth.go:397 lxc/auth.go:398
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1810 lxc/auth.go:1811
+#: lxc/auth.go:1959 lxc/auth.go:1960
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -4884,7 +4902,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:838 lxc/remote.go:839
+#: lxc/remote.go:872 lxc/remote.go:873
 msgid "Rename remotes"
 msgstr ""
 
@@ -5029,7 +5047,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:820
+#: lxc/remote.go:854
 msgid "STATIC"
 msgstr ""
 
@@ -5070,11 +5088,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:532
+#: lxc/remote.go:546
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:285 lxc/remote.go:683
+#: lxc/remote.go:299 lxc/remote.go:717
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5285,7 +5303,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1031 lxc/remote.go:1032
+#: lxc/remote.go:1065 lxc/remote.go:1066
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5381,7 +5399,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1859 lxc/auth.go:1860
+#: lxc/auth.go:2008 lxc/auth.go:2009
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5409,11 +5427,11 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:441 lxc/auth.go:442
+#: lxc/auth.go:446 lxc/auth.go:447
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:836
+#: lxc/auth.go:985
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5518,7 +5536,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:899
+#: lxc/auth.go:1048
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5528,7 +5546,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:714 lxc/remote.go:715
+#: lxc/remote.go:748 lxc/remote.go:749
 msgid "Show the default remote"
 msgstr ""
 
@@ -5740,7 +5758,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:983 lxc/remote.go:984
+#: lxc/remote.go:1017 lxc/remote.go:1018
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5752,11 +5770,21 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
+#: lxc/auth.go:876
+#, c-format
+msgid "TLS identity %q (%s) pending identity token:"
+msgstr ""
+
+#: lxc/auth.go:902
+#, c-format
+msgid "TLS identity %q created with fingerprint %q"
+msgstr ""
+
 #: lxc/cluster.go:1070 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:818 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
 #: lxc/storage_volume.go:1736 lxc/warning.go:216
@@ -5775,7 +5803,7 @@ msgstr ""
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/remote.go:161 lxc/remote.go:334
+#: lxc/remote.go:161 lxc/remote.go:348
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
@@ -5931,7 +5959,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:527
+#: lxc/remote.go:541
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
@@ -6069,15 +6097,15 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:329
+#: lxc/remote.go:343
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:324
+#: lxc/remote.go:338
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr ""
 
-#: lxc/remote.go:639
+#: lxc/remote.go:653
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6120,7 +6148,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:193 lxc/remote.go:816
+#: lxc/cluster.go:193 lxc/remote.go:850
 msgid "URL"
 msgstr ""
 
@@ -6428,11 +6456,11 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:835
+#: lxc/auth.go:984
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:898
+#: lxc/auth.go:1047
 msgid "View the current identity"
 msgstr ""
 
@@ -6471,7 +6499,7 @@ msgstr ""
 
 #: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:777 lxc/remote.go:782 lxc/remote.go:787
+#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr ""
 
@@ -6503,7 +6531,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:330 lxc/auth.go:766 lxc/auth.go:897 lxc/auth.go:1748
+#: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
@@ -6536,7 +6564,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1313
+#: lxc/auth.go:1462
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6597,11 +6625,17 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:834 lxc/auth.go:1086
+#: lxc/auth.go:774
+msgid ""
+"[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
+"certificate>] [[--group <group_name>]]"
+msgstr ""
+
+#: lxc/auth.go:983 lxc/auth.go:1235
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1164 lxc/auth.go:1222 lxc/auth.go:1985
+#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:2134
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6609,13 +6643,13 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:97 lxc/auth.go:150 lxc/auth.go:200 lxc/auth.go:440
-#: lxc/auth.go:958 lxc/auth.go:1529 lxc/cluster_group.go:168
+#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:445
+#: lxc/auth.go:1107 lxc/auth.go:1678 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:515 lxc/auth.go:573
+#: lxc/auth.go:520 lxc/auth.go:578
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
@@ -6625,19 +6659,19 @@ msgstr ""
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:390
+#: lxc/auth.go:395
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1580 lxc/auth.go:1630 lxc/auth.go:1858
+#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1932
+#: lxc/auth.go:2081
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1808
+#: lxc/auth.go:1957
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -7128,7 +7162,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:806
+#: lxc/project.go:557 lxc/remote.go:840
 msgid "current"
 msgstr ""
 
@@ -7175,20 +7209,20 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/auth.go:204
+#: lxc/auth.go:209
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:962
+#: lxc/auth.go:1111
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1634
+#: lxc/auth.go:1783
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7612,7 +7646,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:531
+#: lxc/remote.go:545
 msgid "n"
 msgstr ""
 
@@ -7624,7 +7658,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:510
+#: lxc/remote.go:524
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7661,7 +7695,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:519
+#: lxc/remote.go:533
 msgid "y"
 msgstr ""
 

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-14 13:30+0000\n"
+"POT-Creation-Date: 2024-10-15 14:52+0100\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Krombel <krombel@krombel.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/linux-containers/"
@@ -198,7 +198,7 @@ msgstr ""
 "###\n"
 "### Der Name wird zwar angezeigt, lässt sich jedoch nicht ändern.\n"
 
-#: lxc/auth.go:214
+#: lxc/auth.go:219
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -225,7 +225,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:972
+#: lxc/auth.go:1121
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -246,7 +246,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1644
+#: lxc/auth.go:1793
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
@@ -774,15 +774,15 @@ msgstr "Ungültiges Ziel %s"
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:917 lxc/remote.go:982
+#: lxc/remote.go:951 lxc/remote.go:1016
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1030
+#: lxc/remote.go:1064
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:836
+#: lxc/remote.go:870
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -820,11 +820,11 @@ msgstr "ALIASES"
 msgid "ARCHITECTURE"
 msgstr "ARCHITEKTUR"
 
-#: lxc/remote.go:818
+#: lxc/remote.go:852
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:817
+#: lxc/auth.go:966
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -866,11 +866,11 @@ msgstr "Aktion (Standard: GET)"
 msgid "Add a cluster member to a cluster group"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/auth.go:1165 lxc/auth.go:1166
+#: lxc/auth.go:1314 lxc/auth.go:1315
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1933 lxc/auth.go:1934
+#: lxc/auth.go:2082 lxc/auth.go:2083
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -942,7 +942,7 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:516 lxc/auth.go:517
+#: lxc/auth.go:521 lxc/auth.go:522
 msgid "Add permissions to groups"
 msgstr ""
 
@@ -979,7 +979,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Admin access key: %s"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/remote.go:648
+#: lxc/remote.go:680
 #, fuzzy, c-format
 msgid "Admin password (or token) for %s:"
 msgstr "Administrator Passwort für %s: "
@@ -1096,7 +1096,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:621
+#: lxc/remote.go:635
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -1287,7 +1287,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:961
+#: lxc/remote.go:995
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1357,7 +1357,7 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: lxc/remote.go:509
+#: lxc/remote.go:523
 #, fuzzy
 msgid "Certificate fingerprint"
 msgstr "Fingerabdruck des Zertifikats: % x\n"
@@ -1377,7 +1377,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/remote.go:687
+#: lxc/remote.go:721
 #, fuzzy
 msgid "Client certificate now trusted by server:"
 msgstr "Gespeichertes Nutzerzertifikat auf dem Server: "
@@ -1634,12 +1634,12 @@ msgstr "Fehler: %v\n"
 msgid "Cores:"
 msgstr "Fehler: %v\n"
 
-#: lxc/remote.go:559
+#: lxc/remote.go:573
 #, fuzzy, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "Kann Verzeichnis für Zertifikate auf dem Server nicht erstellen"
 
-#: lxc/remote.go:237 lxc/remote.go:543
+#: lxc/remote.go:237 lxc/remote.go:557
 msgid "Could not create server cert dir"
 msgstr "Kann Verzeichnis für Zertifikate auf dem Server nicht erstellen"
 
@@ -1653,12 +1653,12 @@ msgstr "Fingerabdruck des Zertifikats: % x\n"
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:1719
+#: lxc/auth.go:306 lxc/auth.go:1868
 #, fuzzy, c-format
 msgid "Could not parse group: %s"
 msgstr "YAML Analyse Fehler %v\n"
 
-#: lxc/auth.go:1058
+#: lxc/auth.go:1207
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1678,13 +1678,17 @@ msgstr "Fingerabdruck des Zertifikats: % x\n"
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:554
+#: lxc/remote.go:568
 #, fuzzy, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "Kann Verzeichnis für Zertifikate auf dem Server nicht erstellen"
 
 #: lxc/network_zone.go:1536
 msgid "Couldn't find a matching entry"
+msgstr ""
+
+#: lxc/auth.go:776
+msgid "Create a TLS identity"
 msgstr ""
 
 #: lxc/cluster_group.go:169 lxc/cluster_group.go:170
@@ -1705,6 +1709,11 @@ msgstr ""
 msgid "Create an empty instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
+#: lxc/auth.go:775
+#, fuzzy
+msgid "Create an identity"
+msgstr "kann nicht zum selben Container Namen kopieren"
+
 #: lxc/launch.go:23 lxc/launch.go:24
 #, fuzzy
 msgid "Create and start instances from images"
@@ -1719,12 +1728,12 @@ msgstr ""
 msgid "Create files and directories in instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/auth.go:98 lxc/auth.go:99
+#: lxc/auth.go:103 lxc/auth.go:104
 #, fuzzy
 msgid "Create groups"
 msgstr "Fehlerhafte Profil URL %s"
 
-#: lxc/auth.go:1530 lxc/auth.go:1531
+#: lxc/auth.go:1679 lxc/auth.go:1680
 #, fuzzy
 msgid "Create identity provider groups"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -1849,7 +1858,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
@@ -1892,7 +1901,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/auth.go:1088 lxc/auth.go:1089
+#: lxc/auth.go:1237 lxc/auth.go:1238
 msgid "Delete an identity"
 msgstr ""
 
@@ -1901,12 +1910,12 @@ msgstr ""
 msgid "Delete files in instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/auth.go:152 lxc/auth.go:153
+#: lxc/auth.go:157 lxc/auth.go:158
 #, fuzzy
 msgid "Delete groups"
 msgstr "Fehlerhafte Profil URL %s"
 
-#: lxc/auth.go:1582 lxc/auth.go:1583
+#: lxc/auth.go:1731 lxc/auth.go:1732
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1993,18 +2002,18 @@ msgstr ""
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:31 lxc/auth.go:60 lxc/auth.go:99
-#: lxc/auth.go:153 lxc/auth.go:202 lxc/auth.go:333 lxc/auth.go:393
-#: lxc/auth.go:442 lxc/auth.go:494 lxc/auth.go:517 lxc/auth.go:576
-#: lxc/auth.go:732 lxc/auth.go:769 lxc/auth.go:836 lxc/auth.go:899
-#: lxc/auth.go:960 lxc/auth.go:1089 lxc/auth.go:1143 lxc/auth.go:1166
-#: lxc/auth.go:1224 lxc/auth.go:1293 lxc/auth.go:1315 lxc/auth.go:1493
-#: lxc/auth.go:1531 lxc/auth.go:1583 lxc/auth.go:1632 lxc/auth.go:1751
-#: lxc/auth.go:1811 lxc/auth.go:1860 lxc/auth.go:1911 lxc/auth.go:1934
-#: lxc/auth.go:1987 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215
-#: lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:484
-#: lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677 lxc/cluster.go:770
-#: lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
+#: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
+#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:338 lxc/auth.go:398
+#: lxc/auth.go:447 lxc/auth.go:499 lxc/auth.go:522 lxc/auth.go:581
+#: lxc/auth.go:737 lxc/auth.go:776 lxc/auth.go:918 lxc/auth.go:985
+#: lxc/auth.go:1048 lxc/auth.go:1109 lxc/auth.go:1238 lxc/auth.go:1292
+#: lxc/auth.go:1315 lxc/auth.go:1373 lxc/auth.go:1442 lxc/auth.go:1464
+#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
+#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
+#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
+#: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
+#: lxc/cluster.go:770 lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
 #: lxc/cluster.go:1175 lxc/cluster.go:1299 lxc/cluster.go:1329
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
@@ -2075,9 +2084,9 @@ msgstr ""
 #: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
 #: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
 #: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:715
-#: lxc/remote.go:753 lxc/remote.go:839 lxc/remote.go:920 lxc/remote.go:984
-#: lxc/remote.go:1032 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
+#: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
+#: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -2277,7 +2286,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:959 lxc/auth.go:960
+#: lxc/auth.go:1108 lxc/auth.go:1109
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -2291,12 +2300,12 @@ msgstr "Alternatives config Verzeichnis."
 msgid "Edit files in instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/auth.go:201 lxc/auth.go:202
+#: lxc/auth.go:206 lxc/auth.go:207
 #, fuzzy
 msgid "Edit groups as YAML"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/auth.go:1631 lxc/auth.go:1632
+#: lxc/auth.go:1780 lxc/auth.go:1781
 #, fuzzy
 msgid "Edit identity provider groups as YAML"
 msgstr "Alternatives config Verzeichnis."
@@ -2699,12 +2708,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/remote.go:486
+#: lxc/remote.go:500
 #, fuzzy, c-format
 msgid "Failed to decode trust token: %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/remote.go:292
+#: lxc/remote.go:306
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2812,7 +2821,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:773 lxc/auth.go:1755
+#: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
@@ -2820,7 +2829,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:757 lxc/storage.go:657
+#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2858,7 +2867,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:821
+#: lxc/remote.go:855
 msgid "GLOBAL"
 msgstr ""
 
@@ -2870,7 +2879,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:821 lxc/auth.go:1795
+#: lxc/auth.go:970 lxc/auth.go:1944
 msgid "GROUPS"
 msgstr ""
 
@@ -2878,7 +2887,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:165 lxc/remote.go:443
+#: lxc/remote.go:165 lxc/remote.go:457
 #, fuzzy
 msgid "Generating a client certificate. This may take a minute..."
 msgstr "Generiere Nutzerzertifikat. Dies kann wenige Minuten dauern...\n"
@@ -3040,17 +3049,17 @@ msgstr ""
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: lxc/auth.go:137
+#: lxc/auth.go:142
 #, fuzzy, c-format
 msgid "Group %s created"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/auth.go:187
+#: lxc/auth.go:192
 #, fuzzy, c-format
 msgid "Group %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: lxc/auth.go:427 lxc/auth.go:1845
+#: lxc/auth.go:432 lxc/auth.go:1994
 #, fuzzy, c-format
 msgid "Group %s renamed to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
@@ -3110,7 +3119,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:820
+#: lxc/auth.go:969
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -3144,12 +3153,16 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1567
+#: lxc/auth.go:829
+msgid "Identity creation only supported for TLS identities"
+msgstr ""
+
+#: lxc/auth.go:1716
 #, fuzzy, c-format
 msgid "Identity provider group %s created"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/auth.go:1617
+#: lxc/auth.go:1766
 #, fuzzy, c-format
 msgid "Identity provider group %s deleted"
 msgstr "Profil %s erstellt\n"
@@ -3282,7 +3295,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1292 lxc/auth.go:1293
+#: lxc/auth.go:1441 lxc/auth.go:1442
 msgid "Inspect permissions"
 msgstr ""
 
@@ -3331,7 +3344,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:395
+#: lxc/remote.go:409
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3415,7 +3428,7 @@ msgstr "ungültiges Argument %s"
 msgid "Invalid path %s"
 msgstr "Ungültiges Ziel %s"
 
-#: lxc/remote.go:384
+#: lxc/remote.go:398
 #, fuzzy, c-format
 msgid "Invalid protocol: %s"
 msgstr "Ungültiges Ziel %s"
@@ -3603,16 +3616,16 @@ msgstr ""
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:332 lxc/auth.go:333
+#: lxc/auth.go:337 lxc/auth.go:338
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:768 lxc/auth.go:769
+#: lxc/auth.go:917 lxc/auth.go:918
 #, fuzzy
 msgid "List identities"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/auth.go:1750 lxc/auth.go:1751
+#: lxc/auth.go:1899 lxc/auth.go:1900
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3783,7 +3796,7 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/auth.go:1314 lxc/auth.go:1315
+#: lxc/auth.go:1463 lxc/auth.go:1464
 #, fuzzy
 msgid "List permissions"
 msgstr "Aliasse:\n"
@@ -3831,7 +3844,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:752 lxc/remote.go:753
+#: lxc/remote.go:786 lxc/remote.go:787
 msgid "List the available remotes"
 msgstr ""
 
@@ -3963,6 +3976,12 @@ msgstr "Veröffentliche Abbild"
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
+#: lxc/auth.go:825
+msgid ""
+"Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
+"got "
+msgstr ""
+
 #: lxc/network.go:32 lxc/network.go:33
 msgid "Manage and attach instances to networks"
 msgstr ""
@@ -3996,21 +4015,21 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Manage files in instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/auth.go:59 lxc/auth.go:60 lxc/auth.go:1492 lxc/auth.go:1493
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
 #, fuzzy
 msgid "Manage groups"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/auth.go:1142 lxc/auth.go:1143
+#: lxc/auth.go:1291 lxc/auth.go:1292
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:731 lxc/auth.go:732
+#: lxc/auth.go:736 lxc/auth.go:737
 #, fuzzy
 msgid "Manage identities"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/auth.go:1910 lxc/auth.go:1911
+#: lxc/auth.go:2059 lxc/auth.go:2060
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -4117,7 +4136,7 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Manage network zones"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/auth.go:493 lxc/auth.go:494
+#: lxc/auth.go:498 lxc/auth.go:499
 #, fuzzy
 msgid "Manage permissions"
 msgstr "Fehlerhafte Profil URL %s"
@@ -4178,7 +4197,7 @@ msgstr ""
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/auth.go:30 lxc/auth.go:31
+#: lxc/auth.go:35 lxc/auth.go:36
 #, fuzzy
 msgid "Manage user authorization"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -4282,24 +4301,24 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 msgid "Missing cluster member name"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/auth.go:123 lxc/auth.go:177 lxc/auth.go:255 lxc/auth.go:417
-#: lxc/auth.go:466 lxc/auth.go:541 lxc/auth.go:600 lxc/auth.go:1884
+#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:260 lxc/auth.go:422
+#: lxc/auth.go:471 lxc/auth.go:546 lxc/auth.go:605 lxc/auth.go:2033
 #, fuzzy
 msgid "Missing group name"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/auth.go:866 lxc/auth.go:1007 lxc/auth.go:1124 lxc/auth.go:1190
-#: lxc/auth.go:1248
+#: lxc/auth.go:820 lxc/auth.go:1015 lxc/auth.go:1156 lxc/auth.go:1273
+#: lxc/auth.go:1339 lxc/auth.go:1397
 #, fuzzy
 msgid "Missing identity argument"
 msgstr "Fehlende Zusammenfassung."
 
-#: lxc/auth.go:1554 lxc/auth.go:1607 lxc/auth.go:1673 lxc/auth.go:1835
+#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
 #, fuzzy
 msgid "Missing identity provider group name"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/auth.go:1958 lxc/auth.go:2011
+#: lxc/auth.go:2107 lxc/auth.go:2160
 #, fuzzy
 msgid "Missing identity provider group name argument"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -4540,12 +4559,12 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/auth.go:376 lxc/auth.go:819 lxc/auth.go:1794 lxc/cluster.go:192
+#: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
-#: lxc/remote.go:815 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
 msgstr ""
@@ -4572,7 +4591,7 @@ msgstr ""
 
 #: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:775 lxc/remote.go:780 lxc/remote.go:785
+#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr ""
 
@@ -4807,7 +4826,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:378
+#: lxc/remote.go:392
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4878,11 +4897,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:817
+#: lxc/remote.go:851
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:819
+#: lxc/image.go:1136 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4926,7 +4945,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/remote.go:536
+#: lxc/remote.go:550
 #, fuzzy
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr "Abbild mit Fingerabdruck %s importiert\n"
@@ -4944,7 +4963,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:302 lxc/auth.go:1059 lxc/auth.go:1720 lxc/cluster.go:860
+#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -5259,33 +5278,33 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:877
+#: lxc/remote.go:911
 #, fuzzy, c-format
 msgid "Remote %s already exists"
 msgstr "entfernte Instanz %s existiert bereits"
 
-#: lxc/project.go:884 lxc/remote.go:868 lxc/remote.go:949 lxc/remote.go:1013
-#: lxc/remote.go:1061
+#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/remote.go:1095
 #, fuzzy, c-format
 msgid "Remote %s doesn't exist"
 msgstr "entfernte Instanz %s existiert nicht"
 
-#: lxc/remote.go:345
+#: lxc/remote.go:359
 #, fuzzy, c-format
 msgid "Remote %s exists as <%s>"
 msgstr "entfernte Instanz %s existiert als <%s>"
 
-#: lxc/remote.go:957
+#: lxc/remote.go:991
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:872 lxc/remote.go:953 lxc/remote.go:1065
+#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1099
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:319
+#: lxc/remote.go:333
 msgid "Remote address must not be empty"
 msgstr ""
 
@@ -5293,7 +5312,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr "Entferntes Administrator Passwort"
 
-#: lxc/remote.go:339
+#: lxc/remote.go:353
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -5316,7 +5335,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/auth.go:1223 lxc/auth.go:1224
+#: lxc/auth.go:1372 lxc/auth.go:1373
 #, fuzzy
 msgid "Remove a group from an identity"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -5358,7 +5377,7 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 msgid "Remove entries from a network zone record"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/auth.go:1986 lxc/auth.go:1987
+#: lxc/auth.go:2135 lxc/auth.go:2136
 #, fuzzy
 msgid "Remove identities from groups"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -5372,7 +5391,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:575 lxc/auth.go:576
+#: lxc/auth.go:580 lxc/auth.go:581
 #, fuzzy
 msgid "Remove permissions from groups"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -5392,7 +5411,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Remove profiles from instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/remote.go:919 lxc/remote.go:920
+#: lxc/remote.go:953 lxc/remote.go:954
 msgid "Remove remotes"
 msgstr ""
 
@@ -5423,12 +5442,12 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:392 lxc/auth.go:393
+#: lxc/auth.go:397 lxc/auth.go:398
 #, fuzzy
 msgid "Rename groups"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/auth.go:1810 lxc/auth.go:1811
+#: lxc/auth.go:1959 lxc/auth.go:1960
 #, fuzzy
 msgid "Rename identity provider groups"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -5456,7 +5475,7 @@ msgstr "Fehlerhafte Profil URL %s"
 msgid "Rename projects"
 msgstr "Fehlerhafte Profil URL %s"
 
-#: lxc/remote.go:838 lxc/remote.go:839
+#: lxc/remote.go:872 lxc/remote.go:873
 msgid "Rename remotes"
 msgstr ""
 
@@ -5611,7 +5630,7 @@ msgstr "Entferntes Administrator Passwort"
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:820
+#: lxc/remote.go:854
 msgid "STATIC"
 msgstr ""
 
@@ -5652,11 +5671,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:532
+#: lxc/remote.go:546
 msgid "Server certificate NACKed by user"
 msgstr "Server Zertifikat vom Benutzer nicht akzeptiert"
 
-#: lxc/remote.go:285 lxc/remote.go:683
+#: lxc/remote.go:299 lxc/remote.go:717
 #, fuzzy
 msgid "Server doesn't trust us after authentication"
 msgstr ""
@@ -5883,7 +5902,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1031 lxc/remote.go:1032
+#: lxc/remote.go:1065 lxc/remote.go:1066
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5990,7 +6009,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1859 lxc/auth.go:1860
+#: lxc/auth.go:2008 lxc/auth.go:2009
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -6021,12 +6040,12 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr "Geräte zu Containern oder Profilen hinzufügen"
 
-#: lxc/auth.go:441 lxc/auth.go:442
+#: lxc/auth.go:446 lxc/auth.go:447
 #, fuzzy
 msgid "Show group configurations"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/auth.go:836
+#: lxc/auth.go:985
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -6147,7 +6166,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Show storage volume state information"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/auth.go:899
+#: lxc/auth.go:1048
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -6157,7 +6176,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:714 lxc/remote.go:715
+#: lxc/remote.go:748 lxc/remote.go:749
 msgid "Show the default remote"
 msgstr ""
 
@@ -6381,7 +6400,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:983 lxc/remote.go:984
+#: lxc/remote.go:1017 lxc/remote.go:1018
 msgid "Switch the default remote"
 msgstr ""
 
@@ -6393,11 +6412,21 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
+#: lxc/auth.go:876
+#, c-format
+msgid "TLS identity %q (%s) pending identity token:"
+msgstr ""
+
+#: lxc/auth.go:902
+#, fuzzy, c-format
+msgid "TLS identity %q created with fingerprint %q"
+msgstr "Abbild mit Fingerabdruck %s importiert\n"
+
 #: lxc/cluster.go:1070 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:818 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
 #: lxc/storage_volume.go:1736 lxc/warning.go:216
@@ -6417,7 +6446,7 @@ msgstr "--refresh kann nur mit Containern verwendet werden"
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/remote.go:161 lxc/remote.go:334
+#: lxc/remote.go:161 lxc/remote.go:348
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
@@ -6578,7 +6607,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:527
+#: lxc/remote.go:541
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
@@ -6721,16 +6750,16 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:329
+#: lxc/remote.go:343
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:324
+#: lxc/remote.go:338
 #, fuzzy
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr "--refresh kann nur mit Containern verwendet werden"
 
-#: lxc/remote.go:639
+#: lxc/remote.go:653
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6774,7 +6803,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:193 lxc/remote.go:816
+#: lxc/cluster.go:193 lxc/remote.go:850
 msgid "URL"
 msgstr ""
 
@@ -7115,11 +7144,11 @@ msgstr ""
 "Optionen:\n"
 "\n"
 
-#: lxc/auth.go:835
+#: lxc/auth.go:984
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:898
+#: lxc/auth.go:1047
 msgid "View the current identity"
 msgstr ""
 
@@ -7163,7 +7192,7 @@ msgstr ""
 
 #: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:777 lxc/remote.go:782 lxc/remote.go:787
+#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr ""
 
@@ -7207,7 +7236,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/auth.go:330 lxc/auth.go:766 lxc/auth.go:897 lxc/auth.go:1748
+#: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
@@ -7271,7 +7300,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/auth.go:1313
+#: lxc/auth.go:1462
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -7391,11 +7420,17 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/auth.go:834 lxc/auth.go:1086
+#: lxc/auth.go:774
+msgid ""
+"[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
+"certificate>] [[--group <group_name>]]"
+msgstr ""
+
+#: lxc/auth.go:983 lxc/auth.go:1235
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1164 lxc/auth.go:1222 lxc/auth.go:1985
+#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:2134
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -7408,8 +7443,8 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/auth.go:97 lxc/auth.go:150 lxc/auth.go:200 lxc/auth.go:440
-#: lxc/auth.go:958 lxc/auth.go:1529 lxc/cluster_group.go:168
+#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:445
+#: lxc/auth.go:1107 lxc/auth.go:1678 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 #, fuzzy
 msgid "[<remote>:]<group>"
@@ -7418,7 +7453,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/auth.go:515 lxc/auth.go:573
+#: lxc/auth.go:520 lxc/auth.go:578
 #, fuzzy
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
@@ -7436,7 +7471,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/auth.go:390
+#: lxc/auth.go:395
 #, fuzzy
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
@@ -7444,7 +7479,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/auth.go:1580 lxc/auth.go:1630 lxc/auth.go:1858
+#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
@@ -7452,7 +7487,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/auth.go:1932
+#: lxc/auth.go:2081
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
@@ -7461,7 +7496,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/auth.go:1808
+#: lxc/auth.go:1957
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
@@ -8445,7 +8480,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/project.go:557 lxc/remote.go:806
+#: lxc/project.go:557 lxc/remote.go:840
 msgid "current"
 msgstr ""
 
@@ -8492,20 +8527,20 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/auth.go:204
+#: lxc/auth.go:209
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:962
+#: lxc/auth.go:1111
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1634
+#: lxc/auth.go:1783
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -8933,7 +8968,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:531
+#: lxc/remote.go:545
 msgid "n"
 msgstr ""
 
@@ -8945,7 +8980,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:510
+#: lxc/remote.go:524
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -8982,7 +9017,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:519
+#: lxc/remote.go:533
 msgid "y"
 msgstr ""
 

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-14 13:30+0000\n"
+"POT-Creation-Date: 2024-10-15 14:52+0100\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/linux-containers/"
@@ -133,7 +133,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:214
+#: lxc/auth.go:219
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -160,7 +160,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:972
+#: lxc/auth.go:1121
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -181,7 +181,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1644
+#: lxc/auth.go:1793
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -515,15 +515,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:917 lxc/remote.go:982
+#: lxc/remote.go:951 lxc/remote.go:1016
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1030
+#: lxc/remote.go:1064
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:836
+#: lxc/remote.go:870
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -556,11 +556,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:818
+#: lxc/remote.go:852
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:817
+#: lxc/auth.go:966
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -599,11 +599,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/auth.go:1165 lxc/auth.go:1166
+#: lxc/auth.go:1314 lxc/auth.go:1315
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1933 lxc/auth.go:1934
+#: lxc/auth.go:2082 lxc/auth.go:2083
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -673,7 +673,7 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:516 lxc/auth.go:517
+#: lxc/auth.go:521 lxc/auth.go:522
 msgid "Add permissions to groups"
 msgstr ""
 
@@ -708,7 +708,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:648
+#: lxc/remote.go:680
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -816,7 +816,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:621
+#: lxc/remote.go:635
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -995,7 +995,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:961
+#: lxc/remote.go:995
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1061,7 +1061,7 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/remote.go:509
+#: lxc/remote.go:523
 msgid "Certificate fingerprint"
 msgstr ""
 
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/remote.go:687
+#: lxc/remote.go:721
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1328,12 +1328,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:559
+#: lxc/remote.go:573
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:237 lxc/remote.go:543
+#: lxc/remote.go:237 lxc/remote.go:557
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1347,12 +1347,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:1719
+#: lxc/auth.go:306 lxc/auth.go:1868
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1058
+#: lxc/auth.go:1207
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1372,13 +1372,17 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:554
+#: lxc/remote.go:568
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
 #: lxc/network_zone.go:1536
 msgid "Couldn't find a matching entry"
+msgstr ""
+
+#: lxc/auth.go:776
+msgid "Create a TLS identity"
 msgstr ""
 
 #: lxc/cluster_group.go:169 lxc/cluster_group.go:170
@@ -1397,6 +1401,10 @@ msgstr ""
 msgid "Create an empty instance"
 msgstr ""
 
+#: lxc/auth.go:775
+msgid "Create an identity"
+msgstr ""
+
 #: lxc/launch.go:23 lxc/launch.go:24
 msgid "Create and start instances from images"
 msgstr ""
@@ -1409,11 +1417,11 @@ msgstr ""
 msgid "Create files and directories in instances"
 msgstr ""
 
-#: lxc/auth.go:98 lxc/auth.go:99
+#: lxc/auth.go:103 lxc/auth.go:104
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1530 lxc/auth.go:1531
+#: lxc/auth.go:1679 lxc/auth.go:1680
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1524,7 +1532,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
@@ -1567,7 +1575,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/auth.go:1088 lxc/auth.go:1089
+#: lxc/auth.go:1237 lxc/auth.go:1238
 msgid "Delete an identity"
 msgstr ""
 
@@ -1575,12 +1583,12 @@ msgstr ""
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/auth.go:152 lxc/auth.go:153
+#: lxc/auth.go:157 lxc/auth.go:158
 #, fuzzy
 msgid "Delete groups"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/auth.go:1582 lxc/auth.go:1583
+#: lxc/auth.go:1731 lxc/auth.go:1732
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1662,18 +1670,18 @@ msgstr ""
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:31 lxc/auth.go:60 lxc/auth.go:99
-#: lxc/auth.go:153 lxc/auth.go:202 lxc/auth.go:333 lxc/auth.go:393
-#: lxc/auth.go:442 lxc/auth.go:494 lxc/auth.go:517 lxc/auth.go:576
-#: lxc/auth.go:732 lxc/auth.go:769 lxc/auth.go:836 lxc/auth.go:899
-#: lxc/auth.go:960 lxc/auth.go:1089 lxc/auth.go:1143 lxc/auth.go:1166
-#: lxc/auth.go:1224 lxc/auth.go:1293 lxc/auth.go:1315 lxc/auth.go:1493
-#: lxc/auth.go:1531 lxc/auth.go:1583 lxc/auth.go:1632 lxc/auth.go:1751
-#: lxc/auth.go:1811 lxc/auth.go:1860 lxc/auth.go:1911 lxc/auth.go:1934
-#: lxc/auth.go:1987 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215
-#: lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:484
-#: lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677 lxc/cluster.go:770
-#: lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
+#: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
+#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:338 lxc/auth.go:398
+#: lxc/auth.go:447 lxc/auth.go:499 lxc/auth.go:522 lxc/auth.go:581
+#: lxc/auth.go:737 lxc/auth.go:776 lxc/auth.go:918 lxc/auth.go:985
+#: lxc/auth.go:1048 lxc/auth.go:1109 lxc/auth.go:1238 lxc/auth.go:1292
+#: lxc/auth.go:1315 lxc/auth.go:1373 lxc/auth.go:1442 lxc/auth.go:1464
+#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
+#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
+#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
+#: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
+#: lxc/cluster.go:770 lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
 #: lxc/cluster.go:1175 lxc/cluster.go:1299 lxc/cluster.go:1329
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
@@ -1744,9 +1752,9 @@ msgstr ""
 #: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
 #: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
 #: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:715
-#: lxc/remote.go:753 lxc/remote.go:839 lxc/remote.go:920 lxc/remote.go:984
-#: lxc/remote.go:1032 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
+#: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
+#: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1935,7 +1943,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:959 lxc/auth.go:960
+#: lxc/auth.go:1108 lxc/auth.go:1109
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1947,11 +1955,11 @@ msgstr ""
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/auth.go:201 lxc/auth.go:202
+#: lxc/auth.go:206 lxc/auth.go:207
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1631 lxc/auth.go:1632
+#: lxc/auth.go:1780 lxc/auth.go:1781
 #, fuzzy
 msgid "Edit identity provider groups as YAML"
 msgstr "  Χρήση δικτύου:"
@@ -2333,12 +2341,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:486
+#: lxc/remote.go:500
 #, fuzzy, c-format
 msgid "Failed to decode trust token: %w"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/remote.go:292
+#: lxc/remote.go:306
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2442,7 +2450,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:773 lxc/auth.go:1755
+#: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
@@ -2450,7 +2458,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:757 lxc/storage.go:657
+#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2488,7 +2496,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:821
+#: lxc/remote.go:855
 msgid "GLOBAL"
 msgstr ""
 
@@ -2500,7 +2508,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:821 lxc/auth.go:1795
+#: lxc/auth.go:970 lxc/auth.go:1944
 msgid "GROUPS"
 msgstr ""
 
@@ -2508,7 +2516,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:165 lxc/remote.go:443
+#: lxc/remote.go:165 lxc/remote.go:457
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2662,17 +2670,17 @@ msgstr ""
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: lxc/auth.go:137
+#: lxc/auth.go:142
 #, fuzzy, c-format
 msgid "Group %s created"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/auth.go:187
+#: lxc/auth.go:192
 #, fuzzy, c-format
 msgid "Group %s deleted"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/auth.go:427 lxc/auth.go:1845
+#: lxc/auth.go:432 lxc/auth.go:1994
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2731,7 +2739,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:820
+#: lxc/auth.go:969
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -2763,12 +2771,16 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1567
+#: lxc/auth.go:829
+msgid "Identity creation only supported for TLS identities"
+msgstr ""
+
+#: lxc/auth.go:1716
 #, fuzzy, c-format
 msgid "Identity provider group %s created"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/auth.go:1617
+#: lxc/auth.go:1766
 #, fuzzy, c-format
 msgid "Identity provider group %s deleted"
 msgstr "  Χρήση δικτύου:"
@@ -2897,7 +2909,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1292 lxc/auth.go:1293
+#: lxc/auth.go:1441 lxc/auth.go:1442
 msgid "Inspect permissions"
 msgstr ""
 
@@ -2945,7 +2957,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:395
+#: lxc/remote.go:409
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3026,7 +3038,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:384
+#: lxc/remote.go:398
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3203,15 +3215,15 @@ msgstr ""
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:332 lxc/auth.go:333
+#: lxc/auth.go:337 lxc/auth.go:338
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:768 lxc/auth.go:769
+#: lxc/auth.go:917 lxc/auth.go:918
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1750 lxc/auth.go:1751
+#: lxc/auth.go:1899 lxc/auth.go:1900
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3364,7 +3376,7 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1314 lxc/auth.go:1315
+#: lxc/auth.go:1463 lxc/auth.go:1464
 msgid "List permissions"
 msgstr ""
 
@@ -3408,7 +3420,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:752 lxc/remote.go:753
+#: lxc/remote.go:786 lxc/remote.go:787
 msgid "List the available remotes"
 msgstr ""
 
@@ -3532,6 +3544,12 @@ msgstr ""
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
+#: lxc/auth.go:825
+msgid ""
+"Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
+"got "
+msgstr ""
+
 #: lxc/network.go:32 lxc/network.go:33
 msgid "Manage and attach instances to networks"
 msgstr ""
@@ -3561,20 +3579,20 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:59 lxc/auth.go:60 lxc/auth.go:1492 lxc/auth.go:1493
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
 #, fuzzy
 msgid "Manage groups"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/auth.go:1142 lxc/auth.go:1143
+#: lxc/auth.go:1291 lxc/auth.go:1292
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:731 lxc/auth.go:732
+#: lxc/auth.go:736 lxc/auth.go:737
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1910 lxc/auth.go:1911
+#: lxc/auth.go:2059 lxc/auth.go:2060
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3672,7 +3690,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Manage network zones"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/auth.go:493 lxc/auth.go:494
+#: lxc/auth.go:498 lxc/auth.go:499
 #, fuzzy
 msgid "Manage permissions"
 msgstr "  Χρήση δικτύου:"
@@ -3728,7 +3746,7 @@ msgstr ""
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/auth.go:30 lxc/auth.go:31
+#: lxc/auth.go:35 lxc/auth.go:36
 #, fuzzy
 msgid "Manage user authorization"
 msgstr "  Χρήση δικτύου:"
@@ -3830,24 +3848,24 @@ msgstr "  Χρήση δικτύου:"
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:123 lxc/auth.go:177 lxc/auth.go:255 lxc/auth.go:417
-#: lxc/auth.go:466 lxc/auth.go:541 lxc/auth.go:600 lxc/auth.go:1884
+#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:260 lxc/auth.go:422
+#: lxc/auth.go:471 lxc/auth.go:546 lxc/auth.go:605 lxc/auth.go:2033
 #, fuzzy
 msgid "Missing group name"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/auth.go:866 lxc/auth.go:1007 lxc/auth.go:1124 lxc/auth.go:1190
-#: lxc/auth.go:1248
+#: lxc/auth.go:820 lxc/auth.go:1015 lxc/auth.go:1156 lxc/auth.go:1273
+#: lxc/auth.go:1339 lxc/auth.go:1397
 #, fuzzy
 msgid "Missing identity argument"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/auth.go:1554 lxc/auth.go:1607 lxc/auth.go:1673 lxc/auth.go:1835
+#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
 #, fuzzy
 msgid "Missing identity provider group name"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/auth.go:1958 lxc/auth.go:2011
+#: lxc/auth.go:2107 lxc/auth.go:2160
 #, fuzzy
 msgid "Missing identity provider group name argument"
 msgstr "  Χρήση δικτύου:"
@@ -4072,12 +4090,12 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:376 lxc/auth.go:819 lxc/auth.go:1794 lxc/cluster.go:192
+#: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
-#: lxc/remote.go:815 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
 msgstr ""
@@ -4104,7 +4122,7 @@ msgstr ""
 
 #: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:775 lxc/remote.go:780 lxc/remote.go:785
+#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr ""
 
@@ -4335,7 +4353,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:378
+#: lxc/remote.go:392
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4406,11 +4424,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:817
+#: lxc/remote.go:851
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:819
+#: lxc/image.go:1136 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4452,7 +4470,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/remote.go:536
+#: lxc/remote.go:550
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
@@ -4469,7 +4487,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:302 lxc/auth.go:1059 lxc/auth.go:1720 lxc/cluster.go:860
+#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -4772,33 +4790,33 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:877
+#: lxc/remote.go:911
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:868 lxc/remote.go:949 lxc/remote.go:1013
-#: lxc/remote.go:1061
+#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/remote.go:1095
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:345
+#: lxc/remote.go:359
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:957
+#: lxc/remote.go:991
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:872 lxc/remote.go:953 lxc/remote.go:1065
+#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1099
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:319
+#: lxc/remote.go:333
 msgid "Remote address must not be empty"
 msgstr ""
 
@@ -4806,7 +4824,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:339
+#: lxc/remote.go:353
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4828,7 +4846,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1223 lxc/auth.go:1224
+#: lxc/auth.go:1372 lxc/auth.go:1373
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4867,7 +4885,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1986 lxc/auth.go:1987
+#: lxc/auth.go:2135 lxc/auth.go:2136
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4879,7 +4897,7 @@ msgstr ""
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:575 lxc/auth.go:576
+#: lxc/auth.go:580 lxc/auth.go:581
 msgid "Remove permissions from groups"
 msgstr ""
 
@@ -4896,7 +4914,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:919 lxc/remote.go:920
+#: lxc/remote.go:953 lxc/remote.go:954
 msgid "Remove remotes"
 msgstr ""
 
@@ -4926,11 +4944,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:392 lxc/auth.go:393
+#: lxc/auth.go:397 lxc/auth.go:398
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1810 lxc/auth.go:1811
+#: lxc/auth.go:1959 lxc/auth.go:1960
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -4954,7 +4972,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:838 lxc/remote.go:839
+#: lxc/remote.go:872 lxc/remote.go:873
 msgid "Rename remotes"
 msgstr ""
 
@@ -5100,7 +5118,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:820
+#: lxc/remote.go:854
 msgid "STATIC"
 msgstr ""
 
@@ -5141,11 +5159,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:532
+#: lxc/remote.go:546
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:285 lxc/remote.go:683
+#: lxc/remote.go:299 lxc/remote.go:717
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5363,7 +5381,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1031 lxc/remote.go:1032
+#: lxc/remote.go:1065 lxc/remote.go:1066
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5465,7 +5483,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1859 lxc/auth.go:1860
+#: lxc/auth.go:2008 lxc/auth.go:2009
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5494,12 +5512,12 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:441 lxc/auth.go:442
+#: lxc/auth.go:446 lxc/auth.go:447
 #, fuzzy
 msgid "Show group configurations"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/auth.go:836
+#: lxc/auth.go:985
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5612,7 +5630,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:899
+#: lxc/auth.go:1048
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5622,7 +5640,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:714 lxc/remote.go:715
+#: lxc/remote.go:748 lxc/remote.go:749
 msgid "Show the default remote"
 msgstr ""
 
@@ -5835,7 +5853,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:983 lxc/remote.go:984
+#: lxc/remote.go:1017 lxc/remote.go:1018
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5847,11 +5865,21 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
+#: lxc/auth.go:876
+#, c-format
+msgid "TLS identity %q (%s) pending identity token:"
+msgstr ""
+
+#: lxc/auth.go:902
+#, c-format
+msgid "TLS identity %q created with fingerprint %q"
+msgstr ""
+
 #: lxc/cluster.go:1070 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:818 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
 #: lxc/storage_volume.go:1736 lxc/warning.go:216
@@ -5870,7 +5898,7 @@ msgstr ""
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/remote.go:161 lxc/remote.go:334
+#: lxc/remote.go:161 lxc/remote.go:348
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
@@ -6026,7 +6054,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:527
+#: lxc/remote.go:541
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
@@ -6165,15 +6193,15 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:329
+#: lxc/remote.go:343
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:324
+#: lxc/remote.go:338
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr ""
 
-#: lxc/remote.go:639
+#: lxc/remote.go:653
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6216,7 +6244,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:193 lxc/remote.go:816
+#: lxc/cluster.go:193 lxc/remote.go:850
 msgid "URL"
 msgstr ""
 
@@ -6541,11 +6569,11 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:835
+#: lxc/auth.go:984
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:898
+#: lxc/auth.go:1047
 msgid "View the current identity"
 msgstr ""
 
@@ -6584,7 +6612,7 @@ msgstr ""
 
 #: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:777 lxc/remote.go:782 lxc/remote.go:787
+#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr ""
 
@@ -6616,7 +6644,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:330 lxc/auth.go:766 lxc/auth.go:897 lxc/auth.go:1748
+#: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
@@ -6649,7 +6677,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1313
+#: lxc/auth.go:1462
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6710,11 +6738,17 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:834 lxc/auth.go:1086
+#: lxc/auth.go:774
+msgid ""
+"[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
+"certificate>] [[--group <group_name>]]"
+msgstr ""
+
+#: lxc/auth.go:983 lxc/auth.go:1235
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1164 lxc/auth.go:1222 lxc/auth.go:1985
+#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:2134
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6722,13 +6756,13 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:97 lxc/auth.go:150 lxc/auth.go:200 lxc/auth.go:440
-#: lxc/auth.go:958 lxc/auth.go:1529 lxc/cluster_group.go:168
+#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:445
+#: lxc/auth.go:1107 lxc/auth.go:1678 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:515 lxc/auth.go:573
+#: lxc/auth.go:520 lxc/auth.go:578
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
@@ -6738,19 +6772,19 @@ msgstr ""
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:390
+#: lxc/auth.go:395
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1580 lxc/auth.go:1630 lxc/auth.go:1858
+#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1932
+#: lxc/auth.go:2081
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1808
+#: lxc/auth.go:1957
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -7241,7 +7275,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:806
+#: lxc/project.go:557 lxc/remote.go:840
 msgid "current"
 msgstr ""
 
@@ -7288,20 +7322,20 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/auth.go:204
+#: lxc/auth.go:209
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:962
+#: lxc/auth.go:1111
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1634
+#: lxc/auth.go:1783
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7725,7 +7759,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:531
+#: lxc/remote.go:545
 msgid "n"
 msgstr ""
 
@@ -7737,7 +7771,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:510
+#: lxc/remote.go:524
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7774,7 +7808,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:519
+#: lxc/remote.go:533
 msgid "y"
 msgstr ""
 

--- a/po/eo.po
+++ b/po/eo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-14 13:30+0000\n"
+"POT-Creation-Date: 2024-10-15 14:52+0100\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Esperanto <https://hosted.weblate.org/projects/linux-"
@@ -133,7 +133,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:214
+#: lxc/auth.go:219
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -160,7 +160,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:972
+#: lxc/auth.go:1121
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -181,7 +181,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1644
+#: lxc/auth.go:1793
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -515,15 +515,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:917 lxc/remote.go:982
+#: lxc/remote.go:951 lxc/remote.go:1016
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1030
+#: lxc/remote.go:1064
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:836
+#: lxc/remote.go:870
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -556,11 +556,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:818
+#: lxc/remote.go:852
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:817
+#: lxc/auth.go:966
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -598,11 +598,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1165 lxc/auth.go:1166
+#: lxc/auth.go:1314 lxc/auth.go:1315
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1933 lxc/auth.go:1934
+#: lxc/auth.go:2082 lxc/auth.go:2083
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -671,7 +671,7 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:516 lxc/auth.go:517
+#: lxc/auth.go:521 lxc/auth.go:522
 msgid "Add permissions to groups"
 msgstr ""
 
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:648
+#: lxc/remote.go:680
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -813,7 +813,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:621
+#: lxc/remote.go:635
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -991,7 +991,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:961
+#: lxc/remote.go:995
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1057,7 +1057,7 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:509
+#: lxc/remote.go:523
 msgid "Certificate fingerprint"
 msgstr ""
 
@@ -1076,7 +1076,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:687
+#: lxc/remote.go:721
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1324,12 +1324,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:559
+#: lxc/remote.go:573
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:237 lxc/remote.go:543
+#: lxc/remote.go:237 lxc/remote.go:557
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1343,12 +1343,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:1719
+#: lxc/auth.go:306 lxc/auth.go:1868
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1058
+#: lxc/auth.go:1207
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1368,13 +1368,17 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:554
+#: lxc/remote.go:568
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
 #: lxc/network_zone.go:1536
 msgid "Couldn't find a matching entry"
+msgstr ""
+
+#: lxc/auth.go:776
+msgid "Create a TLS identity"
 msgstr ""
 
 #: lxc/cluster_group.go:169 lxc/cluster_group.go:170
@@ -1393,6 +1397,10 @@ msgstr ""
 msgid "Create an empty instance"
 msgstr ""
 
+#: lxc/auth.go:775
+msgid "Create an identity"
+msgstr ""
+
 #: lxc/launch.go:23 lxc/launch.go:24
 msgid "Create and start instances from images"
 msgstr ""
@@ -1405,11 +1413,11 @@ msgstr ""
 msgid "Create files and directories in instances"
 msgstr ""
 
-#: lxc/auth.go:98 lxc/auth.go:99
+#: lxc/auth.go:103 lxc/auth.go:104
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1530 lxc/auth.go:1531
+#: lxc/auth.go:1679 lxc/auth.go:1680
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1517,7 +1525,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
@@ -1560,7 +1568,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/auth.go:1088 lxc/auth.go:1089
+#: lxc/auth.go:1237 lxc/auth.go:1238
 msgid "Delete an identity"
 msgstr ""
 
@@ -1568,11 +1576,11 @@ msgstr ""
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/auth.go:152 lxc/auth.go:153
+#: lxc/auth.go:157 lxc/auth.go:158
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1582 lxc/auth.go:1583
+#: lxc/auth.go:1731 lxc/auth.go:1732
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1650,18 +1658,18 @@ msgstr ""
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:31 lxc/auth.go:60 lxc/auth.go:99
-#: lxc/auth.go:153 lxc/auth.go:202 lxc/auth.go:333 lxc/auth.go:393
-#: lxc/auth.go:442 lxc/auth.go:494 lxc/auth.go:517 lxc/auth.go:576
-#: lxc/auth.go:732 lxc/auth.go:769 lxc/auth.go:836 lxc/auth.go:899
-#: lxc/auth.go:960 lxc/auth.go:1089 lxc/auth.go:1143 lxc/auth.go:1166
-#: lxc/auth.go:1224 lxc/auth.go:1293 lxc/auth.go:1315 lxc/auth.go:1493
-#: lxc/auth.go:1531 lxc/auth.go:1583 lxc/auth.go:1632 lxc/auth.go:1751
-#: lxc/auth.go:1811 lxc/auth.go:1860 lxc/auth.go:1911 lxc/auth.go:1934
-#: lxc/auth.go:1987 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215
-#: lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:484
-#: lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677 lxc/cluster.go:770
-#: lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
+#: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
+#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:338 lxc/auth.go:398
+#: lxc/auth.go:447 lxc/auth.go:499 lxc/auth.go:522 lxc/auth.go:581
+#: lxc/auth.go:737 lxc/auth.go:776 lxc/auth.go:918 lxc/auth.go:985
+#: lxc/auth.go:1048 lxc/auth.go:1109 lxc/auth.go:1238 lxc/auth.go:1292
+#: lxc/auth.go:1315 lxc/auth.go:1373 lxc/auth.go:1442 lxc/auth.go:1464
+#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
+#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
+#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
+#: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
+#: lxc/cluster.go:770 lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
 #: lxc/cluster.go:1175 lxc/cluster.go:1299 lxc/cluster.go:1329
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
@@ -1732,9 +1740,9 @@ msgstr ""
 #: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
 #: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
 #: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:715
-#: lxc/remote.go:753 lxc/remote.go:839 lxc/remote.go:920 lxc/remote.go:984
-#: lxc/remote.go:1032 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
+#: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
+#: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1919,7 +1927,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:959 lxc/auth.go:960
+#: lxc/auth.go:1108 lxc/auth.go:1109
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1931,11 +1939,11 @@ msgstr ""
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/auth.go:201 lxc/auth.go:202
+#: lxc/auth.go:206 lxc/auth.go:207
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1631 lxc/auth.go:1632
+#: lxc/auth.go:1780 lxc/auth.go:1781
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2311,12 +2319,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:486
+#: lxc/remote.go:500
 #, c-format
 msgid "Failed to decode trust token: %w"
 msgstr ""
 
-#: lxc/remote.go:292
+#: lxc/remote.go:306
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2420,7 +2428,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:773 lxc/auth.go:1755
+#: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
@@ -2428,7 +2436,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:757 lxc/storage.go:657
+#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2466,7 +2474,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:821
+#: lxc/remote.go:855
 msgid "GLOBAL"
 msgstr ""
 
@@ -2478,7 +2486,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:821 lxc/auth.go:1795
+#: lxc/auth.go:970 lxc/auth.go:1944
 msgid "GROUPS"
 msgstr ""
 
@@ -2486,7 +2494,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:165 lxc/remote.go:443
+#: lxc/remote.go:165 lxc/remote.go:457
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2627,17 +2635,17 @@ msgstr ""
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: lxc/auth.go:137
+#: lxc/auth.go:142
 #, c-format
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:187
+#: lxc/auth.go:192
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:427 lxc/auth.go:1845
+#: lxc/auth.go:432 lxc/auth.go:1994
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2696,7 +2704,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:820
+#: lxc/auth.go:969
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -2728,12 +2736,16 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1567
+#: lxc/auth.go:829
+msgid "Identity creation only supported for TLS identities"
+msgstr ""
+
+#: lxc/auth.go:1716
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1617
+#: lxc/auth.go:1766
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2862,7 +2874,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1292 lxc/auth.go:1293
+#: lxc/auth.go:1441 lxc/auth.go:1442
 msgid "Inspect permissions"
 msgstr ""
 
@@ -2910,7 +2922,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:395
+#: lxc/remote.go:409
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2991,7 +3003,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:384
+#: lxc/remote.go:398
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3166,15 +3178,15 @@ msgstr ""
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:332 lxc/auth.go:333
+#: lxc/auth.go:337 lxc/auth.go:338
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:768 lxc/auth.go:769
+#: lxc/auth.go:917 lxc/auth.go:918
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1750 lxc/auth.go:1751
+#: lxc/auth.go:1899 lxc/auth.go:1900
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3327,7 +3339,7 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1314 lxc/auth.go:1315
+#: lxc/auth.go:1463 lxc/auth.go:1464
 msgid "List permissions"
 msgstr ""
 
@@ -3371,7 +3383,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:752 lxc/remote.go:753
+#: lxc/remote.go:786 lxc/remote.go:787
 msgid "List the available remotes"
 msgstr ""
 
@@ -3495,6 +3507,12 @@ msgstr ""
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
+#: lxc/auth.go:825
+msgid ""
+"Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
+"got "
+msgstr ""
+
 #: lxc/network.go:32 lxc/network.go:33
 msgid "Manage and attach instances to networks"
 msgstr ""
@@ -3523,19 +3541,19 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:59 lxc/auth.go:60 lxc/auth.go:1492 lxc/auth.go:1493
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1142 lxc/auth.go:1143
+#: lxc/auth.go:1291 lxc/auth.go:1292
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:731 lxc/auth.go:732
+#: lxc/auth.go:736 lxc/auth.go:737
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1910 lxc/auth.go:1911
+#: lxc/auth.go:2059 lxc/auth.go:2060
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3626,7 +3644,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:493 lxc/auth.go:494
+#: lxc/auth.go:498 lxc/auth.go:499
 msgid "Manage permissions"
 msgstr ""
 
@@ -3678,7 +3696,7 @@ msgstr ""
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/auth.go:30 lxc/auth.go:31
+#: lxc/auth.go:35 lxc/auth.go:36
 msgid "Manage user authorization"
 msgstr ""
 
@@ -3775,21 +3793,21 @@ msgstr ""
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:123 lxc/auth.go:177 lxc/auth.go:255 lxc/auth.go:417
-#: lxc/auth.go:466 lxc/auth.go:541 lxc/auth.go:600 lxc/auth.go:1884
+#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:260 lxc/auth.go:422
+#: lxc/auth.go:471 lxc/auth.go:546 lxc/auth.go:605 lxc/auth.go:2033
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:866 lxc/auth.go:1007 lxc/auth.go:1124 lxc/auth.go:1190
-#: lxc/auth.go:1248
+#: lxc/auth.go:820 lxc/auth.go:1015 lxc/auth.go:1156 lxc/auth.go:1273
+#: lxc/auth.go:1339 lxc/auth.go:1397
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1554 lxc/auth.go:1607 lxc/auth.go:1673 lxc/auth.go:1835
+#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1958 lxc/auth.go:2011
+#: lxc/auth.go:2107 lxc/auth.go:2160
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -4010,12 +4028,12 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:376 lxc/auth.go:819 lxc/auth.go:1794 lxc/cluster.go:192
+#: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
-#: lxc/remote.go:815 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
 msgstr ""
@@ -4042,7 +4060,7 @@ msgstr ""
 
 #: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:775 lxc/remote.go:780 lxc/remote.go:785
+#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr ""
 
@@ -4271,7 +4289,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:378
+#: lxc/remote.go:392
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4342,11 +4360,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:817
+#: lxc/remote.go:851
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:819
+#: lxc/image.go:1136 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4387,7 +4405,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:536
+#: lxc/remote.go:550
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
@@ -4404,7 +4422,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:302 lxc/auth.go:1059 lxc/auth.go:1720 lxc/cluster.go:860
+#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -4707,33 +4725,33 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:877
+#: lxc/remote.go:911
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:868 lxc/remote.go:949 lxc/remote.go:1013
-#: lxc/remote.go:1061
+#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/remote.go:1095
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:345
+#: lxc/remote.go:359
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:957
+#: lxc/remote.go:991
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:872 lxc/remote.go:953 lxc/remote.go:1065
+#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1099
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:319
+#: lxc/remote.go:333
 msgid "Remote address must not be empty"
 msgstr ""
 
@@ -4741,7 +4759,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:339
+#: lxc/remote.go:353
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4763,7 +4781,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1223 lxc/auth.go:1224
+#: lxc/auth.go:1372 lxc/auth.go:1373
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4799,7 +4817,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1986 lxc/auth.go:1987
+#: lxc/auth.go:2135 lxc/auth.go:2136
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4811,7 +4829,7 @@ msgstr ""
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:575 lxc/auth.go:576
+#: lxc/auth.go:580 lxc/auth.go:581
 msgid "Remove permissions from groups"
 msgstr ""
 
@@ -4827,7 +4845,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:919 lxc/remote.go:920
+#: lxc/remote.go:953 lxc/remote.go:954
 msgid "Remove remotes"
 msgstr ""
 
@@ -4856,11 +4874,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:392 lxc/auth.go:393
+#: lxc/auth.go:397 lxc/auth.go:398
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1810 lxc/auth.go:1811
+#: lxc/auth.go:1959 lxc/auth.go:1960
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -4884,7 +4902,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:838 lxc/remote.go:839
+#: lxc/remote.go:872 lxc/remote.go:873
 msgid "Rename remotes"
 msgstr ""
 
@@ -5029,7 +5047,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:820
+#: lxc/remote.go:854
 msgid "STATIC"
 msgstr ""
 
@@ -5070,11 +5088,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:532
+#: lxc/remote.go:546
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:285 lxc/remote.go:683
+#: lxc/remote.go:299 lxc/remote.go:717
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5285,7 +5303,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1031 lxc/remote.go:1032
+#: lxc/remote.go:1065 lxc/remote.go:1066
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5381,7 +5399,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1859 lxc/auth.go:1860
+#: lxc/auth.go:2008 lxc/auth.go:2009
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5409,11 +5427,11 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:441 lxc/auth.go:442
+#: lxc/auth.go:446 lxc/auth.go:447
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:836
+#: lxc/auth.go:985
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5518,7 +5536,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:899
+#: lxc/auth.go:1048
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5528,7 +5546,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:714 lxc/remote.go:715
+#: lxc/remote.go:748 lxc/remote.go:749
 msgid "Show the default remote"
 msgstr ""
 
@@ -5740,7 +5758,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:983 lxc/remote.go:984
+#: lxc/remote.go:1017 lxc/remote.go:1018
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5752,11 +5770,21 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
+#: lxc/auth.go:876
+#, c-format
+msgid "TLS identity %q (%s) pending identity token:"
+msgstr ""
+
+#: lxc/auth.go:902
+#, c-format
+msgid "TLS identity %q created with fingerprint %q"
+msgstr ""
+
 #: lxc/cluster.go:1070 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:818 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
 #: lxc/storage_volume.go:1736 lxc/warning.go:216
@@ -5775,7 +5803,7 @@ msgstr ""
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/remote.go:161 lxc/remote.go:334
+#: lxc/remote.go:161 lxc/remote.go:348
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
@@ -5931,7 +5959,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:527
+#: lxc/remote.go:541
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
@@ -6069,15 +6097,15 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:329
+#: lxc/remote.go:343
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:324
+#: lxc/remote.go:338
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr ""
 
-#: lxc/remote.go:639
+#: lxc/remote.go:653
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6120,7 +6148,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:193 lxc/remote.go:816
+#: lxc/cluster.go:193 lxc/remote.go:850
 msgid "URL"
 msgstr ""
 
@@ -6428,11 +6456,11 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:835
+#: lxc/auth.go:984
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:898
+#: lxc/auth.go:1047
 msgid "View the current identity"
 msgstr ""
 
@@ -6471,7 +6499,7 @@ msgstr ""
 
 #: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:777 lxc/remote.go:782 lxc/remote.go:787
+#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr ""
 
@@ -6503,7 +6531,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:330 lxc/auth.go:766 lxc/auth.go:897 lxc/auth.go:1748
+#: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
@@ -6536,7 +6564,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1313
+#: lxc/auth.go:1462
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6597,11 +6625,17 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:834 lxc/auth.go:1086
+#: lxc/auth.go:774
+msgid ""
+"[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
+"certificate>] [[--group <group_name>]]"
+msgstr ""
+
+#: lxc/auth.go:983 lxc/auth.go:1235
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1164 lxc/auth.go:1222 lxc/auth.go:1985
+#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:2134
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6609,13 +6643,13 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:97 lxc/auth.go:150 lxc/auth.go:200 lxc/auth.go:440
-#: lxc/auth.go:958 lxc/auth.go:1529 lxc/cluster_group.go:168
+#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:445
+#: lxc/auth.go:1107 lxc/auth.go:1678 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:515 lxc/auth.go:573
+#: lxc/auth.go:520 lxc/auth.go:578
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
@@ -6625,19 +6659,19 @@ msgstr ""
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:390
+#: lxc/auth.go:395
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1580 lxc/auth.go:1630 lxc/auth.go:1858
+#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1932
+#: lxc/auth.go:2081
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1808
+#: lxc/auth.go:1957
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -7128,7 +7162,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:806
+#: lxc/project.go:557 lxc/remote.go:840
 msgid "current"
 msgstr ""
 
@@ -7175,20 +7209,20 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/auth.go:204
+#: lxc/auth.go:209
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:962
+#: lxc/auth.go:1111
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1634
+#: lxc/auth.go:1783
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7612,7 +7646,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:531
+#: lxc/remote.go:545
 msgid "n"
 msgstr ""
 
@@ -7624,7 +7658,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:510
+#: lxc/remote.go:524
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7661,7 +7695,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:519
+#: lxc/remote.go:533
 msgid "y"
 msgstr ""
 

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-14 13:30+0000\n"
+"POT-Creation-Date: 2024-10-15 14:52+0100\n"
 "PO-Revision-Date: 2023-06-16 20:55+0000\n"
 "Last-Translator: Francisco Serrador <fserrador@gmail.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -202,7 +202,7 @@ msgstr ""
 "###\n"
 "### Note que el nombre se muestra pero no puede ser cambiado"
 
-#: lxc/auth.go:214
+#: lxc/auth.go:219
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -229,7 +229,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:972
+#: lxc/auth.go:1121
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -250,7 +250,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1644
+#: lxc/auth.go:1793
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
@@ -757,15 +757,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:917 lxc/remote.go:982
+#: lxc/remote.go:951 lxc/remote.go:1016
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1030
+#: lxc/remote.go:1064
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:836
+#: lxc/remote.go:870
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -799,11 +799,11 @@ msgstr "ALIASES"
 msgid "ARCHITECTURE"
 msgstr "ARQUITECTURA"
 
-#: lxc/remote.go:818
+#: lxc/remote.go:852
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:817
+#: lxc/auth.go:966
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -842,11 +842,11 @@ msgstr "Accion (predeterminados a GET)"
 msgid "Add a cluster member to a cluster group"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/auth.go:1165 lxc/auth.go:1166
+#: lxc/auth.go:1314 lxc/auth.go:1315
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1933 lxc/auth.go:1934
+#: lxc/auth.go:2082 lxc/auth.go:2083
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -917,7 +917,7 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:516 lxc/auth.go:517
+#: lxc/auth.go:521 lxc/auth.go:522
 msgid "Add permissions to groups"
 msgstr ""
 
@@ -952,7 +952,7 @@ msgstr "Expira: %s"
 msgid "Admin access key: %s"
 msgstr "Expira: %s"
 
-#: lxc/remote.go:648
+#: lxc/remote.go:680
 #, fuzzy, c-format
 msgid "Admin password (or token) for %s:"
 msgstr "Contraseña admin para %s: "
@@ -1062,7 +1062,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:621
+#: lxc/remote.go:635
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr "Tipo de autenticación %s no está soportada por el servidor"
@@ -1244,7 +1244,7 @@ msgstr "No se puede jalar un directorio sin - recursivo"
 msgid "Can't read from stdin: %w"
 msgstr "No se peude leer desde stdin: %s"
 
-#: lxc/remote.go:961
+#: lxc/remote.go:995
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1311,7 +1311,7 @@ msgstr "Cacheado: %s"
 msgid "Certificate add token for %s deleted"
 msgstr "Perfil %s eliminado"
 
-#: lxc/remote.go:509
+#: lxc/remote.go:523
 #, fuzzy
 msgid "Certificate fingerprint"
 msgstr "Certificado de la huella digital: %s"
@@ -1331,7 +1331,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/remote.go:687
+#: lxc/remote.go:721
 #, fuzzy
 msgid "Client certificate now trusted by server:"
 msgstr "Certificado del cliente almacenado en el servidor: "
@@ -1584,12 +1584,12 @@ msgstr "Expira: %s"
 msgid "Cores:"
 msgstr "Expira: %s"
 
-#: lxc/remote.go:559
+#: lxc/remote.go:573
 #, fuzzy, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "Certificado de la huella digital: %s"
 
-#: lxc/remote.go:237 lxc/remote.go:543
+#: lxc/remote.go:237 lxc/remote.go:557
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1603,12 +1603,12 @@ msgstr "Certificado de la huella digital: %s"
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:1719
+#: lxc/auth.go:306 lxc/auth.go:1868
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1058
+#: lxc/auth.go:1207
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1628,13 +1628,17 @@ msgstr "Certificado de la huella digital: %s"
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:554
+#: lxc/remote.go:568
 #, fuzzy, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "Certificado de la huella digital: %s"
 
 #: lxc/network_zone.go:1536
 msgid "Couldn't find a matching entry"
+msgstr ""
+
+#: lxc/auth.go:776
+msgid "Create a TLS identity"
 msgstr ""
 
 #: lxc/cluster_group.go:169 lxc/cluster_group.go:170
@@ -1655,6 +1659,11 @@ msgstr ""
 msgid "Create an empty instance"
 msgstr "Creando el contenedor"
 
+#: lxc/auth.go:775
+#, fuzzy
+msgid "Create an identity"
+msgstr "Creando el contenedor"
+
 #: lxc/launch.go:23 lxc/launch.go:24
 msgid "Create and start instances from images"
 msgstr ""
@@ -1668,12 +1677,12 @@ msgstr ""
 msgid "Create files and directories in instances"
 msgstr "Creando el contenedor"
 
-#: lxc/auth.go:98 lxc/auth.go:99
+#: lxc/auth.go:103 lxc/auth.go:104
 #, fuzzy
 msgid "Create groups"
 msgstr "Creado: %s"
 
-#: lxc/auth.go:1530 lxc/auth.go:1531
+#: lxc/auth.go:1679 lxc/auth.go:1680
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1786,7 +1795,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
@@ -1829,7 +1838,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/auth.go:1088 lxc/auth.go:1089
+#: lxc/auth.go:1237 lxc/auth.go:1238
 msgid "Delete an identity"
 msgstr ""
 
@@ -1837,12 +1846,12 @@ msgstr ""
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/auth.go:152 lxc/auth.go:153
+#: lxc/auth.go:157 lxc/auth.go:158
 #, fuzzy
 msgid "Delete groups"
 msgstr "Eliminar imágenes"
 
-#: lxc/auth.go:1582 lxc/auth.go:1583
+#: lxc/auth.go:1731 lxc/auth.go:1732
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1925,18 +1934,18 @@ msgstr ""
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:31 lxc/auth.go:60 lxc/auth.go:99
-#: lxc/auth.go:153 lxc/auth.go:202 lxc/auth.go:333 lxc/auth.go:393
-#: lxc/auth.go:442 lxc/auth.go:494 lxc/auth.go:517 lxc/auth.go:576
-#: lxc/auth.go:732 lxc/auth.go:769 lxc/auth.go:836 lxc/auth.go:899
-#: lxc/auth.go:960 lxc/auth.go:1089 lxc/auth.go:1143 lxc/auth.go:1166
-#: lxc/auth.go:1224 lxc/auth.go:1293 lxc/auth.go:1315 lxc/auth.go:1493
-#: lxc/auth.go:1531 lxc/auth.go:1583 lxc/auth.go:1632 lxc/auth.go:1751
-#: lxc/auth.go:1811 lxc/auth.go:1860 lxc/auth.go:1911 lxc/auth.go:1934
-#: lxc/auth.go:1987 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215
-#: lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:484
-#: lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677 lxc/cluster.go:770
-#: lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
+#: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
+#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:338 lxc/auth.go:398
+#: lxc/auth.go:447 lxc/auth.go:499 lxc/auth.go:522 lxc/auth.go:581
+#: lxc/auth.go:737 lxc/auth.go:776 lxc/auth.go:918 lxc/auth.go:985
+#: lxc/auth.go:1048 lxc/auth.go:1109 lxc/auth.go:1238 lxc/auth.go:1292
+#: lxc/auth.go:1315 lxc/auth.go:1373 lxc/auth.go:1442 lxc/auth.go:1464
+#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
+#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
+#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
+#: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
+#: lxc/cluster.go:770 lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
 #: lxc/cluster.go:1175 lxc/cluster.go:1299 lxc/cluster.go:1329
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
@@ -2007,9 +2016,9 @@ msgstr ""
 #: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
 #: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
 #: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:715
-#: lxc/remote.go:753 lxc/remote.go:839 lxc/remote.go:920 lxc/remote.go:984
-#: lxc/remote.go:1032 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
+#: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
+#: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -2198,7 +2207,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:959 lxc/auth.go:960
+#: lxc/auth.go:1108 lxc/auth.go:1109
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -2210,11 +2219,11 @@ msgstr ""
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/auth.go:201 lxc/auth.go:202
+#: lxc/auth.go:206 lxc/auth.go:207
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1631 lxc/auth.go:1632
+#: lxc/auth.go:1780 lxc/auth.go:1781
 #, fuzzy
 msgid "Edit identity provider groups as YAML"
 msgstr "Perfil %s creado"
@@ -2600,12 +2609,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr "Acepta certificado"
 
-#: lxc/remote.go:486
+#: lxc/remote.go:500
 #, fuzzy, c-format
 msgid "Failed to decode trust token: %w"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/remote.go:292
+#: lxc/remote.go:306
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2710,7 +2719,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:773 lxc/auth.go:1755
+#: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
@@ -2718,7 +2727,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:757 lxc/storage.go:657
+#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2756,7 +2765,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:821
+#: lxc/remote.go:855
 msgid "GLOBAL"
 msgstr ""
 
@@ -2768,7 +2777,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:821 lxc/auth.go:1795
+#: lxc/auth.go:970 lxc/auth.go:1944
 msgid "GROUPS"
 msgstr ""
 
@@ -2776,7 +2785,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:165 lxc/remote.go:443
+#: lxc/remote.go:165 lxc/remote.go:457
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2931,17 +2940,17 @@ msgstr ""
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: lxc/auth.go:137
+#: lxc/auth.go:142
 #, fuzzy, c-format
 msgid "Group %s created"
 msgstr "Perfil %s creado"
 
-#: lxc/auth.go:187
+#: lxc/auth.go:192
 #, fuzzy, c-format
 msgid "Group %s deleted"
 msgstr "Perfil %s eliminado"
 
-#: lxc/auth.go:427 lxc/auth.go:1845
+#: lxc/auth.go:432 lxc/auth.go:1994
 #, fuzzy, c-format
 msgid "Group %s renamed to %s"
 msgstr "Perfil %s renombrado a %s"
@@ -3001,7 +3010,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:820
+#: lxc/auth.go:969
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -3035,12 +3044,16 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1567
+#: lxc/auth.go:829
+msgid "Identity creation only supported for TLS identities"
+msgstr ""
+
+#: lxc/auth.go:1716
 #, fuzzy, c-format
 msgid "Identity provider group %s created"
 msgstr "Perfil %s creado"
 
-#: lxc/auth.go:1617
+#: lxc/auth.go:1766
 #, fuzzy, c-format
 msgid "Identity provider group %s deleted"
 msgstr "Perfil %s creado"
@@ -3170,7 +3183,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1292 lxc/auth.go:1293
+#: lxc/auth.go:1441 lxc/auth.go:1442
 msgid "Inspect permissions"
 msgstr ""
 
@@ -3221,7 +3234,7 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:395
+#: lxc/remote.go:409
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3303,7 +3316,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:384
+#: lxc/remote.go:398
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3487,16 +3500,16 @@ msgstr ""
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:332 lxc/auth.go:333
+#: lxc/auth.go:337 lxc/auth.go:338
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:768 lxc/auth.go:769
+#: lxc/auth.go:917 lxc/auth.go:918
 #, fuzzy
 msgid "List identities"
 msgstr "Aliases:"
 
-#: lxc/auth.go:1750 lxc/auth.go:1751
+#: lxc/auth.go:1899 lxc/auth.go:1900
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3651,7 +3664,7 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/auth.go:1314 lxc/auth.go:1315
+#: lxc/auth.go:1463 lxc/auth.go:1464
 #, fuzzy
 msgid "List permissions"
 msgstr "Aliases:"
@@ -3697,7 +3710,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:752 lxc/remote.go:753
+#: lxc/remote.go:786 lxc/remote.go:787
 msgid "List the available remotes"
 msgstr ""
 
@@ -3823,6 +3836,12 @@ msgstr ""
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
+#: lxc/auth.go:825
+msgid ""
+"Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
+"got "
+msgstr ""
+
 #: lxc/network.go:32 lxc/network.go:33
 msgid "Manage and attach instances to networks"
 msgstr ""
@@ -3852,20 +3871,20 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:59 lxc/auth.go:60 lxc/auth.go:1492 lxc/auth.go:1493
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
 #, fuzzy
 msgid "Manage groups"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/auth.go:1142 lxc/auth.go:1143
+#: lxc/auth.go:1291 lxc/auth.go:1292
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:731 lxc/auth.go:732
+#: lxc/auth.go:736 lxc/auth.go:737
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1910 lxc/auth.go:1911
+#: lxc/auth.go:2059 lxc/auth.go:2060
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3963,7 +3982,7 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Manage network zones"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/auth.go:493 lxc/auth.go:494
+#: lxc/auth.go:498 lxc/auth.go:499
 #, fuzzy
 msgid "Manage permissions"
 msgstr "Nombre del contenedor es: %s"
@@ -4019,7 +4038,7 @@ msgstr ""
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/auth.go:30 lxc/auth.go:31
+#: lxc/auth.go:35 lxc/auth.go:36
 #, fuzzy
 msgid "Manage user authorization"
 msgstr "Nombre del Miembro del Cluster"
@@ -4122,24 +4141,24 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "Missing cluster member name"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/auth.go:123 lxc/auth.go:177 lxc/auth.go:255 lxc/auth.go:417
-#: lxc/auth.go:466 lxc/auth.go:541 lxc/auth.go:600 lxc/auth.go:1884
+#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:260 lxc/auth.go:422
+#: lxc/auth.go:471 lxc/auth.go:546 lxc/auth.go:605 lxc/auth.go:2033
 #, fuzzy
 msgid "Missing group name"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/auth.go:866 lxc/auth.go:1007 lxc/auth.go:1124 lxc/auth.go:1190
-#: lxc/auth.go:1248
+#: lxc/auth.go:820 lxc/auth.go:1015 lxc/auth.go:1156 lxc/auth.go:1273
+#: lxc/auth.go:1339 lxc/auth.go:1397
 #, fuzzy
 msgid "Missing identity argument"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/auth.go:1554 lxc/auth.go:1607 lxc/auth.go:1673 lxc/auth.go:1835
+#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
 #, fuzzy
 msgid "Missing identity provider group name"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/auth.go:1958 lxc/auth.go:2011
+#: lxc/auth.go:2107 lxc/auth.go:2160
 #, fuzzy
 msgid "Missing identity provider group name argument"
 msgstr "Nombre del Miembro del Cluster"
@@ -4373,12 +4392,12 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:376 lxc/auth.go:819 lxc/auth.go:1794 lxc/cluster.go:192
+#: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
-#: lxc/remote.go:815 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
 msgstr ""
@@ -4405,7 +4424,7 @@ msgstr ""
 
 #: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:775 lxc/remote.go:780 lxc/remote.go:785
+#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr ""
 
@@ -4634,7 +4653,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:378
+#: lxc/remote.go:392
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4705,11 +4724,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:817
+#: lxc/remote.go:851
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:819
+#: lxc/image.go:1136 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4751,7 +4770,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/remote.go:536
+#: lxc/remote.go:550
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
@@ -4768,7 +4787,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:302 lxc/auth.go:1059 lxc/auth.go:1720 lxc/cluster.go:860
+#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -5077,33 +5096,33 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "Refreshing the image: %s"
 msgstr "Refrescando la imagen: %s"
 
-#: lxc/remote.go:877
+#: lxc/remote.go:911
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:868 lxc/remote.go:949 lxc/remote.go:1013
-#: lxc/remote.go:1061
+#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/remote.go:1095
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:345
+#: lxc/remote.go:359
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:957
+#: lxc/remote.go:991
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:872 lxc/remote.go:953 lxc/remote.go:1065
+#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1099
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:319
+#: lxc/remote.go:333
 msgid "Remote address must not be empty"
 msgstr ""
 
@@ -5112,7 +5131,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr "Contraseña admin para %s: "
 
-#: lxc/remote.go:339
+#: lxc/remote.go:353
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -5135,7 +5154,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/auth.go:1223 lxc/auth.go:1224
+#: lxc/auth.go:1372 lxc/auth.go:1373
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -5174,7 +5193,7 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1986 lxc/auth.go:1987
+#: lxc/auth.go:2135 lxc/auth.go:2136
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -5186,7 +5205,7 @@ msgstr ""
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:575 lxc/auth.go:576
+#: lxc/auth.go:580 lxc/auth.go:581
 msgid "Remove permissions from groups"
 msgstr ""
 
@@ -5203,7 +5222,7 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:919 lxc/remote.go:920
+#: lxc/remote.go:953 lxc/remote.go:954
 msgid "Remove remotes"
 msgstr ""
 
@@ -5233,11 +5252,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:392 lxc/auth.go:393
+#: lxc/auth.go:397 lxc/auth.go:398
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1810 lxc/auth.go:1811
+#: lxc/auth.go:1959 lxc/auth.go:1960
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5262,7 +5281,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:838 lxc/remote.go:839
+#: lxc/remote.go:872 lxc/remote.go:873
 msgid "Rename remotes"
 msgstr ""
 
@@ -5413,7 +5432,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:820
+#: lxc/remote.go:854
 msgid "STATIC"
 msgstr ""
 
@@ -5454,11 +5473,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:532
+#: lxc/remote.go:546
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:285 lxc/remote.go:683
+#: lxc/remote.go:299 lxc/remote.go:717
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5677,7 +5696,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1031 lxc/remote.go:1032
+#: lxc/remote.go:1065 lxc/remote.go:1066
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5779,7 +5798,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1859 lxc/auth.go:1860
+#: lxc/auth.go:2008 lxc/auth.go:2009
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5808,12 +5827,12 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:441 lxc/auth.go:442
+#: lxc/auth.go:446 lxc/auth.go:447
 #, fuzzy
 msgid "Show group configurations"
 msgstr "Perfil %s creado"
 
-#: lxc/auth.go:836
+#: lxc/auth.go:985
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5927,7 +5946,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:899
+#: lxc/auth.go:1048
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5937,7 +5956,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:714 lxc/remote.go:715
+#: lxc/remote.go:748 lxc/remote.go:749
 msgid "Show the default remote"
 msgstr ""
 
@@ -6151,7 +6170,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:983 lxc/remote.go:984
+#: lxc/remote.go:1017 lxc/remote.go:1018
 msgid "Switch the default remote"
 msgstr ""
 
@@ -6163,11 +6182,21 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
+#: lxc/auth.go:876
+#, c-format
+msgid "TLS identity %q (%s) pending identity token:"
+msgstr ""
+
+#: lxc/auth.go:902
+#, fuzzy, c-format
+msgid "TLS identity %q created with fingerprint %q"
+msgstr "Contenedor publicado con huella digital: %s"
+
 #: lxc/cluster.go:1070 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:818 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
 #: lxc/storage_volume.go:1736 lxc/warning.go:216
@@ -6186,7 +6215,7 @@ msgstr ""
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/remote.go:161 lxc/remote.go:334
+#: lxc/remote.go:161 lxc/remote.go:348
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
@@ -6344,7 +6373,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:527
+#: lxc/remote.go:541
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
@@ -6484,15 +6513,15 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:329
+#: lxc/remote.go:343
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:324
+#: lxc/remote.go:338
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr ""
 
-#: lxc/remote.go:639
+#: lxc/remote.go:653
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6537,7 +6566,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:193 lxc/remote.go:816
+#: lxc/cluster.go:193 lxc/remote.go:850
 msgid "URL"
 msgstr ""
 
@@ -6864,11 +6893,11 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr "Cacheado: %s"
 
-#: lxc/auth.go:835
+#: lxc/auth.go:984
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:898
+#: lxc/auth.go:1047
 msgid "View the current identity"
 msgstr ""
 
@@ -6907,7 +6936,7 @@ msgstr ""
 
 #: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:777 lxc/remote.go:782 lxc/remote.go:787
+#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr ""
 
@@ -6941,7 +6970,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/auth.go:330 lxc/auth.go:766 lxc/auth.go:897 lxc/auth.go:1748
+#: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
@@ -6981,7 +7010,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:] [<filters>...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/auth.go:1313
+#: lxc/auth.go:1462
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -7056,11 +7085,17 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<alias> <new-name>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/auth.go:834 lxc/auth.go:1086
+#: lxc/auth.go:774
+msgid ""
+"[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
+"certificate>] [[--group <group_name>]]"
+msgstr ""
+
+#: lxc/auth.go:983 lxc/auth.go:1235
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1164 lxc/auth.go:1222 lxc/auth.go:1985
+#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:2134
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -7069,14 +7104,14 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/auth.go:97 lxc/auth.go:150 lxc/auth.go:200 lxc/auth.go:440
-#: lxc/auth.go:958 lxc/auth.go:1529 lxc/cluster_group.go:168
+#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:445
+#: lxc/auth.go:1107 lxc/auth.go:1678 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 #, fuzzy
 msgid "[<remote>:]<group>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/auth.go:515 lxc/auth.go:573
+#: lxc/auth.go:520 lxc/auth.go:578
 #, fuzzy
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
@@ -7088,22 +7123,22 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<group> <new-name>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/auth.go:390
+#: lxc/auth.go:395
 #, fuzzy
 msgid "[<remote>:]<group> <new_name>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/auth.go:1580 lxc/auth.go:1630 lxc/auth.go:1858
+#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/auth.go:1932
+#: lxc/auth.go:2081
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/auth.go:1808
+#: lxc/auth.go:1957
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7708,7 +7743,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[[<remote>:]<member>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/project.go:557 lxc/remote.go:806
+#: lxc/project.go:557 lxc/remote.go:840
 msgid "current"
 msgstr ""
 
@@ -7755,20 +7790,20 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/auth.go:204
+#: lxc/auth.go:209
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:962
+#: lxc/auth.go:1111
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1634
+#: lxc/auth.go:1783
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -8192,7 +8227,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:531
+#: lxc/remote.go:545
 msgid "n"
 msgstr ""
 
@@ -8204,7 +8239,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:510
+#: lxc/remote.go:524
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -8241,7 +8276,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:519
+#: lxc/remote.go:533
 msgid "y"
 msgstr ""
 

--- a/po/fa.po
+++ b/po/fa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-14 13:30+0000\n"
+"POT-Creation-Date: 2024-10-15 14:52+0100\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Persian <https://hosted.weblate.org/projects/linux-containers/"
@@ -133,7 +133,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:214
+#: lxc/auth.go:219
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -160,7 +160,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:972
+#: lxc/auth.go:1121
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -181,7 +181,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1644
+#: lxc/auth.go:1793
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -515,15 +515,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:917 lxc/remote.go:982
+#: lxc/remote.go:951 lxc/remote.go:1016
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1030
+#: lxc/remote.go:1064
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:836
+#: lxc/remote.go:870
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -556,11 +556,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:818
+#: lxc/remote.go:852
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:817
+#: lxc/auth.go:966
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -598,11 +598,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1165 lxc/auth.go:1166
+#: lxc/auth.go:1314 lxc/auth.go:1315
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1933 lxc/auth.go:1934
+#: lxc/auth.go:2082 lxc/auth.go:2083
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -671,7 +671,7 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:516 lxc/auth.go:517
+#: lxc/auth.go:521 lxc/auth.go:522
 msgid "Add permissions to groups"
 msgstr ""
 
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:648
+#: lxc/remote.go:680
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -813,7 +813,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:621
+#: lxc/remote.go:635
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -991,7 +991,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:961
+#: lxc/remote.go:995
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1057,7 +1057,7 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:509
+#: lxc/remote.go:523
 msgid "Certificate fingerprint"
 msgstr ""
 
@@ -1076,7 +1076,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:687
+#: lxc/remote.go:721
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1324,12 +1324,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:559
+#: lxc/remote.go:573
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:237 lxc/remote.go:543
+#: lxc/remote.go:237 lxc/remote.go:557
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1343,12 +1343,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:1719
+#: lxc/auth.go:306 lxc/auth.go:1868
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1058
+#: lxc/auth.go:1207
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1368,13 +1368,17 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:554
+#: lxc/remote.go:568
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
 #: lxc/network_zone.go:1536
 msgid "Couldn't find a matching entry"
+msgstr ""
+
+#: lxc/auth.go:776
+msgid "Create a TLS identity"
 msgstr ""
 
 #: lxc/cluster_group.go:169 lxc/cluster_group.go:170
@@ -1393,6 +1397,10 @@ msgstr ""
 msgid "Create an empty instance"
 msgstr ""
 
+#: lxc/auth.go:775
+msgid "Create an identity"
+msgstr ""
+
 #: lxc/launch.go:23 lxc/launch.go:24
 msgid "Create and start instances from images"
 msgstr ""
@@ -1405,11 +1413,11 @@ msgstr ""
 msgid "Create files and directories in instances"
 msgstr ""
 
-#: lxc/auth.go:98 lxc/auth.go:99
+#: lxc/auth.go:103 lxc/auth.go:104
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1530 lxc/auth.go:1531
+#: lxc/auth.go:1679 lxc/auth.go:1680
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1517,7 +1525,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
@@ -1560,7 +1568,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/auth.go:1088 lxc/auth.go:1089
+#: lxc/auth.go:1237 lxc/auth.go:1238
 msgid "Delete an identity"
 msgstr ""
 
@@ -1568,11 +1576,11 @@ msgstr ""
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/auth.go:152 lxc/auth.go:153
+#: lxc/auth.go:157 lxc/auth.go:158
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1582 lxc/auth.go:1583
+#: lxc/auth.go:1731 lxc/auth.go:1732
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1650,18 +1658,18 @@ msgstr ""
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:31 lxc/auth.go:60 lxc/auth.go:99
-#: lxc/auth.go:153 lxc/auth.go:202 lxc/auth.go:333 lxc/auth.go:393
-#: lxc/auth.go:442 lxc/auth.go:494 lxc/auth.go:517 lxc/auth.go:576
-#: lxc/auth.go:732 lxc/auth.go:769 lxc/auth.go:836 lxc/auth.go:899
-#: lxc/auth.go:960 lxc/auth.go:1089 lxc/auth.go:1143 lxc/auth.go:1166
-#: lxc/auth.go:1224 lxc/auth.go:1293 lxc/auth.go:1315 lxc/auth.go:1493
-#: lxc/auth.go:1531 lxc/auth.go:1583 lxc/auth.go:1632 lxc/auth.go:1751
-#: lxc/auth.go:1811 lxc/auth.go:1860 lxc/auth.go:1911 lxc/auth.go:1934
-#: lxc/auth.go:1987 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215
-#: lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:484
-#: lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677 lxc/cluster.go:770
-#: lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
+#: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
+#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:338 lxc/auth.go:398
+#: lxc/auth.go:447 lxc/auth.go:499 lxc/auth.go:522 lxc/auth.go:581
+#: lxc/auth.go:737 lxc/auth.go:776 lxc/auth.go:918 lxc/auth.go:985
+#: lxc/auth.go:1048 lxc/auth.go:1109 lxc/auth.go:1238 lxc/auth.go:1292
+#: lxc/auth.go:1315 lxc/auth.go:1373 lxc/auth.go:1442 lxc/auth.go:1464
+#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
+#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
+#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
+#: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
+#: lxc/cluster.go:770 lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
 #: lxc/cluster.go:1175 lxc/cluster.go:1299 lxc/cluster.go:1329
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
@@ -1732,9 +1740,9 @@ msgstr ""
 #: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
 #: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
 #: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:715
-#: lxc/remote.go:753 lxc/remote.go:839 lxc/remote.go:920 lxc/remote.go:984
-#: lxc/remote.go:1032 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
+#: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
+#: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1919,7 +1927,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:959 lxc/auth.go:960
+#: lxc/auth.go:1108 lxc/auth.go:1109
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1931,11 +1939,11 @@ msgstr ""
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/auth.go:201 lxc/auth.go:202
+#: lxc/auth.go:206 lxc/auth.go:207
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1631 lxc/auth.go:1632
+#: lxc/auth.go:1780 lxc/auth.go:1781
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2311,12 +2319,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:486
+#: lxc/remote.go:500
 #, c-format
 msgid "Failed to decode trust token: %w"
 msgstr ""
 
-#: lxc/remote.go:292
+#: lxc/remote.go:306
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2420,7 +2428,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:773 lxc/auth.go:1755
+#: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
@@ -2428,7 +2436,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:757 lxc/storage.go:657
+#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2466,7 +2474,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:821
+#: lxc/remote.go:855
 msgid "GLOBAL"
 msgstr ""
 
@@ -2478,7 +2486,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:821 lxc/auth.go:1795
+#: lxc/auth.go:970 lxc/auth.go:1944
 msgid "GROUPS"
 msgstr ""
 
@@ -2486,7 +2494,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:165 lxc/remote.go:443
+#: lxc/remote.go:165 lxc/remote.go:457
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2627,17 +2635,17 @@ msgstr ""
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: lxc/auth.go:137
+#: lxc/auth.go:142
 #, c-format
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:187
+#: lxc/auth.go:192
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:427 lxc/auth.go:1845
+#: lxc/auth.go:432 lxc/auth.go:1994
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2696,7 +2704,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:820
+#: lxc/auth.go:969
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -2728,12 +2736,16 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1567
+#: lxc/auth.go:829
+msgid "Identity creation only supported for TLS identities"
+msgstr ""
+
+#: lxc/auth.go:1716
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1617
+#: lxc/auth.go:1766
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2862,7 +2874,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1292 lxc/auth.go:1293
+#: lxc/auth.go:1441 lxc/auth.go:1442
 msgid "Inspect permissions"
 msgstr ""
 
@@ -2910,7 +2922,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:395
+#: lxc/remote.go:409
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2991,7 +3003,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:384
+#: lxc/remote.go:398
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3166,15 +3178,15 @@ msgstr ""
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:332 lxc/auth.go:333
+#: lxc/auth.go:337 lxc/auth.go:338
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:768 lxc/auth.go:769
+#: lxc/auth.go:917 lxc/auth.go:918
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1750 lxc/auth.go:1751
+#: lxc/auth.go:1899 lxc/auth.go:1900
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3327,7 +3339,7 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1314 lxc/auth.go:1315
+#: lxc/auth.go:1463 lxc/auth.go:1464
 msgid "List permissions"
 msgstr ""
 
@@ -3371,7 +3383,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:752 lxc/remote.go:753
+#: lxc/remote.go:786 lxc/remote.go:787
 msgid "List the available remotes"
 msgstr ""
 
@@ -3495,6 +3507,12 @@ msgstr ""
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
+#: lxc/auth.go:825
+msgid ""
+"Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
+"got "
+msgstr ""
+
 #: lxc/network.go:32 lxc/network.go:33
 msgid "Manage and attach instances to networks"
 msgstr ""
@@ -3523,19 +3541,19 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:59 lxc/auth.go:60 lxc/auth.go:1492 lxc/auth.go:1493
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1142 lxc/auth.go:1143
+#: lxc/auth.go:1291 lxc/auth.go:1292
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:731 lxc/auth.go:732
+#: lxc/auth.go:736 lxc/auth.go:737
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1910 lxc/auth.go:1911
+#: lxc/auth.go:2059 lxc/auth.go:2060
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3626,7 +3644,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:493 lxc/auth.go:494
+#: lxc/auth.go:498 lxc/auth.go:499
 msgid "Manage permissions"
 msgstr ""
 
@@ -3678,7 +3696,7 @@ msgstr ""
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/auth.go:30 lxc/auth.go:31
+#: lxc/auth.go:35 lxc/auth.go:36
 msgid "Manage user authorization"
 msgstr ""
 
@@ -3775,21 +3793,21 @@ msgstr ""
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:123 lxc/auth.go:177 lxc/auth.go:255 lxc/auth.go:417
-#: lxc/auth.go:466 lxc/auth.go:541 lxc/auth.go:600 lxc/auth.go:1884
+#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:260 lxc/auth.go:422
+#: lxc/auth.go:471 lxc/auth.go:546 lxc/auth.go:605 lxc/auth.go:2033
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:866 lxc/auth.go:1007 lxc/auth.go:1124 lxc/auth.go:1190
-#: lxc/auth.go:1248
+#: lxc/auth.go:820 lxc/auth.go:1015 lxc/auth.go:1156 lxc/auth.go:1273
+#: lxc/auth.go:1339 lxc/auth.go:1397
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1554 lxc/auth.go:1607 lxc/auth.go:1673 lxc/auth.go:1835
+#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1958 lxc/auth.go:2011
+#: lxc/auth.go:2107 lxc/auth.go:2160
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -4010,12 +4028,12 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:376 lxc/auth.go:819 lxc/auth.go:1794 lxc/cluster.go:192
+#: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
-#: lxc/remote.go:815 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
 msgstr ""
@@ -4042,7 +4060,7 @@ msgstr ""
 
 #: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:775 lxc/remote.go:780 lxc/remote.go:785
+#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr ""
 
@@ -4271,7 +4289,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:378
+#: lxc/remote.go:392
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4342,11 +4360,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:817
+#: lxc/remote.go:851
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:819
+#: lxc/image.go:1136 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4387,7 +4405,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:536
+#: lxc/remote.go:550
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
@@ -4404,7 +4422,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:302 lxc/auth.go:1059 lxc/auth.go:1720 lxc/cluster.go:860
+#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -4707,33 +4725,33 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:877
+#: lxc/remote.go:911
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:868 lxc/remote.go:949 lxc/remote.go:1013
-#: lxc/remote.go:1061
+#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/remote.go:1095
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:345
+#: lxc/remote.go:359
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:957
+#: lxc/remote.go:991
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:872 lxc/remote.go:953 lxc/remote.go:1065
+#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1099
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:319
+#: lxc/remote.go:333
 msgid "Remote address must not be empty"
 msgstr ""
 
@@ -4741,7 +4759,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:339
+#: lxc/remote.go:353
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4763,7 +4781,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1223 lxc/auth.go:1224
+#: lxc/auth.go:1372 lxc/auth.go:1373
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4799,7 +4817,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1986 lxc/auth.go:1987
+#: lxc/auth.go:2135 lxc/auth.go:2136
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4811,7 +4829,7 @@ msgstr ""
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:575 lxc/auth.go:576
+#: lxc/auth.go:580 lxc/auth.go:581
 msgid "Remove permissions from groups"
 msgstr ""
 
@@ -4827,7 +4845,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:919 lxc/remote.go:920
+#: lxc/remote.go:953 lxc/remote.go:954
 msgid "Remove remotes"
 msgstr ""
 
@@ -4856,11 +4874,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:392 lxc/auth.go:393
+#: lxc/auth.go:397 lxc/auth.go:398
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1810 lxc/auth.go:1811
+#: lxc/auth.go:1959 lxc/auth.go:1960
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -4884,7 +4902,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:838 lxc/remote.go:839
+#: lxc/remote.go:872 lxc/remote.go:873
 msgid "Rename remotes"
 msgstr ""
 
@@ -5029,7 +5047,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:820
+#: lxc/remote.go:854
 msgid "STATIC"
 msgstr ""
 
@@ -5070,11 +5088,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:532
+#: lxc/remote.go:546
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:285 lxc/remote.go:683
+#: lxc/remote.go:299 lxc/remote.go:717
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5285,7 +5303,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1031 lxc/remote.go:1032
+#: lxc/remote.go:1065 lxc/remote.go:1066
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5381,7 +5399,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1859 lxc/auth.go:1860
+#: lxc/auth.go:2008 lxc/auth.go:2009
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5409,11 +5427,11 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:441 lxc/auth.go:442
+#: lxc/auth.go:446 lxc/auth.go:447
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:836
+#: lxc/auth.go:985
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5518,7 +5536,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:899
+#: lxc/auth.go:1048
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5528,7 +5546,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:714 lxc/remote.go:715
+#: lxc/remote.go:748 lxc/remote.go:749
 msgid "Show the default remote"
 msgstr ""
 
@@ -5740,7 +5758,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:983 lxc/remote.go:984
+#: lxc/remote.go:1017 lxc/remote.go:1018
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5752,11 +5770,21 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
+#: lxc/auth.go:876
+#, c-format
+msgid "TLS identity %q (%s) pending identity token:"
+msgstr ""
+
+#: lxc/auth.go:902
+#, c-format
+msgid "TLS identity %q created with fingerprint %q"
+msgstr ""
+
 #: lxc/cluster.go:1070 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:818 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
 #: lxc/storage_volume.go:1736 lxc/warning.go:216
@@ -5775,7 +5803,7 @@ msgstr ""
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/remote.go:161 lxc/remote.go:334
+#: lxc/remote.go:161 lxc/remote.go:348
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
@@ -5931,7 +5959,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:527
+#: lxc/remote.go:541
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
@@ -6069,15 +6097,15 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:329
+#: lxc/remote.go:343
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:324
+#: lxc/remote.go:338
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr ""
 
-#: lxc/remote.go:639
+#: lxc/remote.go:653
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6120,7 +6148,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:193 lxc/remote.go:816
+#: lxc/cluster.go:193 lxc/remote.go:850
 msgid "URL"
 msgstr ""
 
@@ -6428,11 +6456,11 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:835
+#: lxc/auth.go:984
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:898
+#: lxc/auth.go:1047
 msgid "View the current identity"
 msgstr ""
 
@@ -6471,7 +6499,7 @@ msgstr ""
 
 #: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:777 lxc/remote.go:782 lxc/remote.go:787
+#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr ""
 
@@ -6503,7 +6531,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:330 lxc/auth.go:766 lxc/auth.go:897 lxc/auth.go:1748
+#: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
@@ -6536,7 +6564,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1313
+#: lxc/auth.go:1462
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6597,11 +6625,17 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:834 lxc/auth.go:1086
+#: lxc/auth.go:774
+msgid ""
+"[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
+"certificate>] [[--group <group_name>]]"
+msgstr ""
+
+#: lxc/auth.go:983 lxc/auth.go:1235
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1164 lxc/auth.go:1222 lxc/auth.go:1985
+#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:2134
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6609,13 +6643,13 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:97 lxc/auth.go:150 lxc/auth.go:200 lxc/auth.go:440
-#: lxc/auth.go:958 lxc/auth.go:1529 lxc/cluster_group.go:168
+#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:445
+#: lxc/auth.go:1107 lxc/auth.go:1678 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:515 lxc/auth.go:573
+#: lxc/auth.go:520 lxc/auth.go:578
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
@@ -6625,19 +6659,19 @@ msgstr ""
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:390
+#: lxc/auth.go:395
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1580 lxc/auth.go:1630 lxc/auth.go:1858
+#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1932
+#: lxc/auth.go:2081
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1808
+#: lxc/auth.go:1957
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -7128,7 +7162,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:806
+#: lxc/project.go:557 lxc/remote.go:840
 msgid "current"
 msgstr ""
 
@@ -7175,20 +7209,20 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/auth.go:204
+#: lxc/auth.go:209
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:962
+#: lxc/auth.go:1111
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1634
+#: lxc/auth.go:1783
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7612,7 +7646,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:531
+#: lxc/remote.go:545
 msgid "n"
 msgstr ""
 
@@ -7624,7 +7658,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:510
+#: lxc/remote.go:524
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7661,7 +7695,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:519
+#: lxc/remote.go:533
 msgid "y"
 msgstr ""
 

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-14 13:30+0000\n"
+"POT-Creation-Date: 2024-10-15 14:52+0100\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/linux-containers/"
@@ -133,7 +133,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:214
+#: lxc/auth.go:219
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -160,7 +160,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:972
+#: lxc/auth.go:1121
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -181,7 +181,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1644
+#: lxc/auth.go:1793
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -515,15 +515,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:917 lxc/remote.go:982
+#: lxc/remote.go:951 lxc/remote.go:1016
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1030
+#: lxc/remote.go:1064
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:836
+#: lxc/remote.go:870
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -556,11 +556,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:818
+#: lxc/remote.go:852
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:817
+#: lxc/auth.go:966
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -598,11 +598,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1165 lxc/auth.go:1166
+#: lxc/auth.go:1314 lxc/auth.go:1315
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1933 lxc/auth.go:1934
+#: lxc/auth.go:2082 lxc/auth.go:2083
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -671,7 +671,7 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:516 lxc/auth.go:517
+#: lxc/auth.go:521 lxc/auth.go:522
 msgid "Add permissions to groups"
 msgstr ""
 
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:648
+#: lxc/remote.go:680
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -813,7 +813,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:621
+#: lxc/remote.go:635
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -991,7 +991,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:961
+#: lxc/remote.go:995
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1057,7 +1057,7 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:509
+#: lxc/remote.go:523
 msgid "Certificate fingerprint"
 msgstr ""
 
@@ -1076,7 +1076,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:687
+#: lxc/remote.go:721
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1324,12 +1324,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:559
+#: lxc/remote.go:573
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:237 lxc/remote.go:543
+#: lxc/remote.go:237 lxc/remote.go:557
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1343,12 +1343,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:1719
+#: lxc/auth.go:306 lxc/auth.go:1868
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1058
+#: lxc/auth.go:1207
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1368,13 +1368,17 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:554
+#: lxc/remote.go:568
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
 #: lxc/network_zone.go:1536
 msgid "Couldn't find a matching entry"
+msgstr ""
+
+#: lxc/auth.go:776
+msgid "Create a TLS identity"
 msgstr ""
 
 #: lxc/cluster_group.go:169 lxc/cluster_group.go:170
@@ -1393,6 +1397,10 @@ msgstr ""
 msgid "Create an empty instance"
 msgstr ""
 
+#: lxc/auth.go:775
+msgid "Create an identity"
+msgstr ""
+
 #: lxc/launch.go:23 lxc/launch.go:24
 msgid "Create and start instances from images"
 msgstr ""
@@ -1405,11 +1413,11 @@ msgstr ""
 msgid "Create files and directories in instances"
 msgstr ""
 
-#: lxc/auth.go:98 lxc/auth.go:99
+#: lxc/auth.go:103 lxc/auth.go:104
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1530 lxc/auth.go:1531
+#: lxc/auth.go:1679 lxc/auth.go:1680
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1517,7 +1525,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
@@ -1560,7 +1568,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/auth.go:1088 lxc/auth.go:1089
+#: lxc/auth.go:1237 lxc/auth.go:1238
 msgid "Delete an identity"
 msgstr ""
 
@@ -1568,11 +1576,11 @@ msgstr ""
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/auth.go:152 lxc/auth.go:153
+#: lxc/auth.go:157 lxc/auth.go:158
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1582 lxc/auth.go:1583
+#: lxc/auth.go:1731 lxc/auth.go:1732
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1650,18 +1658,18 @@ msgstr ""
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:31 lxc/auth.go:60 lxc/auth.go:99
-#: lxc/auth.go:153 lxc/auth.go:202 lxc/auth.go:333 lxc/auth.go:393
-#: lxc/auth.go:442 lxc/auth.go:494 lxc/auth.go:517 lxc/auth.go:576
-#: lxc/auth.go:732 lxc/auth.go:769 lxc/auth.go:836 lxc/auth.go:899
-#: lxc/auth.go:960 lxc/auth.go:1089 lxc/auth.go:1143 lxc/auth.go:1166
-#: lxc/auth.go:1224 lxc/auth.go:1293 lxc/auth.go:1315 lxc/auth.go:1493
-#: lxc/auth.go:1531 lxc/auth.go:1583 lxc/auth.go:1632 lxc/auth.go:1751
-#: lxc/auth.go:1811 lxc/auth.go:1860 lxc/auth.go:1911 lxc/auth.go:1934
-#: lxc/auth.go:1987 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215
-#: lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:484
-#: lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677 lxc/cluster.go:770
-#: lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
+#: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
+#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:338 lxc/auth.go:398
+#: lxc/auth.go:447 lxc/auth.go:499 lxc/auth.go:522 lxc/auth.go:581
+#: lxc/auth.go:737 lxc/auth.go:776 lxc/auth.go:918 lxc/auth.go:985
+#: lxc/auth.go:1048 lxc/auth.go:1109 lxc/auth.go:1238 lxc/auth.go:1292
+#: lxc/auth.go:1315 lxc/auth.go:1373 lxc/auth.go:1442 lxc/auth.go:1464
+#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
+#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
+#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
+#: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
+#: lxc/cluster.go:770 lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
 #: lxc/cluster.go:1175 lxc/cluster.go:1299 lxc/cluster.go:1329
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
@@ -1732,9 +1740,9 @@ msgstr ""
 #: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
 #: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
 #: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:715
-#: lxc/remote.go:753 lxc/remote.go:839 lxc/remote.go:920 lxc/remote.go:984
-#: lxc/remote.go:1032 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
+#: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
+#: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1919,7 +1927,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:959 lxc/auth.go:960
+#: lxc/auth.go:1108 lxc/auth.go:1109
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1931,11 +1939,11 @@ msgstr ""
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/auth.go:201 lxc/auth.go:202
+#: lxc/auth.go:206 lxc/auth.go:207
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1631 lxc/auth.go:1632
+#: lxc/auth.go:1780 lxc/auth.go:1781
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2311,12 +2319,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:486
+#: lxc/remote.go:500
 #, c-format
 msgid "Failed to decode trust token: %w"
 msgstr ""
 
-#: lxc/remote.go:292
+#: lxc/remote.go:306
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2420,7 +2428,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:773 lxc/auth.go:1755
+#: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
@@ -2428,7 +2436,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:757 lxc/storage.go:657
+#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2466,7 +2474,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:821
+#: lxc/remote.go:855
 msgid "GLOBAL"
 msgstr ""
 
@@ -2478,7 +2486,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:821 lxc/auth.go:1795
+#: lxc/auth.go:970 lxc/auth.go:1944
 msgid "GROUPS"
 msgstr ""
 
@@ -2486,7 +2494,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:165 lxc/remote.go:443
+#: lxc/remote.go:165 lxc/remote.go:457
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2627,17 +2635,17 @@ msgstr ""
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: lxc/auth.go:137
+#: lxc/auth.go:142
 #, c-format
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:187
+#: lxc/auth.go:192
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:427 lxc/auth.go:1845
+#: lxc/auth.go:432 lxc/auth.go:1994
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2696,7 +2704,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:820
+#: lxc/auth.go:969
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -2728,12 +2736,16 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1567
+#: lxc/auth.go:829
+msgid "Identity creation only supported for TLS identities"
+msgstr ""
+
+#: lxc/auth.go:1716
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1617
+#: lxc/auth.go:1766
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2862,7 +2874,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1292 lxc/auth.go:1293
+#: lxc/auth.go:1441 lxc/auth.go:1442
 msgid "Inspect permissions"
 msgstr ""
 
@@ -2910,7 +2922,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:395
+#: lxc/remote.go:409
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2991,7 +3003,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:384
+#: lxc/remote.go:398
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3166,15 +3178,15 @@ msgstr ""
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:332 lxc/auth.go:333
+#: lxc/auth.go:337 lxc/auth.go:338
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:768 lxc/auth.go:769
+#: lxc/auth.go:917 lxc/auth.go:918
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1750 lxc/auth.go:1751
+#: lxc/auth.go:1899 lxc/auth.go:1900
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3327,7 +3339,7 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1314 lxc/auth.go:1315
+#: lxc/auth.go:1463 lxc/auth.go:1464
 msgid "List permissions"
 msgstr ""
 
@@ -3371,7 +3383,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:752 lxc/remote.go:753
+#: lxc/remote.go:786 lxc/remote.go:787
 msgid "List the available remotes"
 msgstr ""
 
@@ -3495,6 +3507,12 @@ msgstr ""
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
+#: lxc/auth.go:825
+msgid ""
+"Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
+"got "
+msgstr ""
+
 #: lxc/network.go:32 lxc/network.go:33
 msgid "Manage and attach instances to networks"
 msgstr ""
@@ -3523,19 +3541,19 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:59 lxc/auth.go:60 lxc/auth.go:1492 lxc/auth.go:1493
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1142 lxc/auth.go:1143
+#: lxc/auth.go:1291 lxc/auth.go:1292
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:731 lxc/auth.go:732
+#: lxc/auth.go:736 lxc/auth.go:737
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1910 lxc/auth.go:1911
+#: lxc/auth.go:2059 lxc/auth.go:2060
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3626,7 +3644,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:493 lxc/auth.go:494
+#: lxc/auth.go:498 lxc/auth.go:499
 msgid "Manage permissions"
 msgstr ""
 
@@ -3678,7 +3696,7 @@ msgstr ""
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/auth.go:30 lxc/auth.go:31
+#: lxc/auth.go:35 lxc/auth.go:36
 msgid "Manage user authorization"
 msgstr ""
 
@@ -3775,21 +3793,21 @@ msgstr ""
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:123 lxc/auth.go:177 lxc/auth.go:255 lxc/auth.go:417
-#: lxc/auth.go:466 lxc/auth.go:541 lxc/auth.go:600 lxc/auth.go:1884
+#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:260 lxc/auth.go:422
+#: lxc/auth.go:471 lxc/auth.go:546 lxc/auth.go:605 lxc/auth.go:2033
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:866 lxc/auth.go:1007 lxc/auth.go:1124 lxc/auth.go:1190
-#: lxc/auth.go:1248
+#: lxc/auth.go:820 lxc/auth.go:1015 lxc/auth.go:1156 lxc/auth.go:1273
+#: lxc/auth.go:1339 lxc/auth.go:1397
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1554 lxc/auth.go:1607 lxc/auth.go:1673 lxc/auth.go:1835
+#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1958 lxc/auth.go:2011
+#: lxc/auth.go:2107 lxc/auth.go:2160
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -4010,12 +4028,12 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:376 lxc/auth.go:819 lxc/auth.go:1794 lxc/cluster.go:192
+#: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
-#: lxc/remote.go:815 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
 msgstr ""
@@ -4042,7 +4060,7 @@ msgstr ""
 
 #: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:775 lxc/remote.go:780 lxc/remote.go:785
+#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr ""
 
@@ -4271,7 +4289,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:378
+#: lxc/remote.go:392
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4342,11 +4360,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:817
+#: lxc/remote.go:851
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:819
+#: lxc/image.go:1136 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4387,7 +4405,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:536
+#: lxc/remote.go:550
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
@@ -4404,7 +4422,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:302 lxc/auth.go:1059 lxc/auth.go:1720 lxc/cluster.go:860
+#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -4707,33 +4725,33 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:877
+#: lxc/remote.go:911
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:868 lxc/remote.go:949 lxc/remote.go:1013
-#: lxc/remote.go:1061
+#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/remote.go:1095
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:345
+#: lxc/remote.go:359
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:957
+#: lxc/remote.go:991
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:872 lxc/remote.go:953 lxc/remote.go:1065
+#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1099
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:319
+#: lxc/remote.go:333
 msgid "Remote address must not be empty"
 msgstr ""
 
@@ -4741,7 +4759,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:339
+#: lxc/remote.go:353
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4763,7 +4781,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1223 lxc/auth.go:1224
+#: lxc/auth.go:1372 lxc/auth.go:1373
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4799,7 +4817,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1986 lxc/auth.go:1987
+#: lxc/auth.go:2135 lxc/auth.go:2136
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4811,7 +4829,7 @@ msgstr ""
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:575 lxc/auth.go:576
+#: lxc/auth.go:580 lxc/auth.go:581
 msgid "Remove permissions from groups"
 msgstr ""
 
@@ -4827,7 +4845,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:919 lxc/remote.go:920
+#: lxc/remote.go:953 lxc/remote.go:954
 msgid "Remove remotes"
 msgstr ""
 
@@ -4856,11 +4874,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:392 lxc/auth.go:393
+#: lxc/auth.go:397 lxc/auth.go:398
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1810 lxc/auth.go:1811
+#: lxc/auth.go:1959 lxc/auth.go:1960
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -4884,7 +4902,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:838 lxc/remote.go:839
+#: lxc/remote.go:872 lxc/remote.go:873
 msgid "Rename remotes"
 msgstr ""
 
@@ -5029,7 +5047,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:820
+#: lxc/remote.go:854
 msgid "STATIC"
 msgstr ""
 
@@ -5070,11 +5088,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:532
+#: lxc/remote.go:546
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:285 lxc/remote.go:683
+#: lxc/remote.go:299 lxc/remote.go:717
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5285,7 +5303,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1031 lxc/remote.go:1032
+#: lxc/remote.go:1065 lxc/remote.go:1066
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5381,7 +5399,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1859 lxc/auth.go:1860
+#: lxc/auth.go:2008 lxc/auth.go:2009
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5409,11 +5427,11 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:441 lxc/auth.go:442
+#: lxc/auth.go:446 lxc/auth.go:447
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:836
+#: lxc/auth.go:985
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5518,7 +5536,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:899
+#: lxc/auth.go:1048
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5528,7 +5546,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:714 lxc/remote.go:715
+#: lxc/remote.go:748 lxc/remote.go:749
 msgid "Show the default remote"
 msgstr ""
 
@@ -5740,7 +5758,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:983 lxc/remote.go:984
+#: lxc/remote.go:1017 lxc/remote.go:1018
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5752,11 +5770,21 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
+#: lxc/auth.go:876
+#, c-format
+msgid "TLS identity %q (%s) pending identity token:"
+msgstr ""
+
+#: lxc/auth.go:902
+#, c-format
+msgid "TLS identity %q created with fingerprint %q"
+msgstr ""
+
 #: lxc/cluster.go:1070 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:818 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
 #: lxc/storage_volume.go:1736 lxc/warning.go:216
@@ -5775,7 +5803,7 @@ msgstr ""
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/remote.go:161 lxc/remote.go:334
+#: lxc/remote.go:161 lxc/remote.go:348
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
@@ -5931,7 +5959,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:527
+#: lxc/remote.go:541
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
@@ -6069,15 +6097,15 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:329
+#: lxc/remote.go:343
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:324
+#: lxc/remote.go:338
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr ""
 
-#: lxc/remote.go:639
+#: lxc/remote.go:653
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6120,7 +6148,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:193 lxc/remote.go:816
+#: lxc/cluster.go:193 lxc/remote.go:850
 msgid "URL"
 msgstr ""
 
@@ -6428,11 +6456,11 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:835
+#: lxc/auth.go:984
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:898
+#: lxc/auth.go:1047
 msgid "View the current identity"
 msgstr ""
 
@@ -6471,7 +6499,7 @@ msgstr ""
 
 #: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:777 lxc/remote.go:782 lxc/remote.go:787
+#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr ""
 
@@ -6503,7 +6531,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:330 lxc/auth.go:766 lxc/auth.go:897 lxc/auth.go:1748
+#: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
@@ -6536,7 +6564,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1313
+#: lxc/auth.go:1462
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6597,11 +6625,17 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:834 lxc/auth.go:1086
+#: lxc/auth.go:774
+msgid ""
+"[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
+"certificate>] [[--group <group_name>]]"
+msgstr ""
+
+#: lxc/auth.go:983 lxc/auth.go:1235
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1164 lxc/auth.go:1222 lxc/auth.go:1985
+#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:2134
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6609,13 +6643,13 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:97 lxc/auth.go:150 lxc/auth.go:200 lxc/auth.go:440
-#: lxc/auth.go:958 lxc/auth.go:1529 lxc/cluster_group.go:168
+#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:445
+#: lxc/auth.go:1107 lxc/auth.go:1678 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:515 lxc/auth.go:573
+#: lxc/auth.go:520 lxc/auth.go:578
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
@@ -6625,19 +6659,19 @@ msgstr ""
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:390
+#: lxc/auth.go:395
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1580 lxc/auth.go:1630 lxc/auth.go:1858
+#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1932
+#: lxc/auth.go:2081
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1808
+#: lxc/auth.go:1957
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -7128,7 +7162,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:806
+#: lxc/project.go:557 lxc/remote.go:840
 msgid "current"
 msgstr ""
 
@@ -7175,20 +7209,20 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/auth.go:204
+#: lxc/auth.go:209
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:962
+#: lxc/auth.go:1111
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1634
+#: lxc/auth.go:1783
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7612,7 +7646,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:531
+#: lxc/remote.go:545
 msgid "n"
 msgstr ""
 
@@ -7624,7 +7658,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:510
+#: lxc/remote.go:524
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7661,7 +7695,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:519
+#: lxc/remote.go:533
 msgid "y"
 msgstr ""
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-14 13:30+0000\n"
+"POT-Creation-Date: 2024-10-15 14:52+0100\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Wivik <seb+weblate@zedas.fr>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/linux-containers/"
@@ -200,7 +200,7 @@ msgstr ""
 "###\n"
 "### Notez que le nom est affiché mais ne peut être modifié"
 
-#: lxc/auth.go:214
+#: lxc/auth.go:219
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -227,7 +227,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:972
+#: lxc/auth.go:1121
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -248,7 +248,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1644
+#: lxc/auth.go:1793
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
@@ -764,17 +764,17 @@ msgstr "Cible invalide %s"
 msgid "<old alias> <new alias>"
 msgstr "<ancien alias> <nouvel alias>"
 
-#: lxc/remote.go:917 lxc/remote.go:982
+#: lxc/remote.go:951 lxc/remote.go:1016
 #, fuzzy
 msgid "<remote>"
 msgstr "Serveur distant : %s"
 
-#: lxc/remote.go:1030
+#: lxc/remote.go:1064
 #, fuzzy
 msgid "<remote> <URL>"
 msgstr "Serveur distant : %s"
 
-#: lxc/remote.go:836
+#: lxc/remote.go:870
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -817,12 +817,12 @@ msgstr "ALIAS"
 msgid "ARCHITECTURE"
 msgstr "ARCHITECTURE"
 
-#: lxc/remote.go:818
+#: lxc/remote.go:852
 #, fuzzy
 msgid "AUTH TYPE"
 msgstr "TYPE"
 
-#: lxc/auth.go:817
+#: lxc/auth.go:966
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -862,11 +862,11 @@ msgstr "Action (GET par défaut)"
 msgid "Add a cluster member to a cluster group"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/auth.go:1165 lxc/auth.go:1166
+#: lxc/auth.go:1314 lxc/auth.go:1315
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1933 lxc/auth.go:1934
+#: lxc/auth.go:2082 lxc/auth.go:2083
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -947,7 +947,7 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:516 lxc/auth.go:517
+#: lxc/auth.go:521 lxc/auth.go:522
 msgid "Add permissions to groups"
 msgstr ""
 
@@ -984,7 +984,7 @@ msgstr "Expire : %s"
 msgid "Admin access key: %s"
 msgstr "Expire : %s"
 
-#: lxc/remote.go:648
+#: lxc/remote.go:680
 #, fuzzy, c-format
 msgid "Admin password (or token) for %s:"
 msgstr "Mot de passe administrateur pour %s : "
@@ -1099,7 +1099,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:621
+#: lxc/remote.go:635
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr "Le type d'authentification '%s' n'est pas supporté par le serveur"
@@ -1282,7 +1282,7 @@ msgstr "impossible de récupérer un répertoire sans --recursive"
 msgid "Can't read from stdin: %w"
 msgstr "Impossible de lire depuis stdin : %s"
 
-#: lxc/remote.go:961
+#: lxc/remote.go:995
 #, fuzzy
 msgid "Can't remove the default remote"
 msgstr "impossible de supprimer le serveur distant par défaut"
@@ -1351,7 +1351,7 @@ msgstr "Créé : %s"
 msgid "Certificate add token for %s deleted"
 msgstr "Le réseau %s a été supprimé"
 
-#: lxc/remote.go:509
+#: lxc/remote.go:523
 #, fuzzy
 msgid "Certificate fingerprint"
 msgstr "Empreinte du certificat : %s"
@@ -1371,7 +1371,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/remote.go:687
+#: lxc/remote.go:721
 #, fuzzy
 msgid "Client certificate now trusted by server:"
 msgstr "Certificat client enregistré sur le serveur : "
@@ -1637,12 +1637,12 @@ msgstr "erreur : %v"
 msgid "Cores:"
 msgstr "erreur : %v"
 
-#: lxc/remote.go:559
+#: lxc/remote.go:573
 #, fuzzy, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "Impossible de créer le dossier de stockage des certificats serveurs"
 
-#: lxc/remote.go:237 lxc/remote.go:543
+#: lxc/remote.go:237 lxc/remote.go:557
 msgid "Could not create server cert dir"
 msgstr "Impossible de créer le dossier de stockage des certificats serveurs"
 
@@ -1656,12 +1656,12 @@ msgstr "Impossible d'assainir le chemin %s"
 msgid "Could not find certificate key file path: %s"
 msgstr "Impossible d'assainir le chemin %s"
 
-#: lxc/auth.go:301 lxc/auth.go:1719
+#: lxc/auth.go:306 lxc/auth.go:1868
 #, fuzzy, c-format
 msgid "Could not parse group: %s"
 msgstr "Erreur lors de la lecture de la configuration : %s"
 
-#: lxc/auth.go:1058
+#: lxc/auth.go:1207
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1681,7 +1681,7 @@ msgstr "Impossible d'assainir le chemin %s"
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:554
+#: lxc/remote.go:568
 #, fuzzy, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "Impossible de créer le dossier de stockage des certificats serveurs"
@@ -1689,6 +1689,11 @@ msgstr "Impossible de créer le dossier de stockage des certificats serveurs"
 #: lxc/network_zone.go:1536
 msgid "Couldn't find a matching entry"
 msgstr ""
+
+#: lxc/auth.go:776
+#, fuzzy
+msgid "Create a TLS identity"
+msgstr "Récupération de l'image : %s"
 
 #: lxc/cluster_group.go:169 lxc/cluster_group.go:170
 msgid "Create a cluster group"
@@ -1708,6 +1713,11 @@ msgstr ""
 msgid "Create an empty instance"
 msgstr "Création du conteneur"
 
+#: lxc/auth.go:775
+#, fuzzy
+msgid "Create an identity"
+msgstr "Récupération de l'image : %s"
+
 #: lxc/launch.go:23 lxc/launch.go:24
 #, fuzzy
 msgid "Create and start instances from images"
@@ -1722,12 +1732,12 @@ msgstr "Créer tous répertoires nécessaires"
 msgid "Create files and directories in instances"
 msgstr "Créer tous répertoires nécessaires"
 
-#: lxc/auth.go:98 lxc/auth.go:99
+#: lxc/auth.go:103 lxc/auth.go:104
 #, fuzzy
 msgid "Create groups"
 msgstr "Créé : %s"
 
-#: lxc/auth.go:1530 lxc/auth.go:1531
+#: lxc/auth.go:1679 lxc/auth.go:1680
 #, fuzzy
 msgid "Create identity provider groups"
 msgstr "Copie de l'image : %s"
@@ -1868,7 +1878,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
@@ -1913,7 +1923,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr "Récupération de l'image : %s"
 
-#: lxc/auth.go:1088 lxc/auth.go:1089
+#: lxc/auth.go:1237 lxc/auth.go:1238
 #, fuzzy
 msgid "Delete an identity"
 msgstr "Récupération de l'image : %s"
@@ -1923,12 +1933,12 @@ msgstr "Récupération de l'image : %s"
 msgid "Delete files in instances"
 msgstr "Création du conteneur"
 
-#: lxc/auth.go:152 lxc/auth.go:153
+#: lxc/auth.go:157 lxc/auth.go:158
 #, fuzzy
 msgid "Delete groups"
 msgstr "Récupération de l'image : %s"
 
-#: lxc/auth.go:1582 lxc/auth.go:1583
+#: lxc/auth.go:1731 lxc/auth.go:1732
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -2018,18 +2028,18 @@ msgstr "Récupération de l'image : %s"
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:31 lxc/auth.go:60 lxc/auth.go:99
-#: lxc/auth.go:153 lxc/auth.go:202 lxc/auth.go:333 lxc/auth.go:393
-#: lxc/auth.go:442 lxc/auth.go:494 lxc/auth.go:517 lxc/auth.go:576
-#: lxc/auth.go:732 lxc/auth.go:769 lxc/auth.go:836 lxc/auth.go:899
-#: lxc/auth.go:960 lxc/auth.go:1089 lxc/auth.go:1143 lxc/auth.go:1166
-#: lxc/auth.go:1224 lxc/auth.go:1293 lxc/auth.go:1315 lxc/auth.go:1493
-#: lxc/auth.go:1531 lxc/auth.go:1583 lxc/auth.go:1632 lxc/auth.go:1751
-#: lxc/auth.go:1811 lxc/auth.go:1860 lxc/auth.go:1911 lxc/auth.go:1934
-#: lxc/auth.go:1987 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215
-#: lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:484
-#: lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677 lxc/cluster.go:770
-#: lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
+#: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
+#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:338 lxc/auth.go:398
+#: lxc/auth.go:447 lxc/auth.go:499 lxc/auth.go:522 lxc/auth.go:581
+#: lxc/auth.go:737 lxc/auth.go:776 lxc/auth.go:918 lxc/auth.go:985
+#: lxc/auth.go:1048 lxc/auth.go:1109 lxc/auth.go:1238 lxc/auth.go:1292
+#: lxc/auth.go:1315 lxc/auth.go:1373 lxc/auth.go:1442 lxc/auth.go:1464
+#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
+#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
+#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
+#: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
+#: lxc/cluster.go:770 lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
 #: lxc/cluster.go:1175 lxc/cluster.go:1299 lxc/cluster.go:1329
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
@@ -2100,9 +2110,9 @@ msgstr "Récupération de l'image : %s"
 #: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
 #: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
 #: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:715
-#: lxc/remote.go:753 lxc/remote.go:839 lxc/remote.go:920 lxc/remote.go:984
-#: lxc/remote.go:1032 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
+#: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
+#: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -2297,7 +2307,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:959 lxc/auth.go:960
+#: lxc/auth.go:1108 lxc/auth.go:1109
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -2311,12 +2321,12 @@ msgstr "Clé de configuration invalide"
 msgid "Edit files in instances"
 msgstr "Création du conteneur"
 
-#: lxc/auth.go:201 lxc/auth.go:202
+#: lxc/auth.go:206 lxc/auth.go:207
 #, fuzzy
 msgid "Edit groups as YAML"
 msgstr "Clé de configuration invalide"
 
-#: lxc/auth.go:1631 lxc/auth.go:1632
+#: lxc/auth.go:1780 lxc/auth.go:1781
 #, fuzzy
 msgid "Edit identity provider groups as YAML"
 msgstr "Clé de configuration invalide"
@@ -2732,12 +2742,12 @@ msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 msgid "Failed to create alias %s: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
-#: lxc/remote.go:486
+#: lxc/remote.go:500
 #, fuzzy, c-format
 msgid "Failed to decode trust token: %w"
 msgstr "Profil à appliquer au nouveau conteneur"
 
-#: lxc/remote.go:292
+#: lxc/remote.go:306
 #, fuzzy, c-format
 msgid "Failed to find project: %w"
 msgstr "Échec lors de la génération de 'lxc.1': %v"
@@ -2846,7 +2856,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:773 lxc/auth.go:1755
+#: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
@@ -2854,7 +2864,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:757 lxc/storage.go:657
+#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2892,7 +2902,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:821
+#: lxc/remote.go:855
 msgid "GLOBAL"
 msgstr ""
 
@@ -2904,7 +2914,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:821 lxc/auth.go:1795
+#: lxc/auth.go:970 lxc/auth.go:1944
 msgid "GROUPS"
 msgstr ""
 
@@ -2912,7 +2922,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:165 lxc/remote.go:443
+#: lxc/remote.go:165 lxc/remote.go:457
 msgid "Generating a client certificate. This may take a minute..."
 msgstr "Génération d'un certificat client. Ceci peut prendre une minute…"
 
@@ -3075,17 +3085,17 @@ msgstr ""
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: lxc/auth.go:137
+#: lxc/auth.go:142
 #, fuzzy, c-format
 msgid "Group %s created"
 msgstr "Profil %s créé"
 
-#: lxc/auth.go:187
+#: lxc/auth.go:192
 #, fuzzy, c-format
 msgid "Group %s deleted"
 msgstr "Profil %s supprimé"
 
-#: lxc/auth.go:427 lxc/auth.go:1845
+#: lxc/auth.go:432 lxc/auth.go:1994
 #, fuzzy, c-format
 msgid "Group %s renamed to %s"
 msgstr "Profil %s ajouté à %s"
@@ -3147,7 +3157,7 @@ msgstr "Pid : %d"
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:820
+#: lxc/auth.go:969
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -3181,12 +3191,16 @@ msgstr "IPv6"
 msgid "ISSUE DATE"
 msgstr "DATE D'ÉMISSION"
 
-#: lxc/auth.go:1567
+#: lxc/auth.go:829
+msgid "Identity creation only supported for TLS identities"
+msgstr ""
+
+#: lxc/auth.go:1716
 #, fuzzy, c-format
 msgid "Identity provider group %s created"
 msgstr "Profil %s créé"
 
-#: lxc/auth.go:1617
+#: lxc/auth.go:1766
 #, fuzzy, c-format
 msgid "Identity provider group %s deleted"
 msgstr "Profil %s créé"
@@ -3325,7 +3339,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1292 lxc/auth.go:1293
+#: lxc/auth.go:1441 lxc/auth.go:1442
 msgid "Inspect permissions"
 msgstr ""
 
@@ -3377,7 +3391,7 @@ msgstr "Le nom du conteneur est : %s"
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:395
+#: lxc/remote.go:409
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr "Schème d'URL invalide \"%s\" in \"%s\""
@@ -3460,7 +3474,7 @@ msgstr "nombre d'arguments incorrect pour la sous-comande"
 msgid "Invalid path %s"
 msgstr "Cible invalide %s"
 
-#: lxc/remote.go:384
+#: lxc/remote.go:398
 #, fuzzy, c-format
 msgid "Invalid protocol: %s"
 msgstr "Cible invalide %s"
@@ -3645,16 +3659,16 @@ msgstr ""
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:332 lxc/auth.go:333
+#: lxc/auth.go:337 lxc/auth.go:338
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:768 lxc/auth.go:769
+#: lxc/auth.go:917 lxc/auth.go:918
 #, fuzzy
 msgid "List identities"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/auth.go:1750 lxc/auth.go:1751
+#: lxc/auth.go:1899 lxc/auth.go:1900
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3871,7 +3885,7 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: lxc/auth.go:1314 lxc/auth.go:1315
+#: lxc/auth.go:1463 lxc/auth.go:1464
 #, fuzzy
 msgid "List permissions"
 msgstr "Alias :"
@@ -3919,7 +3933,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:752 lxc/remote.go:753
+#: lxc/remote.go:786 lxc/remote.go:787
 msgid "List the available remotes"
 msgstr ""
 
@@ -4047,6 +4061,12 @@ msgstr "Rendre l'image publique"
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
+#: lxc/auth.go:825
+msgid ""
+"Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
+"got "
+msgstr ""
+
 #: lxc/network.go:32 lxc/network.go:33
 msgid "Manage and attach instances to networks"
 msgstr ""
@@ -4079,21 +4099,21 @@ msgstr "Création du conteneur"
 msgid "Manage files in instances"
 msgstr "Transfert de l'image : %s"
 
-#: lxc/auth.go:59 lxc/auth.go:60 lxc/auth.go:1492 lxc/auth.go:1493
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
 #, fuzzy
 msgid "Manage groups"
 msgstr "Copie de l'image : %s"
 
-#: lxc/auth.go:1142 lxc/auth.go:1143
+#: lxc/auth.go:1291 lxc/auth.go:1292
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:731 lxc/auth.go:732
+#: lxc/auth.go:736 lxc/auth.go:737
 #, fuzzy
 msgid "Manage identities"
 msgstr "Création du conteneur"
 
-#: lxc/auth.go:1910 lxc/auth.go:1911
+#: lxc/auth.go:2059 lxc/auth.go:2060
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -4201,7 +4221,7 @@ msgstr "Nom du réseau"
 msgid "Manage network zones"
 msgstr "Nom du réseau"
 
-#: lxc/auth.go:493 lxc/auth.go:494
+#: lxc/auth.go:498 lxc/auth.go:499
 #, fuzzy
 msgid "Manage permissions"
 msgstr "Rendre l'image publique"
@@ -4261,7 +4281,7 @@ msgstr ""
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/auth.go:30 lxc/auth.go:31
+#: lxc/auth.go:35 lxc/auth.go:36
 #, fuzzy
 msgid "Manage user authorization"
 msgstr "Copie de l'image : %s"
@@ -4367,24 +4387,24 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 msgid "Missing cluster member name"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/auth.go:123 lxc/auth.go:177 lxc/auth.go:255 lxc/auth.go:417
-#: lxc/auth.go:466 lxc/auth.go:541 lxc/auth.go:600 lxc/auth.go:1884
+#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:260 lxc/auth.go:422
+#: lxc/auth.go:471 lxc/auth.go:546 lxc/auth.go:605 lxc/auth.go:2033
 #, fuzzy
 msgid "Missing group name"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/auth.go:866 lxc/auth.go:1007 lxc/auth.go:1124 lxc/auth.go:1190
-#: lxc/auth.go:1248
+#: lxc/auth.go:820 lxc/auth.go:1015 lxc/auth.go:1156 lxc/auth.go:1273
+#: lxc/auth.go:1339 lxc/auth.go:1397
 #, fuzzy
 msgid "Missing identity argument"
 msgstr "Résumé manquant."
 
-#: lxc/auth.go:1554 lxc/auth.go:1607 lxc/auth.go:1673 lxc/auth.go:1835
+#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
 #, fuzzy
 msgid "Missing identity provider group name"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/auth.go:1958 lxc/auth.go:2011
+#: lxc/auth.go:2107 lxc/auth.go:2160
 #, fuzzy
 msgid "Missing identity provider group name argument"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -4629,12 +4649,12 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/auth.go:376 lxc/auth.go:819 lxc/auth.go:1794 lxc/cluster.go:192
+#: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
-#: lxc/remote.go:815 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
 msgstr "NOM"
@@ -4661,7 +4681,7 @@ msgstr ""
 
 #: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:775 lxc/remote.go:780 lxc/remote.go:785
+#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr "NON"
 
@@ -4903,7 +4923,7 @@ msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 "Seuls les volumes \"personnalisés\" peuvent être attachés aux conteneurs."
 
-#: lxc/remote.go:378
+#: lxc/remote.go:392
 msgid "Only https URLs are supported for simplestreams"
 msgstr "Seules les URLs https sont supportées par simplestreams"
 
@@ -4979,11 +4999,11 @@ msgstr "PROFILS"
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:817
+#: lxc/remote.go:851
 msgid "PROTOCOL"
 msgstr "PROTOCOLE"
 
-#: lxc/image.go:1136 lxc/remote.go:819
+#: lxc/image.go:1136 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr "PUBLIC"
 
@@ -5028,7 +5048,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/remote.go:536
+#: lxc/remote.go:550
 #, fuzzy
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr "Image importée avec l'empreinte : %s"
@@ -5046,7 +5066,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:302 lxc/auth.go:1059 lxc/auth.go:1720 lxc/cluster.go:860
+#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -5364,33 +5384,33 @@ msgstr "Ignorer l'état du conteneur (seulement pour start)"
 msgid "Refreshing the image: %s"
 msgstr "Récupération de l'image : %s"
 
-#: lxc/remote.go:877
+#: lxc/remote.go:911
 #, fuzzy, c-format
 msgid "Remote %s already exists"
 msgstr "le serveur distant %s existe déjà"
 
-#: lxc/project.go:884 lxc/remote.go:868 lxc/remote.go:949 lxc/remote.go:1013
-#: lxc/remote.go:1061
+#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/remote.go:1095
 #, fuzzy, c-format
 msgid "Remote %s doesn't exist"
 msgstr "le serveur distant %s n'existe pas"
 
-#: lxc/remote.go:345
+#: lxc/remote.go:359
 #, fuzzy, c-format
 msgid "Remote %s exists as <%s>"
 msgstr "le serveur distant %s existe en tant que <%s>"
 
-#: lxc/remote.go:957
+#: lxc/remote.go:991
 #, fuzzy, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr "le serveur distant %s est statique et ne peut être modifié"
 
-#: lxc/remote.go:872 lxc/remote.go:953 lxc/remote.go:1065
+#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1099
 #, fuzzy, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr "le serveur distant %s est statique et ne peut être modifié"
 
-#: lxc/remote.go:319
+#: lxc/remote.go:333
 msgid "Remote address must not be empty"
 msgstr ""
 
@@ -5398,7 +5418,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr "Mot de passe de l'administrateur distant"
 
-#: lxc/remote.go:339
+#: lxc/remote.go:353
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -5422,7 +5442,7 @@ msgstr "Supprimer %s (oui/non) : "
 msgid "Remove a cluster member from a cluster group"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/auth.go:1223 lxc/auth.go:1224
+#: lxc/auth.go:1372 lxc/auth.go:1373
 #, fuzzy
 msgid "Remove a group from an identity"
 msgstr "Création du conteneur"
@@ -5464,7 +5484,7 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 msgid "Remove entries from a network zone record"
 msgstr "Création du conteneur"
 
-#: lxc/auth.go:1986 lxc/auth.go:1987
+#: lxc/auth.go:2135 lxc/auth.go:2136
 #, fuzzy
 msgid "Remove identities from groups"
 msgstr "Création du conteneur"
@@ -5478,7 +5498,7 @@ msgstr "L'arrêt du conteneur a échoué !"
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:575 lxc/auth.go:576
+#: lxc/auth.go:580 lxc/auth.go:581
 #, fuzzy
 msgid "Remove permissions from groups"
 msgstr "Création du conteneur"
@@ -5498,7 +5518,7 @@ msgstr "Création du conteneur"
 msgid "Remove profiles from instances"
 msgstr "Création du conteneur"
 
-#: lxc/remote.go:919 lxc/remote.go:920
+#: lxc/remote.go:953 lxc/remote.go:954
 msgid "Remove remotes"
 msgstr ""
 
@@ -5530,12 +5550,12 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:392 lxc/auth.go:393
+#: lxc/auth.go:397 lxc/auth.go:398
 #, fuzzy
 msgid "Rename groups"
 msgstr "Copie de l'image : %s"
 
-#: lxc/auth.go:1810 lxc/auth.go:1811
+#: lxc/auth.go:1959 lxc/auth.go:1960
 #, fuzzy
 msgid "Rename identity provider groups"
 msgstr "Copie de l'image : %s"
@@ -5562,7 +5582,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr "Créé : %s"
 
-#: lxc/remote.go:838 lxc/remote.go:839
+#: lxc/remote.go:872 lxc/remote.go:873
 msgid "Rename remotes"
 msgstr ""
 
@@ -5734,7 +5754,7 @@ msgstr "Mot de passe de l'administrateur distant"
 msgid "STATE"
 msgstr "ÉTAT"
 
-#: lxc/remote.go:820
+#: lxc/remote.go:854
 msgid "STATIC"
 msgstr "STATIQUE"
 
@@ -5778,11 +5798,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:532
+#: lxc/remote.go:546
 msgid "Server certificate NACKed by user"
 msgstr "Certificat serveur rejeté par l'utilisateur"
 
-#: lxc/remote.go:285 lxc/remote.go:683
+#: lxc/remote.go:299 lxc/remote.go:717
 #, fuzzy
 msgid "Server doesn't trust us after authentication"
 msgstr ""
@@ -6011,7 +6031,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1031 lxc/remote.go:1032
+#: lxc/remote.go:1065 lxc/remote.go:1066
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -6118,7 +6138,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1859 lxc/auth.go:1860
+#: lxc/auth.go:2008 lxc/auth.go:2009
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -6149,12 +6169,12 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr "Afficher la configuration étendue"
 
-#: lxc/auth.go:441 lxc/auth.go:442
+#: lxc/auth.go:446 lxc/auth.go:447
 #, fuzzy
 msgid "Show group configurations"
 msgstr "Afficher la configuration étendue"
 
-#: lxc/auth.go:836
+#: lxc/auth.go:985
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -6280,7 +6300,7 @@ msgstr "Afficher la configuration étendue"
 msgid "Show storage volume state information"
 msgstr "Afficher la configuration étendue"
 
-#: lxc/auth.go:899
+#: lxc/auth.go:1048
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -6290,7 +6310,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:714 lxc/remote.go:715
+#: lxc/remote.go:748 lxc/remote.go:749
 #, fuzzy
 msgid "Show the default remote"
 msgstr "impossible de supprimer le serveur distant par défaut"
@@ -6517,7 +6537,7 @@ msgstr "Swap (pointe)"
 msgid "Switch the current project"
 msgstr "impossible de supprimer le serveur distant par défaut"
 
-#: lxc/remote.go:983 lxc/remote.go:984
+#: lxc/remote.go:1017 lxc/remote.go:1018
 #, fuzzy
 msgid "Switch the default remote"
 msgstr "impossible de supprimer le serveur distant par défaut"
@@ -6530,11 +6550,21 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
+#: lxc/auth.go:876
+#, c-format
+msgid "TLS identity %q (%s) pending identity token:"
+msgstr ""
+
+#: lxc/auth.go:902
+#, fuzzy, c-format
+msgid "TLS identity %q created with fingerprint %q"
+msgstr "Image importée avec l'empreinte : %s"
+
 #: lxc/cluster.go:1070 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:818 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
 #: lxc/storage_volume.go:1736 lxc/warning.go:216
@@ -6554,7 +6584,7 @@ msgstr ""
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/remote.go:161 lxc/remote.go:334
+#: lxc/remote.go:161 lxc/remote.go:348
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
@@ -6719,7 +6749,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:527
+#: lxc/remote.go:541
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
@@ -6863,16 +6893,16 @@ msgstr "Transfert de l'image : %s"
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:329
+#: lxc/remote.go:343
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:324
+#: lxc/remote.go:338
 #, fuzzy
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr "--project ne peut pas être utilisé avec la commande query"
 
-#: lxc/remote.go:639
+#: lxc/remote.go:653
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6917,7 +6947,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr "DATE DE PUBLICATION"
 
-#: lxc/cluster.go:193 lxc/remote.go:816
+#: lxc/cluster.go:193 lxc/remote.go:850
 msgid "URL"
 msgstr "URL"
 
@@ -7258,11 +7288,11 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr "Créé : %s"
 
-#: lxc/auth.go:835
+#: lxc/auth.go:984
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:898
+#: lxc/auth.go:1047
 #, fuzzy
 msgid "View the current identity"
 msgstr "impossible de supprimer le serveur distant par défaut"
@@ -7307,7 +7337,7 @@ msgstr ""
 
 #: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:777 lxc/remote.go:782 lxc/remote.go:787
+#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr "OUI"
 
@@ -7351,7 +7381,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/auth.go:330 lxc/auth.go:766 lxc/auth.go:897 lxc/auth.go:1748
+#: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
@@ -7421,7 +7451,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/auth.go:1313
+#: lxc/auth.go:1462
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -7547,11 +7577,17 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/auth.go:834 lxc/auth.go:1086
+#: lxc/auth.go:774
+msgid ""
+"[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
+"certificate>] [[--group <group_name>]]"
+msgstr ""
+
+#: lxc/auth.go:983 lxc/auth.go:1235
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1164 lxc/auth.go:1222 lxc/auth.go:1985
+#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:2134
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -7567,8 +7603,8 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/auth.go:97 lxc/auth.go:150 lxc/auth.go:200 lxc/auth.go:440
-#: lxc/auth.go:958 lxc/auth.go:1529 lxc/cluster_group.go:168
+#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:445
+#: lxc/auth.go:1107 lxc/auth.go:1678 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 #, fuzzy
 msgid "[<remote>:]<group>"
@@ -7577,7 +7613,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/auth.go:515 lxc/auth.go:573
+#: lxc/auth.go:520 lxc/auth.go:578
 #, fuzzy
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
@@ -7595,7 +7631,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/auth.go:390
+#: lxc/auth.go:395
 #, fuzzy
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
@@ -7603,7 +7639,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/auth.go:1580 lxc/auth.go:1630 lxc/auth.go:1858
+#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
@@ -7611,7 +7647,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/auth.go:1932
+#: lxc/auth.go:2081
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
@@ -7623,7 +7659,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/auth.go:1808
+#: lxc/auth.go:1957
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
@@ -8703,7 +8739,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/project.go:557 lxc/remote.go:806
+#: lxc/project.go:557 lxc/remote.go:840
 #, fuzzy
 msgid "current"
 msgstr "Swap (courant)"
@@ -8751,20 +8787,20 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/auth.go:204
+#: lxc/auth.go:209
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:962
+#: lxc/auth.go:1111
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1634
+#: lxc/auth.go:1783
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -9210,7 +9246,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:531
+#: lxc/remote.go:545
 #, fuzzy
 msgid "n"
 msgstr "non"
@@ -9223,7 +9259,7 @@ msgstr ""
 msgid "no"
 msgstr "non"
 
-#: lxc/remote.go:510
+#: lxc/remote.go:524
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -9260,7 +9296,7 @@ msgstr "inaccessible"
 msgid "used by"
 msgstr "utilisé par"
 
-#: lxc/remote.go:519
+#: lxc/remote.go:533
 msgid "y"
 msgstr "o"
 

--- a/po/he.po
+++ b/po/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-14 13:30+0000\n"
+"POT-Creation-Date: 2024-10-15 14:52+0100\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hebrew <https://hosted.weblate.org/projects/linux-containers/"
@@ -134,7 +134,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:214
+#: lxc/auth.go:219
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -161,7 +161,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:972
+#: lxc/auth.go:1121
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -182,7 +182,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1644
+#: lxc/auth.go:1793
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -516,15 +516,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:917 lxc/remote.go:982
+#: lxc/remote.go:951 lxc/remote.go:1016
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1030
+#: lxc/remote.go:1064
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:836
+#: lxc/remote.go:870
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -557,11 +557,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:818
+#: lxc/remote.go:852
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:817
+#: lxc/auth.go:966
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -599,11 +599,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1165 lxc/auth.go:1166
+#: lxc/auth.go:1314 lxc/auth.go:1315
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1933 lxc/auth.go:1934
+#: lxc/auth.go:2082 lxc/auth.go:2083
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -672,7 +672,7 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:516 lxc/auth.go:517
+#: lxc/auth.go:521 lxc/auth.go:522
 msgid "Add permissions to groups"
 msgstr ""
 
@@ -706,7 +706,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:648
+#: lxc/remote.go:680
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -814,7 +814,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:621
+#: lxc/remote.go:635
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -992,7 +992,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:961
+#: lxc/remote.go:995
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1058,7 +1058,7 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:509
+#: lxc/remote.go:523
 msgid "Certificate fingerprint"
 msgstr ""
 
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:687
+#: lxc/remote.go:721
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1325,12 +1325,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:559
+#: lxc/remote.go:573
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:237 lxc/remote.go:543
+#: lxc/remote.go:237 lxc/remote.go:557
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1344,12 +1344,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:1719
+#: lxc/auth.go:306 lxc/auth.go:1868
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1058
+#: lxc/auth.go:1207
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1369,13 +1369,17 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:554
+#: lxc/remote.go:568
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
 #: lxc/network_zone.go:1536
 msgid "Couldn't find a matching entry"
+msgstr ""
+
+#: lxc/auth.go:776
+msgid "Create a TLS identity"
 msgstr ""
 
 #: lxc/cluster_group.go:169 lxc/cluster_group.go:170
@@ -1394,6 +1398,10 @@ msgstr ""
 msgid "Create an empty instance"
 msgstr ""
 
+#: lxc/auth.go:775
+msgid "Create an identity"
+msgstr ""
+
 #: lxc/launch.go:23 lxc/launch.go:24
 msgid "Create and start instances from images"
 msgstr ""
@@ -1406,11 +1414,11 @@ msgstr ""
 msgid "Create files and directories in instances"
 msgstr ""
 
-#: lxc/auth.go:98 lxc/auth.go:99
+#: lxc/auth.go:103 lxc/auth.go:104
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1530 lxc/auth.go:1531
+#: lxc/auth.go:1679 lxc/auth.go:1680
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1518,7 +1526,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
@@ -1561,7 +1569,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/auth.go:1088 lxc/auth.go:1089
+#: lxc/auth.go:1237 lxc/auth.go:1238
 msgid "Delete an identity"
 msgstr ""
 
@@ -1569,11 +1577,11 @@ msgstr ""
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/auth.go:152 lxc/auth.go:153
+#: lxc/auth.go:157 lxc/auth.go:158
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1582 lxc/auth.go:1583
+#: lxc/auth.go:1731 lxc/auth.go:1732
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1651,18 +1659,18 @@ msgstr ""
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:31 lxc/auth.go:60 lxc/auth.go:99
-#: lxc/auth.go:153 lxc/auth.go:202 lxc/auth.go:333 lxc/auth.go:393
-#: lxc/auth.go:442 lxc/auth.go:494 lxc/auth.go:517 lxc/auth.go:576
-#: lxc/auth.go:732 lxc/auth.go:769 lxc/auth.go:836 lxc/auth.go:899
-#: lxc/auth.go:960 lxc/auth.go:1089 lxc/auth.go:1143 lxc/auth.go:1166
-#: lxc/auth.go:1224 lxc/auth.go:1293 lxc/auth.go:1315 lxc/auth.go:1493
-#: lxc/auth.go:1531 lxc/auth.go:1583 lxc/auth.go:1632 lxc/auth.go:1751
-#: lxc/auth.go:1811 lxc/auth.go:1860 lxc/auth.go:1911 lxc/auth.go:1934
-#: lxc/auth.go:1987 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215
-#: lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:484
-#: lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677 lxc/cluster.go:770
-#: lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
+#: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
+#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:338 lxc/auth.go:398
+#: lxc/auth.go:447 lxc/auth.go:499 lxc/auth.go:522 lxc/auth.go:581
+#: lxc/auth.go:737 lxc/auth.go:776 lxc/auth.go:918 lxc/auth.go:985
+#: lxc/auth.go:1048 lxc/auth.go:1109 lxc/auth.go:1238 lxc/auth.go:1292
+#: lxc/auth.go:1315 lxc/auth.go:1373 lxc/auth.go:1442 lxc/auth.go:1464
+#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
+#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
+#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
+#: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
+#: lxc/cluster.go:770 lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
 #: lxc/cluster.go:1175 lxc/cluster.go:1299 lxc/cluster.go:1329
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
@@ -1733,9 +1741,9 @@ msgstr ""
 #: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
 #: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
 #: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:715
-#: lxc/remote.go:753 lxc/remote.go:839 lxc/remote.go:920 lxc/remote.go:984
-#: lxc/remote.go:1032 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
+#: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
+#: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1920,7 +1928,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:959 lxc/auth.go:960
+#: lxc/auth.go:1108 lxc/auth.go:1109
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1932,11 +1940,11 @@ msgstr ""
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/auth.go:201 lxc/auth.go:202
+#: lxc/auth.go:206 lxc/auth.go:207
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1631 lxc/auth.go:1632
+#: lxc/auth.go:1780 lxc/auth.go:1781
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2312,12 +2320,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:486
+#: lxc/remote.go:500
 #, c-format
 msgid "Failed to decode trust token: %w"
 msgstr ""
 
-#: lxc/remote.go:292
+#: lxc/remote.go:306
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2421,7 +2429,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:773 lxc/auth.go:1755
+#: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
@@ -2429,7 +2437,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:757 lxc/storage.go:657
+#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2467,7 +2475,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:821
+#: lxc/remote.go:855
 msgid "GLOBAL"
 msgstr ""
 
@@ -2479,7 +2487,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:821 lxc/auth.go:1795
+#: lxc/auth.go:970 lxc/auth.go:1944
 msgid "GROUPS"
 msgstr ""
 
@@ -2487,7 +2495,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:165 lxc/remote.go:443
+#: lxc/remote.go:165 lxc/remote.go:457
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2628,17 +2636,17 @@ msgstr ""
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: lxc/auth.go:137
+#: lxc/auth.go:142
 #, c-format
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:187
+#: lxc/auth.go:192
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:427 lxc/auth.go:1845
+#: lxc/auth.go:432 lxc/auth.go:1994
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2697,7 +2705,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:820
+#: lxc/auth.go:969
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -2729,12 +2737,16 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1567
+#: lxc/auth.go:829
+msgid "Identity creation only supported for TLS identities"
+msgstr ""
+
+#: lxc/auth.go:1716
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1617
+#: lxc/auth.go:1766
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2863,7 +2875,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1292 lxc/auth.go:1293
+#: lxc/auth.go:1441 lxc/auth.go:1442
 msgid "Inspect permissions"
 msgstr ""
 
@@ -2911,7 +2923,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:395
+#: lxc/remote.go:409
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2992,7 +3004,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:384
+#: lxc/remote.go:398
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3167,15 +3179,15 @@ msgstr ""
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:332 lxc/auth.go:333
+#: lxc/auth.go:337 lxc/auth.go:338
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:768 lxc/auth.go:769
+#: lxc/auth.go:917 lxc/auth.go:918
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1750 lxc/auth.go:1751
+#: lxc/auth.go:1899 lxc/auth.go:1900
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3328,7 +3340,7 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1314 lxc/auth.go:1315
+#: lxc/auth.go:1463 lxc/auth.go:1464
 msgid "List permissions"
 msgstr ""
 
@@ -3372,7 +3384,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:752 lxc/remote.go:753
+#: lxc/remote.go:786 lxc/remote.go:787
 msgid "List the available remotes"
 msgstr ""
 
@@ -3496,6 +3508,12 @@ msgstr ""
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
+#: lxc/auth.go:825
+msgid ""
+"Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
+"got "
+msgstr ""
+
 #: lxc/network.go:32 lxc/network.go:33
 msgid "Manage and attach instances to networks"
 msgstr ""
@@ -3524,19 +3542,19 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:59 lxc/auth.go:60 lxc/auth.go:1492 lxc/auth.go:1493
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1142 lxc/auth.go:1143
+#: lxc/auth.go:1291 lxc/auth.go:1292
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:731 lxc/auth.go:732
+#: lxc/auth.go:736 lxc/auth.go:737
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1910 lxc/auth.go:1911
+#: lxc/auth.go:2059 lxc/auth.go:2060
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3627,7 +3645,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:493 lxc/auth.go:494
+#: lxc/auth.go:498 lxc/auth.go:499
 msgid "Manage permissions"
 msgstr ""
 
@@ -3679,7 +3697,7 @@ msgstr ""
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/auth.go:30 lxc/auth.go:31
+#: lxc/auth.go:35 lxc/auth.go:36
 msgid "Manage user authorization"
 msgstr ""
 
@@ -3776,21 +3794,21 @@ msgstr ""
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:123 lxc/auth.go:177 lxc/auth.go:255 lxc/auth.go:417
-#: lxc/auth.go:466 lxc/auth.go:541 lxc/auth.go:600 lxc/auth.go:1884
+#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:260 lxc/auth.go:422
+#: lxc/auth.go:471 lxc/auth.go:546 lxc/auth.go:605 lxc/auth.go:2033
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:866 lxc/auth.go:1007 lxc/auth.go:1124 lxc/auth.go:1190
-#: lxc/auth.go:1248
+#: lxc/auth.go:820 lxc/auth.go:1015 lxc/auth.go:1156 lxc/auth.go:1273
+#: lxc/auth.go:1339 lxc/auth.go:1397
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1554 lxc/auth.go:1607 lxc/auth.go:1673 lxc/auth.go:1835
+#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1958 lxc/auth.go:2011
+#: lxc/auth.go:2107 lxc/auth.go:2160
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -4011,12 +4029,12 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:376 lxc/auth.go:819 lxc/auth.go:1794 lxc/cluster.go:192
+#: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
-#: lxc/remote.go:815 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
 msgstr ""
@@ -4043,7 +4061,7 @@ msgstr ""
 
 #: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:775 lxc/remote.go:780 lxc/remote.go:785
+#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr ""
 
@@ -4272,7 +4290,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:378
+#: lxc/remote.go:392
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4343,11 +4361,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:817
+#: lxc/remote.go:851
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:819
+#: lxc/image.go:1136 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4388,7 +4406,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:536
+#: lxc/remote.go:550
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
@@ -4405,7 +4423,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:302 lxc/auth.go:1059 lxc/auth.go:1720 lxc/cluster.go:860
+#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -4708,33 +4726,33 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:877
+#: lxc/remote.go:911
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:868 lxc/remote.go:949 lxc/remote.go:1013
-#: lxc/remote.go:1061
+#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/remote.go:1095
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:345
+#: lxc/remote.go:359
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:957
+#: lxc/remote.go:991
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:872 lxc/remote.go:953 lxc/remote.go:1065
+#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1099
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:319
+#: lxc/remote.go:333
 msgid "Remote address must not be empty"
 msgstr ""
 
@@ -4742,7 +4760,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:339
+#: lxc/remote.go:353
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4764,7 +4782,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1223 lxc/auth.go:1224
+#: lxc/auth.go:1372 lxc/auth.go:1373
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4800,7 +4818,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1986 lxc/auth.go:1987
+#: lxc/auth.go:2135 lxc/auth.go:2136
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4812,7 +4830,7 @@ msgstr ""
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:575 lxc/auth.go:576
+#: lxc/auth.go:580 lxc/auth.go:581
 msgid "Remove permissions from groups"
 msgstr ""
 
@@ -4828,7 +4846,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:919 lxc/remote.go:920
+#: lxc/remote.go:953 lxc/remote.go:954
 msgid "Remove remotes"
 msgstr ""
 
@@ -4857,11 +4875,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:392 lxc/auth.go:393
+#: lxc/auth.go:397 lxc/auth.go:398
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1810 lxc/auth.go:1811
+#: lxc/auth.go:1959 lxc/auth.go:1960
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -4885,7 +4903,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:838 lxc/remote.go:839
+#: lxc/remote.go:872 lxc/remote.go:873
 msgid "Rename remotes"
 msgstr ""
 
@@ -5030,7 +5048,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:820
+#: lxc/remote.go:854
 msgid "STATIC"
 msgstr ""
 
@@ -5071,11 +5089,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:532
+#: lxc/remote.go:546
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:285 lxc/remote.go:683
+#: lxc/remote.go:299 lxc/remote.go:717
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5286,7 +5304,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1031 lxc/remote.go:1032
+#: lxc/remote.go:1065 lxc/remote.go:1066
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5382,7 +5400,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1859 lxc/auth.go:1860
+#: lxc/auth.go:2008 lxc/auth.go:2009
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5410,11 +5428,11 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:441 lxc/auth.go:442
+#: lxc/auth.go:446 lxc/auth.go:447
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:836
+#: lxc/auth.go:985
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5519,7 +5537,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:899
+#: lxc/auth.go:1048
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5529,7 +5547,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:714 lxc/remote.go:715
+#: lxc/remote.go:748 lxc/remote.go:749
 msgid "Show the default remote"
 msgstr ""
 
@@ -5741,7 +5759,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:983 lxc/remote.go:984
+#: lxc/remote.go:1017 lxc/remote.go:1018
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5753,11 +5771,21 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
+#: lxc/auth.go:876
+#, c-format
+msgid "TLS identity %q (%s) pending identity token:"
+msgstr ""
+
+#: lxc/auth.go:902
+#, c-format
+msgid "TLS identity %q created with fingerprint %q"
+msgstr ""
+
 #: lxc/cluster.go:1070 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:818 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
 #: lxc/storage_volume.go:1736 lxc/warning.go:216
@@ -5776,7 +5804,7 @@ msgstr ""
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/remote.go:161 lxc/remote.go:334
+#: lxc/remote.go:161 lxc/remote.go:348
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
@@ -5932,7 +5960,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:527
+#: lxc/remote.go:541
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
@@ -6070,15 +6098,15 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:329
+#: lxc/remote.go:343
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:324
+#: lxc/remote.go:338
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr ""
 
-#: lxc/remote.go:639
+#: lxc/remote.go:653
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6121,7 +6149,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:193 lxc/remote.go:816
+#: lxc/cluster.go:193 lxc/remote.go:850
 msgid "URL"
 msgstr ""
 
@@ -6429,11 +6457,11 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:835
+#: lxc/auth.go:984
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:898
+#: lxc/auth.go:1047
 msgid "View the current identity"
 msgstr ""
 
@@ -6472,7 +6500,7 @@ msgstr ""
 
 #: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:777 lxc/remote.go:782 lxc/remote.go:787
+#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr ""
 
@@ -6504,7 +6532,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:330 lxc/auth.go:766 lxc/auth.go:897 lxc/auth.go:1748
+#: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
@@ -6537,7 +6565,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1313
+#: lxc/auth.go:1462
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6598,11 +6626,17 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:834 lxc/auth.go:1086
+#: lxc/auth.go:774
+msgid ""
+"[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
+"certificate>] [[--group <group_name>]]"
+msgstr ""
+
+#: lxc/auth.go:983 lxc/auth.go:1235
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1164 lxc/auth.go:1222 lxc/auth.go:1985
+#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:2134
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6610,13 +6644,13 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:97 lxc/auth.go:150 lxc/auth.go:200 lxc/auth.go:440
-#: lxc/auth.go:958 lxc/auth.go:1529 lxc/cluster_group.go:168
+#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:445
+#: lxc/auth.go:1107 lxc/auth.go:1678 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:515 lxc/auth.go:573
+#: lxc/auth.go:520 lxc/auth.go:578
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
@@ -6626,19 +6660,19 @@ msgstr ""
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:390
+#: lxc/auth.go:395
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1580 lxc/auth.go:1630 lxc/auth.go:1858
+#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1932
+#: lxc/auth.go:2081
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1808
+#: lxc/auth.go:1957
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -7129,7 +7163,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:806
+#: lxc/project.go:557 lxc/remote.go:840
 msgid "current"
 msgstr ""
 
@@ -7176,20 +7210,20 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/auth.go:204
+#: lxc/auth.go:209
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:962
+#: lxc/auth.go:1111
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1634
+#: lxc/auth.go:1783
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7613,7 +7647,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:531
+#: lxc/remote.go:545
 msgid "n"
 msgstr ""
 
@@ -7625,7 +7659,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:510
+#: lxc/remote.go:524
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7662,7 +7696,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:519
+#: lxc/remote.go:533
 msgid "y"
 msgstr ""
 

--- a/po/hi.po
+++ b/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-14 13:30+0000\n"
+"POT-Creation-Date: 2024-10-15 14:52+0100\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hindi <https://hosted.weblate.org/projects/linux-containers/"
@@ -133,7 +133,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:214
+#: lxc/auth.go:219
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -160,7 +160,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:972
+#: lxc/auth.go:1121
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -181,7 +181,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1644
+#: lxc/auth.go:1793
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -515,15 +515,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:917 lxc/remote.go:982
+#: lxc/remote.go:951 lxc/remote.go:1016
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1030
+#: lxc/remote.go:1064
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:836
+#: lxc/remote.go:870
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -556,11 +556,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:818
+#: lxc/remote.go:852
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:817
+#: lxc/auth.go:966
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -598,11 +598,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1165 lxc/auth.go:1166
+#: lxc/auth.go:1314 lxc/auth.go:1315
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1933 lxc/auth.go:1934
+#: lxc/auth.go:2082 lxc/auth.go:2083
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -671,7 +671,7 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:516 lxc/auth.go:517
+#: lxc/auth.go:521 lxc/auth.go:522
 msgid "Add permissions to groups"
 msgstr ""
 
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:648
+#: lxc/remote.go:680
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -813,7 +813,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:621
+#: lxc/remote.go:635
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -991,7 +991,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:961
+#: lxc/remote.go:995
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1057,7 +1057,7 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:509
+#: lxc/remote.go:523
 msgid "Certificate fingerprint"
 msgstr ""
 
@@ -1076,7 +1076,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:687
+#: lxc/remote.go:721
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1324,12 +1324,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:559
+#: lxc/remote.go:573
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:237 lxc/remote.go:543
+#: lxc/remote.go:237 lxc/remote.go:557
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1343,12 +1343,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:1719
+#: lxc/auth.go:306 lxc/auth.go:1868
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1058
+#: lxc/auth.go:1207
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1368,13 +1368,17 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:554
+#: lxc/remote.go:568
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
 #: lxc/network_zone.go:1536
 msgid "Couldn't find a matching entry"
+msgstr ""
+
+#: lxc/auth.go:776
+msgid "Create a TLS identity"
 msgstr ""
 
 #: lxc/cluster_group.go:169 lxc/cluster_group.go:170
@@ -1393,6 +1397,10 @@ msgstr ""
 msgid "Create an empty instance"
 msgstr ""
 
+#: lxc/auth.go:775
+msgid "Create an identity"
+msgstr ""
+
 #: lxc/launch.go:23 lxc/launch.go:24
 msgid "Create and start instances from images"
 msgstr ""
@@ -1405,11 +1413,11 @@ msgstr ""
 msgid "Create files and directories in instances"
 msgstr ""
 
-#: lxc/auth.go:98 lxc/auth.go:99
+#: lxc/auth.go:103 lxc/auth.go:104
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1530 lxc/auth.go:1531
+#: lxc/auth.go:1679 lxc/auth.go:1680
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1517,7 +1525,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
@@ -1560,7 +1568,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/auth.go:1088 lxc/auth.go:1089
+#: lxc/auth.go:1237 lxc/auth.go:1238
 msgid "Delete an identity"
 msgstr ""
 
@@ -1568,11 +1576,11 @@ msgstr ""
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/auth.go:152 lxc/auth.go:153
+#: lxc/auth.go:157 lxc/auth.go:158
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1582 lxc/auth.go:1583
+#: lxc/auth.go:1731 lxc/auth.go:1732
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1650,18 +1658,18 @@ msgstr ""
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:31 lxc/auth.go:60 lxc/auth.go:99
-#: lxc/auth.go:153 lxc/auth.go:202 lxc/auth.go:333 lxc/auth.go:393
-#: lxc/auth.go:442 lxc/auth.go:494 lxc/auth.go:517 lxc/auth.go:576
-#: lxc/auth.go:732 lxc/auth.go:769 lxc/auth.go:836 lxc/auth.go:899
-#: lxc/auth.go:960 lxc/auth.go:1089 lxc/auth.go:1143 lxc/auth.go:1166
-#: lxc/auth.go:1224 lxc/auth.go:1293 lxc/auth.go:1315 lxc/auth.go:1493
-#: lxc/auth.go:1531 lxc/auth.go:1583 lxc/auth.go:1632 lxc/auth.go:1751
-#: lxc/auth.go:1811 lxc/auth.go:1860 lxc/auth.go:1911 lxc/auth.go:1934
-#: lxc/auth.go:1987 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215
-#: lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:484
-#: lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677 lxc/cluster.go:770
-#: lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
+#: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
+#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:338 lxc/auth.go:398
+#: lxc/auth.go:447 lxc/auth.go:499 lxc/auth.go:522 lxc/auth.go:581
+#: lxc/auth.go:737 lxc/auth.go:776 lxc/auth.go:918 lxc/auth.go:985
+#: lxc/auth.go:1048 lxc/auth.go:1109 lxc/auth.go:1238 lxc/auth.go:1292
+#: lxc/auth.go:1315 lxc/auth.go:1373 lxc/auth.go:1442 lxc/auth.go:1464
+#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
+#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
+#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
+#: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
+#: lxc/cluster.go:770 lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
 #: lxc/cluster.go:1175 lxc/cluster.go:1299 lxc/cluster.go:1329
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
@@ -1732,9 +1740,9 @@ msgstr ""
 #: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
 #: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
 #: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:715
-#: lxc/remote.go:753 lxc/remote.go:839 lxc/remote.go:920 lxc/remote.go:984
-#: lxc/remote.go:1032 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
+#: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
+#: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1919,7 +1927,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:959 lxc/auth.go:960
+#: lxc/auth.go:1108 lxc/auth.go:1109
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1931,11 +1939,11 @@ msgstr ""
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/auth.go:201 lxc/auth.go:202
+#: lxc/auth.go:206 lxc/auth.go:207
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1631 lxc/auth.go:1632
+#: lxc/auth.go:1780 lxc/auth.go:1781
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2311,12 +2319,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:486
+#: lxc/remote.go:500
 #, c-format
 msgid "Failed to decode trust token: %w"
 msgstr ""
 
-#: lxc/remote.go:292
+#: lxc/remote.go:306
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2420,7 +2428,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:773 lxc/auth.go:1755
+#: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
@@ -2428,7 +2436,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:757 lxc/storage.go:657
+#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2466,7 +2474,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:821
+#: lxc/remote.go:855
 msgid "GLOBAL"
 msgstr ""
 
@@ -2478,7 +2486,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:821 lxc/auth.go:1795
+#: lxc/auth.go:970 lxc/auth.go:1944
 msgid "GROUPS"
 msgstr ""
 
@@ -2486,7 +2494,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:165 lxc/remote.go:443
+#: lxc/remote.go:165 lxc/remote.go:457
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2627,17 +2635,17 @@ msgstr ""
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: lxc/auth.go:137
+#: lxc/auth.go:142
 #, c-format
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:187
+#: lxc/auth.go:192
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:427 lxc/auth.go:1845
+#: lxc/auth.go:432 lxc/auth.go:1994
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2696,7 +2704,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:820
+#: lxc/auth.go:969
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -2728,12 +2736,16 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1567
+#: lxc/auth.go:829
+msgid "Identity creation only supported for TLS identities"
+msgstr ""
+
+#: lxc/auth.go:1716
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1617
+#: lxc/auth.go:1766
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2862,7 +2874,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1292 lxc/auth.go:1293
+#: lxc/auth.go:1441 lxc/auth.go:1442
 msgid "Inspect permissions"
 msgstr ""
 
@@ -2910,7 +2922,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:395
+#: lxc/remote.go:409
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2991,7 +3003,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:384
+#: lxc/remote.go:398
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3166,15 +3178,15 @@ msgstr ""
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:332 lxc/auth.go:333
+#: lxc/auth.go:337 lxc/auth.go:338
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:768 lxc/auth.go:769
+#: lxc/auth.go:917 lxc/auth.go:918
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1750 lxc/auth.go:1751
+#: lxc/auth.go:1899 lxc/auth.go:1900
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3327,7 +3339,7 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1314 lxc/auth.go:1315
+#: lxc/auth.go:1463 lxc/auth.go:1464
 msgid "List permissions"
 msgstr ""
 
@@ -3371,7 +3383,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:752 lxc/remote.go:753
+#: lxc/remote.go:786 lxc/remote.go:787
 msgid "List the available remotes"
 msgstr ""
 
@@ -3495,6 +3507,12 @@ msgstr ""
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
+#: lxc/auth.go:825
+msgid ""
+"Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
+"got "
+msgstr ""
+
 #: lxc/network.go:32 lxc/network.go:33
 msgid "Manage and attach instances to networks"
 msgstr ""
@@ -3523,19 +3541,19 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:59 lxc/auth.go:60 lxc/auth.go:1492 lxc/auth.go:1493
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1142 lxc/auth.go:1143
+#: lxc/auth.go:1291 lxc/auth.go:1292
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:731 lxc/auth.go:732
+#: lxc/auth.go:736 lxc/auth.go:737
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1910 lxc/auth.go:1911
+#: lxc/auth.go:2059 lxc/auth.go:2060
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3626,7 +3644,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:493 lxc/auth.go:494
+#: lxc/auth.go:498 lxc/auth.go:499
 msgid "Manage permissions"
 msgstr ""
 
@@ -3678,7 +3696,7 @@ msgstr ""
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/auth.go:30 lxc/auth.go:31
+#: lxc/auth.go:35 lxc/auth.go:36
 msgid "Manage user authorization"
 msgstr ""
 
@@ -3775,21 +3793,21 @@ msgstr ""
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:123 lxc/auth.go:177 lxc/auth.go:255 lxc/auth.go:417
-#: lxc/auth.go:466 lxc/auth.go:541 lxc/auth.go:600 lxc/auth.go:1884
+#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:260 lxc/auth.go:422
+#: lxc/auth.go:471 lxc/auth.go:546 lxc/auth.go:605 lxc/auth.go:2033
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:866 lxc/auth.go:1007 lxc/auth.go:1124 lxc/auth.go:1190
-#: lxc/auth.go:1248
+#: lxc/auth.go:820 lxc/auth.go:1015 lxc/auth.go:1156 lxc/auth.go:1273
+#: lxc/auth.go:1339 lxc/auth.go:1397
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1554 lxc/auth.go:1607 lxc/auth.go:1673 lxc/auth.go:1835
+#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1958 lxc/auth.go:2011
+#: lxc/auth.go:2107 lxc/auth.go:2160
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -4010,12 +4028,12 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:376 lxc/auth.go:819 lxc/auth.go:1794 lxc/cluster.go:192
+#: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
-#: lxc/remote.go:815 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
 msgstr ""
@@ -4042,7 +4060,7 @@ msgstr ""
 
 #: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:775 lxc/remote.go:780 lxc/remote.go:785
+#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr ""
 
@@ -4271,7 +4289,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:378
+#: lxc/remote.go:392
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4342,11 +4360,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:817
+#: lxc/remote.go:851
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:819
+#: lxc/image.go:1136 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4387,7 +4405,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:536
+#: lxc/remote.go:550
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
@@ -4404,7 +4422,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:302 lxc/auth.go:1059 lxc/auth.go:1720 lxc/cluster.go:860
+#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -4707,33 +4725,33 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:877
+#: lxc/remote.go:911
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:868 lxc/remote.go:949 lxc/remote.go:1013
-#: lxc/remote.go:1061
+#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/remote.go:1095
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:345
+#: lxc/remote.go:359
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:957
+#: lxc/remote.go:991
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:872 lxc/remote.go:953 lxc/remote.go:1065
+#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1099
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:319
+#: lxc/remote.go:333
 msgid "Remote address must not be empty"
 msgstr ""
 
@@ -4741,7 +4759,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:339
+#: lxc/remote.go:353
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4763,7 +4781,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1223 lxc/auth.go:1224
+#: lxc/auth.go:1372 lxc/auth.go:1373
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4799,7 +4817,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1986 lxc/auth.go:1987
+#: lxc/auth.go:2135 lxc/auth.go:2136
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4811,7 +4829,7 @@ msgstr ""
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:575 lxc/auth.go:576
+#: lxc/auth.go:580 lxc/auth.go:581
 msgid "Remove permissions from groups"
 msgstr ""
 
@@ -4827,7 +4845,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:919 lxc/remote.go:920
+#: lxc/remote.go:953 lxc/remote.go:954
 msgid "Remove remotes"
 msgstr ""
 
@@ -4856,11 +4874,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:392 lxc/auth.go:393
+#: lxc/auth.go:397 lxc/auth.go:398
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1810 lxc/auth.go:1811
+#: lxc/auth.go:1959 lxc/auth.go:1960
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -4884,7 +4902,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:838 lxc/remote.go:839
+#: lxc/remote.go:872 lxc/remote.go:873
 msgid "Rename remotes"
 msgstr ""
 
@@ -5029,7 +5047,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:820
+#: lxc/remote.go:854
 msgid "STATIC"
 msgstr ""
 
@@ -5070,11 +5088,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:532
+#: lxc/remote.go:546
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:285 lxc/remote.go:683
+#: lxc/remote.go:299 lxc/remote.go:717
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5285,7 +5303,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1031 lxc/remote.go:1032
+#: lxc/remote.go:1065 lxc/remote.go:1066
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5381,7 +5399,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1859 lxc/auth.go:1860
+#: lxc/auth.go:2008 lxc/auth.go:2009
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5409,11 +5427,11 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:441 lxc/auth.go:442
+#: lxc/auth.go:446 lxc/auth.go:447
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:836
+#: lxc/auth.go:985
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5518,7 +5536,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:899
+#: lxc/auth.go:1048
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5528,7 +5546,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:714 lxc/remote.go:715
+#: lxc/remote.go:748 lxc/remote.go:749
 msgid "Show the default remote"
 msgstr ""
 
@@ -5740,7 +5758,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:983 lxc/remote.go:984
+#: lxc/remote.go:1017 lxc/remote.go:1018
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5752,11 +5770,21 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
+#: lxc/auth.go:876
+#, c-format
+msgid "TLS identity %q (%s) pending identity token:"
+msgstr ""
+
+#: lxc/auth.go:902
+#, c-format
+msgid "TLS identity %q created with fingerprint %q"
+msgstr ""
+
 #: lxc/cluster.go:1070 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:818 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
 #: lxc/storage_volume.go:1736 lxc/warning.go:216
@@ -5775,7 +5803,7 @@ msgstr ""
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/remote.go:161 lxc/remote.go:334
+#: lxc/remote.go:161 lxc/remote.go:348
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
@@ -5931,7 +5959,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:527
+#: lxc/remote.go:541
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
@@ -6069,15 +6097,15 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:329
+#: lxc/remote.go:343
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:324
+#: lxc/remote.go:338
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr ""
 
-#: lxc/remote.go:639
+#: lxc/remote.go:653
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6120,7 +6148,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:193 lxc/remote.go:816
+#: lxc/cluster.go:193 lxc/remote.go:850
 msgid "URL"
 msgstr ""
 
@@ -6428,11 +6456,11 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:835
+#: lxc/auth.go:984
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:898
+#: lxc/auth.go:1047
 msgid "View the current identity"
 msgstr ""
 
@@ -6471,7 +6499,7 @@ msgstr ""
 
 #: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:777 lxc/remote.go:782 lxc/remote.go:787
+#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr ""
 
@@ -6503,7 +6531,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:330 lxc/auth.go:766 lxc/auth.go:897 lxc/auth.go:1748
+#: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
@@ -6536,7 +6564,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1313
+#: lxc/auth.go:1462
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6597,11 +6625,17 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:834 lxc/auth.go:1086
+#: lxc/auth.go:774
+msgid ""
+"[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
+"certificate>] [[--group <group_name>]]"
+msgstr ""
+
+#: lxc/auth.go:983 lxc/auth.go:1235
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1164 lxc/auth.go:1222 lxc/auth.go:1985
+#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:2134
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6609,13 +6643,13 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:97 lxc/auth.go:150 lxc/auth.go:200 lxc/auth.go:440
-#: lxc/auth.go:958 lxc/auth.go:1529 lxc/cluster_group.go:168
+#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:445
+#: lxc/auth.go:1107 lxc/auth.go:1678 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:515 lxc/auth.go:573
+#: lxc/auth.go:520 lxc/auth.go:578
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
@@ -6625,19 +6659,19 @@ msgstr ""
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:390
+#: lxc/auth.go:395
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1580 lxc/auth.go:1630 lxc/auth.go:1858
+#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1932
+#: lxc/auth.go:2081
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1808
+#: lxc/auth.go:1957
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -7128,7 +7162,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:806
+#: lxc/project.go:557 lxc/remote.go:840
 msgid "current"
 msgstr ""
 
@@ -7175,20 +7209,20 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/auth.go:204
+#: lxc/auth.go:209
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:962
+#: lxc/auth.go:1111
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1634
+#: lxc/auth.go:1783
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7612,7 +7646,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:531
+#: lxc/remote.go:545
 msgid "n"
 msgstr ""
 
@@ -7624,7 +7658,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:510
+#: lxc/remote.go:524
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7661,7 +7695,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:519
+#: lxc/remote.go:533
 msgid "y"
 msgstr ""
 

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-14 13:30+0000\n"
+"POT-Creation-Date: 2024-10-15 14:52+0100\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Indonesian <https://hosted.weblate.org/projects/linux-"
@@ -133,7 +133,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:214
+#: lxc/auth.go:219
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -160,7 +160,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:972
+#: lxc/auth.go:1121
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -181,7 +181,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1644
+#: lxc/auth.go:1793
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -515,15 +515,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:917 lxc/remote.go:982
+#: lxc/remote.go:951 lxc/remote.go:1016
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1030
+#: lxc/remote.go:1064
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:836
+#: lxc/remote.go:870
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -556,11 +556,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:818
+#: lxc/remote.go:852
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:817
+#: lxc/auth.go:966
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -598,11 +598,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1165 lxc/auth.go:1166
+#: lxc/auth.go:1314 lxc/auth.go:1315
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1933 lxc/auth.go:1934
+#: lxc/auth.go:2082 lxc/auth.go:2083
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -671,7 +671,7 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:516 lxc/auth.go:517
+#: lxc/auth.go:521 lxc/auth.go:522
 msgid "Add permissions to groups"
 msgstr ""
 
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:648
+#: lxc/remote.go:680
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -813,7 +813,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:621
+#: lxc/remote.go:635
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -991,7 +991,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:961
+#: lxc/remote.go:995
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1057,7 +1057,7 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:509
+#: lxc/remote.go:523
 msgid "Certificate fingerprint"
 msgstr ""
 
@@ -1076,7 +1076,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:687
+#: lxc/remote.go:721
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1324,12 +1324,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:559
+#: lxc/remote.go:573
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:237 lxc/remote.go:543
+#: lxc/remote.go:237 lxc/remote.go:557
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1343,12 +1343,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:1719
+#: lxc/auth.go:306 lxc/auth.go:1868
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1058
+#: lxc/auth.go:1207
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1368,13 +1368,17 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:554
+#: lxc/remote.go:568
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
 #: lxc/network_zone.go:1536
 msgid "Couldn't find a matching entry"
+msgstr ""
+
+#: lxc/auth.go:776
+msgid "Create a TLS identity"
 msgstr ""
 
 #: lxc/cluster_group.go:169 lxc/cluster_group.go:170
@@ -1393,6 +1397,10 @@ msgstr ""
 msgid "Create an empty instance"
 msgstr ""
 
+#: lxc/auth.go:775
+msgid "Create an identity"
+msgstr ""
+
 #: lxc/launch.go:23 lxc/launch.go:24
 msgid "Create and start instances from images"
 msgstr ""
@@ -1405,11 +1413,11 @@ msgstr ""
 msgid "Create files and directories in instances"
 msgstr ""
 
-#: lxc/auth.go:98 lxc/auth.go:99
+#: lxc/auth.go:103 lxc/auth.go:104
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1530 lxc/auth.go:1531
+#: lxc/auth.go:1679 lxc/auth.go:1680
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1517,7 +1525,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
@@ -1560,7 +1568,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/auth.go:1088 lxc/auth.go:1089
+#: lxc/auth.go:1237 lxc/auth.go:1238
 msgid "Delete an identity"
 msgstr ""
 
@@ -1568,11 +1576,11 @@ msgstr ""
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/auth.go:152 lxc/auth.go:153
+#: lxc/auth.go:157 lxc/auth.go:158
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1582 lxc/auth.go:1583
+#: lxc/auth.go:1731 lxc/auth.go:1732
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1650,18 +1658,18 @@ msgstr ""
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:31 lxc/auth.go:60 lxc/auth.go:99
-#: lxc/auth.go:153 lxc/auth.go:202 lxc/auth.go:333 lxc/auth.go:393
-#: lxc/auth.go:442 lxc/auth.go:494 lxc/auth.go:517 lxc/auth.go:576
-#: lxc/auth.go:732 lxc/auth.go:769 lxc/auth.go:836 lxc/auth.go:899
-#: lxc/auth.go:960 lxc/auth.go:1089 lxc/auth.go:1143 lxc/auth.go:1166
-#: lxc/auth.go:1224 lxc/auth.go:1293 lxc/auth.go:1315 lxc/auth.go:1493
-#: lxc/auth.go:1531 lxc/auth.go:1583 lxc/auth.go:1632 lxc/auth.go:1751
-#: lxc/auth.go:1811 lxc/auth.go:1860 lxc/auth.go:1911 lxc/auth.go:1934
-#: lxc/auth.go:1987 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215
-#: lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:484
-#: lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677 lxc/cluster.go:770
-#: lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
+#: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
+#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:338 lxc/auth.go:398
+#: lxc/auth.go:447 lxc/auth.go:499 lxc/auth.go:522 lxc/auth.go:581
+#: lxc/auth.go:737 lxc/auth.go:776 lxc/auth.go:918 lxc/auth.go:985
+#: lxc/auth.go:1048 lxc/auth.go:1109 lxc/auth.go:1238 lxc/auth.go:1292
+#: lxc/auth.go:1315 lxc/auth.go:1373 lxc/auth.go:1442 lxc/auth.go:1464
+#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
+#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
+#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
+#: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
+#: lxc/cluster.go:770 lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
 #: lxc/cluster.go:1175 lxc/cluster.go:1299 lxc/cluster.go:1329
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
@@ -1732,9 +1740,9 @@ msgstr ""
 #: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
 #: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
 #: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:715
-#: lxc/remote.go:753 lxc/remote.go:839 lxc/remote.go:920 lxc/remote.go:984
-#: lxc/remote.go:1032 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
+#: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
+#: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1919,7 +1927,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:959 lxc/auth.go:960
+#: lxc/auth.go:1108 lxc/auth.go:1109
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1931,11 +1939,11 @@ msgstr ""
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/auth.go:201 lxc/auth.go:202
+#: lxc/auth.go:206 lxc/auth.go:207
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1631 lxc/auth.go:1632
+#: lxc/auth.go:1780 lxc/auth.go:1781
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2311,12 +2319,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:486
+#: lxc/remote.go:500
 #, c-format
 msgid "Failed to decode trust token: %w"
 msgstr ""
 
-#: lxc/remote.go:292
+#: lxc/remote.go:306
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2420,7 +2428,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:773 lxc/auth.go:1755
+#: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
@@ -2428,7 +2436,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:757 lxc/storage.go:657
+#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2466,7 +2474,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:821
+#: lxc/remote.go:855
 msgid "GLOBAL"
 msgstr ""
 
@@ -2478,7 +2486,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:821 lxc/auth.go:1795
+#: lxc/auth.go:970 lxc/auth.go:1944
 msgid "GROUPS"
 msgstr ""
 
@@ -2486,7 +2494,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:165 lxc/remote.go:443
+#: lxc/remote.go:165 lxc/remote.go:457
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2627,17 +2635,17 @@ msgstr ""
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: lxc/auth.go:137
+#: lxc/auth.go:142
 #, c-format
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:187
+#: lxc/auth.go:192
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:427 lxc/auth.go:1845
+#: lxc/auth.go:432 lxc/auth.go:1994
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2696,7 +2704,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:820
+#: lxc/auth.go:969
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -2728,12 +2736,16 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1567
+#: lxc/auth.go:829
+msgid "Identity creation only supported for TLS identities"
+msgstr ""
+
+#: lxc/auth.go:1716
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1617
+#: lxc/auth.go:1766
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2862,7 +2874,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1292 lxc/auth.go:1293
+#: lxc/auth.go:1441 lxc/auth.go:1442
 msgid "Inspect permissions"
 msgstr ""
 
@@ -2910,7 +2922,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:395
+#: lxc/remote.go:409
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2991,7 +3003,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:384
+#: lxc/remote.go:398
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3166,15 +3178,15 @@ msgstr ""
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:332 lxc/auth.go:333
+#: lxc/auth.go:337 lxc/auth.go:338
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:768 lxc/auth.go:769
+#: lxc/auth.go:917 lxc/auth.go:918
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1750 lxc/auth.go:1751
+#: lxc/auth.go:1899 lxc/auth.go:1900
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3327,7 +3339,7 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1314 lxc/auth.go:1315
+#: lxc/auth.go:1463 lxc/auth.go:1464
 msgid "List permissions"
 msgstr ""
 
@@ -3371,7 +3383,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:752 lxc/remote.go:753
+#: lxc/remote.go:786 lxc/remote.go:787
 msgid "List the available remotes"
 msgstr ""
 
@@ -3495,6 +3507,12 @@ msgstr ""
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
+#: lxc/auth.go:825
+msgid ""
+"Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
+"got "
+msgstr ""
+
 #: lxc/network.go:32 lxc/network.go:33
 msgid "Manage and attach instances to networks"
 msgstr ""
@@ -3523,19 +3541,19 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:59 lxc/auth.go:60 lxc/auth.go:1492 lxc/auth.go:1493
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1142 lxc/auth.go:1143
+#: lxc/auth.go:1291 lxc/auth.go:1292
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:731 lxc/auth.go:732
+#: lxc/auth.go:736 lxc/auth.go:737
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1910 lxc/auth.go:1911
+#: lxc/auth.go:2059 lxc/auth.go:2060
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3626,7 +3644,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:493 lxc/auth.go:494
+#: lxc/auth.go:498 lxc/auth.go:499
 msgid "Manage permissions"
 msgstr ""
 
@@ -3678,7 +3696,7 @@ msgstr ""
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/auth.go:30 lxc/auth.go:31
+#: lxc/auth.go:35 lxc/auth.go:36
 msgid "Manage user authorization"
 msgstr ""
 
@@ -3775,21 +3793,21 @@ msgstr ""
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:123 lxc/auth.go:177 lxc/auth.go:255 lxc/auth.go:417
-#: lxc/auth.go:466 lxc/auth.go:541 lxc/auth.go:600 lxc/auth.go:1884
+#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:260 lxc/auth.go:422
+#: lxc/auth.go:471 lxc/auth.go:546 lxc/auth.go:605 lxc/auth.go:2033
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:866 lxc/auth.go:1007 lxc/auth.go:1124 lxc/auth.go:1190
-#: lxc/auth.go:1248
+#: lxc/auth.go:820 lxc/auth.go:1015 lxc/auth.go:1156 lxc/auth.go:1273
+#: lxc/auth.go:1339 lxc/auth.go:1397
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1554 lxc/auth.go:1607 lxc/auth.go:1673 lxc/auth.go:1835
+#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1958 lxc/auth.go:2011
+#: lxc/auth.go:2107 lxc/auth.go:2160
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -4010,12 +4028,12 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:376 lxc/auth.go:819 lxc/auth.go:1794 lxc/cluster.go:192
+#: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
-#: lxc/remote.go:815 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
 msgstr ""
@@ -4042,7 +4060,7 @@ msgstr ""
 
 #: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:775 lxc/remote.go:780 lxc/remote.go:785
+#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr ""
 
@@ -4271,7 +4289,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:378
+#: lxc/remote.go:392
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4342,11 +4360,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:817
+#: lxc/remote.go:851
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:819
+#: lxc/image.go:1136 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4387,7 +4405,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:536
+#: lxc/remote.go:550
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
@@ -4404,7 +4422,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:302 lxc/auth.go:1059 lxc/auth.go:1720 lxc/cluster.go:860
+#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -4707,33 +4725,33 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:877
+#: lxc/remote.go:911
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:868 lxc/remote.go:949 lxc/remote.go:1013
-#: lxc/remote.go:1061
+#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/remote.go:1095
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:345
+#: lxc/remote.go:359
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:957
+#: lxc/remote.go:991
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:872 lxc/remote.go:953 lxc/remote.go:1065
+#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1099
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:319
+#: lxc/remote.go:333
 msgid "Remote address must not be empty"
 msgstr ""
 
@@ -4741,7 +4759,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:339
+#: lxc/remote.go:353
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4763,7 +4781,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1223 lxc/auth.go:1224
+#: lxc/auth.go:1372 lxc/auth.go:1373
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4799,7 +4817,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1986 lxc/auth.go:1987
+#: lxc/auth.go:2135 lxc/auth.go:2136
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4811,7 +4829,7 @@ msgstr ""
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:575 lxc/auth.go:576
+#: lxc/auth.go:580 lxc/auth.go:581
 msgid "Remove permissions from groups"
 msgstr ""
 
@@ -4827,7 +4845,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:919 lxc/remote.go:920
+#: lxc/remote.go:953 lxc/remote.go:954
 msgid "Remove remotes"
 msgstr ""
 
@@ -4856,11 +4874,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:392 lxc/auth.go:393
+#: lxc/auth.go:397 lxc/auth.go:398
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1810 lxc/auth.go:1811
+#: lxc/auth.go:1959 lxc/auth.go:1960
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -4884,7 +4902,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:838 lxc/remote.go:839
+#: lxc/remote.go:872 lxc/remote.go:873
 msgid "Rename remotes"
 msgstr ""
 
@@ -5029,7 +5047,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:820
+#: lxc/remote.go:854
 msgid "STATIC"
 msgstr ""
 
@@ -5070,11 +5088,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:532
+#: lxc/remote.go:546
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:285 lxc/remote.go:683
+#: lxc/remote.go:299 lxc/remote.go:717
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5285,7 +5303,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1031 lxc/remote.go:1032
+#: lxc/remote.go:1065 lxc/remote.go:1066
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5381,7 +5399,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1859 lxc/auth.go:1860
+#: lxc/auth.go:2008 lxc/auth.go:2009
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5409,11 +5427,11 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:441 lxc/auth.go:442
+#: lxc/auth.go:446 lxc/auth.go:447
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:836
+#: lxc/auth.go:985
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5518,7 +5536,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:899
+#: lxc/auth.go:1048
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5528,7 +5546,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:714 lxc/remote.go:715
+#: lxc/remote.go:748 lxc/remote.go:749
 msgid "Show the default remote"
 msgstr ""
 
@@ -5740,7 +5758,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:983 lxc/remote.go:984
+#: lxc/remote.go:1017 lxc/remote.go:1018
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5752,11 +5770,21 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
+#: lxc/auth.go:876
+#, c-format
+msgid "TLS identity %q (%s) pending identity token:"
+msgstr ""
+
+#: lxc/auth.go:902
+#, c-format
+msgid "TLS identity %q created with fingerprint %q"
+msgstr ""
+
 #: lxc/cluster.go:1070 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:818 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
 #: lxc/storage_volume.go:1736 lxc/warning.go:216
@@ -5775,7 +5803,7 @@ msgstr ""
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/remote.go:161 lxc/remote.go:334
+#: lxc/remote.go:161 lxc/remote.go:348
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
@@ -5931,7 +5959,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:527
+#: lxc/remote.go:541
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
@@ -6069,15 +6097,15 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:329
+#: lxc/remote.go:343
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:324
+#: lxc/remote.go:338
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr ""
 
-#: lxc/remote.go:639
+#: lxc/remote.go:653
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6120,7 +6148,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:193 lxc/remote.go:816
+#: lxc/cluster.go:193 lxc/remote.go:850
 msgid "URL"
 msgstr ""
 
@@ -6428,11 +6456,11 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:835
+#: lxc/auth.go:984
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:898
+#: lxc/auth.go:1047
 msgid "View the current identity"
 msgstr ""
 
@@ -6471,7 +6499,7 @@ msgstr ""
 
 #: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:777 lxc/remote.go:782 lxc/remote.go:787
+#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr ""
 
@@ -6503,7 +6531,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:330 lxc/auth.go:766 lxc/auth.go:897 lxc/auth.go:1748
+#: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
@@ -6536,7 +6564,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1313
+#: lxc/auth.go:1462
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6597,11 +6625,17 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:834 lxc/auth.go:1086
+#: lxc/auth.go:774
+msgid ""
+"[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
+"certificate>] [[--group <group_name>]]"
+msgstr ""
+
+#: lxc/auth.go:983 lxc/auth.go:1235
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1164 lxc/auth.go:1222 lxc/auth.go:1985
+#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:2134
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6609,13 +6643,13 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:97 lxc/auth.go:150 lxc/auth.go:200 lxc/auth.go:440
-#: lxc/auth.go:958 lxc/auth.go:1529 lxc/cluster_group.go:168
+#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:445
+#: lxc/auth.go:1107 lxc/auth.go:1678 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:515 lxc/auth.go:573
+#: lxc/auth.go:520 lxc/auth.go:578
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
@@ -6625,19 +6659,19 @@ msgstr ""
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:390
+#: lxc/auth.go:395
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1580 lxc/auth.go:1630 lxc/auth.go:1858
+#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1932
+#: lxc/auth.go:2081
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1808
+#: lxc/auth.go:1957
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -7128,7 +7162,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:806
+#: lxc/project.go:557 lxc/remote.go:840
 msgid "current"
 msgstr ""
 
@@ -7175,20 +7209,20 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/auth.go:204
+#: lxc/auth.go:209
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:962
+#: lxc/auth.go:1111
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1634
+#: lxc/auth.go:1783
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7612,7 +7646,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:531
+#: lxc/remote.go:545
 msgid "n"
 msgstr ""
 
@@ -7624,7 +7658,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:510
+#: lxc/remote.go:524
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7661,7 +7695,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:519
+#: lxc/remote.go:533
 msgid "y"
 msgstr ""
 

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-14 13:30+0000\n"
+"POT-Creation-Date: 2024-10-15 14:52+0100\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Luigi Operoso <brokenpip3@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/linux-containers/"
@@ -209,7 +209,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/auth.go:214
+#: lxc/auth.go:219
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -236,7 +236,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:972
+#: lxc/auth.go:1121
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -257,7 +257,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1644
+#: lxc/auth.go:1793
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
@@ -759,15 +759,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:917 lxc/remote.go:982
+#: lxc/remote.go:951 lxc/remote.go:1016
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1030
+#: lxc/remote.go:1064
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:836
+#: lxc/remote.go:870
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -801,11 +801,11 @@ msgstr "ALIAS"
 msgid "ARCHITECTURE"
 msgstr "ARCHITETTURA"
 
-#: lxc/remote.go:818
+#: lxc/remote.go:852
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:817
+#: lxc/auth.go:966
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -844,11 +844,11 @@ msgstr "Azione (default a GET)"
 msgid "Add a cluster member to a cluster group"
 msgstr "Il nome del container è: %s"
 
-#: lxc/auth.go:1165 lxc/auth.go:1166
+#: lxc/auth.go:1314 lxc/auth.go:1315
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1933 lxc/auth.go:1934
+#: lxc/auth.go:2082 lxc/auth.go:2083
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -919,7 +919,7 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:516 lxc/auth.go:517
+#: lxc/auth.go:521 lxc/auth.go:522
 msgid "Add permissions to groups"
 msgstr ""
 
@@ -954,7 +954,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr "Password amministratore per %s: "
 
-#: lxc/remote.go:648
+#: lxc/remote.go:680
 #, fuzzy, c-format
 msgid "Admin password (or token) for %s:"
 msgstr "Password amministratore per %s: "
@@ -1064,7 +1064,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:621
+#: lxc/remote.go:635
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -1243,7 +1243,7 @@ msgstr "Impossibile effettuare il pull di una directory senza --recursive"
 msgid "Can't read from stdin: %w"
 msgstr "Impossible leggere da stdin: %s"
 
-#: lxc/remote.go:961
+#: lxc/remote.go:995
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1309,7 +1309,7 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr "Il nome del container è: %s"
 
-#: lxc/remote.go:509
+#: lxc/remote.go:523
 #, fuzzy
 msgid "Certificate fingerprint"
 msgstr "Creazione del container in corso"
@@ -1329,7 +1329,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr "Il nome del container è: %s"
 
-#: lxc/remote.go:687
+#: lxc/remote.go:721
 #, fuzzy
 msgid "Client certificate now trusted by server:"
 msgstr "Certificato del client salvato dal server: "
@@ -1578,12 +1578,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:559
+#: lxc/remote.go:573
 #, fuzzy, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "Certificato del client salvato dal server: "
 
-#: lxc/remote.go:237 lxc/remote.go:543
+#: lxc/remote.go:237 lxc/remote.go:557
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1597,12 +1597,12 @@ msgstr "Certificato del client salvato dal server: "
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:1719
+#: lxc/auth.go:306 lxc/auth.go:1868
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1058
+#: lxc/auth.go:1207
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1622,13 +1622,17 @@ msgstr "Certificato del client salvato dal server: "
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:554
+#: lxc/remote.go:568
 #, fuzzy, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "Certificato del client salvato dal server: "
 
 #: lxc/network_zone.go:1536
 msgid "Couldn't find a matching entry"
+msgstr ""
+
+#: lxc/auth.go:776
+msgid "Create a TLS identity"
 msgstr ""
 
 #: lxc/cluster_group.go:169 lxc/cluster_group.go:170
@@ -1649,6 +1653,11 @@ msgstr ""
 msgid "Create an empty instance"
 msgstr "Creazione del container in corso"
 
+#: lxc/auth.go:775
+#, fuzzy
+msgid "Create an identity"
+msgstr "Creazione del container in corso"
+
 #: lxc/launch.go:23 lxc/launch.go:24
 #, fuzzy
 msgid "Create and start instances from images"
@@ -1663,11 +1672,11 @@ msgstr ""
 msgid "Create files and directories in instances"
 msgstr "Creazione del container in corso"
 
-#: lxc/auth.go:98 lxc/auth.go:99
+#: lxc/auth.go:103 lxc/auth.go:104
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1530 lxc/auth.go:1531
+#: lxc/auth.go:1679 lxc/auth.go:1680
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1782,7 +1791,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
@@ -1825,7 +1834,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/auth.go:1088 lxc/auth.go:1089
+#: lxc/auth.go:1237 lxc/auth.go:1238
 msgid "Delete an identity"
 msgstr ""
 
@@ -1834,11 +1843,11 @@ msgstr ""
 msgid "Delete files in instances"
 msgstr "Creazione del container in corso"
 
-#: lxc/auth.go:152 lxc/auth.go:153
+#: lxc/auth.go:157 lxc/auth.go:158
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1582 lxc/auth.go:1583
+#: lxc/auth.go:1731 lxc/auth.go:1732
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1920,18 +1929,18 @@ msgstr ""
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:31 lxc/auth.go:60 lxc/auth.go:99
-#: lxc/auth.go:153 lxc/auth.go:202 lxc/auth.go:333 lxc/auth.go:393
-#: lxc/auth.go:442 lxc/auth.go:494 lxc/auth.go:517 lxc/auth.go:576
-#: lxc/auth.go:732 lxc/auth.go:769 lxc/auth.go:836 lxc/auth.go:899
-#: lxc/auth.go:960 lxc/auth.go:1089 lxc/auth.go:1143 lxc/auth.go:1166
-#: lxc/auth.go:1224 lxc/auth.go:1293 lxc/auth.go:1315 lxc/auth.go:1493
-#: lxc/auth.go:1531 lxc/auth.go:1583 lxc/auth.go:1632 lxc/auth.go:1751
-#: lxc/auth.go:1811 lxc/auth.go:1860 lxc/auth.go:1911 lxc/auth.go:1934
-#: lxc/auth.go:1987 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215
-#: lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:484
-#: lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677 lxc/cluster.go:770
-#: lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
+#: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
+#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:338 lxc/auth.go:398
+#: lxc/auth.go:447 lxc/auth.go:499 lxc/auth.go:522 lxc/auth.go:581
+#: lxc/auth.go:737 lxc/auth.go:776 lxc/auth.go:918 lxc/auth.go:985
+#: lxc/auth.go:1048 lxc/auth.go:1109 lxc/auth.go:1238 lxc/auth.go:1292
+#: lxc/auth.go:1315 lxc/auth.go:1373 lxc/auth.go:1442 lxc/auth.go:1464
+#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
+#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
+#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
+#: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
+#: lxc/cluster.go:770 lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
 #: lxc/cluster.go:1175 lxc/cluster.go:1299 lxc/cluster.go:1329
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
@@ -2002,9 +2011,9 @@ msgstr ""
 #: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
 #: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
 #: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:715
-#: lxc/remote.go:753 lxc/remote.go:839 lxc/remote.go:920 lxc/remote.go:984
-#: lxc/remote.go:1032 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
+#: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
+#: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -2195,7 +2204,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:959 lxc/auth.go:960
+#: lxc/auth.go:1108 lxc/auth.go:1109
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -2208,11 +2217,11 @@ msgstr ""
 msgid "Edit files in instances"
 msgstr "Creazione del container in corso"
 
-#: lxc/auth.go:201 lxc/auth.go:202
+#: lxc/auth.go:206 lxc/auth.go:207
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1631 lxc/auth.go:1632
+#: lxc/auth.go:1780 lxc/auth.go:1781
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2596,12 +2605,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr "Accetta certificato"
 
-#: lxc/remote.go:486
+#: lxc/remote.go:500
 #, fuzzy, c-format
 msgid "Failed to decode trust token: %w"
 msgstr "Il nome del container è: %s"
 
-#: lxc/remote.go:292
+#: lxc/remote.go:306
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2707,7 +2716,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:773 lxc/auth.go:1755
+#: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
@@ -2715,7 +2724,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:757 lxc/storage.go:657
+#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2753,7 +2762,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:821
+#: lxc/remote.go:855
 msgid "GLOBAL"
 msgstr ""
 
@@ -2765,7 +2774,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:821 lxc/auth.go:1795
+#: lxc/auth.go:970 lxc/auth.go:1944
 msgid "GROUPS"
 msgstr ""
 
@@ -2773,7 +2782,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:165 lxc/remote.go:443
+#: lxc/remote.go:165 lxc/remote.go:457
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2925,17 +2934,17 @@ msgstr ""
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: lxc/auth.go:137
+#: lxc/auth.go:142
 #, c-format
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:187
+#: lxc/auth.go:192
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:427 lxc/auth.go:1845
+#: lxc/auth.go:432 lxc/auth.go:1994
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2995,7 +3004,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:820
+#: lxc/auth.go:969
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -3027,12 +3036,16 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1567
+#: lxc/auth.go:829
+msgid "Identity creation only supported for TLS identities"
+msgstr ""
+
+#: lxc/auth.go:1716
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1617
+#: lxc/auth.go:1766
 #, fuzzy, c-format
 msgid "Identity provider group %s deleted"
 msgstr "Il nome del container è: %s"
@@ -3163,7 +3176,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1292 lxc/auth.go:1293
+#: lxc/auth.go:1441 lxc/auth.go:1442
 msgid "Inspect permissions"
 msgstr ""
 
@@ -3213,7 +3226,7 @@ msgstr "Il nome del container è: %s"
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:395
+#: lxc/remote.go:409
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3296,7 +3309,7 @@ msgstr "numero errato di argomenti del sottocomando"
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:384
+#: lxc/remote.go:398
 #, fuzzy, c-format
 msgid "Invalid protocol: %s"
 msgstr "Proprietà errata: %s"
@@ -3480,16 +3493,16 @@ msgstr ""
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:332 lxc/auth.go:333
+#: lxc/auth.go:337 lxc/auth.go:338
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:768 lxc/auth.go:769
+#: lxc/auth.go:917 lxc/auth.go:918
 #, fuzzy
 msgid "List identities"
 msgstr "Creazione del container in corso"
 
-#: lxc/auth.go:1750 lxc/auth.go:1751
+#: lxc/auth.go:1899 lxc/auth.go:1900
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3645,7 +3658,7 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr "Creazione del container in corso"
 
-#: lxc/auth.go:1314 lxc/auth.go:1315
+#: lxc/auth.go:1463 lxc/auth.go:1464
 #, fuzzy
 msgid "List permissions"
 msgstr "Alias:"
@@ -3691,7 +3704,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:752 lxc/remote.go:753
+#: lxc/remote.go:786 lxc/remote.go:787
 msgid "List the available remotes"
 msgstr ""
 
@@ -3818,6 +3831,12 @@ msgstr ""
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
+#: lxc/auth.go:825
+msgid ""
+"Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
+"got "
+msgstr ""
+
 #: lxc/network.go:32 lxc/network.go:33
 msgid "Manage and attach instances to networks"
 msgstr ""
@@ -3849,21 +3868,21 @@ msgstr "Creazione del container in corso"
 msgid "Manage files in instances"
 msgstr "Creazione del container in corso"
 
-#: lxc/auth.go:59 lxc/auth.go:60 lxc/auth.go:1492 lxc/auth.go:1493
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
 #, fuzzy
 msgid "Manage groups"
 msgstr "Creazione del container in corso"
 
-#: lxc/auth.go:1142 lxc/auth.go:1143
+#: lxc/auth.go:1291 lxc/auth.go:1292
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:731 lxc/auth.go:732
+#: lxc/auth.go:736 lxc/auth.go:737
 #, fuzzy
 msgid "Manage identities"
 msgstr "Creazione del container in corso"
 
-#: lxc/auth.go:1910 lxc/auth.go:1911
+#: lxc/auth.go:2059 lxc/auth.go:2060
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3963,7 +3982,7 @@ msgstr "Creazione del container in corso"
 msgid "Manage network zones"
 msgstr "Creazione del container in corso"
 
-#: lxc/auth.go:493 lxc/auth.go:494
+#: lxc/auth.go:498 lxc/auth.go:499
 #, fuzzy
 msgid "Manage permissions"
 msgstr "Creazione del container in corso"
@@ -4019,7 +4038,7 @@ msgstr ""
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/auth.go:30 lxc/auth.go:31
+#: lxc/auth.go:35 lxc/auth.go:36
 #, fuzzy
 msgid "Manage user authorization"
 msgstr "Il nome del container è: %s"
@@ -4121,24 +4140,24 @@ msgstr "Il nome del container è: %s"
 msgid "Missing cluster member name"
 msgstr "Il nome del container è: %s"
 
-#: lxc/auth.go:123 lxc/auth.go:177 lxc/auth.go:255 lxc/auth.go:417
-#: lxc/auth.go:466 lxc/auth.go:541 lxc/auth.go:600 lxc/auth.go:1884
+#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:260 lxc/auth.go:422
+#: lxc/auth.go:471 lxc/auth.go:546 lxc/auth.go:605 lxc/auth.go:2033
 #, fuzzy
 msgid "Missing group name"
 msgstr "Il nome del container è: %s"
 
-#: lxc/auth.go:866 lxc/auth.go:1007 lxc/auth.go:1124 lxc/auth.go:1190
-#: lxc/auth.go:1248
+#: lxc/auth.go:820 lxc/auth.go:1015 lxc/auth.go:1156 lxc/auth.go:1273
+#: lxc/auth.go:1339 lxc/auth.go:1397
 #, fuzzy
 msgid "Missing identity argument"
 msgstr "Il nome del container è: %s"
 
-#: lxc/auth.go:1554 lxc/auth.go:1607 lxc/auth.go:1673 lxc/auth.go:1835
+#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
 #, fuzzy
 msgid "Missing identity provider group name"
 msgstr "Il nome del container è: %s"
 
-#: lxc/auth.go:1958 lxc/auth.go:2011
+#: lxc/auth.go:2107 lxc/auth.go:2160
 #, fuzzy
 msgid "Missing identity provider group name argument"
 msgstr "Il nome del container è: %s"
@@ -4371,12 +4390,12 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:376 lxc/auth.go:819 lxc/auth.go:1794 lxc/cluster.go:192
+#: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
-#: lxc/remote.go:815 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
 msgstr ""
@@ -4403,7 +4422,7 @@ msgstr ""
 
 #: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:775 lxc/remote.go:780 lxc/remote.go:785
+#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr ""
 
@@ -4633,7 +4652,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:378
+#: lxc/remote.go:392
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4704,11 +4723,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:817
+#: lxc/remote.go:851
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:819
+#: lxc/image.go:1136 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4751,7 +4770,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr "Il nome del container è: %s"
 
-#: lxc/remote.go:536
+#: lxc/remote.go:550
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
@@ -4768,7 +4787,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:302 lxc/auth.go:1059 lxc/auth.go:1720 lxc/cluster.go:860
+#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -5076,33 +5095,33 @@ msgstr "Creazione del container in corso"
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:877
+#: lxc/remote.go:911
 #, fuzzy, c-format
 msgid "Remote %s already exists"
 msgstr "il remote %s esiste già"
 
-#: lxc/project.go:884 lxc/remote.go:868 lxc/remote.go:949 lxc/remote.go:1013
-#: lxc/remote.go:1061
+#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/remote.go:1095
 #, fuzzy, c-format
 msgid "Remote %s doesn't exist"
 msgstr "il remote %s non esiste"
 
-#: lxc/remote.go:345
+#: lxc/remote.go:359
 #, fuzzy, c-format
 msgid "Remote %s exists as <%s>"
 msgstr "il remote %s esiste come %s"
 
-#: lxc/remote.go:957
+#: lxc/remote.go:991
 #, fuzzy, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr "il remote %s è statico e non può essere modificato"
 
-#: lxc/remote.go:872 lxc/remote.go:953 lxc/remote.go:1065
+#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1099
 #, fuzzy, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr "il remote %s è statico e non può essere modificato"
 
-#: lxc/remote.go:319
+#: lxc/remote.go:333
 msgid "Remote address must not be empty"
 msgstr ""
 
@@ -5111,7 +5130,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr "Password amministratore per %s: "
 
-#: lxc/remote.go:339
+#: lxc/remote.go:353
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -5134,7 +5153,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr "Il nome del container è: %s"
 
-#: lxc/auth.go:1223 lxc/auth.go:1224
+#: lxc/auth.go:1372 lxc/auth.go:1373
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -5173,7 +5192,7 @@ msgstr "Il nome del container è: %s"
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1986 lxc/auth.go:1987
+#: lxc/auth.go:2135 lxc/auth.go:2136
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -5186,7 +5205,7 @@ msgstr "Creazione del container in corso"
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:575 lxc/auth.go:576
+#: lxc/auth.go:580 lxc/auth.go:581
 msgid "Remove permissions from groups"
 msgstr ""
 
@@ -5203,7 +5222,7 @@ msgstr "Il nome del container è: %s"
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:919 lxc/remote.go:920
+#: lxc/remote.go:953 lxc/remote.go:954
 msgid "Remove remotes"
 msgstr ""
 
@@ -5233,11 +5252,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:392 lxc/auth.go:393
+#: lxc/auth.go:397 lxc/auth.go:398
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1810 lxc/auth.go:1811
+#: lxc/auth.go:1959 lxc/auth.go:1960
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5262,7 +5281,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:838 lxc/remote.go:839
+#: lxc/remote.go:872 lxc/remote.go:873
 msgid "Rename remotes"
 msgstr ""
 
@@ -5413,7 +5432,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:820
+#: lxc/remote.go:854
 msgid "STATIC"
 msgstr ""
 
@@ -5454,11 +5473,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:532
+#: lxc/remote.go:546
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:285 lxc/remote.go:683
+#: lxc/remote.go:299 lxc/remote.go:717
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5675,7 +5694,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1031 lxc/remote.go:1032
+#: lxc/remote.go:1065 lxc/remote.go:1066
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5775,7 +5794,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1859 lxc/auth.go:1860
+#: lxc/auth.go:2008 lxc/auth.go:2009
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5804,12 +5823,12 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:441 lxc/auth.go:442
+#: lxc/auth.go:446 lxc/auth.go:447
 #, fuzzy
 msgid "Show group configurations"
 msgstr "Il nome del container è: %s"
 
-#: lxc/auth.go:836
+#: lxc/auth.go:985
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5923,7 +5942,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:899
+#: lxc/auth.go:1048
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5933,7 +5952,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:714 lxc/remote.go:715
+#: lxc/remote.go:748 lxc/remote.go:749
 msgid "Show the default remote"
 msgstr ""
 
@@ -6149,7 +6168,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:983 lxc/remote.go:984
+#: lxc/remote.go:1017 lxc/remote.go:1018
 msgid "Switch the default remote"
 msgstr ""
 
@@ -6161,11 +6180,21 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
+#: lxc/auth.go:876
+#, c-format
+msgid "TLS identity %q (%s) pending identity token:"
+msgstr ""
+
+#: lxc/auth.go:902
+#, c-format
+msgid "TLS identity %q created with fingerprint %q"
+msgstr ""
+
 #: lxc/cluster.go:1070 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:818 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
 #: lxc/storage_volume.go:1736 lxc/warning.go:216
@@ -6185,7 +6214,7 @@ msgstr ""
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/remote.go:161 lxc/remote.go:334
+#: lxc/remote.go:161 lxc/remote.go:348
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
@@ -6342,7 +6371,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:527
+#: lxc/remote.go:541
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
@@ -6482,15 +6511,15 @@ msgstr "Creazione del container in corso"
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:329
+#: lxc/remote.go:343
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:324
+#: lxc/remote.go:338
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr ""
 
-#: lxc/remote.go:639
+#: lxc/remote.go:653
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6534,7 +6563,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:193 lxc/remote.go:816
+#: lxc/cluster.go:193 lxc/remote.go:850
 msgid "URL"
 msgstr ""
 
@@ -6858,11 +6887,11 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:835
+#: lxc/auth.go:984
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:898
+#: lxc/auth.go:1047
 msgid "View the current identity"
 msgstr ""
 
@@ -6901,7 +6930,7 @@ msgstr ""
 
 #: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:777 lxc/remote.go:782 lxc/remote.go:787
+#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr ""
 
@@ -6938,7 +6967,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/auth.go:330 lxc/auth.go:766 lxc/auth.go:897 lxc/auth.go:1748
+#: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
@@ -6978,7 +7007,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:] [<filters>...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/auth.go:1313
+#: lxc/auth.go:1462
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -7053,11 +7082,17 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<alias> <new-name>"
 msgstr "Creazione del container in corso"
 
-#: lxc/auth.go:834 lxc/auth.go:1086
+#: lxc/auth.go:774
+msgid ""
+"[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
+"certificate>] [[--group <group_name>]]"
+msgstr ""
+
+#: lxc/auth.go:983 lxc/auth.go:1235
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1164 lxc/auth.go:1222 lxc/auth.go:1985
+#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:2134
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -7066,14 +7101,14 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr "Creazione del container in corso"
 
-#: lxc/auth.go:97 lxc/auth.go:150 lxc/auth.go:200 lxc/auth.go:440
-#: lxc/auth.go:958 lxc/auth.go:1529 lxc/cluster_group.go:168
+#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:445
+#: lxc/auth.go:1107 lxc/auth.go:1678 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 #, fuzzy
 msgid "[<remote>:]<group>"
 msgstr "Creazione del container in corso"
 
-#: lxc/auth.go:515 lxc/auth.go:573
+#: lxc/auth.go:520 lxc/auth.go:578
 #, fuzzy
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
@@ -7085,22 +7120,22 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<group> <new-name>"
 msgstr "Creazione del container in corso"
 
-#: lxc/auth.go:390
+#: lxc/auth.go:395
 #, fuzzy
 msgid "[<remote>:]<group> <new_name>"
 msgstr "Creazione del container in corso"
 
-#: lxc/auth.go:1580 lxc/auth.go:1630 lxc/auth.go:1858
+#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group>"
 msgstr "Creazione del container in corso"
 
-#: lxc/auth.go:1932
+#: lxc/auth.go:2081
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr "Creazione del container in corso"
 
-#: lxc/auth.go:1808
+#: lxc/auth.go:1957
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr "Creazione del container in corso"
@@ -7705,7 +7740,7 @@ msgstr "Creazione del container in corso"
 msgid "[[<remote>:]<member>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/project.go:557 lxc/remote.go:806
+#: lxc/project.go:557 lxc/remote.go:840
 msgid "current"
 msgstr ""
 
@@ -7752,20 +7787,20 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/auth.go:204
+#: lxc/auth.go:209
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:962
+#: lxc/auth.go:1111
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1634
+#: lxc/auth.go:1783
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -8189,7 +8224,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:531
+#: lxc/remote.go:545
 #, fuzzy
 msgid "n"
 msgstr "no"
@@ -8202,7 +8237,7 @@ msgstr ""
 msgid "no"
 msgstr "no"
 
-#: lxc/remote.go:510
+#: lxc/remote.go:524
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -8239,7 +8274,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:519
+#: lxc/remote.go:533
 msgid "y"
 msgstr ""
 

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-14 13:30+0000\n"
+"POT-Creation-Date: 2024-10-15 14:52+0100\n"
 "PO-Revision-Date: 2023-03-10 15:14+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/linux-"
@@ -188,7 +188,7 @@ msgstr ""
 "###\n"
 "### Note that the name is shown but cannot be changed"
 
-#: lxc/auth.go:214
+#: lxc/auth.go:219
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -215,7 +215,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:972
+#: lxc/auth.go:1121
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -236,7 +236,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1644
+#: lxc/auth.go:1793
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
@@ -749,15 +749,15 @@ msgstr "<alias> <target>"
 msgid "<old alias> <new alias>"
 msgstr "<old alias> <new alias>"
 
-#: lxc/remote.go:917 lxc/remote.go:982
+#: lxc/remote.go:951 lxc/remote.go:1016
 msgid "<remote>"
 msgstr "<remote>"
 
-#: lxc/remote.go:1030
+#: lxc/remote.go:1064
 msgid "<remote> <URL>"
 msgstr "<remote> <URL>"
 
-#: lxc/remote.go:836
+#: lxc/remote.go:870
 msgid "<remote> <new-name>"
 msgstr "<remote> <new-name>"
 
@@ -792,11 +792,11 @@ msgstr "ALIASES"
 msgid "ARCHITECTURE"
 msgstr "ARCHITECTURE"
 
-#: lxc/remote.go:818
+#: lxc/remote.go:852
 msgid "AUTH TYPE"
 msgstr "AUTH TYPE"
 
-#: lxc/auth.go:817
+#: lxc/auth.go:966
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -835,11 +835,11 @@ msgstr "使用するHTTPのメソッド (デフォルト: GET)"
 msgid "Add a cluster member to a cluster group"
 msgstr "クラスタグループからメンバを削除します"
 
-#: lxc/auth.go:1165 lxc/auth.go:1166
+#: lxc/auth.go:1314 lxc/auth.go:1315
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1933 lxc/auth.go:1934
+#: lxc/auth.go:2082 lxc/auth.go:2083
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -927,7 +927,7 @@ msgstr ""
 "使ったトークンは無効化されます。\n"
 "証明書と同様に、トークンも 1 つ以上のプロジェクトに制限できます。\n"
 
-#: lxc/auth.go:516 lxc/auth.go:517
+#: lxc/auth.go:521 lxc/auth.go:522
 #, fuzzy
 msgid "Add permissions to groups"
 msgstr "グループからメンバーを削除します"
@@ -962,7 +962,7 @@ msgstr "アドレス: %s"
 msgid "Admin access key: %s"
 msgstr "管理者アクセスキー: %s"
 
-#: lxc/remote.go:648
+#: lxc/remote.go:680
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr "%s の管理者パスワード（もしくはトークン）:"
@@ -1075,7 +1075,7 @@ msgstr ""
 "このコマンドはインスタンスのブートコンソールに接続できます。\n"
 "そしてそこから過去のログエントリを取り出すことができます。"
 
-#: lxc/remote.go:621
+#: lxc/remote.go:635
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr "認証タイプ '%s' はサーバではサポートされていません"
@@ -1256,7 +1256,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr "標準入力から読み込めません: %w"
 
-#: lxc/remote.go:961
+#: lxc/remote.go:995
 msgid "Can't remove the default remote"
 msgstr "デフォルトのリモートは削除できません"
 
@@ -1325,7 +1325,7 @@ msgstr "カード: %s (%s)"
 msgid "Certificate add token for %s deleted"
 msgstr "%s に対する証明書追加トークンが削除されました"
 
-#: lxc/remote.go:509
+#: lxc/remote.go:523
 #, fuzzy
 msgid "Certificate fingerprint"
 msgstr "証明書のフィンガープリント: %s"
@@ -1346,7 +1346,7 @@ msgstr "Chassis"
 msgid "Client %s certificate add token:"
 msgstr "クライアント %s の証明書追加トークン:"
 
-#: lxc/remote.go:687
+#: lxc/remote.go:721
 msgid "Client certificate now trusted by server:"
 msgstr "クライアント証明書がサーバに信頼されました:"
 
@@ -1613,12 +1613,12 @@ msgstr "コア %d"
 msgid "Cores:"
 msgstr "コア:"
 
-#: lxc/remote.go:559
+#: lxc/remote.go:573
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "サーバ証明書ファイル %q をクローズできません: %w"
 
-#: lxc/remote.go:237 lxc/remote.go:543
+#: lxc/remote.go:237 lxc/remote.go:557
 msgid "Could not create server cert dir"
 msgstr "サーバ証明書格納用のディレクトリを作成できません"
 
@@ -1632,12 +1632,12 @@ msgstr "証明書のファイルパスが見つかりません: %s"
 msgid "Could not find certificate key file path: %s"
 msgstr "証明書の鍵のパスが見つかりません: %s"
 
-#: lxc/auth.go:301 lxc/auth.go:1719
+#: lxc/auth.go:306 lxc/auth.go:1868
 #, fuzzy, c-format
 msgid "Could not parse group: %s"
 msgstr "設定の構文エラー: %s"
 
-#: lxc/auth.go:1058
+#: lxc/auth.go:1207
 #, fuzzy, c-format
 msgid "Could not parse identity: %s"
 msgstr "設定キーを設定できません: %s"
@@ -1657,7 +1657,7 @@ msgstr "秘密鍵ファイル %s をエラーで読み込めません: %v"
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr "リモート '%s' に対する新しいリモート証明書がエラーで書き込めません: %v"
 
-#: lxc/remote.go:554
+#: lxc/remote.go:568
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "サーバ証明書ファイル %q を書き込めません: %w"
@@ -1665,6 +1665,11 @@ msgstr "サーバ証明書ファイル %q を書き込めません: %w"
 #: lxc/network_zone.go:1536
 msgid "Couldn't find a matching entry"
 msgstr "一致するエントリを見つけられませんでした"
+
+#: lxc/auth.go:776
+#, fuzzy
+msgid "Create a TLS identity"
+msgstr "警告を削除します"
 
 #: lxc/cluster_group.go:169 lxc/cluster_group.go:170
 msgid "Create a cluster group"
@@ -1682,6 +1687,11 @@ msgstr "既存のイメージに対するエイリアスを作成します"
 msgid "Create an empty instance"
 msgstr "空のインスタンスを作成"
 
+#: lxc/auth.go:775
+#, fuzzy
+msgid "Create an identity"
+msgstr "警告を削除します"
+
 #: lxc/launch.go:23 lxc/launch.go:24
 msgid "Create and start instances from images"
 msgstr "イメージからインスタンスを作成し、起動します"
@@ -1695,12 +1705,12 @@ msgstr "必要なディレクトリをすべて作成します"
 msgid "Create files and directories in instances"
 msgstr "必要なディレクトリをすべて作成します"
 
-#: lxc/auth.go:98 lxc/auth.go:99
+#: lxc/auth.go:103 lxc/auth.go:104
 #, fuzzy
 msgid "Create groups"
 msgstr "プロファイルを作成します"
 
-#: lxc/auth.go:1530 lxc/auth.go:1531
+#: lxc/auth.go:1679 lxc/auth.go:1680
 #, fuzzy
 msgid "Create identity provider groups"
 msgstr "新たにクラスターグループを作成します"
@@ -1813,7 +1823,7 @@ msgstr "現在の VF 数: %d"
 msgid "DEFAULT TARGET ADDRESS"
 msgstr "DEFAULT TARGET ADDRESS"
 
-#: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
@@ -1856,7 +1866,7 @@ msgstr "クラスタグループを削除します"
 msgid "Delete all warnings"
 msgstr "警告をすべて削除します"
 
-#: lxc/auth.go:1088 lxc/auth.go:1089
+#: lxc/auth.go:1237 lxc/auth.go:1238
 #, fuzzy
 msgid "Delete an identity"
 msgstr "警告を削除します"
@@ -1865,12 +1875,12 @@ msgstr "警告を削除します"
 msgid "Delete files in instances"
 msgstr "インスタンス内のファイルを削除します"
 
-#: lxc/auth.go:152 lxc/auth.go:153
+#: lxc/auth.go:157 lxc/auth.go:158
 #, fuzzy
 msgid "Delete groups"
 msgstr "プロファイルを削除します"
 
-#: lxc/auth.go:1582 lxc/auth.go:1583
+#: lxc/auth.go:1731 lxc/auth.go:1732
 #, fuzzy
 msgid "Delete identity provider groups"
 msgstr "クラスタグループを削除します"
@@ -1949,18 +1959,18 @@ msgstr "警告を削除します"
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:31 lxc/auth.go:60 lxc/auth.go:99
-#: lxc/auth.go:153 lxc/auth.go:202 lxc/auth.go:333 lxc/auth.go:393
-#: lxc/auth.go:442 lxc/auth.go:494 lxc/auth.go:517 lxc/auth.go:576
-#: lxc/auth.go:732 lxc/auth.go:769 lxc/auth.go:836 lxc/auth.go:899
-#: lxc/auth.go:960 lxc/auth.go:1089 lxc/auth.go:1143 lxc/auth.go:1166
-#: lxc/auth.go:1224 lxc/auth.go:1293 lxc/auth.go:1315 lxc/auth.go:1493
-#: lxc/auth.go:1531 lxc/auth.go:1583 lxc/auth.go:1632 lxc/auth.go:1751
-#: lxc/auth.go:1811 lxc/auth.go:1860 lxc/auth.go:1911 lxc/auth.go:1934
-#: lxc/auth.go:1987 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215
-#: lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:484
-#: lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677 lxc/cluster.go:770
-#: lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
+#: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
+#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:338 lxc/auth.go:398
+#: lxc/auth.go:447 lxc/auth.go:499 lxc/auth.go:522 lxc/auth.go:581
+#: lxc/auth.go:737 lxc/auth.go:776 lxc/auth.go:918 lxc/auth.go:985
+#: lxc/auth.go:1048 lxc/auth.go:1109 lxc/auth.go:1238 lxc/auth.go:1292
+#: lxc/auth.go:1315 lxc/auth.go:1373 lxc/auth.go:1442 lxc/auth.go:1464
+#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
+#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
+#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
+#: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
+#: lxc/cluster.go:770 lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
 #: lxc/cluster.go:1175 lxc/cluster.go:1299 lxc/cluster.go:1329
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
@@ -2031,9 +2041,9 @@ msgstr "警告を削除します"
 #: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
 #: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
 #: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:715
-#: lxc/remote.go:753 lxc/remote.go:839 lxc/remote.go:920 lxc/remote.go:984
-#: lxc/remote.go:1032 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
+#: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
+#: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -2226,7 +2236,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr "クラスタグループを編集します"
 
-#: lxc/auth.go:959 lxc/auth.go:960
+#: lxc/auth.go:1108 lxc/auth.go:1109
 #, fuzzy
 msgid "Edit an identity as YAML"
 msgstr "ストレージバケットの設定をYAMLで編集します"
@@ -2239,12 +2249,12 @@ msgstr "クラスターメンバーの設定をYAMLファイルで編集しま�
 msgid "Edit files in instances"
 msgstr "インスタンス内のファイルを編集します"
 
-#: lxc/auth.go:201 lxc/auth.go:202
+#: lxc/auth.go:206 lxc/auth.go:207
 #, fuzzy
 msgid "Edit groups as YAML"
 msgstr "信頼済みクライアント設定をYAMLで編集します"
 
-#: lxc/auth.go:1631 lxc/auth.go:1632
+#: lxc/auth.go:1780 lxc/auth.go:1781
 #, fuzzy
 msgid "Edit identity provider groups as YAML"
 msgstr "プロファイル設定をYAMLで編集します"
@@ -2648,12 +2658,12 @@ msgstr "%q の作成に失敗しました: %w"
 msgid "Failed to create alias %s: %w"
 msgstr "エイリアス %s の作成に失敗しました: %w"
 
-#: lxc/remote.go:486
+#: lxc/remote.go:500
 #, fuzzy, c-format
 msgid "Failed to decode trust token: %w"
 msgstr "クラスタメンバへの接続に失敗しました: %w"
 
-#: lxc/remote.go:292
+#: lxc/remote.go:306
 #, c-format
 msgid "Failed to find project: %w"
 msgstr "プロジェクトが見つけられませんでした: %w"
@@ -2773,7 +2783,7 @@ msgstr ""
 "\n"
 "本当に強制的に %s を削除してもよろしいですか? (yes/no): "
 
-#: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:773 lxc/auth.go:1755
+#: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
@@ -2781,7 +2791,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:757 lxc/storage.go:657
+#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2819,7 +2829,7 @@ msgstr "クロック数: %vMhz"
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr "クロック数: %vMhz (最小: %vMhz, 最大: %vMhz)"
 
-#: lxc/remote.go:821
+#: lxc/remote.go:855
 msgid "GLOBAL"
 msgstr "GLOBAL"
 
@@ -2831,7 +2841,7 @@ msgstr "GPU:"
 msgid "GPUs:"
 msgstr "GPUs:"
 
-#: lxc/auth.go:821 lxc/auth.go:1795
+#: lxc/auth.go:970 lxc/auth.go:1944
 msgid "GROUPS"
 msgstr ""
 
@@ -2839,7 +2849,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr "すべてのコマンドに対する man ページを作成します"
 
-#: lxc/remote.go:165 lxc/remote.go:443
+#: lxc/remote.go:165 lxc/remote.go:457
 msgid "Generating a client certificate. This may take a minute..."
 msgstr "クライアント証明書を生成します。1分ぐらいかかります..."
 
@@ -2990,17 +3000,17 @@ msgstr "ストレージボリュームの設定値を取得します"
 msgid "Given target %q does not match source volume location %q"
 msgstr "指定したコピー先 %q がコピー元のボリュームの場所 %q と一致しません"
 
-#: lxc/auth.go:137
+#: lxc/auth.go:142
 #, fuzzy, c-format
 msgid "Group %s created"
 msgstr "プロファイル %s を作成しました"
 
-#: lxc/auth.go:187
+#: lxc/auth.go:192
 #, fuzzy, c-format
 msgid "Group %s deleted"
 msgstr "プロファイル %s を削除しました"
 
-#: lxc/auth.go:427 lxc/auth.go:1845
+#: lxc/auth.go:432 lxc/auth.go:1994
 #, fuzzy, c-format
 msgid "Group %s renamed to %s"
 msgstr "プロファイル名 %s を %s に変更しました"
@@ -3060,7 +3070,7 @@ msgstr "ID: %d"
 msgid "ID: %s"
 msgstr "ID: %s"
 
-#: lxc/auth.go:820
+#: lxc/auth.go:969
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -3092,12 +3102,16 @@ msgstr "IPV6"
 msgid "ISSUE DATE"
 msgstr "ISSUE DATE"
 
-#: lxc/auth.go:1567
+#: lxc/auth.go:829
+msgid "Identity creation only supported for TLS identities"
+msgstr ""
+
+#: lxc/auth.go:1716
 #, fuzzy, c-format
 msgid "Identity provider group %s created"
 msgstr "クラスターグループ %s を作成しました"
 
-#: lxc/auth.go:1617
+#: lxc/auth.go:1766
 #, fuzzy, c-format
 msgid "Identity provider group %s deleted"
 msgstr "クラスターグループ %s を作成しました"
@@ -3239,7 +3253,7 @@ msgstr "Infiniband:"
 msgid "Input data"
 msgstr "入力するデータ"
 
-#: lxc/auth.go:1292 lxc/auth.go:1293
+#: lxc/auth.go:1441 lxc/auth.go:1442
 msgid "Inspect permissions"
 msgstr ""
 
@@ -3288,7 +3302,7 @@ msgstr "インスタンス名: %s"
 msgid "Instance type"
 msgstr "インスタンスタイプ"
 
-#: lxc/remote.go:395
+#: lxc/remote.go:409
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr "不正な URL スキーム \"%s\" (\"%s\" 内)"
@@ -3377,7 +3391,7 @@ msgstr "引数の数が不正です"
 msgid "Invalid path %s"
 msgstr "不正なパス %s"
 
-#: lxc/remote.go:384
+#: lxc/remote.go:398
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr "不正なプロトコル: %s"
@@ -3555,17 +3569,17 @@ msgstr "利用可能なストレージプールを一覧表示します"
 msgid "List background operations"
 msgstr "バックグラウンド操作を一覧表示します"
 
-#: lxc/auth.go:332 lxc/auth.go:333
+#: lxc/auth.go:337 lxc/auth.go:338
 #, fuzzy
 msgid "List groups"
 msgstr "プロファイルを一覧表示します"
 
-#: lxc/auth.go:768 lxc/auth.go:769
+#: lxc/auth.go:917 lxc/auth.go:918
 #, fuzzy
 msgid "List identities"
 msgstr "インスタンスを一覧表示します"
 
-#: lxc/auth.go:1750 lxc/auth.go:1751
+#: lxc/auth.go:1899 lxc/auth.go:1900
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3825,7 +3839,7 @@ msgstr "証明書の使用を制限するプロジェクトのリスト"
 msgid "List operations from all projects"
 msgstr "すべてのプロジェクトのインスタンスを表示します"
 
-#: lxc/auth.go:1314 lxc/auth.go:1315
+#: lxc/auth.go:1463 lxc/auth.go:1464
 #, fuzzy
 msgid "List permissions"
 msgstr "プロファイルを一覧表示します"
@@ -3885,7 +3899,7 @@ msgstr ""
 "    u - （使用中の）リファレンス数\n"
 "    U - 現在のディスク使用量"
 
-#: lxc/remote.go:752 lxc/remote.go:753
+#: lxc/remote.go:786 lxc/remote.go:787
 msgid "List the available remotes"
 msgstr "利用可能なリモートサーバを一覧表示します"
 
@@ -4027,6 +4041,12 @@ msgstr "イメージを public にする"
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
+#: lxc/auth.go:825
+msgid ""
+"Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
+"got "
+msgstr ""
+
 #: lxc/network.go:32 lxc/network.go:33
 msgid "Manage and attach instances to networks"
 msgstr "ネットワークを管理し、インスタンスをネットワークに接続します"
@@ -4055,22 +4075,22 @@ msgstr "デバイスを管理します"
 msgid "Manage files in instances"
 msgstr "インスタンス内のファイルを管理します"
 
-#: lxc/auth.go:59 lxc/auth.go:60 lxc/auth.go:1492 lxc/auth.go:1493
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
 #, fuzzy
 msgid "Manage groups"
 msgstr "クラスタグループを管理します"
 
-#: lxc/auth.go:1142 lxc/auth.go:1143
+#: lxc/auth.go:1291 lxc/auth.go:1292
 #, fuzzy
 msgid "Manage groups for the identity"
 msgstr "信頼済みのクライアントを管理します"
 
-#: lxc/auth.go:731 lxc/auth.go:732
+#: lxc/auth.go:736 lxc/auth.go:737
 #, fuzzy
 msgid "Manage identities"
 msgstr "デバイスを管理します"
 
-#: lxc/auth.go:1910 lxc/auth.go:1911
+#: lxc/auth.go:2059 lxc/auth.go:2060
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -4175,7 +4195,7 @@ msgstr "ネットワークゾーンレコードを管理します"
 msgid "Manage network zones"
 msgstr "ネットワークゾーンを管理します"
 
-#: lxc/auth.go:493 lxc/auth.go:494
+#: lxc/auth.go:498 lxc/auth.go:499
 #, fuzzy
 msgid "Manage permissions"
 msgstr "プロファイルを管理します"
@@ -4232,7 +4252,7 @@ msgstr "リモートサーバのリストを管理します"
 msgid "Manage trusted clients"
 msgstr "信頼済みのクライアントを管理します"
 
-#: lxc/auth.go:30 lxc/auth.go:31
+#: lxc/auth.go:35 lxc/auth.go:36
 #, fuzzy
 msgid "Manage user authorization"
 msgstr "クラスタロールを管理します"
@@ -4330,24 +4350,24 @@ msgstr "クラスターグループ名がありません"
 msgid "Missing cluster member name"
 msgstr "クラスターメンバー名がありません"
 
-#: lxc/auth.go:123 lxc/auth.go:177 lxc/auth.go:255 lxc/auth.go:417
-#: lxc/auth.go:466 lxc/auth.go:541 lxc/auth.go:600 lxc/auth.go:1884
+#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:260 lxc/auth.go:422
+#: lxc/auth.go:471 lxc/auth.go:546 lxc/auth.go:605 lxc/auth.go:2033
 #, fuzzy
 msgid "Missing group name"
 msgstr "クラスターグループ名がありません"
 
-#: lxc/auth.go:866 lxc/auth.go:1007 lxc/auth.go:1124 lxc/auth.go:1190
-#: lxc/auth.go:1248
+#: lxc/auth.go:820 lxc/auth.go:1015 lxc/auth.go:1156 lxc/auth.go:1273
+#: lxc/auth.go:1339 lxc/auth.go:1397
 #, fuzzy
 msgid "Missing identity argument"
 msgstr "鍵の名前を指定する必要があります"
 
-#: lxc/auth.go:1554 lxc/auth.go:1607 lxc/auth.go:1673 lxc/auth.go:1835
+#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
 #, fuzzy
 msgid "Missing identity provider group name"
 msgstr "クラスターグループ名がありません"
 
-#: lxc/auth.go:1958 lxc/auth.go:2011
+#: lxc/auth.go:2107 lxc/auth.go:2160
 #, fuzzy
 msgid "Missing identity provider group name argument"
 msgstr "クラスターグループ名がありません"
@@ -4587,12 +4607,12 @@ msgstr "ディレクトリからのインポートは root で実行する必要
 msgid "Must supply instance name for: "
 msgstr "インスタンス名を指定する必要があります: "
 
-#: lxc/auth.go:376 lxc/auth.go:819 lxc/auth.go:1794 lxc/cluster.go:192
+#: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
-#: lxc/remote.go:815 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
 msgstr "NAME"
@@ -4619,7 +4639,7 @@ msgstr "NICs:"
 
 #: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:775 lxc/remote.go:780 lxc/remote.go:785
+#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr "NO"
 
@@ -4851,7 +4871,7 @@ msgstr "\"カスタム\" のボリュームのみがエクスポートできま�
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr "\"カスタム\" のボリュームのみがスナップショットを取得できます"
 
-#: lxc/remote.go:378
+#: lxc/remote.go:392
 msgid "Only https URLs are supported for simplestreams"
 msgstr "simplestreams は https の URL のみサポートします"
 
@@ -4922,11 +4942,11 @@ msgstr "PROFILES"
 msgid "PROJECT"
 msgstr "PROJECT"
 
-#: lxc/remote.go:817
+#: lxc/remote.go:851
 msgid "PROTOCOL"
 msgstr "PROTOCOL"
 
-#: lxc/image.go:1136 lxc/remote.go:819
+#: lxc/image.go:1136 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr "PUBLIC"
 
@@ -4967,7 +4987,7 @@ msgstr "クライアント名を入力してください: "
 msgid "Please provide cluster member name: "
 msgstr "クラスターメンバー名を入力してください: "
 
-#: lxc/remote.go:536
+#: lxc/remote.go:550
 #, fuzzy
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr "'y', 'n', フィンガープリントのどれかを入力してください:"
@@ -4985,7 +5005,7 @@ msgstr "ポート:"
 msgid "Press ctrl+c to finish"
 msgstr "終了するには ctrl+c を押してください"
 
-#: lxc/auth.go:302 lxc/auth.go:1059 lxc/auth.go:1720 lxc/cluster.go:860
+#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -5295,33 +5315,33 @@ msgstr "インスタンスの更新中: %s"
 msgid "Refreshing the image: %s"
 msgstr "イメージの更新中: %s"
 
-#: lxc/remote.go:877
+#: lxc/remote.go:911
 #, c-format
 msgid "Remote %s already exists"
 msgstr "リモート %s は既に存在します"
 
-#: lxc/project.go:884 lxc/remote.go:868 lxc/remote.go:949 lxc/remote.go:1013
-#: lxc/remote.go:1061
+#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/remote.go:1095
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr "リモート %s は存在しません"
 
-#: lxc/remote.go:345
+#: lxc/remote.go:359
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr "リモート %s は <%s> として存在します"
 
-#: lxc/remote.go:957
+#: lxc/remote.go:991
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr "リモート %s は global ですので削除できません"
 
-#: lxc/remote.go:872 lxc/remote.go:953 lxc/remote.go:1065
+#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1099
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr "リモート %s は static ですので変更できません"
 
-#: lxc/remote.go:319
+#: lxc/remote.go:333
 msgid "Remote address must not be empty"
 msgstr ""
 
@@ -5329,7 +5349,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr "リモートの管理者パスワード"
 
-#: lxc/remote.go:339
+#: lxc/remote.go:353
 msgid "Remote names may not contain colons"
 msgstr "リモート名にコロンを含めることはできません"
 
@@ -5352,7 +5372,7 @@ msgstr "%s を消去しますか (yes/no): "
 msgid "Remove a cluster member from a cluster group"
 msgstr "クラスタグループからメンバを削除します"
 
-#: lxc/auth.go:1223 lxc/auth.go:1224
+#: lxc/auth.go:1372 lxc/auth.go:1373
 #, fuzzy
 msgid "Remove a group from an identity"
 msgstr "ACL からルールを削除します"
@@ -5389,7 +5409,7 @@ msgstr "ロードバランサーからバックエンドを削除します"
 msgid "Remove entries from a network zone record"
 msgstr "ネットワークゾーンレコードからエントリを削除します"
 
-#: lxc/auth.go:1986 lxc/auth.go:1987
+#: lxc/auth.go:2135 lxc/auth.go:2136
 #, fuzzy
 msgid "Remove identities from groups"
 msgstr "グループからメンバーを削除します"
@@ -5402,7 +5422,7 @@ msgstr "インスタンスのデバイスを削除します"
 msgid "Remove member from group"
 msgstr "グループからメンバーを削除します"
 
-#: lxc/auth.go:575 lxc/auth.go:576
+#: lxc/auth.go:580 lxc/auth.go:581
 #, fuzzy
 msgid "Remove permissions from groups"
 msgstr "グループからメンバーを削除します"
@@ -5419,7 +5439,7 @@ msgstr "ロードバランサーからポートを削除します"
 msgid "Remove profiles from instances"
 msgstr "インスタンスからプロファイルを削除します"
 
-#: lxc/remote.go:919 lxc/remote.go:920
+#: lxc/remote.go:953 lxc/remote.go:954
 msgid "Remove remotes"
 msgstr "リモートサーバを削除します"
 
@@ -5448,12 +5468,12 @@ msgstr "クラスタメンバの名前を変更します"
 msgid "Rename aliases"
 msgstr "エイリアスの名前を変更します"
 
-#: lxc/auth.go:392 lxc/auth.go:393
+#: lxc/auth.go:397 lxc/auth.go:398
 #, fuzzy
 msgid "Rename groups"
 msgstr "リモートサーバ名を変更します"
 
-#: lxc/auth.go:1810 lxc/auth.go:1811
+#: lxc/auth.go:1959 lxc/auth.go:1960
 #, fuzzy
 msgid "Rename identity provider groups"
 msgstr "クラスタグループの名前を変更します"
@@ -5478,7 +5498,7 @@ msgstr "プロファイル名を変更します"
 msgid "Rename projects"
 msgstr "プロジェクト名を変更します"
 
-#: lxc/remote.go:838 lxc/remote.go:839
+#: lxc/remote.go:872 lxc/remote.go:873
 msgid "Rename remotes"
 msgstr "リモートサーバ名を変更します"
 
@@ -5632,7 +5652,7 @@ msgstr "SSH クライアントが切断されました %q"
 msgid "STATE"
 msgstr "STATE"
 
-#: lxc/remote.go:820
+#: lxc/remote.go:854
 msgid "STATIC"
 msgstr "STATIC"
 
@@ -5674,11 +5694,11 @@ msgstr "直接リクエスト (raw query) を LXD に送ります"
 msgid "Server authentication type (tls or oidc)"
 msgstr "サーバの認証タイプ (tls もしくは candid)"
 
-#: lxc/remote.go:532
+#: lxc/remote.go:546
 msgid "Server certificate NACKed by user"
 msgstr "ユーザによりサーバ証明書が拒否されました"
 
-#: lxc/remote.go:285 lxc/remote.go:683
+#: lxc/remote.go:299 lxc/remote.go:717
 msgid "Server doesn't trust us after authentication"
 msgstr "認証後、サーバが我々を信用していません"
 
@@ -5947,7 +5967,7 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 
-#: lxc/remote.go:1031 lxc/remote.go:1032
+#: lxc/remote.go:1065 lxc/remote.go:1066
 msgid "Set the URL for the remote"
 msgstr "リモートの URL を設定します"
 
@@ -6056,7 +6076,7 @@ msgstr "デバッグメッセージをすべて表示します"
 msgid "Show all information messages"
 msgstr "詳細な情報を出力します"
 
-#: lxc/auth.go:1859 lxc/auth.go:1860
+#: lxc/auth.go:2008 lxc/auth.go:2009
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -6084,12 +6104,12 @@ msgstr "すべてのプロジェクトのイベントを表示します"
 msgid "Show full device configuration"
 msgstr "デバイスの設定をすべて表示します"
 
-#: lxc/auth.go:441 lxc/auth.go:442
+#: lxc/auth.go:446 lxc/auth.go:447
 #, fuzzy
 msgid "Show group configurations"
 msgstr "信頼済みクライアントの設定を表示します"
 
-#: lxc/auth.go:836
+#: lxc/auth.go:985
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -6195,7 +6215,7 @@ msgstr "ストレージボリュームの設定を表示する"
 msgid "Show storage volume state information"
 msgstr "ストレージボリュームの状態を表示します"
 
-#: lxc/auth.go:899
+#: lxc/auth.go:1048
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -6205,7 +6225,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:714 lxc/remote.go:715
+#: lxc/remote.go:748 lxc/remote.go:749
 msgid "Show the default remote"
 msgstr "デフォルトのリモートを表示します"
 
@@ -6417,7 +6437,7 @@ msgstr "Swap (ピーク)"
 msgid "Switch the current project"
 msgstr "現在のプロジェクトを切り替えます"
 
-#: lxc/remote.go:983 lxc/remote.go:984
+#: lxc/remote.go:1017 lxc/remote.go:1018
 msgid "Switch the default remote"
 msgstr "デフォルトのリモートを切り替えます"
 
@@ -6429,11 +6449,21 @@ msgstr ""
 msgid "TARGET"
 msgstr "TARGET"
 
+#: lxc/auth.go:876
+#, c-format
+msgid "TLS identity %q (%s) pending identity token:"
+msgstr ""
+
+#: lxc/auth.go:902
+#, fuzzy, c-format
+msgid "TLS identity %q created with fingerprint %q"
+msgstr "イメージは以下のフィンガープリントでインポートされました: %s"
+
 #: lxc/cluster.go:1070 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr "TOKEN"
 
-#: lxc/auth.go:818 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
 #: lxc/storage_volume.go:1736 lxc/warning.go:216
@@ -6452,7 +6482,7 @@ msgstr "ターゲットのパスと --listen オプションは同時に指定�
 msgid "Target path must be a directory"
 msgstr "ターゲットのパスはディレクトリでなければなりません"
 
-#: lxc/remote.go:161 lxc/remote.go:334
+#: lxc/remote.go:161 lxc/remote.go:348
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
@@ -6614,7 +6644,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:527
+#: lxc/remote.go:541
 #, fuzzy
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
@@ -6775,16 +6805,16 @@ msgstr "インスタンスを転送中: %s"
 msgid "Transmit policy"
 msgstr "通信ポリシー"
 
-#: lxc/remote.go:329
+#: lxc/remote.go:343
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:324
+#: lxc/remote.go:338
 #, fuzzy
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr "--project は query コマンドでは使えません"
 
-#: lxc/remote.go:639
+#: lxc/remote.go:653
 #, fuzzy, c-format
 msgid "Trust token for %s: "
 msgstr "%s:%s のクラスターに join するためのトークンが削除されました"
@@ -6829,7 +6859,7 @@ msgstr "UNLIMITED"
 msgid "UPLOAD DATE"
 msgstr "UPLOAD DATE"
 
-#: lxc/cluster.go:193 lxc/remote.go:816
+#: lxc/cluster.go:193 lxc/remote.go:850
 msgid "URL"
 msgstr "URL"
 
@@ -7153,11 +7183,11 @@ msgstr "ベンダ: %v (%v)"
 msgid "Verb: %s (%s)"
 msgstr "Verb: %s (%s)"
 
-#: lxc/auth.go:835
+#: lxc/auth.go:984
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:898
+#: lxc/auth.go:1047
 #, fuzzy
 msgid "View the current identity"
 msgstr "現在のプロジェクトを切り替えます"
@@ -7199,7 +7229,7 @@ msgstr ""
 
 #: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:777 lxc/remote.go:782 lxc/remote.go:787
+#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr "YES"
 
@@ -7234,7 +7264,7 @@ msgstr "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 
-#: lxc/auth.go:330 lxc/auth.go:766 lxc/auth.go:897 lxc/auth.go:1748
+#: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
@@ -7267,7 +7297,7 @@ msgstr "[<remote>:] [<filter>...]"
 msgid "[<remote>:] [<filters>...]"
 msgstr "[<remote>:] [<filters>...]"
 
-#: lxc/auth.go:1313
+#: lxc/auth.go:1462
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -7328,11 +7358,17 @@ msgstr "[<remote>:]<alias> <fingerprint>"
 msgid "[<remote>:]<alias> <new-name>"
 msgstr "[<remote>:]<alias> <new-name>"
 
-#: lxc/auth.go:834 lxc/auth.go:1086
+#: lxc/auth.go:774
+msgid ""
+"[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
+"certificate>] [[--group <group_name>]]"
+msgstr ""
+
+#: lxc/auth.go:983 lxc/auth.go:1235
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1164 lxc/auth.go:1222 lxc/auth.go:1985
+#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:2134
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -7340,13 +7376,13 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr "[<remote>:]<fingerprint>"
 
-#: lxc/auth.go:97 lxc/auth.go:150 lxc/auth.go:200 lxc/auth.go:440
-#: lxc/auth.go:958 lxc/auth.go:1529 lxc/cluster_group.go:168
+#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:445
+#: lxc/auth.go:1107 lxc/auth.go:1678 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr "[<remote>:]<group>"
 
-#: lxc/auth.go:515 lxc/auth.go:573
+#: lxc/auth.go:520 lxc/auth.go:578
 #, fuzzy
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
@@ -7357,22 +7393,22 @@ msgstr "[<remote>:]<pool> <volume> <key>=<value>..."
 msgid "[<remote>:]<group> <new-name>"
 msgstr "[<remote>:]<group> <new-name>"
 
-#: lxc/auth.go:390
+#: lxc/auth.go:395
 #, fuzzy
 msgid "[<remote>:]<group> <new_name>"
 msgstr "[<remote>:]<group> <new-name>"
 
-#: lxc/auth.go:1580 lxc/auth.go:1630 lxc/auth.go:1858
+#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group>"
 msgstr "[<remote>:]<group>"
 
-#: lxc/auth.go:1932
+#: lxc/auth.go:2081
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr "[<remote>:]<member> <group>"
 
-#: lxc/auth.go:1808
+#: lxc/auth.go:1957
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr "[<remote>:]<group> <new-name>"
@@ -7889,7 +7925,7 @@ msgstr "[<remote>] <IP|FQDN|URL|token>"
 msgid "[[<remote>:]<member>]"
 msgstr "[[<remote>:]<member>]"
 
-#: lxc/project.go:557 lxc/remote.go:806
+#: lxc/project.go:557 lxc/remote.go:840
 msgid "current"
 msgstr "現在値"
 
@@ -7942,7 +7978,7 @@ msgstr ""
 "lxc alias rename list my-list\n"
 "    エイリアス名 \"list\" を \"my-list\" に変更します。"
 
-#: lxc/auth.go:204
+#: lxc/auth.go:209
 #, fuzzy
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
@@ -7951,7 +7987,7 @@ msgstr ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    profile.yaml の内容でプロファイルを更新します"
 
-#: lxc/auth.go:962
+#: lxc/auth.go:1111
 #, fuzzy
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
@@ -7961,7 +7997,7 @@ msgstr ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    profile.yaml の内容でプロファイルを更新します"
 
-#: lxc/auth.go:1634
+#: lxc/auth.go:1783
 #, fuzzy
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
@@ -8583,7 +8619,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:531
+#: lxc/remote.go:545
 msgid "n"
 msgstr "n"
 
@@ -8595,7 +8631,7 @@ msgstr "名前"
 msgid "no"
 msgstr "no"
 
-#: lxc/remote.go:510
+#: lxc/remote.go:524
 msgid "ok (y/n/[fingerprint])?"
 msgstr "ok (y/n/[fingerprint])?"
 
@@ -8634,7 +8670,7 @@ msgstr "サーバに接続できません"
 msgid "used by"
 msgstr "ストレージを使用中の"
 
-#: lxc/remote.go:519
+#: lxc/remote.go:533
 msgid "y"
 msgstr "y"
 

--- a/po/ka.po
+++ b/po/ka.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-14 13:30+0000\n"
+"POT-Creation-Date: 2024-10-15 14:52+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -130,7 +130,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:214
+#: lxc/auth.go:219
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -157,7 +157,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:972
+#: lxc/auth.go:1121
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -178,7 +178,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1644
+#: lxc/auth.go:1793
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -512,15 +512,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:917 lxc/remote.go:982
+#: lxc/remote.go:951 lxc/remote.go:1016
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1030
+#: lxc/remote.go:1064
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:836
+#: lxc/remote.go:870
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -553,11 +553,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:818
+#: lxc/remote.go:852
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:817
+#: lxc/auth.go:966
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -595,11 +595,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1165 lxc/auth.go:1166
+#: lxc/auth.go:1314 lxc/auth.go:1315
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1933 lxc/auth.go:1934
+#: lxc/auth.go:2082 lxc/auth.go:2083
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -668,7 +668,7 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:516 lxc/auth.go:517
+#: lxc/auth.go:521 lxc/auth.go:522
 msgid "Add permissions to groups"
 msgstr ""
 
@@ -702,7 +702,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:648
+#: lxc/remote.go:680
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -810,7 +810,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:621
+#: lxc/remote.go:635
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -988,7 +988,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:961
+#: lxc/remote.go:995
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1054,7 +1054,7 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:509
+#: lxc/remote.go:523
 msgid "Certificate fingerprint"
 msgstr ""
 
@@ -1073,7 +1073,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:687
+#: lxc/remote.go:721
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1321,12 +1321,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:559
+#: lxc/remote.go:573
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:237 lxc/remote.go:543
+#: lxc/remote.go:237 lxc/remote.go:557
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1340,12 +1340,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:1719
+#: lxc/auth.go:306 lxc/auth.go:1868
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1058
+#: lxc/auth.go:1207
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1365,13 +1365,17 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:554
+#: lxc/remote.go:568
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
 #: lxc/network_zone.go:1536
 msgid "Couldn't find a matching entry"
+msgstr ""
+
+#: lxc/auth.go:776
+msgid "Create a TLS identity"
 msgstr ""
 
 #: lxc/cluster_group.go:169 lxc/cluster_group.go:170
@@ -1390,6 +1394,10 @@ msgstr ""
 msgid "Create an empty instance"
 msgstr ""
 
+#: lxc/auth.go:775
+msgid "Create an identity"
+msgstr ""
+
 #: lxc/launch.go:23 lxc/launch.go:24
 msgid "Create and start instances from images"
 msgstr ""
@@ -1402,11 +1410,11 @@ msgstr ""
 msgid "Create files and directories in instances"
 msgstr ""
 
-#: lxc/auth.go:98 lxc/auth.go:99
+#: lxc/auth.go:103 lxc/auth.go:104
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1530 lxc/auth.go:1531
+#: lxc/auth.go:1679 lxc/auth.go:1680
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1514,7 +1522,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
@@ -1557,7 +1565,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/auth.go:1088 lxc/auth.go:1089
+#: lxc/auth.go:1237 lxc/auth.go:1238
 msgid "Delete an identity"
 msgstr ""
 
@@ -1565,11 +1573,11 @@ msgstr ""
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/auth.go:152 lxc/auth.go:153
+#: lxc/auth.go:157 lxc/auth.go:158
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1582 lxc/auth.go:1583
+#: lxc/auth.go:1731 lxc/auth.go:1732
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1647,18 +1655,18 @@ msgstr ""
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:31 lxc/auth.go:60 lxc/auth.go:99
-#: lxc/auth.go:153 lxc/auth.go:202 lxc/auth.go:333 lxc/auth.go:393
-#: lxc/auth.go:442 lxc/auth.go:494 lxc/auth.go:517 lxc/auth.go:576
-#: lxc/auth.go:732 lxc/auth.go:769 lxc/auth.go:836 lxc/auth.go:899
-#: lxc/auth.go:960 lxc/auth.go:1089 lxc/auth.go:1143 lxc/auth.go:1166
-#: lxc/auth.go:1224 lxc/auth.go:1293 lxc/auth.go:1315 lxc/auth.go:1493
-#: lxc/auth.go:1531 lxc/auth.go:1583 lxc/auth.go:1632 lxc/auth.go:1751
-#: lxc/auth.go:1811 lxc/auth.go:1860 lxc/auth.go:1911 lxc/auth.go:1934
-#: lxc/auth.go:1987 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215
-#: lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:484
-#: lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677 lxc/cluster.go:770
-#: lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
+#: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
+#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:338 lxc/auth.go:398
+#: lxc/auth.go:447 lxc/auth.go:499 lxc/auth.go:522 lxc/auth.go:581
+#: lxc/auth.go:737 lxc/auth.go:776 lxc/auth.go:918 lxc/auth.go:985
+#: lxc/auth.go:1048 lxc/auth.go:1109 lxc/auth.go:1238 lxc/auth.go:1292
+#: lxc/auth.go:1315 lxc/auth.go:1373 lxc/auth.go:1442 lxc/auth.go:1464
+#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
+#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
+#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
+#: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
+#: lxc/cluster.go:770 lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
 #: lxc/cluster.go:1175 lxc/cluster.go:1299 lxc/cluster.go:1329
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
@@ -1729,9 +1737,9 @@ msgstr ""
 #: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
 #: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
 #: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:715
-#: lxc/remote.go:753 lxc/remote.go:839 lxc/remote.go:920 lxc/remote.go:984
-#: lxc/remote.go:1032 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
+#: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
+#: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1916,7 +1924,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:959 lxc/auth.go:960
+#: lxc/auth.go:1108 lxc/auth.go:1109
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1928,11 +1936,11 @@ msgstr ""
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/auth.go:201 lxc/auth.go:202
+#: lxc/auth.go:206 lxc/auth.go:207
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1631 lxc/auth.go:1632
+#: lxc/auth.go:1780 lxc/auth.go:1781
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2308,12 +2316,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:486
+#: lxc/remote.go:500
 #, c-format
 msgid "Failed to decode trust token: %w"
 msgstr ""
 
-#: lxc/remote.go:292
+#: lxc/remote.go:306
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2417,7 +2425,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:773 lxc/auth.go:1755
+#: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
@@ -2425,7 +2433,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:757 lxc/storage.go:657
+#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2463,7 +2471,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:821
+#: lxc/remote.go:855
 msgid "GLOBAL"
 msgstr ""
 
@@ -2475,7 +2483,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:821 lxc/auth.go:1795
+#: lxc/auth.go:970 lxc/auth.go:1944
 msgid "GROUPS"
 msgstr ""
 
@@ -2483,7 +2491,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:165 lxc/remote.go:443
+#: lxc/remote.go:165 lxc/remote.go:457
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2624,17 +2632,17 @@ msgstr ""
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: lxc/auth.go:137
+#: lxc/auth.go:142
 #, c-format
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:187
+#: lxc/auth.go:192
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:427 lxc/auth.go:1845
+#: lxc/auth.go:432 lxc/auth.go:1994
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2693,7 +2701,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:820
+#: lxc/auth.go:969
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -2725,12 +2733,16 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1567
+#: lxc/auth.go:829
+msgid "Identity creation only supported for TLS identities"
+msgstr ""
+
+#: lxc/auth.go:1716
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1617
+#: lxc/auth.go:1766
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2859,7 +2871,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1292 lxc/auth.go:1293
+#: lxc/auth.go:1441 lxc/auth.go:1442
 msgid "Inspect permissions"
 msgstr ""
 
@@ -2907,7 +2919,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:395
+#: lxc/remote.go:409
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2988,7 +3000,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:384
+#: lxc/remote.go:398
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3163,15 +3175,15 @@ msgstr ""
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:332 lxc/auth.go:333
+#: lxc/auth.go:337 lxc/auth.go:338
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:768 lxc/auth.go:769
+#: lxc/auth.go:917 lxc/auth.go:918
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1750 lxc/auth.go:1751
+#: lxc/auth.go:1899 lxc/auth.go:1900
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3324,7 +3336,7 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1314 lxc/auth.go:1315
+#: lxc/auth.go:1463 lxc/auth.go:1464
 msgid "List permissions"
 msgstr ""
 
@@ -3368,7 +3380,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:752 lxc/remote.go:753
+#: lxc/remote.go:786 lxc/remote.go:787
 msgid "List the available remotes"
 msgstr ""
 
@@ -3492,6 +3504,12 @@ msgstr ""
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
+#: lxc/auth.go:825
+msgid ""
+"Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
+"got "
+msgstr ""
+
 #: lxc/network.go:32 lxc/network.go:33
 msgid "Manage and attach instances to networks"
 msgstr ""
@@ -3520,19 +3538,19 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:59 lxc/auth.go:60 lxc/auth.go:1492 lxc/auth.go:1493
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1142 lxc/auth.go:1143
+#: lxc/auth.go:1291 lxc/auth.go:1292
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:731 lxc/auth.go:732
+#: lxc/auth.go:736 lxc/auth.go:737
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1910 lxc/auth.go:1911
+#: lxc/auth.go:2059 lxc/auth.go:2060
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3623,7 +3641,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:493 lxc/auth.go:494
+#: lxc/auth.go:498 lxc/auth.go:499
 msgid "Manage permissions"
 msgstr ""
 
@@ -3675,7 +3693,7 @@ msgstr ""
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/auth.go:30 lxc/auth.go:31
+#: lxc/auth.go:35 lxc/auth.go:36
 msgid "Manage user authorization"
 msgstr ""
 
@@ -3772,21 +3790,21 @@ msgstr ""
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:123 lxc/auth.go:177 lxc/auth.go:255 lxc/auth.go:417
-#: lxc/auth.go:466 lxc/auth.go:541 lxc/auth.go:600 lxc/auth.go:1884
+#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:260 lxc/auth.go:422
+#: lxc/auth.go:471 lxc/auth.go:546 lxc/auth.go:605 lxc/auth.go:2033
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:866 lxc/auth.go:1007 lxc/auth.go:1124 lxc/auth.go:1190
-#: lxc/auth.go:1248
+#: lxc/auth.go:820 lxc/auth.go:1015 lxc/auth.go:1156 lxc/auth.go:1273
+#: lxc/auth.go:1339 lxc/auth.go:1397
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1554 lxc/auth.go:1607 lxc/auth.go:1673 lxc/auth.go:1835
+#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1958 lxc/auth.go:2011
+#: lxc/auth.go:2107 lxc/auth.go:2160
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -4007,12 +4025,12 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:376 lxc/auth.go:819 lxc/auth.go:1794 lxc/cluster.go:192
+#: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
-#: lxc/remote.go:815 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
 msgstr ""
@@ -4039,7 +4057,7 @@ msgstr ""
 
 #: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:775 lxc/remote.go:780 lxc/remote.go:785
+#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr ""
 
@@ -4268,7 +4286,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:378
+#: lxc/remote.go:392
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4339,11 +4357,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:817
+#: lxc/remote.go:851
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:819
+#: lxc/image.go:1136 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4384,7 +4402,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:536
+#: lxc/remote.go:550
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
@@ -4401,7 +4419,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:302 lxc/auth.go:1059 lxc/auth.go:1720 lxc/cluster.go:860
+#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -4704,33 +4722,33 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:877
+#: lxc/remote.go:911
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:868 lxc/remote.go:949 lxc/remote.go:1013
-#: lxc/remote.go:1061
+#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/remote.go:1095
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:345
+#: lxc/remote.go:359
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:957
+#: lxc/remote.go:991
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:872 lxc/remote.go:953 lxc/remote.go:1065
+#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1099
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:319
+#: lxc/remote.go:333
 msgid "Remote address must not be empty"
 msgstr ""
 
@@ -4738,7 +4756,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:339
+#: lxc/remote.go:353
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4760,7 +4778,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1223 lxc/auth.go:1224
+#: lxc/auth.go:1372 lxc/auth.go:1373
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4796,7 +4814,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1986 lxc/auth.go:1987
+#: lxc/auth.go:2135 lxc/auth.go:2136
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4808,7 +4826,7 @@ msgstr ""
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:575 lxc/auth.go:576
+#: lxc/auth.go:580 lxc/auth.go:581
 msgid "Remove permissions from groups"
 msgstr ""
 
@@ -4824,7 +4842,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:919 lxc/remote.go:920
+#: lxc/remote.go:953 lxc/remote.go:954
 msgid "Remove remotes"
 msgstr ""
 
@@ -4853,11 +4871,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:392 lxc/auth.go:393
+#: lxc/auth.go:397 lxc/auth.go:398
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1810 lxc/auth.go:1811
+#: lxc/auth.go:1959 lxc/auth.go:1960
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -4881,7 +4899,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:838 lxc/remote.go:839
+#: lxc/remote.go:872 lxc/remote.go:873
 msgid "Rename remotes"
 msgstr ""
 
@@ -5026,7 +5044,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:820
+#: lxc/remote.go:854
 msgid "STATIC"
 msgstr ""
 
@@ -5067,11 +5085,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:532
+#: lxc/remote.go:546
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:285 lxc/remote.go:683
+#: lxc/remote.go:299 lxc/remote.go:717
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5282,7 +5300,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1031 lxc/remote.go:1032
+#: lxc/remote.go:1065 lxc/remote.go:1066
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5378,7 +5396,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1859 lxc/auth.go:1860
+#: lxc/auth.go:2008 lxc/auth.go:2009
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5406,11 +5424,11 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:441 lxc/auth.go:442
+#: lxc/auth.go:446 lxc/auth.go:447
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:836
+#: lxc/auth.go:985
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5515,7 +5533,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:899
+#: lxc/auth.go:1048
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5525,7 +5543,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:714 lxc/remote.go:715
+#: lxc/remote.go:748 lxc/remote.go:749
 msgid "Show the default remote"
 msgstr ""
 
@@ -5737,7 +5755,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:983 lxc/remote.go:984
+#: lxc/remote.go:1017 lxc/remote.go:1018
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5749,11 +5767,21 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
+#: lxc/auth.go:876
+#, c-format
+msgid "TLS identity %q (%s) pending identity token:"
+msgstr ""
+
+#: lxc/auth.go:902
+#, c-format
+msgid "TLS identity %q created with fingerprint %q"
+msgstr ""
+
 #: lxc/cluster.go:1070 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:818 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
 #: lxc/storage_volume.go:1736 lxc/warning.go:216
@@ -5772,7 +5800,7 @@ msgstr ""
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/remote.go:161 lxc/remote.go:334
+#: lxc/remote.go:161 lxc/remote.go:348
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
@@ -5928,7 +5956,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:527
+#: lxc/remote.go:541
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
@@ -6066,15 +6094,15 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:329
+#: lxc/remote.go:343
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:324
+#: lxc/remote.go:338
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr ""
 
-#: lxc/remote.go:639
+#: lxc/remote.go:653
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6117,7 +6145,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:193 lxc/remote.go:816
+#: lxc/cluster.go:193 lxc/remote.go:850
 msgid "URL"
 msgstr ""
 
@@ -6425,11 +6453,11 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:835
+#: lxc/auth.go:984
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:898
+#: lxc/auth.go:1047
 msgid "View the current identity"
 msgstr ""
 
@@ -6468,7 +6496,7 @@ msgstr ""
 
 #: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:777 lxc/remote.go:782 lxc/remote.go:787
+#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr ""
 
@@ -6500,7 +6528,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:330 lxc/auth.go:766 lxc/auth.go:897 lxc/auth.go:1748
+#: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
@@ -6533,7 +6561,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1313
+#: lxc/auth.go:1462
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6594,11 +6622,17 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:834 lxc/auth.go:1086
+#: lxc/auth.go:774
+msgid ""
+"[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
+"certificate>] [[--group <group_name>]]"
+msgstr ""
+
+#: lxc/auth.go:983 lxc/auth.go:1235
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1164 lxc/auth.go:1222 lxc/auth.go:1985
+#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:2134
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6606,13 +6640,13 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:97 lxc/auth.go:150 lxc/auth.go:200 lxc/auth.go:440
-#: lxc/auth.go:958 lxc/auth.go:1529 lxc/cluster_group.go:168
+#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:445
+#: lxc/auth.go:1107 lxc/auth.go:1678 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:515 lxc/auth.go:573
+#: lxc/auth.go:520 lxc/auth.go:578
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
@@ -6622,19 +6656,19 @@ msgstr ""
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:390
+#: lxc/auth.go:395
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1580 lxc/auth.go:1630 lxc/auth.go:1858
+#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1932
+#: lxc/auth.go:2081
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1808
+#: lxc/auth.go:1957
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -7125,7 +7159,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:806
+#: lxc/project.go:557 lxc/remote.go:840
 msgid "current"
 msgstr ""
 
@@ -7172,20 +7206,20 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/auth.go:204
+#: lxc/auth.go:209
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:962
+#: lxc/auth.go:1111
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1634
+#: lxc/auth.go:1783
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7609,7 +7643,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:531
+#: lxc/remote.go:545
 msgid "n"
 msgstr ""
 
@@ -7621,7 +7655,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:510
+#: lxc/remote.go:524
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7658,7 +7692,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:519
+#: lxc/remote.go:533
 msgid "y"
 msgstr ""
 

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-14 13:30+0000\n"
+"POT-Creation-Date: 2024-10-15 14:52+0100\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Korean <https://hosted.weblate.org/projects/linux-containers/"
@@ -133,7 +133,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:214
+#: lxc/auth.go:219
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -160,7 +160,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:972
+#: lxc/auth.go:1121
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -181,7 +181,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1644
+#: lxc/auth.go:1793
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -515,15 +515,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:917 lxc/remote.go:982
+#: lxc/remote.go:951 lxc/remote.go:1016
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1030
+#: lxc/remote.go:1064
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:836
+#: lxc/remote.go:870
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -556,11 +556,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:818
+#: lxc/remote.go:852
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:817
+#: lxc/auth.go:966
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -598,11 +598,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1165 lxc/auth.go:1166
+#: lxc/auth.go:1314 lxc/auth.go:1315
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1933 lxc/auth.go:1934
+#: lxc/auth.go:2082 lxc/auth.go:2083
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -671,7 +671,7 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:516 lxc/auth.go:517
+#: lxc/auth.go:521 lxc/auth.go:522
 msgid "Add permissions to groups"
 msgstr ""
 
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:648
+#: lxc/remote.go:680
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -813,7 +813,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:621
+#: lxc/remote.go:635
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -991,7 +991,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:961
+#: lxc/remote.go:995
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1057,7 +1057,7 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:509
+#: lxc/remote.go:523
 msgid "Certificate fingerprint"
 msgstr ""
 
@@ -1076,7 +1076,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:687
+#: lxc/remote.go:721
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1324,12 +1324,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:559
+#: lxc/remote.go:573
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:237 lxc/remote.go:543
+#: lxc/remote.go:237 lxc/remote.go:557
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1343,12 +1343,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:1719
+#: lxc/auth.go:306 lxc/auth.go:1868
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1058
+#: lxc/auth.go:1207
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1368,13 +1368,17 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:554
+#: lxc/remote.go:568
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
 #: lxc/network_zone.go:1536
 msgid "Couldn't find a matching entry"
+msgstr ""
+
+#: lxc/auth.go:776
+msgid "Create a TLS identity"
 msgstr ""
 
 #: lxc/cluster_group.go:169 lxc/cluster_group.go:170
@@ -1393,6 +1397,10 @@ msgstr ""
 msgid "Create an empty instance"
 msgstr ""
 
+#: lxc/auth.go:775
+msgid "Create an identity"
+msgstr ""
+
 #: lxc/launch.go:23 lxc/launch.go:24
 msgid "Create and start instances from images"
 msgstr ""
@@ -1405,11 +1413,11 @@ msgstr ""
 msgid "Create files and directories in instances"
 msgstr ""
 
-#: lxc/auth.go:98 lxc/auth.go:99
+#: lxc/auth.go:103 lxc/auth.go:104
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1530 lxc/auth.go:1531
+#: lxc/auth.go:1679 lxc/auth.go:1680
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1517,7 +1525,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
@@ -1560,7 +1568,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/auth.go:1088 lxc/auth.go:1089
+#: lxc/auth.go:1237 lxc/auth.go:1238
 msgid "Delete an identity"
 msgstr ""
 
@@ -1568,11 +1576,11 @@ msgstr ""
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/auth.go:152 lxc/auth.go:153
+#: lxc/auth.go:157 lxc/auth.go:158
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1582 lxc/auth.go:1583
+#: lxc/auth.go:1731 lxc/auth.go:1732
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1650,18 +1658,18 @@ msgstr ""
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:31 lxc/auth.go:60 lxc/auth.go:99
-#: lxc/auth.go:153 lxc/auth.go:202 lxc/auth.go:333 lxc/auth.go:393
-#: lxc/auth.go:442 lxc/auth.go:494 lxc/auth.go:517 lxc/auth.go:576
-#: lxc/auth.go:732 lxc/auth.go:769 lxc/auth.go:836 lxc/auth.go:899
-#: lxc/auth.go:960 lxc/auth.go:1089 lxc/auth.go:1143 lxc/auth.go:1166
-#: lxc/auth.go:1224 lxc/auth.go:1293 lxc/auth.go:1315 lxc/auth.go:1493
-#: lxc/auth.go:1531 lxc/auth.go:1583 lxc/auth.go:1632 lxc/auth.go:1751
-#: lxc/auth.go:1811 lxc/auth.go:1860 lxc/auth.go:1911 lxc/auth.go:1934
-#: lxc/auth.go:1987 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215
-#: lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:484
-#: lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677 lxc/cluster.go:770
-#: lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
+#: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
+#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:338 lxc/auth.go:398
+#: lxc/auth.go:447 lxc/auth.go:499 lxc/auth.go:522 lxc/auth.go:581
+#: lxc/auth.go:737 lxc/auth.go:776 lxc/auth.go:918 lxc/auth.go:985
+#: lxc/auth.go:1048 lxc/auth.go:1109 lxc/auth.go:1238 lxc/auth.go:1292
+#: lxc/auth.go:1315 lxc/auth.go:1373 lxc/auth.go:1442 lxc/auth.go:1464
+#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
+#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
+#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
+#: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
+#: lxc/cluster.go:770 lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
 #: lxc/cluster.go:1175 lxc/cluster.go:1299 lxc/cluster.go:1329
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
@@ -1732,9 +1740,9 @@ msgstr ""
 #: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
 #: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
 #: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:715
-#: lxc/remote.go:753 lxc/remote.go:839 lxc/remote.go:920 lxc/remote.go:984
-#: lxc/remote.go:1032 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
+#: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
+#: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1919,7 +1927,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:959 lxc/auth.go:960
+#: lxc/auth.go:1108 lxc/auth.go:1109
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1931,11 +1939,11 @@ msgstr ""
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/auth.go:201 lxc/auth.go:202
+#: lxc/auth.go:206 lxc/auth.go:207
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1631 lxc/auth.go:1632
+#: lxc/auth.go:1780 lxc/auth.go:1781
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2311,12 +2319,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:486
+#: lxc/remote.go:500
 #, c-format
 msgid "Failed to decode trust token: %w"
 msgstr ""
 
-#: lxc/remote.go:292
+#: lxc/remote.go:306
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2420,7 +2428,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:773 lxc/auth.go:1755
+#: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
@@ -2428,7 +2436,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:757 lxc/storage.go:657
+#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2466,7 +2474,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:821
+#: lxc/remote.go:855
 msgid "GLOBAL"
 msgstr ""
 
@@ -2478,7 +2486,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:821 lxc/auth.go:1795
+#: lxc/auth.go:970 lxc/auth.go:1944
 msgid "GROUPS"
 msgstr ""
 
@@ -2486,7 +2494,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:165 lxc/remote.go:443
+#: lxc/remote.go:165 lxc/remote.go:457
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2627,17 +2635,17 @@ msgstr ""
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: lxc/auth.go:137
+#: lxc/auth.go:142
 #, c-format
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:187
+#: lxc/auth.go:192
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:427 lxc/auth.go:1845
+#: lxc/auth.go:432 lxc/auth.go:1994
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2696,7 +2704,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:820
+#: lxc/auth.go:969
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -2728,12 +2736,16 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1567
+#: lxc/auth.go:829
+msgid "Identity creation only supported for TLS identities"
+msgstr ""
+
+#: lxc/auth.go:1716
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1617
+#: lxc/auth.go:1766
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2862,7 +2874,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1292 lxc/auth.go:1293
+#: lxc/auth.go:1441 lxc/auth.go:1442
 msgid "Inspect permissions"
 msgstr ""
 
@@ -2910,7 +2922,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:395
+#: lxc/remote.go:409
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2991,7 +3003,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:384
+#: lxc/remote.go:398
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3166,15 +3178,15 @@ msgstr ""
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:332 lxc/auth.go:333
+#: lxc/auth.go:337 lxc/auth.go:338
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:768 lxc/auth.go:769
+#: lxc/auth.go:917 lxc/auth.go:918
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1750 lxc/auth.go:1751
+#: lxc/auth.go:1899 lxc/auth.go:1900
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3327,7 +3339,7 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1314 lxc/auth.go:1315
+#: lxc/auth.go:1463 lxc/auth.go:1464
 msgid "List permissions"
 msgstr ""
 
@@ -3371,7 +3383,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:752 lxc/remote.go:753
+#: lxc/remote.go:786 lxc/remote.go:787
 msgid "List the available remotes"
 msgstr ""
 
@@ -3495,6 +3507,12 @@ msgstr ""
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
+#: lxc/auth.go:825
+msgid ""
+"Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
+"got "
+msgstr ""
+
 #: lxc/network.go:32 lxc/network.go:33
 msgid "Manage and attach instances to networks"
 msgstr ""
@@ -3523,19 +3541,19 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:59 lxc/auth.go:60 lxc/auth.go:1492 lxc/auth.go:1493
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1142 lxc/auth.go:1143
+#: lxc/auth.go:1291 lxc/auth.go:1292
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:731 lxc/auth.go:732
+#: lxc/auth.go:736 lxc/auth.go:737
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1910 lxc/auth.go:1911
+#: lxc/auth.go:2059 lxc/auth.go:2060
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3626,7 +3644,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:493 lxc/auth.go:494
+#: lxc/auth.go:498 lxc/auth.go:499
 msgid "Manage permissions"
 msgstr ""
 
@@ -3678,7 +3696,7 @@ msgstr ""
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/auth.go:30 lxc/auth.go:31
+#: lxc/auth.go:35 lxc/auth.go:36
 msgid "Manage user authorization"
 msgstr ""
 
@@ -3775,21 +3793,21 @@ msgstr ""
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:123 lxc/auth.go:177 lxc/auth.go:255 lxc/auth.go:417
-#: lxc/auth.go:466 lxc/auth.go:541 lxc/auth.go:600 lxc/auth.go:1884
+#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:260 lxc/auth.go:422
+#: lxc/auth.go:471 lxc/auth.go:546 lxc/auth.go:605 lxc/auth.go:2033
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:866 lxc/auth.go:1007 lxc/auth.go:1124 lxc/auth.go:1190
-#: lxc/auth.go:1248
+#: lxc/auth.go:820 lxc/auth.go:1015 lxc/auth.go:1156 lxc/auth.go:1273
+#: lxc/auth.go:1339 lxc/auth.go:1397
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1554 lxc/auth.go:1607 lxc/auth.go:1673 lxc/auth.go:1835
+#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1958 lxc/auth.go:2011
+#: lxc/auth.go:2107 lxc/auth.go:2160
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -4010,12 +4028,12 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:376 lxc/auth.go:819 lxc/auth.go:1794 lxc/cluster.go:192
+#: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
-#: lxc/remote.go:815 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
 msgstr ""
@@ -4042,7 +4060,7 @@ msgstr ""
 
 #: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:775 lxc/remote.go:780 lxc/remote.go:785
+#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr ""
 
@@ -4271,7 +4289,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:378
+#: lxc/remote.go:392
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4342,11 +4360,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:817
+#: lxc/remote.go:851
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:819
+#: lxc/image.go:1136 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4387,7 +4405,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:536
+#: lxc/remote.go:550
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
@@ -4404,7 +4422,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:302 lxc/auth.go:1059 lxc/auth.go:1720 lxc/cluster.go:860
+#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -4707,33 +4725,33 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:877
+#: lxc/remote.go:911
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:868 lxc/remote.go:949 lxc/remote.go:1013
-#: lxc/remote.go:1061
+#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/remote.go:1095
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:345
+#: lxc/remote.go:359
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:957
+#: lxc/remote.go:991
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:872 lxc/remote.go:953 lxc/remote.go:1065
+#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1099
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:319
+#: lxc/remote.go:333
 msgid "Remote address must not be empty"
 msgstr ""
 
@@ -4741,7 +4759,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:339
+#: lxc/remote.go:353
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4763,7 +4781,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1223 lxc/auth.go:1224
+#: lxc/auth.go:1372 lxc/auth.go:1373
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4799,7 +4817,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1986 lxc/auth.go:1987
+#: lxc/auth.go:2135 lxc/auth.go:2136
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4811,7 +4829,7 @@ msgstr ""
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:575 lxc/auth.go:576
+#: lxc/auth.go:580 lxc/auth.go:581
 msgid "Remove permissions from groups"
 msgstr ""
 
@@ -4827,7 +4845,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:919 lxc/remote.go:920
+#: lxc/remote.go:953 lxc/remote.go:954
 msgid "Remove remotes"
 msgstr ""
 
@@ -4856,11 +4874,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:392 lxc/auth.go:393
+#: lxc/auth.go:397 lxc/auth.go:398
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1810 lxc/auth.go:1811
+#: lxc/auth.go:1959 lxc/auth.go:1960
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -4884,7 +4902,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:838 lxc/remote.go:839
+#: lxc/remote.go:872 lxc/remote.go:873
 msgid "Rename remotes"
 msgstr ""
 
@@ -5029,7 +5047,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:820
+#: lxc/remote.go:854
 msgid "STATIC"
 msgstr ""
 
@@ -5070,11 +5088,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:532
+#: lxc/remote.go:546
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:285 lxc/remote.go:683
+#: lxc/remote.go:299 lxc/remote.go:717
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5285,7 +5303,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1031 lxc/remote.go:1032
+#: lxc/remote.go:1065 lxc/remote.go:1066
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5381,7 +5399,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1859 lxc/auth.go:1860
+#: lxc/auth.go:2008 lxc/auth.go:2009
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5409,11 +5427,11 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:441 lxc/auth.go:442
+#: lxc/auth.go:446 lxc/auth.go:447
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:836
+#: lxc/auth.go:985
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5518,7 +5536,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:899
+#: lxc/auth.go:1048
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5528,7 +5546,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:714 lxc/remote.go:715
+#: lxc/remote.go:748 lxc/remote.go:749
 msgid "Show the default remote"
 msgstr ""
 
@@ -5740,7 +5758,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:983 lxc/remote.go:984
+#: lxc/remote.go:1017 lxc/remote.go:1018
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5752,11 +5770,21 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
+#: lxc/auth.go:876
+#, c-format
+msgid "TLS identity %q (%s) pending identity token:"
+msgstr ""
+
+#: lxc/auth.go:902
+#, c-format
+msgid "TLS identity %q created with fingerprint %q"
+msgstr ""
+
 #: lxc/cluster.go:1070 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:818 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
 #: lxc/storage_volume.go:1736 lxc/warning.go:216
@@ -5775,7 +5803,7 @@ msgstr ""
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/remote.go:161 lxc/remote.go:334
+#: lxc/remote.go:161 lxc/remote.go:348
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
@@ -5931,7 +5959,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:527
+#: lxc/remote.go:541
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
@@ -6069,15 +6097,15 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:329
+#: lxc/remote.go:343
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:324
+#: lxc/remote.go:338
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr ""
 
-#: lxc/remote.go:639
+#: lxc/remote.go:653
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6120,7 +6148,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:193 lxc/remote.go:816
+#: lxc/cluster.go:193 lxc/remote.go:850
 msgid "URL"
 msgstr ""
 
@@ -6428,11 +6456,11 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:835
+#: lxc/auth.go:984
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:898
+#: lxc/auth.go:1047
 msgid "View the current identity"
 msgstr ""
 
@@ -6471,7 +6499,7 @@ msgstr ""
 
 #: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:777 lxc/remote.go:782 lxc/remote.go:787
+#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr ""
 
@@ -6503,7 +6531,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:330 lxc/auth.go:766 lxc/auth.go:897 lxc/auth.go:1748
+#: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
@@ -6536,7 +6564,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1313
+#: lxc/auth.go:1462
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6597,11 +6625,17 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:834 lxc/auth.go:1086
+#: lxc/auth.go:774
+msgid ""
+"[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
+"certificate>] [[--group <group_name>]]"
+msgstr ""
+
+#: lxc/auth.go:983 lxc/auth.go:1235
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1164 lxc/auth.go:1222 lxc/auth.go:1985
+#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:2134
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6609,13 +6643,13 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:97 lxc/auth.go:150 lxc/auth.go:200 lxc/auth.go:440
-#: lxc/auth.go:958 lxc/auth.go:1529 lxc/cluster_group.go:168
+#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:445
+#: lxc/auth.go:1107 lxc/auth.go:1678 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:515 lxc/auth.go:573
+#: lxc/auth.go:520 lxc/auth.go:578
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
@@ -6625,19 +6659,19 @@ msgstr ""
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:390
+#: lxc/auth.go:395
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1580 lxc/auth.go:1630 lxc/auth.go:1858
+#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1932
+#: lxc/auth.go:2081
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1808
+#: lxc/auth.go:1957
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -7128,7 +7162,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:806
+#: lxc/project.go:557 lxc/remote.go:840
 msgid "current"
 msgstr ""
 
@@ -7175,20 +7209,20 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/auth.go:204
+#: lxc/auth.go:209
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:962
+#: lxc/auth.go:1111
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1634
+#: lxc/auth.go:1783
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7612,7 +7646,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:531
+#: lxc/remote.go:545
 msgid "n"
 msgstr ""
 
@@ -7624,7 +7658,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:510
+#: lxc/remote.go:524
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7661,7 +7695,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:519
+#: lxc/remote.go:533
 msgid "y"
 msgstr ""
 

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-        "POT-Creation-Date: 2024-10-14 13:30+0000\n"
+        "POT-Creation-Date: 2024-10-15 14:52+0100\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -122,7 +122,7 @@ msgid   "### This is a YAML representation of the configuration.\n"
         "### Note that the name is shown but cannot be changed"
 msgstr  ""
 
-#: lxc/auth.go:214
+#: lxc/auth.go:219
 msgid   "### This is a YAML representation of the group.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -147,7 +147,7 @@ msgid   "### This is a YAML representation of the group.\n"
         "### Note that all group information is shown but only the description and permissions can be modified"
 msgstr  ""
 
-#: lxc/auth.go:972
+#: lxc/auth.go:1121
 msgid   "### This is a YAML representation of the group.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -166,7 +166,7 @@ msgid   "### This is a YAML representation of the group.\n"
         "### Note that all identity information is shown but only the projects and groups can be modified"
 msgstr  ""
 
-#: lxc/auth.go:1644
+#: lxc/auth.go:1793
 msgid   "### This is a YAML representation of the identity provider group.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -482,15 +482,15 @@ msgstr  ""
 msgid   "<old alias> <new alias>"
 msgstr  ""
 
-#: lxc/remote.go:917 lxc/remote.go:982
+#: lxc/remote.go:951 lxc/remote.go:1016
 msgid   "<remote>"
 msgstr  ""
 
-#: lxc/remote.go:1030
+#: lxc/remote.go:1064
 msgid   "<remote> <URL>"
 msgstr  ""
 
-#: lxc/remote.go:836
+#: lxc/remote.go:870
 msgid   "<remote> <new-name>"
 msgstr  ""
 
@@ -522,11 +522,11 @@ msgstr  ""
 msgid   "ARCHITECTURE"
 msgstr  ""
 
-#: lxc/remote.go:818
+#: lxc/remote.go:852
 msgid   "AUTH TYPE"
 msgstr  ""
 
-#: lxc/auth.go:817
+#: lxc/auth.go:966
 msgid   "AUTHENTICATION METHOD"
 msgstr  ""
 
@@ -564,11 +564,11 @@ msgstr  ""
 msgid   "Add a cluster member to a cluster group"
 msgstr  ""
 
-#: lxc/auth.go:1165 lxc/auth.go:1166
+#: lxc/auth.go:1314 lxc/auth.go:1315
 msgid   "Add a group to an identity"
 msgstr  ""
 
-#: lxc/auth.go:1933 lxc/auth.go:1934
+#: lxc/auth.go:2082 lxc/auth.go:2083
 msgid   "Add a group to an identity provider group"
 msgstr  ""
 
@@ -630,7 +630,7 @@ msgid   "Add new trusted client\n"
         "restricted to one or more projects.\n"
 msgstr  ""
 
-#: lxc/auth.go:516 lxc/auth.go:517
+#: lxc/auth.go:521 lxc/auth.go:522
 msgid   "Add permissions to groups"
 msgstr  ""
 
@@ -664,7 +664,7 @@ msgstr  ""
 msgid   "Admin access key: %s"
 msgstr  ""
 
-#: lxc/remote.go:648
+#: lxc/remote.go:680
 #, c-format
 msgid   "Admin password (or token) for %s:"
 msgstr  ""
@@ -771,7 +771,7 @@ msgid   "Attach to instance consoles\n"
         "as well as retrieve past log entries from it."
 msgstr  ""
 
-#: lxc/remote.go:621
+#: lxc/remote.go:635
 #, c-format
 msgid   "Authentication type '%s' not supported by server"
 msgstr  ""
@@ -947,7 +947,7 @@ msgstr  ""
 msgid   "Can't read from stdin: %w"
 msgstr  ""
 
-#: lxc/remote.go:961
+#: lxc/remote.go:995
 msgid   "Can't remove the default remote"
 msgstr  ""
 
@@ -1012,7 +1012,7 @@ msgstr  ""
 msgid   "Certificate add token for %s deleted"
 msgstr  ""
 
-#: lxc/remote.go:509
+#: lxc/remote.go:523
 msgid   "Certificate fingerprint"
 msgstr  ""
 
@@ -1030,7 +1030,7 @@ msgstr  ""
 msgid   "Client %s certificate add token:"
 msgstr  ""
 
-#: lxc/remote.go:687
+#: lxc/remote.go:721
 msgid   "Client certificate now trusted by server:"
 msgstr  ""
 
@@ -1235,12 +1235,12 @@ msgstr  ""
 msgid   "Cores:"
 msgstr  ""
 
-#: lxc/remote.go:559
+#: lxc/remote.go:573
 #, c-format
 msgid   "Could not close server cert file %q: %w"
 msgstr  ""
 
-#: lxc/remote.go:237 lxc/remote.go:543
+#: lxc/remote.go:237 lxc/remote.go:557
 msgid   "Could not create server cert dir"
 msgstr  ""
 
@@ -1254,12 +1254,12 @@ msgstr  ""
 msgid   "Could not find certificate key file path: %s"
 msgstr  ""
 
-#: lxc/auth.go:301 lxc/auth.go:1719
+#: lxc/auth.go:306 lxc/auth.go:1868
 #, c-format
 msgid   "Could not parse group: %s"
 msgstr  ""
 
-#: lxc/auth.go:1058
+#: lxc/auth.go:1207
 #, c-format
 msgid   "Could not parse identity: %s"
 msgstr  ""
@@ -1279,13 +1279,17 @@ msgstr  ""
 msgid   "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr  ""
 
-#: lxc/remote.go:554
+#: lxc/remote.go:568
 #, c-format
 msgid   "Could not write server cert file %q: %w"
 msgstr  ""
 
 #: lxc/network_zone.go:1536
 msgid   "Couldn't find a matching entry"
+msgstr  ""
+
+#: lxc/auth.go:776
+msgid   "Create a TLS identity"
 msgstr  ""
 
 #: lxc/cluster_group.go:169 lxc/cluster_group.go:170
@@ -1304,6 +1308,10 @@ msgstr  ""
 msgid   "Create an empty instance"
 msgstr  ""
 
+#: lxc/auth.go:775
+msgid   "Create an identity"
+msgstr  ""
+
 #: lxc/launch.go:23 lxc/launch.go:24
 msgid   "Create and start instances from images"
 msgstr  ""
@@ -1316,11 +1324,11 @@ msgstr  ""
 msgid   "Create files and directories in instances"
 msgstr  ""
 
-#: lxc/auth.go:98 lxc/auth.go:99
+#: lxc/auth.go:103 lxc/auth.go:104
 msgid   "Create groups"
 msgstr  ""
 
-#: lxc/auth.go:1530 lxc/auth.go:1531
+#: lxc/auth.go:1679 lxc/auth.go:1680
 msgid   "Create identity provider groups"
 msgstr  ""
 
@@ -1427,7 +1435,7 @@ msgstr  ""
 msgid   "DEFAULT TARGET ADDRESS"
 msgstr  ""
 
-#: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504 lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086 lxc/network_acl.go:157 lxc/network_forward.go:157 lxc/network_load_balancer.go:160 lxc/network_peer.go:149 lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173 lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723 lxc/storage_bucket.go:513 lxc/storage_bucket.go:833 lxc/storage_volume.go:1738
+#: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504 lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086 lxc/network_acl.go:157 lxc/network_forward.go:157 lxc/network_load_balancer.go:160 lxc/network_peer.go:149 lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173 lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723 lxc/storage_bucket.go:513 lxc/storage_bucket.go:833 lxc/storage_volume.go:1738
 msgid   "DESCRIPTION"
 msgstr  ""
 
@@ -1463,7 +1471,7 @@ msgstr  ""
 msgid   "Delete all warnings"
 msgstr  ""
 
-#: lxc/auth.go:1088 lxc/auth.go:1089
+#: lxc/auth.go:1237 lxc/auth.go:1238
 msgid   "Delete an identity"
 msgstr  ""
 
@@ -1471,11 +1479,11 @@ msgstr  ""
 msgid   "Delete files in instances"
 msgstr  ""
 
-#: lxc/auth.go:152 lxc/auth.go:153
+#: lxc/auth.go:157 lxc/auth.go:158
 msgid   "Delete groups"
 msgstr  ""
 
-#: lxc/auth.go:1582 lxc/auth.go:1583
+#: lxc/auth.go:1731 lxc/auth.go:1732
 msgid   "Delete identity provider groups"
 msgstr  ""
 
@@ -1551,7 +1559,7 @@ msgstr  ""
 msgid   "Delete warning"
 msgstr  ""
 
-#: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159 lxc/alias.go:214 lxc/auth.go:31 lxc/auth.go:60 lxc/auth.go:99 lxc/auth.go:153 lxc/auth.go:202 lxc/auth.go:333 lxc/auth.go:393 lxc/auth.go:442 lxc/auth.go:494 lxc/auth.go:517 lxc/auth.go:576 lxc/auth.go:732 lxc/auth.go:769 lxc/auth.go:836 lxc/auth.go:899 lxc/auth.go:960 lxc/auth.go:1089 lxc/auth.go:1143 lxc/auth.go:1166 lxc/auth.go:1224 lxc/auth.go:1293 lxc/auth.go:1315 lxc/auth.go:1493 lxc/auth.go:1531 lxc/auth.go:1583 lxc/auth.go:1632 lxc/auth.go:1751 lxc/auth.go:1811 lxc/auth.go:1860 lxc/auth.go:1911 lxc/auth.go:1934 lxc/auth.go:1987 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677 lxc/cluster.go:770 lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087 lxc/cluster.go:1175 lxc/cluster.go:1299 lxc/cluster.go:1329 lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170 lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440 lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663 lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51 lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:955 lxc/config.go:995 lxc/config.go:1050 lxc/config.go:1141 lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:25 lxc/config_device.go:79 lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409 lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634 lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28 lxc/config_metadata.go:56 lxc/config_metadata.go:189 lxc/config_template.go:28 lxc/config_template.go:68 lxc/config_template.go:119 lxc/config_template.go:173 lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34 lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651 lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135 lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689 lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090 lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638 lxc/image.go:1701 lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1005 lxc/network.go:1106 lxc/network.go:1185 lxc/network.go:1245 lxc/network.go:1341 lxc/network.go:1413 lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731 lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:51 lxc/network_forward.go:33 lxc/network_forward.go:90 lxc/network_forward.go:179 lxc/network_forward.go:256 lxc/network_forward.go:404 lxc/network_forward.go:489 lxc/network_forward.go:599 lxc/network_forward.go:646 lxc/network_forward.go:800 lxc/network_forward.go:874 lxc/network_forward.go:889 lxc/network_forward.go:970 lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476 lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935 lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1121 lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236 lxc/network_peer.go:360 lxc/network_peer.go:445 lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:165 lxc/network_zone.go:228 lxc/network_zone.go:301 lxc/network_zone.go:396 lxc/network_zone.go:484 lxc/network_zone.go:527 lxc/network_zone.go:654 lxc/network_zone.go:710 lxc/network_zone.go:767 lxc/network_zone.go:845 lxc/network_zone.go:909 lxc/network_zone.go:985 lxc/network_zone.go:1083 lxc/network_zone.go:1172 lxc/network_zone.go:1219 lxc/network_zone.go:1349 lxc/network_zone.go:1410 lxc/network_zone.go:1425 lxc/network_zone.go:1483 lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180 lxc/profile.go:271 lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493 lxc/profile.go:629 lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860 lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31 lxc/project.go:95 lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472 lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789 lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:715 lxc/remote.go:753 lxc/remote.go:839 lxc/remote.go:920 lxc/remote.go:984 lxc/remote.go:1032 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250 lxc/storage_bucket.go:383 lxc/storage_bucket.go:459 lxc/storage_bucket.go:536 lxc/storage_bucket.go:630 lxc/storage_bucket.go:699 lxc/storage_bucket.go:733 lxc/storage_bucket.go:774 lxc/storage_bucket.go:853 lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158 lxc/storage_volume.go:58 lxc/storage_volume.go:169 lxc/storage_volume.go:283 lxc/storage_volume.go:390 lxc/storage_volume.go:611 lxc/storage_volume.go:720 lxc/storage_volume.go:807 lxc/storage_volume.go:905 lxc/storage_volume.go:1002 lxc/storage_volume.go:1223 lxc/storage_volume.go:1354 lxc/storage_volume.go:1513 lxc/storage_volume.go:1597 lxc/storage_volume.go:1850 lxc/storage_volume.go:1943 lxc/storage_volume.go:2070 lxc/storage_volume.go:2228 lxc/storage_volume.go:2349 lxc/storage_volume.go:2411 lxc/storage_volume.go:2547 lxc/storage_volume.go:2630 lxc/storage_volume.go:2796 lxc/version.go:22 lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
+#: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159 lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104 lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:338 lxc/auth.go:398 lxc/auth.go:447 lxc/auth.go:499 lxc/auth.go:522 lxc/auth.go:581 lxc/auth.go:737 lxc/auth.go:776 lxc/auth.go:918 lxc/auth.go:985 lxc/auth.go:1048 lxc/auth.go:1109 lxc/auth.go:1238 lxc/auth.go:1292 lxc/auth.go:1315 lxc/auth.go:1373 lxc/auth.go:1442 lxc/auth.go:1464 lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781 lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060 lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677 lxc/cluster.go:770 lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087 lxc/cluster.go:1175 lxc/cluster.go:1299 lxc/cluster.go:1329 lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170 lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440 lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663 lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51 lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:955 lxc/config.go:995 lxc/config.go:1050 lxc/config.go:1141 lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:25 lxc/config_device.go:79 lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409 lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634 lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28 lxc/config_metadata.go:56 lxc/config_metadata.go:189 lxc/config_template.go:28 lxc/config_template.go:68 lxc/config_template.go:119 lxc/config_template.go:173 lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34 lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651 lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135 lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689 lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090 lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638 lxc/image.go:1701 lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1005 lxc/network.go:1106 lxc/network.go:1185 lxc/network.go:1245 lxc/network.go:1341 lxc/network.go:1413 lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731 lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:51 lxc/network_forward.go:33 lxc/network_forward.go:90 lxc/network_forward.go:179 lxc/network_forward.go:256 lxc/network_forward.go:404 lxc/network_forward.go:489 lxc/network_forward.go:599 lxc/network_forward.go:646 lxc/network_forward.go:800 lxc/network_forward.go:874 lxc/network_forward.go:889 lxc/network_forward.go:970 lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476 lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935 lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1121 lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236 lxc/network_peer.go:360 lxc/network_peer.go:445 lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:165 lxc/network_zone.go:228 lxc/network_zone.go:301 lxc/network_zone.go:396 lxc/network_zone.go:484 lxc/network_zone.go:527 lxc/network_zone.go:654 lxc/network_zone.go:710 lxc/network_zone.go:767 lxc/network_zone.go:845 lxc/network_zone.go:909 lxc/network_zone.go:985 lxc/network_zone.go:1083 lxc/network_zone.go:1172 lxc/network_zone.go:1219 lxc/network_zone.go:1349 lxc/network_zone.go:1410 lxc/network_zone.go:1425 lxc/network_zone.go:1483 lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180 lxc/profile.go:271 lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493 lxc/profile.go:629 lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860 lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31 lxc/project.go:95 lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472 lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789 lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749 lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018 lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250 lxc/storage_bucket.go:383 lxc/storage_bucket.go:459 lxc/storage_bucket.go:536 lxc/storage_bucket.go:630 lxc/storage_bucket.go:699 lxc/storage_bucket.go:733 lxc/storage_bucket.go:774 lxc/storage_bucket.go:853 lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158 lxc/storage_volume.go:58 lxc/storage_volume.go:169 lxc/storage_volume.go:283 lxc/storage_volume.go:390 lxc/storage_volume.go:611 lxc/storage_volume.go:720 lxc/storage_volume.go:807 lxc/storage_volume.go:905 lxc/storage_volume.go:1002 lxc/storage_volume.go:1223 lxc/storage_volume.go:1354 lxc/storage_volume.go:1513 lxc/storage_volume.go:1597 lxc/storage_volume.go:1850 lxc/storage_volume.go:1943 lxc/storage_volume.go:2070 lxc/storage_volume.go:2228 lxc/storage_volume.go:2349 lxc/storage_volume.go:2411 lxc/storage_volume.go:2547 lxc/storage_volume.go:2630 lxc/storage_volume.go:2796 lxc/version.go:22 lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid   "Description"
 msgstr  ""
 
@@ -1707,7 +1715,7 @@ msgstr  ""
 msgid   "Edit a cluster group"
 msgstr  ""
 
-#: lxc/auth.go:959 lxc/auth.go:960
+#: lxc/auth.go:1108 lxc/auth.go:1109
 msgid   "Edit an identity as YAML"
 msgstr  ""
 
@@ -1719,11 +1727,11 @@ msgstr  ""
 msgid   "Edit files in instances"
 msgstr  ""
 
-#: lxc/auth.go:201 lxc/auth.go:202
+#: lxc/auth.go:206 lxc/auth.go:207
 msgid   "Edit groups as YAML"
 msgstr  ""
 
-#: lxc/auth.go:1631 lxc/auth.go:1632
+#: lxc/auth.go:1780 lxc/auth.go:1781
 msgid   "Edit identity provider groups as YAML"
 msgstr  ""
 
@@ -2079,12 +2087,12 @@ msgstr  ""
 msgid   "Failed to create alias %s: %w"
 msgstr  ""
 
-#: lxc/remote.go:486
+#: lxc/remote.go:500
 #, c-format
 msgid   "Failed to decode trust token: %w"
 msgstr  ""
 
-#: lxc/remote.go:292
+#: lxc/remote.go:306
 #, c-format
 msgid   "Failed to find project: %w"
 msgstr  ""
@@ -2182,7 +2190,7 @@ msgid   "Forcefully removing a server from the cluster should only be done as a 
         "Are you really sure you want to force removing %s? (yes/no): "
 msgstr  ""
 
-#: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:773 lxc/auth.go:1755 lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442 lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434 lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009 lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:57 lxc/network_forward.go:93 lxc/network_load_balancer.go:97 lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770 lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474 lxc/project.go:919 lxc/remote.go:757 lxc/storage.go:657 lxc/storage_bucket.go:460 lxc/storage_bucket.go:775 lxc/storage_volume.go:1614 lxc/warning.go:94
+#: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904 lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442 lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434 lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009 lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:57 lxc/network_forward.go:93 lxc/network_load_balancer.go:97 lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770 lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474 lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657 lxc/storage_bucket.go:460 lxc/storage_bucket.go:775 lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid   "Format (csv|json|table|yaml|compact)"
 msgstr  ""
 
@@ -2218,7 +2226,7 @@ msgstr  ""
 msgid   "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr  ""
 
-#: lxc/remote.go:821
+#: lxc/remote.go:855
 msgid   "GLOBAL"
 msgstr  ""
 
@@ -2230,7 +2238,7 @@ msgstr  ""
 msgid   "GPUs:"
 msgstr  ""
 
-#: lxc/auth.go:821 lxc/auth.go:1795
+#: lxc/auth.go:970 lxc/auth.go:1944
 msgid   "GROUPS"
 msgstr  ""
 
@@ -2238,7 +2246,7 @@ msgstr  ""
 msgid   "Generate manpages for all commands"
 msgstr  ""
 
-#: lxc/remote.go:165 lxc/remote.go:443
+#: lxc/remote.go:165 lxc/remote.go:457
 msgid   "Generating a client certificate. This may take a minute..."
 msgstr  ""
 
@@ -2379,17 +2387,17 @@ msgstr  ""
 msgid   "Given target %q does not match source volume location %q"
 msgstr  ""
 
-#: lxc/auth.go:137
+#: lxc/auth.go:142
 #, c-format
 msgid   "Group %s created"
 msgstr  ""
 
-#: lxc/auth.go:187
+#: lxc/auth.go:192
 #, c-format
 msgid   "Group %s deleted"
 msgstr  ""
 
-#: lxc/auth.go:427 lxc/auth.go:1845
+#: lxc/auth.go:432 lxc/auth.go:1994
 #, c-format
 msgid   "Group %s renamed to %s"
 msgstr  ""
@@ -2448,7 +2456,7 @@ msgstr  ""
 msgid   "ID: %s"
 msgstr  ""
 
-#: lxc/auth.go:820
+#: lxc/auth.go:969
 msgid   "IDENTIFIER"
 msgstr  ""
 
@@ -2480,12 +2488,16 @@ msgstr  ""
 msgid   "ISSUE DATE"
 msgstr  ""
 
-#: lxc/auth.go:1567
+#: lxc/auth.go:829
+msgid   "Identity creation only supported for TLS identities"
+msgstr  ""
+
+#: lxc/auth.go:1716
 #, c-format
 msgid   "Identity provider group %s created"
 msgstr  ""
 
-#: lxc/auth.go:1617
+#: lxc/auth.go:1766
 #, c-format
 msgid   "Identity provider group %s deleted"
 msgstr  ""
@@ -2610,7 +2622,7 @@ msgstr  ""
 msgid   "Input data"
 msgstr  ""
 
-#: lxc/auth.go:1292 lxc/auth.go:1293
+#: lxc/auth.go:1441 lxc/auth.go:1442
 msgid   "Inspect permissions"
 msgstr  ""
 
@@ -2658,7 +2670,7 @@ msgstr  ""
 msgid   "Instance type"
 msgstr  ""
 
-#: lxc/remote.go:395
+#: lxc/remote.go:409
 #, c-format
 msgid   "Invalid URL scheme \"%s\" in \"%s\""
 msgstr  ""
@@ -2738,7 +2750,7 @@ msgstr  ""
 msgid   "Invalid path %s"
 msgstr  ""
 
-#: lxc/remote.go:384
+#: lxc/remote.go:398
 #, c-format
 msgid   "Invalid protocol: %s"
 msgstr  ""
@@ -2908,15 +2920,15 @@ msgstr  ""
 msgid   "List background operations"
 msgstr  ""
 
-#: lxc/auth.go:332 lxc/auth.go:333
+#: lxc/auth.go:337 lxc/auth.go:338
 msgid   "List groups"
 msgstr  ""
 
-#: lxc/auth.go:768 lxc/auth.go:769
+#: lxc/auth.go:917 lxc/auth.go:918
 msgid   "List identities"
 msgstr  ""
 
-#: lxc/auth.go:1750 lxc/auth.go:1751
+#: lxc/auth.go:1899 lxc/auth.go:1900
 msgid   "List identity provider groups"
 msgstr  ""
 
@@ -3059,7 +3071,7 @@ msgstr  ""
 msgid   "List operations from all projects"
 msgstr  ""
 
-#: lxc/auth.go:1314 lxc/auth.go:1315
+#: lxc/auth.go:1463 lxc/auth.go:1464
 msgid   "List permissions"
 msgstr  ""
 
@@ -3102,7 +3114,7 @@ msgid   "List storage volumes\n"
         "    U - Current disk usage"
 msgstr  ""
 
-#: lxc/remote.go:752 lxc/remote.go:753
+#: lxc/remote.go:786 lxc/remote.go:787
 msgid   "List the available remotes"
 msgstr  ""
 
@@ -3225,6 +3237,10 @@ msgstr  ""
 msgid   "Make the image public (accessible to unauthenticated clients as well)"
 msgstr  ""
 
+#: lxc/auth.go:825
+msgid   "Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, got "
+msgstr  ""
+
 #: lxc/network.go:32 lxc/network.go:33
 msgid   "Manage and attach instances to networks"
 msgstr  ""
@@ -3253,19 +3269,19 @@ msgstr  ""
 msgid   "Manage files in instances"
 msgstr  ""
 
-#: lxc/auth.go:59 lxc/auth.go:60 lxc/auth.go:1492 lxc/auth.go:1493
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
 msgid   "Manage groups"
 msgstr  ""
 
-#: lxc/auth.go:1142 lxc/auth.go:1143
+#: lxc/auth.go:1291 lxc/auth.go:1292
 msgid   "Manage groups for the identity"
 msgstr  ""
 
-#: lxc/auth.go:731 lxc/auth.go:732
+#: lxc/auth.go:736 lxc/auth.go:737
 msgid   "Manage identities"
 msgstr  ""
 
-#: lxc/auth.go:1910 lxc/auth.go:1911
+#: lxc/auth.go:2059 lxc/auth.go:2060
 msgid   "Manage identity provider group mappings"
 msgstr  ""
 
@@ -3355,7 +3371,7 @@ msgstr  ""
 msgid   "Manage network zones"
 msgstr  ""
 
-#: lxc/auth.go:493 lxc/auth.go:494
+#: lxc/auth.go:498 lxc/auth.go:499
 msgid   "Manage permissions"
 msgstr  ""
 
@@ -3405,7 +3421,7 @@ msgstr  ""
 msgid   "Manage trusted clients"
 msgstr  ""
 
-#: lxc/auth.go:30 lxc/auth.go:31
+#: lxc/auth.go:35 lxc/auth.go:36
 msgid   "Manage user authorization"
 msgstr  ""
 
@@ -3493,19 +3509,19 @@ msgstr  ""
 msgid   "Missing cluster member name"
 msgstr  ""
 
-#: lxc/auth.go:123 lxc/auth.go:177 lxc/auth.go:255 lxc/auth.go:417 lxc/auth.go:466 lxc/auth.go:541 lxc/auth.go:600 lxc/auth.go:1884
+#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:260 lxc/auth.go:422 lxc/auth.go:471 lxc/auth.go:546 lxc/auth.go:605 lxc/auth.go:2033
 msgid   "Missing group name"
 msgstr  ""
 
-#: lxc/auth.go:866 lxc/auth.go:1007 lxc/auth.go:1124 lxc/auth.go:1190 lxc/auth.go:1248
+#: lxc/auth.go:820 lxc/auth.go:1015 lxc/auth.go:1156 lxc/auth.go:1273 lxc/auth.go:1339 lxc/auth.go:1397
 msgid   "Missing identity argument"
 msgstr  ""
 
-#: lxc/auth.go:1554 lxc/auth.go:1607 lxc/auth.go:1673 lxc/auth.go:1835
+#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
 msgid   "Missing identity provider group name"
 msgstr  ""
 
-#: lxc/auth.go:1958 lxc/auth.go:2011
+#: lxc/auth.go:2107 lxc/auth.go:2160
 msgid   "Missing identity provider group name argument"
 msgstr  ""
 
@@ -3666,7 +3682,7 @@ msgstr  ""
 msgid   "Must supply instance name for: "
 msgstr  ""
 
-#: lxc/auth.go:376 lxc/auth.go:819 lxc/auth.go:1794 lxc/cluster.go:192 lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081 lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147 lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567 lxc/remote.go:815 lxc/storage.go:715 lxc/storage_bucket.go:512 lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
+#: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192 lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081 lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147 lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567 lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512 lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid   "NAME"
 msgstr  ""
 
@@ -3690,7 +3706,7 @@ msgstr  ""
 msgid   "NICs:"
 msgstr  ""
 
-#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525 lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545 lxc/project.go:550 lxc/remote.go:775 lxc/remote.go:780 lxc/remote.go:785
+#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525 lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545 lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid   "NO"
 msgstr  ""
 
@@ -3917,7 +3933,7 @@ msgstr  ""
 msgid   "Only \"custom\" volumes can be snapshotted"
 msgstr  ""
 
-#: lxc/remote.go:378
+#: lxc/remote.go:392
 msgid   "Only https URLs are supported for simplestreams"
 msgstr  ""
 
@@ -3988,11 +4004,11 @@ msgstr  ""
 msgid   "PROJECT"
 msgstr  ""
 
-#: lxc/remote.go:817
+#: lxc/remote.go:851
 msgid   "PROTOCOL"
 msgstr  ""
 
-#: lxc/image.go:1136 lxc/remote.go:819
+#: lxc/image.go:1136 lxc/remote.go:853
 msgid   "PUBLIC"
 msgstr  ""
 
@@ -4033,7 +4049,7 @@ msgstr  ""
 msgid   "Please provide cluster member name: "
 msgstr  ""
 
-#: lxc/remote.go:536
+#: lxc/remote.go:550
 msgid   "Please type 'y', 'n' or the fingerprint: "
 msgstr  ""
 
@@ -4050,7 +4066,7 @@ msgstr  ""
 msgid   "Press ctrl+c to finish"
 msgstr  ""
 
-#: lxc/auth.go:302 lxc/auth.go:1059 lxc/auth.go:1720 lxc/cluster.go:860 lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357 lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239 lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760 lxc/network_acl.go:699 lxc/network_forward.go:768 lxc/network_load_balancer.go:739 lxc/network_peer.go:699 lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596 lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350 lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157 lxc/storage_volume.go:1189
+#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860 lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357 lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239 lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760 lxc/network_acl.go:699 lxc/network_forward.go:768 lxc/network_load_balancer.go:739 lxc/network_peer.go:699 lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596 lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350 lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157 lxc/storage_volume.go:1189
 msgid   "Press enter to open the editor again or ctrl+c to abort change"
 msgstr  ""
 
@@ -4328,32 +4344,32 @@ msgstr  ""
 msgid   "Refreshing the image: %s"
 msgstr  ""
 
-#: lxc/remote.go:877
+#: lxc/remote.go:911
 #, c-format
 msgid   "Remote %s already exists"
 msgstr  ""
 
-#: lxc/project.go:884 lxc/remote.go:868 lxc/remote.go:949 lxc/remote.go:1013 lxc/remote.go:1061
+#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047 lxc/remote.go:1095
 #, c-format
 msgid   "Remote %s doesn't exist"
 msgstr  ""
 
-#: lxc/remote.go:345
+#: lxc/remote.go:359
 #, c-format
 msgid   "Remote %s exists as <%s>"
 msgstr  ""
 
-#: lxc/remote.go:957
+#: lxc/remote.go:991
 #, c-format
 msgid   "Remote %s is global and cannot be removed"
 msgstr  ""
 
-#: lxc/remote.go:872 lxc/remote.go:953 lxc/remote.go:1065
+#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1099
 #, c-format
 msgid   "Remote %s is static and cannot be modified"
 msgstr  ""
 
-#: lxc/remote.go:319
+#: lxc/remote.go:333
 msgid   "Remote address must not be empty"
 msgstr  ""
 
@@ -4361,7 +4377,7 @@ msgstr  ""
 msgid   "Remote admin password"
 msgstr  ""
 
-#: lxc/remote.go:339
+#: lxc/remote.go:353
 msgid   "Remote names may not contain colons"
 msgstr  ""
 
@@ -4383,7 +4399,7 @@ msgstr  ""
 msgid   "Remove a cluster member from a cluster group"
 msgstr  ""
 
-#: lxc/auth.go:1223 lxc/auth.go:1224
+#: lxc/auth.go:1372 lxc/auth.go:1373
 msgid   "Remove a group from an identity"
 msgstr  ""
 
@@ -4419,7 +4435,7 @@ msgstr  ""
 msgid   "Remove entries from a network zone record"
 msgstr  ""
 
-#: lxc/auth.go:1986 lxc/auth.go:1987
+#: lxc/auth.go:2135 lxc/auth.go:2136
 msgid   "Remove identities from groups"
 msgstr  ""
 
@@ -4431,7 +4447,7 @@ msgstr  ""
 msgid   "Remove member from group"
 msgstr  ""
 
-#: lxc/auth.go:575 lxc/auth.go:576
+#: lxc/auth.go:580 lxc/auth.go:581
 msgid   "Remove permissions from groups"
 msgstr  ""
 
@@ -4447,7 +4463,7 @@ msgstr  ""
 msgid   "Remove profiles from instances"
 msgstr  ""
 
-#: lxc/remote.go:919 lxc/remote.go:920
+#: lxc/remote.go:953 lxc/remote.go:954
 msgid   "Remove remotes"
 msgstr  ""
 
@@ -4475,11 +4491,11 @@ msgstr  ""
 msgid   "Rename aliases"
 msgstr  ""
 
-#: lxc/auth.go:392 lxc/auth.go:393
+#: lxc/auth.go:397 lxc/auth.go:398
 msgid   "Rename groups"
 msgstr  ""
 
-#: lxc/auth.go:1810 lxc/auth.go:1811
+#: lxc/auth.go:1959 lxc/auth.go:1960
 msgid   "Rename identity provider groups"
 msgstr  ""
 
@@ -4503,7 +4519,7 @@ msgstr  ""
 msgid   "Rename projects"
 msgstr  ""
 
-#: lxc/remote.go:838 lxc/remote.go:839
+#: lxc/remote.go:872 lxc/remote.go:873
 msgid   "Rename remotes"
 msgstr  ""
 
@@ -4645,7 +4661,7 @@ msgstr  ""
 msgid   "STATE"
 msgstr  ""
 
-#: lxc/remote.go:820
+#: lxc/remote.go:854
 msgid   "STATIC"
 msgstr  ""
 
@@ -4686,11 +4702,11 @@ msgstr  ""
 msgid   "Server authentication type (tls or oidc)"
 msgstr  ""
 
-#: lxc/remote.go:532
+#: lxc/remote.go:546
 msgid   "Server certificate NACKed by user"
 msgstr  ""
 
-#: lxc/remote.go:285 lxc/remote.go:683
+#: lxc/remote.go:299 lxc/remote.go:717
 msgid   "Server doesn't trust us after authentication"
 msgstr  ""
 
@@ -4873,7 +4889,7 @@ msgid   "Set storage volume configuration keys\n"
         "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr  ""
 
-#: lxc/remote.go:1031 lxc/remote.go:1032
+#: lxc/remote.go:1065 lxc/remote.go:1066
 msgid   "Set the URL for the remote"
 msgstr  ""
 
@@ -4969,7 +4985,7 @@ msgstr  ""
 msgid   "Show all information messages"
 msgstr  ""
 
-#: lxc/auth.go:1859 lxc/auth.go:1860
+#: lxc/auth.go:2008 lxc/auth.go:2009
 msgid   "Show an identity provider group"
 msgstr  ""
 
@@ -4997,11 +5013,11 @@ msgstr  ""
 msgid   "Show full device configuration"
 msgstr  ""
 
-#: lxc/auth.go:441 lxc/auth.go:442
+#: lxc/auth.go:446 lxc/auth.go:447
 msgid   "Show group configurations"
 msgstr  ""
 
-#: lxc/auth.go:836
+#: lxc/auth.go:985
 msgid   "Show identity configurations\n"
         "\n"
         "The argument must be a concatenation of the authentication method and either the\n"
@@ -5102,7 +5118,7 @@ msgstr  ""
 msgid   "Show storage volume state information"
 msgstr  ""
 
-#: lxc/auth.go:899
+#: lxc/auth.go:1048
 msgid   "Show the current identity\n"
         "\n"
         "This command will display permissions for the current user.\n"
@@ -5110,7 +5126,7 @@ msgid   "Show the current identity\n"
         "that are granted via identity provider group mappings. \n"
 msgstr  ""
 
-#: lxc/remote.go:714 lxc/remote.go:715
+#: lxc/remote.go:748 lxc/remote.go:749
 msgid   "Show the default remote"
 msgstr  ""
 
@@ -5322,7 +5338,7 @@ msgstr  ""
 msgid   "Switch the current project"
 msgstr  ""
 
-#: lxc/remote.go:983 lxc/remote.go:984
+#: lxc/remote.go:1017 lxc/remote.go:1018
 msgid   "Switch the default remote"
 msgstr  ""
 
@@ -5334,11 +5350,21 @@ msgstr  ""
 msgid   "TARGET"
 msgstr  ""
 
+#: lxc/auth.go:876
+#, c-format
+msgid   "TLS identity %q (%s) pending identity token:"
+msgstr  ""
+
+#: lxc/auth.go:902
+#, c-format
+msgid   "TLS identity %q created with fingerprint %q"
+msgstr  ""
+
 #: lxc/cluster.go:1070 lxc/config_trust.go:515
 msgid   "TOKEN"
 msgstr  ""
 
-#: lxc/auth.go:818 lxc/config_trust.go:408 lxc/image.go:1141 lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082 lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172 lxc/storage_volume.go:1736 lxc/warning.go:216
+#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1141 lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082 lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172 lxc/storage_volume.go:1736 lxc/warning.go:216
 msgid   "TYPE"
 msgstr  ""
 
@@ -5354,7 +5380,7 @@ msgstr  ""
 msgid   "Target path must be a directory"
 msgstr  ""
 
-#: lxc/remote.go:161 lxc/remote.go:334
+#: lxc/remote.go:161 lxc/remote.go:348
 msgid   "The --accept-certificate flag is not supported when adding a remote using a trust token"
 msgstr  ""
 
@@ -5505,7 +5531,7 @@ msgstr  ""
 msgid   "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr  ""
 
-#: lxc/remote.go:527
+#: lxc/remote.go:541
 msgid   "The provided fingerprint does not match the server certificate fingerprint"
 msgstr  ""
 
@@ -5635,15 +5661,15 @@ msgstr  ""
 msgid   "Transmit policy"
 msgstr  ""
 
-#: lxc/remote.go:329
+#: lxc/remote.go:343
 msgid   "Trust token cannot be used for public remotes"
 msgstr  ""
 
-#: lxc/remote.go:324
+#: lxc/remote.go:338
 msgid   "Trust token cannot be used with OIDC authentication"
 msgstr  ""
 
-#: lxc/remote.go:639
+#: lxc/remote.go:653
 #, c-format
 msgid   "Trust token for %s: "
 msgstr  ""
@@ -5683,7 +5709,7 @@ msgstr  ""
 msgid   "UPLOAD DATE"
 msgstr  ""
 
-#: lxc/cluster.go:193 lxc/remote.go:816
+#: lxc/cluster.go:193 lxc/remote.go:850
 msgid   "URL"
 msgstr  ""
 
@@ -5984,11 +6010,11 @@ msgstr  ""
 msgid   "Verb: %s (%s)"
 msgstr  ""
 
-#: lxc/auth.go:835
+#: lxc/auth.go:984
 msgid   "View an identity"
 msgstr  ""
 
-#: lxc/auth.go:898
+#: lxc/auth.go:1047
 msgid   "View the current identity"
 msgstr  ""
 
@@ -6021,7 +6047,7 @@ msgstr  ""
 msgid   "Wipe the instance root disk and re-initialize. The original image is used to re-initialize the instance if a different image or --empty is not specified."
 msgstr  ""
 
-#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527 lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547 lxc/project.go:552 lxc/remote.go:777 lxc/remote.go:782 lxc/remote.go:787
+#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527 lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547 lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid   "YES"
 msgstr  ""
 
@@ -6053,7 +6079,7 @@ msgstr  ""
 msgid   "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr  ""
 
-#: lxc/auth.go:330 lxc/auth.go:766 lxc/auth.go:897 lxc/auth.go:1748 lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437 lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32 lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83 lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:469 lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
+#: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897 lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437 lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32 lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83 lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:469 lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid   "[<remote>:]"
 msgstr  ""
 
@@ -6081,7 +6107,7 @@ msgstr  ""
 msgid   "[<remote>:] [<filters>...]"
 msgstr  ""
 
-#: lxc/auth.go:1313
+#: lxc/auth.go:1462
 msgid   "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr  ""
 
@@ -6141,11 +6167,15 @@ msgstr  ""
 msgid   "[<remote>:]<alias> <new-name>"
 msgstr  ""
 
-#: lxc/auth.go:834 lxc/auth.go:1086
+#: lxc/auth.go:774
+msgid   "[<remote>:]<authentication_method>/<name> [<path to PEM encoded certificate>] [[--group <group_name>]]"
+msgstr  ""
+
+#: lxc/auth.go:983 lxc/auth.go:1235
 msgid   "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr  ""
 
-#: lxc/auth.go:1164 lxc/auth.go:1222 lxc/auth.go:1985
+#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:2134
 msgid   "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr  ""
 
@@ -6153,11 +6183,11 @@ msgstr  ""
 msgid   "[<remote>:]<fingerprint>"
 msgstr  ""
 
-#: lxc/auth.go:97 lxc/auth.go:150 lxc/auth.go:200 lxc/auth.go:440 lxc/auth.go:958 lxc/auth.go:1529 lxc/cluster_group.go:168 lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
+#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:445 lxc/auth.go:1107 lxc/auth.go:1678 lxc/cluster_group.go:168 lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid   "[<remote>:]<group>"
 msgstr  ""
 
-#: lxc/auth.go:515 lxc/auth.go:573
+#: lxc/auth.go:520 lxc/auth.go:578
 msgid   "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> [<key>=<value>...]"
 msgstr  ""
 
@@ -6165,19 +6195,19 @@ msgstr  ""
 msgid   "[<remote>:]<group> <new-name>"
 msgstr  ""
 
-#: lxc/auth.go:390
+#: lxc/auth.go:395
 msgid   "[<remote>:]<group> <new_name>"
 msgstr  ""
 
-#: lxc/auth.go:1580 lxc/auth.go:1630 lxc/auth.go:1858
+#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
 msgid   "[<remote>:]<identity_provider_group>"
 msgstr  ""
 
-#: lxc/auth.go:1932
+#: lxc/auth.go:2081
 msgid   "[<remote>:]<identity_provider_group> <group>"
 msgstr  ""
 
-#: lxc/auth.go:1808
+#: lxc/auth.go:1957
 msgid   "[<remote>:]<identity_provider_group> <new_name>"
 msgstr  ""
 
@@ -6641,7 +6671,7 @@ msgstr  ""
 msgid   "[[<remote>:]<member>]"
 msgstr  ""
 
-#: lxc/project.go:557 lxc/remote.go:806
+#: lxc/project.go:557 lxc/remote.go:840
 msgid   "current"
 msgstr  ""
 
@@ -6685,17 +6715,17 @@ msgid   "lxc alias rename list my-list\n"
         "    Rename existing alias \"list\" to \"my-list\"."
 msgstr  ""
 
-#: lxc/auth.go:204
+#: lxc/auth.go:209
 msgid   "lxc auth group edit <group> < group.yaml\n"
         "   Update a group using the content of group.yaml"
 msgstr  ""
 
-#: lxc/auth.go:962
+#: lxc/auth.go:1111
 msgid   "lxc auth identity edit <authentication_method>/<name_or_identifier> < identity.yaml\n"
         "   Update an identity using the content of identity.yaml"
 msgstr  ""
 
-#: lxc/auth.go:1634
+#: lxc/auth.go:1783
 msgid   "lxc auth identity-provider-group edit <identity_provider_group> < identity-provider-group.yaml\n"
         "   Update an identity provider group using the content of identity-provider-group.yaml"
 msgstr  ""
@@ -7043,7 +7073,7 @@ msgid   "lxc storage volume snapshot create default v1 snap0\n"
         "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\" with the configuration from \"config.yaml\"."
 msgstr  ""
 
-#: lxc/remote.go:531
+#: lxc/remote.go:545
 msgid   "n"
 msgstr  ""
 
@@ -7055,7 +7085,7 @@ msgstr  ""
 msgid   "no"
 msgstr  ""
 
-#: lxc/remote.go:510
+#: lxc/remote.go:524
 msgid   "ok (y/n/[fingerprint])?"
 msgstr  ""
 
@@ -7092,7 +7122,7 @@ msgstr  ""
 msgid   "used by"
 msgstr  ""
 
-#: lxc/remote.go:519
+#: lxc/remote.go:533
 msgid   "y"
 msgstr  ""
 

--- a/po/mr.po
+++ b/po/mr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-14 13:30+0000\n"
+"POT-Creation-Date: 2024-10-15 14:52+0100\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Marathi <https://hosted.weblate.org/projects/linux-containers/"
@@ -133,7 +133,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:214
+#: lxc/auth.go:219
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -160,7 +160,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:972
+#: lxc/auth.go:1121
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -181,7 +181,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1644
+#: lxc/auth.go:1793
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -515,15 +515,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:917 lxc/remote.go:982
+#: lxc/remote.go:951 lxc/remote.go:1016
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1030
+#: lxc/remote.go:1064
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:836
+#: lxc/remote.go:870
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -556,11 +556,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:818
+#: lxc/remote.go:852
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:817
+#: lxc/auth.go:966
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -598,11 +598,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1165 lxc/auth.go:1166
+#: lxc/auth.go:1314 lxc/auth.go:1315
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1933 lxc/auth.go:1934
+#: lxc/auth.go:2082 lxc/auth.go:2083
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -671,7 +671,7 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:516 lxc/auth.go:517
+#: lxc/auth.go:521 lxc/auth.go:522
 msgid "Add permissions to groups"
 msgstr ""
 
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:648
+#: lxc/remote.go:680
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -813,7 +813,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:621
+#: lxc/remote.go:635
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -991,7 +991,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:961
+#: lxc/remote.go:995
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1057,7 +1057,7 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:509
+#: lxc/remote.go:523
 msgid "Certificate fingerprint"
 msgstr ""
 
@@ -1076,7 +1076,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:687
+#: lxc/remote.go:721
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1324,12 +1324,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:559
+#: lxc/remote.go:573
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:237 lxc/remote.go:543
+#: lxc/remote.go:237 lxc/remote.go:557
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1343,12 +1343,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:1719
+#: lxc/auth.go:306 lxc/auth.go:1868
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1058
+#: lxc/auth.go:1207
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1368,13 +1368,17 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:554
+#: lxc/remote.go:568
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
 #: lxc/network_zone.go:1536
 msgid "Couldn't find a matching entry"
+msgstr ""
+
+#: lxc/auth.go:776
+msgid "Create a TLS identity"
 msgstr ""
 
 #: lxc/cluster_group.go:169 lxc/cluster_group.go:170
@@ -1393,6 +1397,10 @@ msgstr ""
 msgid "Create an empty instance"
 msgstr ""
 
+#: lxc/auth.go:775
+msgid "Create an identity"
+msgstr ""
+
 #: lxc/launch.go:23 lxc/launch.go:24
 msgid "Create and start instances from images"
 msgstr ""
@@ -1405,11 +1413,11 @@ msgstr ""
 msgid "Create files and directories in instances"
 msgstr ""
 
-#: lxc/auth.go:98 lxc/auth.go:99
+#: lxc/auth.go:103 lxc/auth.go:104
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1530 lxc/auth.go:1531
+#: lxc/auth.go:1679 lxc/auth.go:1680
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1517,7 +1525,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
@@ -1560,7 +1568,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/auth.go:1088 lxc/auth.go:1089
+#: lxc/auth.go:1237 lxc/auth.go:1238
 msgid "Delete an identity"
 msgstr ""
 
@@ -1568,11 +1576,11 @@ msgstr ""
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/auth.go:152 lxc/auth.go:153
+#: lxc/auth.go:157 lxc/auth.go:158
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1582 lxc/auth.go:1583
+#: lxc/auth.go:1731 lxc/auth.go:1732
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1650,18 +1658,18 @@ msgstr ""
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:31 lxc/auth.go:60 lxc/auth.go:99
-#: lxc/auth.go:153 lxc/auth.go:202 lxc/auth.go:333 lxc/auth.go:393
-#: lxc/auth.go:442 lxc/auth.go:494 lxc/auth.go:517 lxc/auth.go:576
-#: lxc/auth.go:732 lxc/auth.go:769 lxc/auth.go:836 lxc/auth.go:899
-#: lxc/auth.go:960 lxc/auth.go:1089 lxc/auth.go:1143 lxc/auth.go:1166
-#: lxc/auth.go:1224 lxc/auth.go:1293 lxc/auth.go:1315 lxc/auth.go:1493
-#: lxc/auth.go:1531 lxc/auth.go:1583 lxc/auth.go:1632 lxc/auth.go:1751
-#: lxc/auth.go:1811 lxc/auth.go:1860 lxc/auth.go:1911 lxc/auth.go:1934
-#: lxc/auth.go:1987 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215
-#: lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:484
-#: lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677 lxc/cluster.go:770
-#: lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
+#: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
+#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:338 lxc/auth.go:398
+#: lxc/auth.go:447 lxc/auth.go:499 lxc/auth.go:522 lxc/auth.go:581
+#: lxc/auth.go:737 lxc/auth.go:776 lxc/auth.go:918 lxc/auth.go:985
+#: lxc/auth.go:1048 lxc/auth.go:1109 lxc/auth.go:1238 lxc/auth.go:1292
+#: lxc/auth.go:1315 lxc/auth.go:1373 lxc/auth.go:1442 lxc/auth.go:1464
+#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
+#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
+#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
+#: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
+#: lxc/cluster.go:770 lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
 #: lxc/cluster.go:1175 lxc/cluster.go:1299 lxc/cluster.go:1329
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
@@ -1732,9 +1740,9 @@ msgstr ""
 #: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
 #: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
 #: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:715
-#: lxc/remote.go:753 lxc/remote.go:839 lxc/remote.go:920 lxc/remote.go:984
-#: lxc/remote.go:1032 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
+#: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
+#: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1919,7 +1927,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:959 lxc/auth.go:960
+#: lxc/auth.go:1108 lxc/auth.go:1109
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1931,11 +1939,11 @@ msgstr ""
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/auth.go:201 lxc/auth.go:202
+#: lxc/auth.go:206 lxc/auth.go:207
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1631 lxc/auth.go:1632
+#: lxc/auth.go:1780 lxc/auth.go:1781
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2311,12 +2319,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:486
+#: lxc/remote.go:500
 #, c-format
 msgid "Failed to decode trust token: %w"
 msgstr ""
 
-#: lxc/remote.go:292
+#: lxc/remote.go:306
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2420,7 +2428,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:773 lxc/auth.go:1755
+#: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
@@ -2428,7 +2436,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:757 lxc/storage.go:657
+#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2466,7 +2474,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:821
+#: lxc/remote.go:855
 msgid "GLOBAL"
 msgstr ""
 
@@ -2478,7 +2486,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:821 lxc/auth.go:1795
+#: lxc/auth.go:970 lxc/auth.go:1944
 msgid "GROUPS"
 msgstr ""
 
@@ -2486,7 +2494,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:165 lxc/remote.go:443
+#: lxc/remote.go:165 lxc/remote.go:457
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2627,17 +2635,17 @@ msgstr ""
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: lxc/auth.go:137
+#: lxc/auth.go:142
 #, c-format
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:187
+#: lxc/auth.go:192
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:427 lxc/auth.go:1845
+#: lxc/auth.go:432 lxc/auth.go:1994
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2696,7 +2704,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:820
+#: lxc/auth.go:969
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -2728,12 +2736,16 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1567
+#: lxc/auth.go:829
+msgid "Identity creation only supported for TLS identities"
+msgstr ""
+
+#: lxc/auth.go:1716
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1617
+#: lxc/auth.go:1766
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2862,7 +2874,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1292 lxc/auth.go:1293
+#: lxc/auth.go:1441 lxc/auth.go:1442
 msgid "Inspect permissions"
 msgstr ""
 
@@ -2910,7 +2922,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:395
+#: lxc/remote.go:409
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2991,7 +3003,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:384
+#: lxc/remote.go:398
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3166,15 +3178,15 @@ msgstr ""
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:332 lxc/auth.go:333
+#: lxc/auth.go:337 lxc/auth.go:338
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:768 lxc/auth.go:769
+#: lxc/auth.go:917 lxc/auth.go:918
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1750 lxc/auth.go:1751
+#: lxc/auth.go:1899 lxc/auth.go:1900
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3327,7 +3339,7 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1314 lxc/auth.go:1315
+#: lxc/auth.go:1463 lxc/auth.go:1464
 msgid "List permissions"
 msgstr ""
 
@@ -3371,7 +3383,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:752 lxc/remote.go:753
+#: lxc/remote.go:786 lxc/remote.go:787
 msgid "List the available remotes"
 msgstr ""
 
@@ -3495,6 +3507,12 @@ msgstr ""
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
+#: lxc/auth.go:825
+msgid ""
+"Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
+"got "
+msgstr ""
+
 #: lxc/network.go:32 lxc/network.go:33
 msgid "Manage and attach instances to networks"
 msgstr ""
@@ -3523,19 +3541,19 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:59 lxc/auth.go:60 lxc/auth.go:1492 lxc/auth.go:1493
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1142 lxc/auth.go:1143
+#: lxc/auth.go:1291 lxc/auth.go:1292
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:731 lxc/auth.go:732
+#: lxc/auth.go:736 lxc/auth.go:737
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1910 lxc/auth.go:1911
+#: lxc/auth.go:2059 lxc/auth.go:2060
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3626,7 +3644,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:493 lxc/auth.go:494
+#: lxc/auth.go:498 lxc/auth.go:499
 msgid "Manage permissions"
 msgstr ""
 
@@ -3678,7 +3696,7 @@ msgstr ""
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/auth.go:30 lxc/auth.go:31
+#: lxc/auth.go:35 lxc/auth.go:36
 msgid "Manage user authorization"
 msgstr ""
 
@@ -3775,21 +3793,21 @@ msgstr ""
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:123 lxc/auth.go:177 lxc/auth.go:255 lxc/auth.go:417
-#: lxc/auth.go:466 lxc/auth.go:541 lxc/auth.go:600 lxc/auth.go:1884
+#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:260 lxc/auth.go:422
+#: lxc/auth.go:471 lxc/auth.go:546 lxc/auth.go:605 lxc/auth.go:2033
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:866 lxc/auth.go:1007 lxc/auth.go:1124 lxc/auth.go:1190
-#: lxc/auth.go:1248
+#: lxc/auth.go:820 lxc/auth.go:1015 lxc/auth.go:1156 lxc/auth.go:1273
+#: lxc/auth.go:1339 lxc/auth.go:1397
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1554 lxc/auth.go:1607 lxc/auth.go:1673 lxc/auth.go:1835
+#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1958 lxc/auth.go:2011
+#: lxc/auth.go:2107 lxc/auth.go:2160
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -4010,12 +4028,12 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:376 lxc/auth.go:819 lxc/auth.go:1794 lxc/cluster.go:192
+#: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
-#: lxc/remote.go:815 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
 msgstr ""
@@ -4042,7 +4060,7 @@ msgstr ""
 
 #: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:775 lxc/remote.go:780 lxc/remote.go:785
+#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr ""
 
@@ -4271,7 +4289,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:378
+#: lxc/remote.go:392
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4342,11 +4360,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:817
+#: lxc/remote.go:851
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:819
+#: lxc/image.go:1136 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4387,7 +4405,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:536
+#: lxc/remote.go:550
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
@@ -4404,7 +4422,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:302 lxc/auth.go:1059 lxc/auth.go:1720 lxc/cluster.go:860
+#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -4707,33 +4725,33 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:877
+#: lxc/remote.go:911
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:868 lxc/remote.go:949 lxc/remote.go:1013
-#: lxc/remote.go:1061
+#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/remote.go:1095
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:345
+#: lxc/remote.go:359
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:957
+#: lxc/remote.go:991
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:872 lxc/remote.go:953 lxc/remote.go:1065
+#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1099
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:319
+#: lxc/remote.go:333
 msgid "Remote address must not be empty"
 msgstr ""
 
@@ -4741,7 +4759,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:339
+#: lxc/remote.go:353
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4763,7 +4781,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1223 lxc/auth.go:1224
+#: lxc/auth.go:1372 lxc/auth.go:1373
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4799,7 +4817,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1986 lxc/auth.go:1987
+#: lxc/auth.go:2135 lxc/auth.go:2136
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4811,7 +4829,7 @@ msgstr ""
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:575 lxc/auth.go:576
+#: lxc/auth.go:580 lxc/auth.go:581
 msgid "Remove permissions from groups"
 msgstr ""
 
@@ -4827,7 +4845,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:919 lxc/remote.go:920
+#: lxc/remote.go:953 lxc/remote.go:954
 msgid "Remove remotes"
 msgstr ""
 
@@ -4856,11 +4874,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:392 lxc/auth.go:393
+#: lxc/auth.go:397 lxc/auth.go:398
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1810 lxc/auth.go:1811
+#: lxc/auth.go:1959 lxc/auth.go:1960
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -4884,7 +4902,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:838 lxc/remote.go:839
+#: lxc/remote.go:872 lxc/remote.go:873
 msgid "Rename remotes"
 msgstr ""
 
@@ -5029,7 +5047,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:820
+#: lxc/remote.go:854
 msgid "STATIC"
 msgstr ""
 
@@ -5070,11 +5088,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:532
+#: lxc/remote.go:546
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:285 lxc/remote.go:683
+#: lxc/remote.go:299 lxc/remote.go:717
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5285,7 +5303,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1031 lxc/remote.go:1032
+#: lxc/remote.go:1065 lxc/remote.go:1066
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5381,7 +5399,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1859 lxc/auth.go:1860
+#: lxc/auth.go:2008 lxc/auth.go:2009
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5409,11 +5427,11 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:441 lxc/auth.go:442
+#: lxc/auth.go:446 lxc/auth.go:447
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:836
+#: lxc/auth.go:985
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5518,7 +5536,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:899
+#: lxc/auth.go:1048
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5528,7 +5546,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:714 lxc/remote.go:715
+#: lxc/remote.go:748 lxc/remote.go:749
 msgid "Show the default remote"
 msgstr ""
 
@@ -5740,7 +5758,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:983 lxc/remote.go:984
+#: lxc/remote.go:1017 lxc/remote.go:1018
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5752,11 +5770,21 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
+#: lxc/auth.go:876
+#, c-format
+msgid "TLS identity %q (%s) pending identity token:"
+msgstr ""
+
+#: lxc/auth.go:902
+#, c-format
+msgid "TLS identity %q created with fingerprint %q"
+msgstr ""
+
 #: lxc/cluster.go:1070 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:818 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
 #: lxc/storage_volume.go:1736 lxc/warning.go:216
@@ -5775,7 +5803,7 @@ msgstr ""
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/remote.go:161 lxc/remote.go:334
+#: lxc/remote.go:161 lxc/remote.go:348
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
@@ -5931,7 +5959,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:527
+#: lxc/remote.go:541
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
@@ -6069,15 +6097,15 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:329
+#: lxc/remote.go:343
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:324
+#: lxc/remote.go:338
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr ""
 
-#: lxc/remote.go:639
+#: lxc/remote.go:653
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6120,7 +6148,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:193 lxc/remote.go:816
+#: lxc/cluster.go:193 lxc/remote.go:850
 msgid "URL"
 msgstr ""
 
@@ -6428,11 +6456,11 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:835
+#: lxc/auth.go:984
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:898
+#: lxc/auth.go:1047
 msgid "View the current identity"
 msgstr ""
 
@@ -6471,7 +6499,7 @@ msgstr ""
 
 #: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:777 lxc/remote.go:782 lxc/remote.go:787
+#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr ""
 
@@ -6503,7 +6531,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:330 lxc/auth.go:766 lxc/auth.go:897 lxc/auth.go:1748
+#: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
@@ -6536,7 +6564,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1313
+#: lxc/auth.go:1462
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6597,11 +6625,17 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:834 lxc/auth.go:1086
+#: lxc/auth.go:774
+msgid ""
+"[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
+"certificate>] [[--group <group_name>]]"
+msgstr ""
+
+#: lxc/auth.go:983 lxc/auth.go:1235
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1164 lxc/auth.go:1222 lxc/auth.go:1985
+#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:2134
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6609,13 +6643,13 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:97 lxc/auth.go:150 lxc/auth.go:200 lxc/auth.go:440
-#: lxc/auth.go:958 lxc/auth.go:1529 lxc/cluster_group.go:168
+#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:445
+#: lxc/auth.go:1107 lxc/auth.go:1678 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:515 lxc/auth.go:573
+#: lxc/auth.go:520 lxc/auth.go:578
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
@@ -6625,19 +6659,19 @@ msgstr ""
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:390
+#: lxc/auth.go:395
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1580 lxc/auth.go:1630 lxc/auth.go:1858
+#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1932
+#: lxc/auth.go:2081
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1808
+#: lxc/auth.go:1957
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -7128,7 +7162,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:806
+#: lxc/project.go:557 lxc/remote.go:840
 msgid "current"
 msgstr ""
 
@@ -7175,20 +7209,20 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/auth.go:204
+#: lxc/auth.go:209
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:962
+#: lxc/auth.go:1111
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1634
+#: lxc/auth.go:1783
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7612,7 +7646,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:531
+#: lxc/remote.go:545
 msgid "n"
 msgstr ""
 
@@ -7624,7 +7658,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:510
+#: lxc/remote.go:524
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7661,7 +7695,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:519
+#: lxc/remote.go:533
 msgid "y"
 msgstr ""
 

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-14 13:30+0000\n"
+"POT-Creation-Date: 2024-10-15 14:52+0100\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Norwegian Bokmål <https://hosted.weblate.org/projects/linux-"
@@ -133,7 +133,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:214
+#: lxc/auth.go:219
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -160,7 +160,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:972
+#: lxc/auth.go:1121
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -181,7 +181,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1644
+#: lxc/auth.go:1793
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -515,15 +515,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:917 lxc/remote.go:982
+#: lxc/remote.go:951 lxc/remote.go:1016
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1030
+#: lxc/remote.go:1064
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:836
+#: lxc/remote.go:870
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -556,11 +556,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:818
+#: lxc/remote.go:852
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:817
+#: lxc/auth.go:966
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -598,11 +598,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1165 lxc/auth.go:1166
+#: lxc/auth.go:1314 lxc/auth.go:1315
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1933 lxc/auth.go:1934
+#: lxc/auth.go:2082 lxc/auth.go:2083
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -671,7 +671,7 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:516 lxc/auth.go:517
+#: lxc/auth.go:521 lxc/auth.go:522
 msgid "Add permissions to groups"
 msgstr ""
 
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:648
+#: lxc/remote.go:680
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -813,7 +813,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:621
+#: lxc/remote.go:635
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -991,7 +991,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:961
+#: lxc/remote.go:995
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1057,7 +1057,7 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:509
+#: lxc/remote.go:523
 msgid "Certificate fingerprint"
 msgstr ""
 
@@ -1076,7 +1076,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:687
+#: lxc/remote.go:721
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1324,12 +1324,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:559
+#: lxc/remote.go:573
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:237 lxc/remote.go:543
+#: lxc/remote.go:237 lxc/remote.go:557
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1343,12 +1343,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:1719
+#: lxc/auth.go:306 lxc/auth.go:1868
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1058
+#: lxc/auth.go:1207
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1368,13 +1368,17 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:554
+#: lxc/remote.go:568
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
 #: lxc/network_zone.go:1536
 msgid "Couldn't find a matching entry"
+msgstr ""
+
+#: lxc/auth.go:776
+msgid "Create a TLS identity"
 msgstr ""
 
 #: lxc/cluster_group.go:169 lxc/cluster_group.go:170
@@ -1393,6 +1397,10 @@ msgstr ""
 msgid "Create an empty instance"
 msgstr ""
 
+#: lxc/auth.go:775
+msgid "Create an identity"
+msgstr ""
+
 #: lxc/launch.go:23 lxc/launch.go:24
 msgid "Create and start instances from images"
 msgstr ""
@@ -1405,11 +1413,11 @@ msgstr ""
 msgid "Create files and directories in instances"
 msgstr ""
 
-#: lxc/auth.go:98 lxc/auth.go:99
+#: lxc/auth.go:103 lxc/auth.go:104
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1530 lxc/auth.go:1531
+#: lxc/auth.go:1679 lxc/auth.go:1680
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1517,7 +1525,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
@@ -1560,7 +1568,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/auth.go:1088 lxc/auth.go:1089
+#: lxc/auth.go:1237 lxc/auth.go:1238
 msgid "Delete an identity"
 msgstr ""
 
@@ -1568,11 +1576,11 @@ msgstr ""
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/auth.go:152 lxc/auth.go:153
+#: lxc/auth.go:157 lxc/auth.go:158
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1582 lxc/auth.go:1583
+#: lxc/auth.go:1731 lxc/auth.go:1732
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1650,18 +1658,18 @@ msgstr ""
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:31 lxc/auth.go:60 lxc/auth.go:99
-#: lxc/auth.go:153 lxc/auth.go:202 lxc/auth.go:333 lxc/auth.go:393
-#: lxc/auth.go:442 lxc/auth.go:494 lxc/auth.go:517 lxc/auth.go:576
-#: lxc/auth.go:732 lxc/auth.go:769 lxc/auth.go:836 lxc/auth.go:899
-#: lxc/auth.go:960 lxc/auth.go:1089 lxc/auth.go:1143 lxc/auth.go:1166
-#: lxc/auth.go:1224 lxc/auth.go:1293 lxc/auth.go:1315 lxc/auth.go:1493
-#: lxc/auth.go:1531 lxc/auth.go:1583 lxc/auth.go:1632 lxc/auth.go:1751
-#: lxc/auth.go:1811 lxc/auth.go:1860 lxc/auth.go:1911 lxc/auth.go:1934
-#: lxc/auth.go:1987 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215
-#: lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:484
-#: lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677 lxc/cluster.go:770
-#: lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
+#: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
+#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:338 lxc/auth.go:398
+#: lxc/auth.go:447 lxc/auth.go:499 lxc/auth.go:522 lxc/auth.go:581
+#: lxc/auth.go:737 lxc/auth.go:776 lxc/auth.go:918 lxc/auth.go:985
+#: lxc/auth.go:1048 lxc/auth.go:1109 lxc/auth.go:1238 lxc/auth.go:1292
+#: lxc/auth.go:1315 lxc/auth.go:1373 lxc/auth.go:1442 lxc/auth.go:1464
+#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
+#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
+#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
+#: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
+#: lxc/cluster.go:770 lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
 #: lxc/cluster.go:1175 lxc/cluster.go:1299 lxc/cluster.go:1329
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
@@ -1732,9 +1740,9 @@ msgstr ""
 #: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
 #: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
 #: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:715
-#: lxc/remote.go:753 lxc/remote.go:839 lxc/remote.go:920 lxc/remote.go:984
-#: lxc/remote.go:1032 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
+#: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
+#: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1919,7 +1927,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:959 lxc/auth.go:960
+#: lxc/auth.go:1108 lxc/auth.go:1109
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1931,11 +1939,11 @@ msgstr ""
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/auth.go:201 lxc/auth.go:202
+#: lxc/auth.go:206 lxc/auth.go:207
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1631 lxc/auth.go:1632
+#: lxc/auth.go:1780 lxc/auth.go:1781
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2311,12 +2319,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:486
+#: lxc/remote.go:500
 #, c-format
 msgid "Failed to decode trust token: %w"
 msgstr ""
 
-#: lxc/remote.go:292
+#: lxc/remote.go:306
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2420,7 +2428,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:773 lxc/auth.go:1755
+#: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
@@ -2428,7 +2436,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:757 lxc/storage.go:657
+#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2466,7 +2474,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:821
+#: lxc/remote.go:855
 msgid "GLOBAL"
 msgstr ""
 
@@ -2478,7 +2486,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:821 lxc/auth.go:1795
+#: lxc/auth.go:970 lxc/auth.go:1944
 msgid "GROUPS"
 msgstr ""
 
@@ -2486,7 +2494,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:165 lxc/remote.go:443
+#: lxc/remote.go:165 lxc/remote.go:457
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2627,17 +2635,17 @@ msgstr ""
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: lxc/auth.go:137
+#: lxc/auth.go:142
 #, c-format
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:187
+#: lxc/auth.go:192
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:427 lxc/auth.go:1845
+#: lxc/auth.go:432 lxc/auth.go:1994
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2696,7 +2704,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:820
+#: lxc/auth.go:969
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -2728,12 +2736,16 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1567
+#: lxc/auth.go:829
+msgid "Identity creation only supported for TLS identities"
+msgstr ""
+
+#: lxc/auth.go:1716
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1617
+#: lxc/auth.go:1766
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2862,7 +2874,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1292 lxc/auth.go:1293
+#: lxc/auth.go:1441 lxc/auth.go:1442
 msgid "Inspect permissions"
 msgstr ""
 
@@ -2910,7 +2922,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:395
+#: lxc/remote.go:409
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2991,7 +3003,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:384
+#: lxc/remote.go:398
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3166,15 +3178,15 @@ msgstr ""
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:332 lxc/auth.go:333
+#: lxc/auth.go:337 lxc/auth.go:338
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:768 lxc/auth.go:769
+#: lxc/auth.go:917 lxc/auth.go:918
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1750 lxc/auth.go:1751
+#: lxc/auth.go:1899 lxc/auth.go:1900
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3327,7 +3339,7 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1314 lxc/auth.go:1315
+#: lxc/auth.go:1463 lxc/auth.go:1464
 msgid "List permissions"
 msgstr ""
 
@@ -3371,7 +3383,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:752 lxc/remote.go:753
+#: lxc/remote.go:786 lxc/remote.go:787
 msgid "List the available remotes"
 msgstr ""
 
@@ -3495,6 +3507,12 @@ msgstr ""
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
+#: lxc/auth.go:825
+msgid ""
+"Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
+"got "
+msgstr ""
+
 #: lxc/network.go:32 lxc/network.go:33
 msgid "Manage and attach instances to networks"
 msgstr ""
@@ -3523,19 +3541,19 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:59 lxc/auth.go:60 lxc/auth.go:1492 lxc/auth.go:1493
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1142 lxc/auth.go:1143
+#: lxc/auth.go:1291 lxc/auth.go:1292
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:731 lxc/auth.go:732
+#: lxc/auth.go:736 lxc/auth.go:737
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1910 lxc/auth.go:1911
+#: lxc/auth.go:2059 lxc/auth.go:2060
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3626,7 +3644,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:493 lxc/auth.go:494
+#: lxc/auth.go:498 lxc/auth.go:499
 msgid "Manage permissions"
 msgstr ""
 
@@ -3678,7 +3696,7 @@ msgstr ""
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/auth.go:30 lxc/auth.go:31
+#: lxc/auth.go:35 lxc/auth.go:36
 msgid "Manage user authorization"
 msgstr ""
 
@@ -3775,21 +3793,21 @@ msgstr ""
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:123 lxc/auth.go:177 lxc/auth.go:255 lxc/auth.go:417
-#: lxc/auth.go:466 lxc/auth.go:541 lxc/auth.go:600 lxc/auth.go:1884
+#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:260 lxc/auth.go:422
+#: lxc/auth.go:471 lxc/auth.go:546 lxc/auth.go:605 lxc/auth.go:2033
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:866 lxc/auth.go:1007 lxc/auth.go:1124 lxc/auth.go:1190
-#: lxc/auth.go:1248
+#: lxc/auth.go:820 lxc/auth.go:1015 lxc/auth.go:1156 lxc/auth.go:1273
+#: lxc/auth.go:1339 lxc/auth.go:1397
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1554 lxc/auth.go:1607 lxc/auth.go:1673 lxc/auth.go:1835
+#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1958 lxc/auth.go:2011
+#: lxc/auth.go:2107 lxc/auth.go:2160
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -4010,12 +4028,12 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:376 lxc/auth.go:819 lxc/auth.go:1794 lxc/cluster.go:192
+#: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
-#: lxc/remote.go:815 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
 msgstr ""
@@ -4042,7 +4060,7 @@ msgstr ""
 
 #: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:775 lxc/remote.go:780 lxc/remote.go:785
+#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr ""
 
@@ -4271,7 +4289,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:378
+#: lxc/remote.go:392
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4342,11 +4360,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:817
+#: lxc/remote.go:851
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:819
+#: lxc/image.go:1136 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4387,7 +4405,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:536
+#: lxc/remote.go:550
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
@@ -4404,7 +4422,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:302 lxc/auth.go:1059 lxc/auth.go:1720 lxc/cluster.go:860
+#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -4707,33 +4725,33 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:877
+#: lxc/remote.go:911
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:868 lxc/remote.go:949 lxc/remote.go:1013
-#: lxc/remote.go:1061
+#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/remote.go:1095
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:345
+#: lxc/remote.go:359
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:957
+#: lxc/remote.go:991
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:872 lxc/remote.go:953 lxc/remote.go:1065
+#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1099
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:319
+#: lxc/remote.go:333
 msgid "Remote address must not be empty"
 msgstr ""
 
@@ -4741,7 +4759,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:339
+#: lxc/remote.go:353
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4763,7 +4781,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1223 lxc/auth.go:1224
+#: lxc/auth.go:1372 lxc/auth.go:1373
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4799,7 +4817,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1986 lxc/auth.go:1987
+#: lxc/auth.go:2135 lxc/auth.go:2136
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4811,7 +4829,7 @@ msgstr ""
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:575 lxc/auth.go:576
+#: lxc/auth.go:580 lxc/auth.go:581
 msgid "Remove permissions from groups"
 msgstr ""
 
@@ -4827,7 +4845,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:919 lxc/remote.go:920
+#: lxc/remote.go:953 lxc/remote.go:954
 msgid "Remove remotes"
 msgstr ""
 
@@ -4856,11 +4874,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:392 lxc/auth.go:393
+#: lxc/auth.go:397 lxc/auth.go:398
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1810 lxc/auth.go:1811
+#: lxc/auth.go:1959 lxc/auth.go:1960
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -4884,7 +4902,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:838 lxc/remote.go:839
+#: lxc/remote.go:872 lxc/remote.go:873
 msgid "Rename remotes"
 msgstr ""
 
@@ -5029,7 +5047,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:820
+#: lxc/remote.go:854
 msgid "STATIC"
 msgstr ""
 
@@ -5070,11 +5088,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:532
+#: lxc/remote.go:546
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:285 lxc/remote.go:683
+#: lxc/remote.go:299 lxc/remote.go:717
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5285,7 +5303,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1031 lxc/remote.go:1032
+#: lxc/remote.go:1065 lxc/remote.go:1066
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5381,7 +5399,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1859 lxc/auth.go:1860
+#: lxc/auth.go:2008 lxc/auth.go:2009
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5409,11 +5427,11 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:441 lxc/auth.go:442
+#: lxc/auth.go:446 lxc/auth.go:447
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:836
+#: lxc/auth.go:985
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5518,7 +5536,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:899
+#: lxc/auth.go:1048
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5528,7 +5546,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:714 lxc/remote.go:715
+#: lxc/remote.go:748 lxc/remote.go:749
 msgid "Show the default remote"
 msgstr ""
 
@@ -5740,7 +5758,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:983 lxc/remote.go:984
+#: lxc/remote.go:1017 lxc/remote.go:1018
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5752,11 +5770,21 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
+#: lxc/auth.go:876
+#, c-format
+msgid "TLS identity %q (%s) pending identity token:"
+msgstr ""
+
+#: lxc/auth.go:902
+#, c-format
+msgid "TLS identity %q created with fingerprint %q"
+msgstr ""
+
 #: lxc/cluster.go:1070 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:818 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
 #: lxc/storage_volume.go:1736 lxc/warning.go:216
@@ -5775,7 +5803,7 @@ msgstr ""
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/remote.go:161 lxc/remote.go:334
+#: lxc/remote.go:161 lxc/remote.go:348
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
@@ -5931,7 +5959,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:527
+#: lxc/remote.go:541
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
@@ -6069,15 +6097,15 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:329
+#: lxc/remote.go:343
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:324
+#: lxc/remote.go:338
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr ""
 
-#: lxc/remote.go:639
+#: lxc/remote.go:653
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6120,7 +6148,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:193 lxc/remote.go:816
+#: lxc/cluster.go:193 lxc/remote.go:850
 msgid "URL"
 msgstr ""
 
@@ -6428,11 +6456,11 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:835
+#: lxc/auth.go:984
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:898
+#: lxc/auth.go:1047
 msgid "View the current identity"
 msgstr ""
 
@@ -6471,7 +6499,7 @@ msgstr ""
 
 #: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:777 lxc/remote.go:782 lxc/remote.go:787
+#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr ""
 
@@ -6503,7 +6531,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:330 lxc/auth.go:766 lxc/auth.go:897 lxc/auth.go:1748
+#: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
@@ -6536,7 +6564,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1313
+#: lxc/auth.go:1462
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6597,11 +6625,17 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:834 lxc/auth.go:1086
+#: lxc/auth.go:774
+msgid ""
+"[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
+"certificate>] [[--group <group_name>]]"
+msgstr ""
+
+#: lxc/auth.go:983 lxc/auth.go:1235
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1164 lxc/auth.go:1222 lxc/auth.go:1985
+#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:2134
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6609,13 +6643,13 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:97 lxc/auth.go:150 lxc/auth.go:200 lxc/auth.go:440
-#: lxc/auth.go:958 lxc/auth.go:1529 lxc/cluster_group.go:168
+#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:445
+#: lxc/auth.go:1107 lxc/auth.go:1678 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:515 lxc/auth.go:573
+#: lxc/auth.go:520 lxc/auth.go:578
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
@@ -6625,19 +6659,19 @@ msgstr ""
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:390
+#: lxc/auth.go:395
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1580 lxc/auth.go:1630 lxc/auth.go:1858
+#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1932
+#: lxc/auth.go:2081
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1808
+#: lxc/auth.go:1957
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -7128,7 +7162,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:806
+#: lxc/project.go:557 lxc/remote.go:840
 msgid "current"
 msgstr ""
 
@@ -7175,20 +7209,20 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/auth.go:204
+#: lxc/auth.go:209
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:962
+#: lxc/auth.go:1111
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1634
+#: lxc/auth.go:1783
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7612,7 +7646,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:531
+#: lxc/remote.go:545
 msgid "n"
 msgstr ""
 
@@ -7624,7 +7658,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:510
+#: lxc/remote.go:524
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7661,7 +7695,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:519
+#: lxc/remote.go:533
 msgid "y"
 msgstr ""
 

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-14 13:30+0000\n"
+"POT-Creation-Date: 2024-10-15 14:52+0100\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Heimen Stoffels <vistausss@fastmail.com>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/linux-containers/"
@@ -201,7 +201,7 @@ msgstr ""
 "###\n"
 "### NB: de naam is weergegeven, maar kan niet worden veranderd"
 
-#: lxc/auth.go:214
+#: lxc/auth.go:219
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -228,7 +228,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:972
+#: lxc/auth.go:1121
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -249,7 +249,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1644
+#: lxc/auth.go:1793
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
@@ -739,15 +739,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:917 lxc/remote.go:982
+#: lxc/remote.go:951 lxc/remote.go:1016
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1030
+#: lxc/remote.go:1064
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:836
+#: lxc/remote.go:870
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -780,11 +780,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr "ARCHITECTUUR"
 
-#: lxc/remote.go:818
+#: lxc/remote.go:852
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:817
+#: lxc/auth.go:966
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -822,11 +822,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1165 lxc/auth.go:1166
+#: lxc/auth.go:1314 lxc/auth.go:1315
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1933 lxc/auth.go:1934
+#: lxc/auth.go:2082 lxc/auth.go:2083
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:516 lxc/auth.go:517
+#: lxc/auth.go:521 lxc/auth.go:522
 msgid "Add permissions to groups"
 msgstr ""
 
@@ -929,7 +929,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:648
+#: lxc/remote.go:680
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -1037,7 +1037,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:621
+#: lxc/remote.go:635
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -1215,7 +1215,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:961
+#: lxc/remote.go:995
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1281,7 +1281,7 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:509
+#: lxc/remote.go:523
 msgid "Certificate fingerprint"
 msgstr ""
 
@@ -1300,7 +1300,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:687
+#: lxc/remote.go:721
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1548,12 +1548,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:559
+#: lxc/remote.go:573
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:237 lxc/remote.go:543
+#: lxc/remote.go:237 lxc/remote.go:557
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1567,12 +1567,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:1719
+#: lxc/auth.go:306 lxc/auth.go:1868
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1058
+#: lxc/auth.go:1207
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1592,13 +1592,17 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:554
+#: lxc/remote.go:568
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
 #: lxc/network_zone.go:1536
 msgid "Couldn't find a matching entry"
+msgstr ""
+
+#: lxc/auth.go:776
+msgid "Create a TLS identity"
 msgstr ""
 
 #: lxc/cluster_group.go:169 lxc/cluster_group.go:170
@@ -1617,6 +1621,10 @@ msgstr ""
 msgid "Create an empty instance"
 msgstr ""
 
+#: lxc/auth.go:775
+msgid "Create an identity"
+msgstr ""
+
 #: lxc/launch.go:23 lxc/launch.go:24
 msgid "Create and start instances from images"
 msgstr ""
@@ -1629,11 +1637,11 @@ msgstr ""
 msgid "Create files and directories in instances"
 msgstr ""
 
-#: lxc/auth.go:98 lxc/auth.go:99
+#: lxc/auth.go:103 lxc/auth.go:104
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1530 lxc/auth.go:1531
+#: lxc/auth.go:1679 lxc/auth.go:1680
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1741,7 +1749,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
@@ -1784,7 +1792,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/auth.go:1088 lxc/auth.go:1089
+#: lxc/auth.go:1237 lxc/auth.go:1238
 msgid "Delete an identity"
 msgstr ""
 
@@ -1792,11 +1800,11 @@ msgstr ""
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/auth.go:152 lxc/auth.go:153
+#: lxc/auth.go:157 lxc/auth.go:158
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1582 lxc/auth.go:1583
+#: lxc/auth.go:1731 lxc/auth.go:1732
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1874,18 +1882,18 @@ msgstr ""
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:31 lxc/auth.go:60 lxc/auth.go:99
-#: lxc/auth.go:153 lxc/auth.go:202 lxc/auth.go:333 lxc/auth.go:393
-#: lxc/auth.go:442 lxc/auth.go:494 lxc/auth.go:517 lxc/auth.go:576
-#: lxc/auth.go:732 lxc/auth.go:769 lxc/auth.go:836 lxc/auth.go:899
-#: lxc/auth.go:960 lxc/auth.go:1089 lxc/auth.go:1143 lxc/auth.go:1166
-#: lxc/auth.go:1224 lxc/auth.go:1293 lxc/auth.go:1315 lxc/auth.go:1493
-#: lxc/auth.go:1531 lxc/auth.go:1583 lxc/auth.go:1632 lxc/auth.go:1751
-#: lxc/auth.go:1811 lxc/auth.go:1860 lxc/auth.go:1911 lxc/auth.go:1934
-#: lxc/auth.go:1987 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215
-#: lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:484
-#: lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677 lxc/cluster.go:770
-#: lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
+#: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
+#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:338 lxc/auth.go:398
+#: lxc/auth.go:447 lxc/auth.go:499 lxc/auth.go:522 lxc/auth.go:581
+#: lxc/auth.go:737 lxc/auth.go:776 lxc/auth.go:918 lxc/auth.go:985
+#: lxc/auth.go:1048 lxc/auth.go:1109 lxc/auth.go:1238 lxc/auth.go:1292
+#: lxc/auth.go:1315 lxc/auth.go:1373 lxc/auth.go:1442 lxc/auth.go:1464
+#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
+#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
+#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
+#: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
+#: lxc/cluster.go:770 lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
 #: lxc/cluster.go:1175 lxc/cluster.go:1299 lxc/cluster.go:1329
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
@@ -1956,9 +1964,9 @@ msgstr ""
 #: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
 #: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
 #: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:715
-#: lxc/remote.go:753 lxc/remote.go:839 lxc/remote.go:920 lxc/remote.go:984
-#: lxc/remote.go:1032 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
+#: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
+#: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -2143,7 +2151,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:959 lxc/auth.go:960
+#: lxc/auth.go:1108 lxc/auth.go:1109
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -2155,11 +2163,11 @@ msgstr ""
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/auth.go:201 lxc/auth.go:202
+#: lxc/auth.go:206 lxc/auth.go:207
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1631 lxc/auth.go:1632
+#: lxc/auth.go:1780 lxc/auth.go:1781
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2535,12 +2543,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:486
+#: lxc/remote.go:500
 #, c-format
 msgid "Failed to decode trust token: %w"
 msgstr ""
 
-#: lxc/remote.go:292
+#: lxc/remote.go:306
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2644,7 +2652,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:773 lxc/auth.go:1755
+#: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
@@ -2652,7 +2660,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:757 lxc/storage.go:657
+#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2690,7 +2698,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:821
+#: lxc/remote.go:855
 msgid "GLOBAL"
 msgstr ""
 
@@ -2702,7 +2710,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:821 lxc/auth.go:1795
+#: lxc/auth.go:970 lxc/auth.go:1944
 msgid "GROUPS"
 msgstr ""
 
@@ -2710,7 +2718,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:165 lxc/remote.go:443
+#: lxc/remote.go:165 lxc/remote.go:457
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2851,17 +2859,17 @@ msgstr ""
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: lxc/auth.go:137
+#: lxc/auth.go:142
 #, c-format
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:187
+#: lxc/auth.go:192
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:427 lxc/auth.go:1845
+#: lxc/auth.go:432 lxc/auth.go:1994
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2920,7 +2928,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:820
+#: lxc/auth.go:969
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -2952,12 +2960,16 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1567
+#: lxc/auth.go:829
+msgid "Identity creation only supported for TLS identities"
+msgstr ""
+
+#: lxc/auth.go:1716
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1617
+#: lxc/auth.go:1766
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -3086,7 +3098,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1292 lxc/auth.go:1293
+#: lxc/auth.go:1441 lxc/auth.go:1442
 msgid "Inspect permissions"
 msgstr ""
 
@@ -3134,7 +3146,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:395
+#: lxc/remote.go:409
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3215,7 +3227,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:384
+#: lxc/remote.go:398
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3390,15 +3402,15 @@ msgstr ""
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:332 lxc/auth.go:333
+#: lxc/auth.go:337 lxc/auth.go:338
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:768 lxc/auth.go:769
+#: lxc/auth.go:917 lxc/auth.go:918
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1750 lxc/auth.go:1751
+#: lxc/auth.go:1899 lxc/auth.go:1900
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3551,7 +3563,7 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1314 lxc/auth.go:1315
+#: lxc/auth.go:1463 lxc/auth.go:1464
 msgid "List permissions"
 msgstr ""
 
@@ -3595,7 +3607,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:752 lxc/remote.go:753
+#: lxc/remote.go:786 lxc/remote.go:787
 msgid "List the available remotes"
 msgstr ""
 
@@ -3719,6 +3731,12 @@ msgstr ""
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
+#: lxc/auth.go:825
+msgid ""
+"Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
+"got "
+msgstr ""
+
 #: lxc/network.go:32 lxc/network.go:33
 msgid "Manage and attach instances to networks"
 msgstr ""
@@ -3747,19 +3765,19 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:59 lxc/auth.go:60 lxc/auth.go:1492 lxc/auth.go:1493
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1142 lxc/auth.go:1143
+#: lxc/auth.go:1291 lxc/auth.go:1292
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:731 lxc/auth.go:732
+#: lxc/auth.go:736 lxc/auth.go:737
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1910 lxc/auth.go:1911
+#: lxc/auth.go:2059 lxc/auth.go:2060
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3850,7 +3868,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:493 lxc/auth.go:494
+#: lxc/auth.go:498 lxc/auth.go:499
 msgid "Manage permissions"
 msgstr ""
 
@@ -3902,7 +3920,7 @@ msgstr ""
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/auth.go:30 lxc/auth.go:31
+#: lxc/auth.go:35 lxc/auth.go:36
 msgid "Manage user authorization"
 msgstr ""
 
@@ -3999,21 +4017,21 @@ msgstr ""
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:123 lxc/auth.go:177 lxc/auth.go:255 lxc/auth.go:417
-#: lxc/auth.go:466 lxc/auth.go:541 lxc/auth.go:600 lxc/auth.go:1884
+#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:260 lxc/auth.go:422
+#: lxc/auth.go:471 lxc/auth.go:546 lxc/auth.go:605 lxc/auth.go:2033
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:866 lxc/auth.go:1007 lxc/auth.go:1124 lxc/auth.go:1190
-#: lxc/auth.go:1248
+#: lxc/auth.go:820 lxc/auth.go:1015 lxc/auth.go:1156 lxc/auth.go:1273
+#: lxc/auth.go:1339 lxc/auth.go:1397
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1554 lxc/auth.go:1607 lxc/auth.go:1673 lxc/auth.go:1835
+#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1958 lxc/auth.go:2011
+#: lxc/auth.go:2107 lxc/auth.go:2160
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -4234,12 +4252,12 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:376 lxc/auth.go:819 lxc/auth.go:1794 lxc/cluster.go:192
+#: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
-#: lxc/remote.go:815 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
 msgstr ""
@@ -4266,7 +4284,7 @@ msgstr ""
 
 #: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:775 lxc/remote.go:780 lxc/remote.go:785
+#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr ""
 
@@ -4495,7 +4513,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:378
+#: lxc/remote.go:392
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4566,11 +4584,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:817
+#: lxc/remote.go:851
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:819
+#: lxc/image.go:1136 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4611,7 +4629,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:536
+#: lxc/remote.go:550
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
@@ -4628,7 +4646,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:302 lxc/auth.go:1059 lxc/auth.go:1720 lxc/cluster.go:860
+#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -4931,33 +4949,33 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:877
+#: lxc/remote.go:911
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:868 lxc/remote.go:949 lxc/remote.go:1013
-#: lxc/remote.go:1061
+#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/remote.go:1095
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:345
+#: lxc/remote.go:359
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:957
+#: lxc/remote.go:991
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:872 lxc/remote.go:953 lxc/remote.go:1065
+#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1099
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:319
+#: lxc/remote.go:333
 msgid "Remote address must not be empty"
 msgstr ""
 
@@ -4965,7 +4983,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:339
+#: lxc/remote.go:353
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4987,7 +5005,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1223 lxc/auth.go:1224
+#: lxc/auth.go:1372 lxc/auth.go:1373
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -5023,7 +5041,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1986 lxc/auth.go:1987
+#: lxc/auth.go:2135 lxc/auth.go:2136
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -5035,7 +5053,7 @@ msgstr ""
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:575 lxc/auth.go:576
+#: lxc/auth.go:580 lxc/auth.go:581
 msgid "Remove permissions from groups"
 msgstr ""
 
@@ -5051,7 +5069,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:919 lxc/remote.go:920
+#: lxc/remote.go:953 lxc/remote.go:954
 msgid "Remove remotes"
 msgstr ""
 
@@ -5080,11 +5098,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:392 lxc/auth.go:393
+#: lxc/auth.go:397 lxc/auth.go:398
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1810 lxc/auth.go:1811
+#: lxc/auth.go:1959 lxc/auth.go:1960
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5108,7 +5126,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:838 lxc/remote.go:839
+#: lxc/remote.go:872 lxc/remote.go:873
 msgid "Rename remotes"
 msgstr ""
 
@@ -5253,7 +5271,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:820
+#: lxc/remote.go:854
 msgid "STATIC"
 msgstr ""
 
@@ -5294,11 +5312,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:532
+#: lxc/remote.go:546
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:285 lxc/remote.go:683
+#: lxc/remote.go:299 lxc/remote.go:717
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5509,7 +5527,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1031 lxc/remote.go:1032
+#: lxc/remote.go:1065 lxc/remote.go:1066
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5605,7 +5623,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1859 lxc/auth.go:1860
+#: lxc/auth.go:2008 lxc/auth.go:2009
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5633,11 +5651,11 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:441 lxc/auth.go:442
+#: lxc/auth.go:446 lxc/auth.go:447
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:836
+#: lxc/auth.go:985
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5742,7 +5760,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:899
+#: lxc/auth.go:1048
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5752,7 +5770,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:714 lxc/remote.go:715
+#: lxc/remote.go:748 lxc/remote.go:749
 msgid "Show the default remote"
 msgstr ""
 
@@ -5964,7 +5982,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:983 lxc/remote.go:984
+#: lxc/remote.go:1017 lxc/remote.go:1018
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5976,11 +5994,21 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
+#: lxc/auth.go:876
+#, c-format
+msgid "TLS identity %q (%s) pending identity token:"
+msgstr ""
+
+#: lxc/auth.go:902
+#, c-format
+msgid "TLS identity %q created with fingerprint %q"
+msgstr ""
+
 #: lxc/cluster.go:1070 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:818 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
 #: lxc/storage_volume.go:1736 lxc/warning.go:216
@@ -5999,7 +6027,7 @@ msgstr ""
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/remote.go:161 lxc/remote.go:334
+#: lxc/remote.go:161 lxc/remote.go:348
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
@@ -6155,7 +6183,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:527
+#: lxc/remote.go:541
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
@@ -6293,15 +6321,15 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:329
+#: lxc/remote.go:343
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:324
+#: lxc/remote.go:338
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr ""
 
-#: lxc/remote.go:639
+#: lxc/remote.go:653
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6344,7 +6372,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:193 lxc/remote.go:816
+#: lxc/cluster.go:193 lxc/remote.go:850
 msgid "URL"
 msgstr ""
 
@@ -6652,11 +6680,11 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:835
+#: lxc/auth.go:984
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:898
+#: lxc/auth.go:1047
 msgid "View the current identity"
 msgstr ""
 
@@ -6695,7 +6723,7 @@ msgstr ""
 
 #: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:777 lxc/remote.go:782 lxc/remote.go:787
+#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr ""
 
@@ -6727,7 +6755,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:330 lxc/auth.go:766 lxc/auth.go:897 lxc/auth.go:1748
+#: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
@@ -6760,7 +6788,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1313
+#: lxc/auth.go:1462
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6821,11 +6849,17 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:834 lxc/auth.go:1086
+#: lxc/auth.go:774
+msgid ""
+"[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
+"certificate>] [[--group <group_name>]]"
+msgstr ""
+
+#: lxc/auth.go:983 lxc/auth.go:1235
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1164 lxc/auth.go:1222 lxc/auth.go:1985
+#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:2134
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6833,13 +6867,13 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:97 lxc/auth.go:150 lxc/auth.go:200 lxc/auth.go:440
-#: lxc/auth.go:958 lxc/auth.go:1529 lxc/cluster_group.go:168
+#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:445
+#: lxc/auth.go:1107 lxc/auth.go:1678 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:515 lxc/auth.go:573
+#: lxc/auth.go:520 lxc/auth.go:578
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
@@ -6849,19 +6883,19 @@ msgstr ""
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:390
+#: lxc/auth.go:395
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1580 lxc/auth.go:1630 lxc/auth.go:1858
+#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1932
+#: lxc/auth.go:2081
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1808
+#: lxc/auth.go:1957
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -7352,7 +7386,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:806
+#: lxc/project.go:557 lxc/remote.go:840
 msgid "current"
 msgstr ""
 
@@ -7399,20 +7433,20 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/auth.go:204
+#: lxc/auth.go:209
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:962
+#: lxc/auth.go:1111
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1634
+#: lxc/auth.go:1783
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7836,7 +7870,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:531
+#: lxc/remote.go:545
 msgid "n"
 msgstr ""
 
@@ -7848,7 +7882,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:510
+#: lxc/remote.go:524
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7885,7 +7919,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:519
+#: lxc/remote.go:533
 msgid "y"
 msgstr ""
 

--- a/po/pa.po
+++ b/po/pa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-14 13:30+0000\n"
+"POT-Creation-Date: 2024-10-15 14:52+0100\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Punjabi <https://hosted.weblate.org/projects/linux-containers/"
@@ -133,7 +133,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:214
+#: lxc/auth.go:219
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -160,7 +160,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:972
+#: lxc/auth.go:1121
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -181,7 +181,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1644
+#: lxc/auth.go:1793
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -515,15 +515,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:917 lxc/remote.go:982
+#: lxc/remote.go:951 lxc/remote.go:1016
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1030
+#: lxc/remote.go:1064
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:836
+#: lxc/remote.go:870
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -556,11 +556,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:818
+#: lxc/remote.go:852
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:817
+#: lxc/auth.go:966
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -598,11 +598,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1165 lxc/auth.go:1166
+#: lxc/auth.go:1314 lxc/auth.go:1315
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1933 lxc/auth.go:1934
+#: lxc/auth.go:2082 lxc/auth.go:2083
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -671,7 +671,7 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:516 lxc/auth.go:517
+#: lxc/auth.go:521 lxc/auth.go:522
 msgid "Add permissions to groups"
 msgstr ""
 
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:648
+#: lxc/remote.go:680
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -813,7 +813,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:621
+#: lxc/remote.go:635
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -991,7 +991,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:961
+#: lxc/remote.go:995
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1057,7 +1057,7 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:509
+#: lxc/remote.go:523
 msgid "Certificate fingerprint"
 msgstr ""
 
@@ -1076,7 +1076,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:687
+#: lxc/remote.go:721
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1324,12 +1324,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:559
+#: lxc/remote.go:573
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:237 lxc/remote.go:543
+#: lxc/remote.go:237 lxc/remote.go:557
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1343,12 +1343,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:1719
+#: lxc/auth.go:306 lxc/auth.go:1868
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1058
+#: lxc/auth.go:1207
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1368,13 +1368,17 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:554
+#: lxc/remote.go:568
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
 #: lxc/network_zone.go:1536
 msgid "Couldn't find a matching entry"
+msgstr ""
+
+#: lxc/auth.go:776
+msgid "Create a TLS identity"
 msgstr ""
 
 #: lxc/cluster_group.go:169 lxc/cluster_group.go:170
@@ -1393,6 +1397,10 @@ msgstr ""
 msgid "Create an empty instance"
 msgstr ""
 
+#: lxc/auth.go:775
+msgid "Create an identity"
+msgstr ""
+
 #: lxc/launch.go:23 lxc/launch.go:24
 msgid "Create and start instances from images"
 msgstr ""
@@ -1405,11 +1413,11 @@ msgstr ""
 msgid "Create files and directories in instances"
 msgstr ""
 
-#: lxc/auth.go:98 lxc/auth.go:99
+#: lxc/auth.go:103 lxc/auth.go:104
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1530 lxc/auth.go:1531
+#: lxc/auth.go:1679 lxc/auth.go:1680
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1517,7 +1525,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
@@ -1560,7 +1568,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/auth.go:1088 lxc/auth.go:1089
+#: lxc/auth.go:1237 lxc/auth.go:1238
 msgid "Delete an identity"
 msgstr ""
 
@@ -1568,11 +1576,11 @@ msgstr ""
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/auth.go:152 lxc/auth.go:153
+#: lxc/auth.go:157 lxc/auth.go:158
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1582 lxc/auth.go:1583
+#: lxc/auth.go:1731 lxc/auth.go:1732
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1650,18 +1658,18 @@ msgstr ""
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:31 lxc/auth.go:60 lxc/auth.go:99
-#: lxc/auth.go:153 lxc/auth.go:202 lxc/auth.go:333 lxc/auth.go:393
-#: lxc/auth.go:442 lxc/auth.go:494 lxc/auth.go:517 lxc/auth.go:576
-#: lxc/auth.go:732 lxc/auth.go:769 lxc/auth.go:836 lxc/auth.go:899
-#: lxc/auth.go:960 lxc/auth.go:1089 lxc/auth.go:1143 lxc/auth.go:1166
-#: lxc/auth.go:1224 lxc/auth.go:1293 lxc/auth.go:1315 lxc/auth.go:1493
-#: lxc/auth.go:1531 lxc/auth.go:1583 lxc/auth.go:1632 lxc/auth.go:1751
-#: lxc/auth.go:1811 lxc/auth.go:1860 lxc/auth.go:1911 lxc/auth.go:1934
-#: lxc/auth.go:1987 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215
-#: lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:484
-#: lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677 lxc/cluster.go:770
-#: lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
+#: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
+#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:338 lxc/auth.go:398
+#: lxc/auth.go:447 lxc/auth.go:499 lxc/auth.go:522 lxc/auth.go:581
+#: lxc/auth.go:737 lxc/auth.go:776 lxc/auth.go:918 lxc/auth.go:985
+#: lxc/auth.go:1048 lxc/auth.go:1109 lxc/auth.go:1238 lxc/auth.go:1292
+#: lxc/auth.go:1315 lxc/auth.go:1373 lxc/auth.go:1442 lxc/auth.go:1464
+#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
+#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
+#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
+#: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
+#: lxc/cluster.go:770 lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
 #: lxc/cluster.go:1175 lxc/cluster.go:1299 lxc/cluster.go:1329
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
@@ -1732,9 +1740,9 @@ msgstr ""
 #: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
 #: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
 #: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:715
-#: lxc/remote.go:753 lxc/remote.go:839 lxc/remote.go:920 lxc/remote.go:984
-#: lxc/remote.go:1032 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
+#: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
+#: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1919,7 +1927,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:959 lxc/auth.go:960
+#: lxc/auth.go:1108 lxc/auth.go:1109
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1931,11 +1939,11 @@ msgstr ""
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/auth.go:201 lxc/auth.go:202
+#: lxc/auth.go:206 lxc/auth.go:207
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1631 lxc/auth.go:1632
+#: lxc/auth.go:1780 lxc/auth.go:1781
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2311,12 +2319,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:486
+#: lxc/remote.go:500
 #, c-format
 msgid "Failed to decode trust token: %w"
 msgstr ""
 
-#: lxc/remote.go:292
+#: lxc/remote.go:306
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2420,7 +2428,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:773 lxc/auth.go:1755
+#: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
@@ -2428,7 +2436,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:757 lxc/storage.go:657
+#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2466,7 +2474,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:821
+#: lxc/remote.go:855
 msgid "GLOBAL"
 msgstr ""
 
@@ -2478,7 +2486,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:821 lxc/auth.go:1795
+#: lxc/auth.go:970 lxc/auth.go:1944
 msgid "GROUPS"
 msgstr ""
 
@@ -2486,7 +2494,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:165 lxc/remote.go:443
+#: lxc/remote.go:165 lxc/remote.go:457
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2627,17 +2635,17 @@ msgstr ""
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: lxc/auth.go:137
+#: lxc/auth.go:142
 #, c-format
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:187
+#: lxc/auth.go:192
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:427 lxc/auth.go:1845
+#: lxc/auth.go:432 lxc/auth.go:1994
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2696,7 +2704,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:820
+#: lxc/auth.go:969
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -2728,12 +2736,16 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1567
+#: lxc/auth.go:829
+msgid "Identity creation only supported for TLS identities"
+msgstr ""
+
+#: lxc/auth.go:1716
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1617
+#: lxc/auth.go:1766
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2862,7 +2874,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1292 lxc/auth.go:1293
+#: lxc/auth.go:1441 lxc/auth.go:1442
 msgid "Inspect permissions"
 msgstr ""
 
@@ -2910,7 +2922,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:395
+#: lxc/remote.go:409
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2991,7 +3003,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:384
+#: lxc/remote.go:398
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3166,15 +3178,15 @@ msgstr ""
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:332 lxc/auth.go:333
+#: lxc/auth.go:337 lxc/auth.go:338
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:768 lxc/auth.go:769
+#: lxc/auth.go:917 lxc/auth.go:918
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1750 lxc/auth.go:1751
+#: lxc/auth.go:1899 lxc/auth.go:1900
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3327,7 +3339,7 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1314 lxc/auth.go:1315
+#: lxc/auth.go:1463 lxc/auth.go:1464
 msgid "List permissions"
 msgstr ""
 
@@ -3371,7 +3383,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:752 lxc/remote.go:753
+#: lxc/remote.go:786 lxc/remote.go:787
 msgid "List the available remotes"
 msgstr ""
 
@@ -3495,6 +3507,12 @@ msgstr ""
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
+#: lxc/auth.go:825
+msgid ""
+"Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
+"got "
+msgstr ""
+
 #: lxc/network.go:32 lxc/network.go:33
 msgid "Manage and attach instances to networks"
 msgstr ""
@@ -3523,19 +3541,19 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:59 lxc/auth.go:60 lxc/auth.go:1492 lxc/auth.go:1493
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1142 lxc/auth.go:1143
+#: lxc/auth.go:1291 lxc/auth.go:1292
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:731 lxc/auth.go:732
+#: lxc/auth.go:736 lxc/auth.go:737
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1910 lxc/auth.go:1911
+#: lxc/auth.go:2059 lxc/auth.go:2060
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3626,7 +3644,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:493 lxc/auth.go:494
+#: lxc/auth.go:498 lxc/auth.go:499
 msgid "Manage permissions"
 msgstr ""
 
@@ -3678,7 +3696,7 @@ msgstr ""
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/auth.go:30 lxc/auth.go:31
+#: lxc/auth.go:35 lxc/auth.go:36
 msgid "Manage user authorization"
 msgstr ""
 
@@ -3775,21 +3793,21 @@ msgstr ""
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:123 lxc/auth.go:177 lxc/auth.go:255 lxc/auth.go:417
-#: lxc/auth.go:466 lxc/auth.go:541 lxc/auth.go:600 lxc/auth.go:1884
+#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:260 lxc/auth.go:422
+#: lxc/auth.go:471 lxc/auth.go:546 lxc/auth.go:605 lxc/auth.go:2033
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:866 lxc/auth.go:1007 lxc/auth.go:1124 lxc/auth.go:1190
-#: lxc/auth.go:1248
+#: lxc/auth.go:820 lxc/auth.go:1015 lxc/auth.go:1156 lxc/auth.go:1273
+#: lxc/auth.go:1339 lxc/auth.go:1397
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1554 lxc/auth.go:1607 lxc/auth.go:1673 lxc/auth.go:1835
+#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1958 lxc/auth.go:2011
+#: lxc/auth.go:2107 lxc/auth.go:2160
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -4010,12 +4028,12 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:376 lxc/auth.go:819 lxc/auth.go:1794 lxc/cluster.go:192
+#: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
-#: lxc/remote.go:815 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
 msgstr ""
@@ -4042,7 +4060,7 @@ msgstr ""
 
 #: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:775 lxc/remote.go:780 lxc/remote.go:785
+#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr ""
 
@@ -4271,7 +4289,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:378
+#: lxc/remote.go:392
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4342,11 +4360,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:817
+#: lxc/remote.go:851
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:819
+#: lxc/image.go:1136 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4387,7 +4405,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:536
+#: lxc/remote.go:550
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
@@ -4404,7 +4422,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:302 lxc/auth.go:1059 lxc/auth.go:1720 lxc/cluster.go:860
+#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -4707,33 +4725,33 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:877
+#: lxc/remote.go:911
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:868 lxc/remote.go:949 lxc/remote.go:1013
-#: lxc/remote.go:1061
+#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/remote.go:1095
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:345
+#: lxc/remote.go:359
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:957
+#: lxc/remote.go:991
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:872 lxc/remote.go:953 lxc/remote.go:1065
+#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1099
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:319
+#: lxc/remote.go:333
 msgid "Remote address must not be empty"
 msgstr ""
 
@@ -4741,7 +4759,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:339
+#: lxc/remote.go:353
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4763,7 +4781,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1223 lxc/auth.go:1224
+#: lxc/auth.go:1372 lxc/auth.go:1373
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4799,7 +4817,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1986 lxc/auth.go:1987
+#: lxc/auth.go:2135 lxc/auth.go:2136
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4811,7 +4829,7 @@ msgstr ""
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:575 lxc/auth.go:576
+#: lxc/auth.go:580 lxc/auth.go:581
 msgid "Remove permissions from groups"
 msgstr ""
 
@@ -4827,7 +4845,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:919 lxc/remote.go:920
+#: lxc/remote.go:953 lxc/remote.go:954
 msgid "Remove remotes"
 msgstr ""
 
@@ -4856,11 +4874,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:392 lxc/auth.go:393
+#: lxc/auth.go:397 lxc/auth.go:398
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1810 lxc/auth.go:1811
+#: lxc/auth.go:1959 lxc/auth.go:1960
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -4884,7 +4902,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:838 lxc/remote.go:839
+#: lxc/remote.go:872 lxc/remote.go:873
 msgid "Rename remotes"
 msgstr ""
 
@@ -5029,7 +5047,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:820
+#: lxc/remote.go:854
 msgid "STATIC"
 msgstr ""
 
@@ -5070,11 +5088,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:532
+#: lxc/remote.go:546
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:285 lxc/remote.go:683
+#: lxc/remote.go:299 lxc/remote.go:717
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5285,7 +5303,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1031 lxc/remote.go:1032
+#: lxc/remote.go:1065 lxc/remote.go:1066
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5381,7 +5399,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1859 lxc/auth.go:1860
+#: lxc/auth.go:2008 lxc/auth.go:2009
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5409,11 +5427,11 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:441 lxc/auth.go:442
+#: lxc/auth.go:446 lxc/auth.go:447
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:836
+#: lxc/auth.go:985
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5518,7 +5536,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:899
+#: lxc/auth.go:1048
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5528,7 +5546,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:714 lxc/remote.go:715
+#: lxc/remote.go:748 lxc/remote.go:749
 msgid "Show the default remote"
 msgstr ""
 
@@ -5740,7 +5758,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:983 lxc/remote.go:984
+#: lxc/remote.go:1017 lxc/remote.go:1018
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5752,11 +5770,21 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
+#: lxc/auth.go:876
+#, c-format
+msgid "TLS identity %q (%s) pending identity token:"
+msgstr ""
+
+#: lxc/auth.go:902
+#, c-format
+msgid "TLS identity %q created with fingerprint %q"
+msgstr ""
+
 #: lxc/cluster.go:1070 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:818 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
 #: lxc/storage_volume.go:1736 lxc/warning.go:216
@@ -5775,7 +5803,7 @@ msgstr ""
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/remote.go:161 lxc/remote.go:334
+#: lxc/remote.go:161 lxc/remote.go:348
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
@@ -5931,7 +5959,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:527
+#: lxc/remote.go:541
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
@@ -6069,15 +6097,15 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:329
+#: lxc/remote.go:343
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:324
+#: lxc/remote.go:338
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr ""
 
-#: lxc/remote.go:639
+#: lxc/remote.go:653
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6120,7 +6148,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:193 lxc/remote.go:816
+#: lxc/cluster.go:193 lxc/remote.go:850
 msgid "URL"
 msgstr ""
 
@@ -6428,11 +6456,11 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:835
+#: lxc/auth.go:984
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:898
+#: lxc/auth.go:1047
 msgid "View the current identity"
 msgstr ""
 
@@ -6471,7 +6499,7 @@ msgstr ""
 
 #: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:777 lxc/remote.go:782 lxc/remote.go:787
+#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr ""
 
@@ -6503,7 +6531,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:330 lxc/auth.go:766 lxc/auth.go:897 lxc/auth.go:1748
+#: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
@@ -6536,7 +6564,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1313
+#: lxc/auth.go:1462
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6597,11 +6625,17 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:834 lxc/auth.go:1086
+#: lxc/auth.go:774
+msgid ""
+"[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
+"certificate>] [[--group <group_name>]]"
+msgstr ""
+
+#: lxc/auth.go:983 lxc/auth.go:1235
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1164 lxc/auth.go:1222 lxc/auth.go:1985
+#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:2134
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6609,13 +6643,13 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:97 lxc/auth.go:150 lxc/auth.go:200 lxc/auth.go:440
-#: lxc/auth.go:958 lxc/auth.go:1529 lxc/cluster_group.go:168
+#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:445
+#: lxc/auth.go:1107 lxc/auth.go:1678 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:515 lxc/auth.go:573
+#: lxc/auth.go:520 lxc/auth.go:578
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
@@ -6625,19 +6659,19 @@ msgstr ""
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:390
+#: lxc/auth.go:395
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1580 lxc/auth.go:1630 lxc/auth.go:1858
+#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1932
+#: lxc/auth.go:2081
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1808
+#: lxc/auth.go:1957
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -7128,7 +7162,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:806
+#: lxc/project.go:557 lxc/remote.go:840
 msgid "current"
 msgstr ""
 
@@ -7175,20 +7209,20 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/auth.go:204
+#: lxc/auth.go:209
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:962
+#: lxc/auth.go:1111
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1634
+#: lxc/auth.go:1783
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7612,7 +7646,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:531
+#: lxc/remote.go:545
 msgid "n"
 msgstr ""
 
@@ -7624,7 +7658,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:510
+#: lxc/remote.go:524
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7661,7 +7695,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:519
+#: lxc/remote.go:533
 msgid "y"
 msgstr ""
 

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-14 13:30+0000\n"
+"POT-Creation-Date: 2024-10-15 14:52+0100\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/linux-containers/"
@@ -207,7 +207,7 @@ msgstr ""
 "###\n"
 "### Nazwa jest widoczna, ale nie może zostać zmieniona"
 
-#: lxc/auth.go:214
+#: lxc/auth.go:219
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -234,7 +234,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:972
+#: lxc/auth.go:1121
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -255,7 +255,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1644
+#: lxc/auth.go:1793
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
@@ -777,15 +777,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:917 lxc/remote.go:982
+#: lxc/remote.go:951 lxc/remote.go:1016
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1030
+#: lxc/remote.go:1064
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:836
+#: lxc/remote.go:870
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -818,11 +818,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:818
+#: lxc/remote.go:852
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:817
+#: lxc/auth.go:966
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -860,11 +860,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1165 lxc/auth.go:1166
+#: lxc/auth.go:1314 lxc/auth.go:1315
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1933 lxc/auth.go:1934
+#: lxc/auth.go:2082 lxc/auth.go:2083
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -933,7 +933,7 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:516 lxc/auth.go:517
+#: lxc/auth.go:521 lxc/auth.go:522
 msgid "Add permissions to groups"
 msgstr ""
 
@@ -967,7 +967,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:648
+#: lxc/remote.go:680
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -1075,7 +1075,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:621
+#: lxc/remote.go:635
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -1253,7 +1253,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:961
+#: lxc/remote.go:995
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1319,7 +1319,7 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:509
+#: lxc/remote.go:523
 msgid "Certificate fingerprint"
 msgstr ""
 
@@ -1338,7 +1338,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:687
+#: lxc/remote.go:721
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1586,12 +1586,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:559
+#: lxc/remote.go:573
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:237 lxc/remote.go:543
+#: lxc/remote.go:237 lxc/remote.go:557
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1605,12 +1605,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:1719
+#: lxc/auth.go:306 lxc/auth.go:1868
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1058
+#: lxc/auth.go:1207
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1630,13 +1630,17 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:554
+#: lxc/remote.go:568
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
 #: lxc/network_zone.go:1536
 msgid "Couldn't find a matching entry"
+msgstr ""
+
+#: lxc/auth.go:776
+msgid "Create a TLS identity"
 msgstr ""
 
 #: lxc/cluster_group.go:169 lxc/cluster_group.go:170
@@ -1655,6 +1659,10 @@ msgstr ""
 msgid "Create an empty instance"
 msgstr ""
 
+#: lxc/auth.go:775
+msgid "Create an identity"
+msgstr ""
+
 #: lxc/launch.go:23 lxc/launch.go:24
 msgid "Create and start instances from images"
 msgstr ""
@@ -1667,11 +1675,11 @@ msgstr ""
 msgid "Create files and directories in instances"
 msgstr ""
 
-#: lxc/auth.go:98 lxc/auth.go:99
+#: lxc/auth.go:103 lxc/auth.go:104
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1530 lxc/auth.go:1531
+#: lxc/auth.go:1679 lxc/auth.go:1680
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1779,7 +1787,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
@@ -1822,7 +1830,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/auth.go:1088 lxc/auth.go:1089
+#: lxc/auth.go:1237 lxc/auth.go:1238
 msgid "Delete an identity"
 msgstr ""
 
@@ -1830,11 +1838,11 @@ msgstr ""
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/auth.go:152 lxc/auth.go:153
+#: lxc/auth.go:157 lxc/auth.go:158
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1582 lxc/auth.go:1583
+#: lxc/auth.go:1731 lxc/auth.go:1732
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1912,18 +1920,18 @@ msgstr ""
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:31 lxc/auth.go:60 lxc/auth.go:99
-#: lxc/auth.go:153 lxc/auth.go:202 lxc/auth.go:333 lxc/auth.go:393
-#: lxc/auth.go:442 lxc/auth.go:494 lxc/auth.go:517 lxc/auth.go:576
-#: lxc/auth.go:732 lxc/auth.go:769 lxc/auth.go:836 lxc/auth.go:899
-#: lxc/auth.go:960 lxc/auth.go:1089 lxc/auth.go:1143 lxc/auth.go:1166
-#: lxc/auth.go:1224 lxc/auth.go:1293 lxc/auth.go:1315 lxc/auth.go:1493
-#: lxc/auth.go:1531 lxc/auth.go:1583 lxc/auth.go:1632 lxc/auth.go:1751
-#: lxc/auth.go:1811 lxc/auth.go:1860 lxc/auth.go:1911 lxc/auth.go:1934
-#: lxc/auth.go:1987 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215
-#: lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:484
-#: lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677 lxc/cluster.go:770
-#: lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
+#: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
+#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:338 lxc/auth.go:398
+#: lxc/auth.go:447 lxc/auth.go:499 lxc/auth.go:522 lxc/auth.go:581
+#: lxc/auth.go:737 lxc/auth.go:776 lxc/auth.go:918 lxc/auth.go:985
+#: lxc/auth.go:1048 lxc/auth.go:1109 lxc/auth.go:1238 lxc/auth.go:1292
+#: lxc/auth.go:1315 lxc/auth.go:1373 lxc/auth.go:1442 lxc/auth.go:1464
+#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
+#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
+#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
+#: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
+#: lxc/cluster.go:770 lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
 #: lxc/cluster.go:1175 lxc/cluster.go:1299 lxc/cluster.go:1329
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
@@ -1994,9 +2002,9 @@ msgstr ""
 #: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
 #: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
 #: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:715
-#: lxc/remote.go:753 lxc/remote.go:839 lxc/remote.go:920 lxc/remote.go:984
-#: lxc/remote.go:1032 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
+#: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
+#: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -2181,7 +2189,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:959 lxc/auth.go:960
+#: lxc/auth.go:1108 lxc/auth.go:1109
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -2193,11 +2201,11 @@ msgstr ""
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/auth.go:201 lxc/auth.go:202
+#: lxc/auth.go:206 lxc/auth.go:207
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1631 lxc/auth.go:1632
+#: lxc/auth.go:1780 lxc/auth.go:1781
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2573,12 +2581,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:486
+#: lxc/remote.go:500
 #, c-format
 msgid "Failed to decode trust token: %w"
 msgstr ""
 
-#: lxc/remote.go:292
+#: lxc/remote.go:306
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2682,7 +2690,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:773 lxc/auth.go:1755
+#: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
@@ -2690,7 +2698,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:757 lxc/storage.go:657
+#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2728,7 +2736,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:821
+#: lxc/remote.go:855
 msgid "GLOBAL"
 msgstr ""
 
@@ -2740,7 +2748,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:821 lxc/auth.go:1795
+#: lxc/auth.go:970 lxc/auth.go:1944
 msgid "GROUPS"
 msgstr ""
 
@@ -2748,7 +2756,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:165 lxc/remote.go:443
+#: lxc/remote.go:165 lxc/remote.go:457
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2889,17 +2897,17 @@ msgstr ""
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: lxc/auth.go:137
+#: lxc/auth.go:142
 #, c-format
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:187
+#: lxc/auth.go:192
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:427 lxc/auth.go:1845
+#: lxc/auth.go:432 lxc/auth.go:1994
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2958,7 +2966,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:820
+#: lxc/auth.go:969
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -2990,12 +2998,16 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1567
+#: lxc/auth.go:829
+msgid "Identity creation only supported for TLS identities"
+msgstr ""
+
+#: lxc/auth.go:1716
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1617
+#: lxc/auth.go:1766
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -3124,7 +3136,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1292 lxc/auth.go:1293
+#: lxc/auth.go:1441 lxc/auth.go:1442
 msgid "Inspect permissions"
 msgstr ""
 
@@ -3172,7 +3184,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:395
+#: lxc/remote.go:409
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3253,7 +3265,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:384
+#: lxc/remote.go:398
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3428,15 +3440,15 @@ msgstr ""
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:332 lxc/auth.go:333
+#: lxc/auth.go:337 lxc/auth.go:338
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:768 lxc/auth.go:769
+#: lxc/auth.go:917 lxc/auth.go:918
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1750 lxc/auth.go:1751
+#: lxc/auth.go:1899 lxc/auth.go:1900
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3589,7 +3601,7 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1314 lxc/auth.go:1315
+#: lxc/auth.go:1463 lxc/auth.go:1464
 msgid "List permissions"
 msgstr ""
 
@@ -3633,7 +3645,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:752 lxc/remote.go:753
+#: lxc/remote.go:786 lxc/remote.go:787
 msgid "List the available remotes"
 msgstr ""
 
@@ -3757,6 +3769,12 @@ msgstr ""
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
+#: lxc/auth.go:825
+msgid ""
+"Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
+"got "
+msgstr ""
+
 #: lxc/network.go:32 lxc/network.go:33
 msgid "Manage and attach instances to networks"
 msgstr ""
@@ -3785,19 +3803,19 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:59 lxc/auth.go:60 lxc/auth.go:1492 lxc/auth.go:1493
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1142 lxc/auth.go:1143
+#: lxc/auth.go:1291 lxc/auth.go:1292
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:731 lxc/auth.go:732
+#: lxc/auth.go:736 lxc/auth.go:737
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1910 lxc/auth.go:1911
+#: lxc/auth.go:2059 lxc/auth.go:2060
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3888,7 +3906,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:493 lxc/auth.go:494
+#: lxc/auth.go:498 lxc/auth.go:499
 msgid "Manage permissions"
 msgstr ""
 
@@ -3940,7 +3958,7 @@ msgstr ""
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/auth.go:30 lxc/auth.go:31
+#: lxc/auth.go:35 lxc/auth.go:36
 msgid "Manage user authorization"
 msgstr ""
 
@@ -4037,21 +4055,21 @@ msgstr ""
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:123 lxc/auth.go:177 lxc/auth.go:255 lxc/auth.go:417
-#: lxc/auth.go:466 lxc/auth.go:541 lxc/auth.go:600 lxc/auth.go:1884
+#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:260 lxc/auth.go:422
+#: lxc/auth.go:471 lxc/auth.go:546 lxc/auth.go:605 lxc/auth.go:2033
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:866 lxc/auth.go:1007 lxc/auth.go:1124 lxc/auth.go:1190
-#: lxc/auth.go:1248
+#: lxc/auth.go:820 lxc/auth.go:1015 lxc/auth.go:1156 lxc/auth.go:1273
+#: lxc/auth.go:1339 lxc/auth.go:1397
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1554 lxc/auth.go:1607 lxc/auth.go:1673 lxc/auth.go:1835
+#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1958 lxc/auth.go:2011
+#: lxc/auth.go:2107 lxc/auth.go:2160
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -4272,12 +4290,12 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:376 lxc/auth.go:819 lxc/auth.go:1794 lxc/cluster.go:192
+#: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
-#: lxc/remote.go:815 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
 msgstr ""
@@ -4304,7 +4322,7 @@ msgstr ""
 
 #: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:775 lxc/remote.go:780 lxc/remote.go:785
+#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr ""
 
@@ -4533,7 +4551,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:378
+#: lxc/remote.go:392
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4604,11 +4622,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:817
+#: lxc/remote.go:851
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:819
+#: lxc/image.go:1136 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4649,7 +4667,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:536
+#: lxc/remote.go:550
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
@@ -4666,7 +4684,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:302 lxc/auth.go:1059 lxc/auth.go:1720 lxc/cluster.go:860
+#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -4969,33 +4987,33 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:877
+#: lxc/remote.go:911
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:868 lxc/remote.go:949 lxc/remote.go:1013
-#: lxc/remote.go:1061
+#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/remote.go:1095
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:345
+#: lxc/remote.go:359
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:957
+#: lxc/remote.go:991
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:872 lxc/remote.go:953 lxc/remote.go:1065
+#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1099
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:319
+#: lxc/remote.go:333
 msgid "Remote address must not be empty"
 msgstr ""
 
@@ -5003,7 +5021,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:339
+#: lxc/remote.go:353
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -5025,7 +5043,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1223 lxc/auth.go:1224
+#: lxc/auth.go:1372 lxc/auth.go:1373
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -5061,7 +5079,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1986 lxc/auth.go:1987
+#: lxc/auth.go:2135 lxc/auth.go:2136
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -5073,7 +5091,7 @@ msgstr ""
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:575 lxc/auth.go:576
+#: lxc/auth.go:580 lxc/auth.go:581
 msgid "Remove permissions from groups"
 msgstr ""
 
@@ -5089,7 +5107,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:919 lxc/remote.go:920
+#: lxc/remote.go:953 lxc/remote.go:954
 msgid "Remove remotes"
 msgstr ""
 
@@ -5118,11 +5136,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:392 lxc/auth.go:393
+#: lxc/auth.go:397 lxc/auth.go:398
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1810 lxc/auth.go:1811
+#: lxc/auth.go:1959 lxc/auth.go:1960
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5146,7 +5164,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:838 lxc/remote.go:839
+#: lxc/remote.go:872 lxc/remote.go:873
 msgid "Rename remotes"
 msgstr ""
 
@@ -5291,7 +5309,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:820
+#: lxc/remote.go:854
 msgid "STATIC"
 msgstr ""
 
@@ -5332,11 +5350,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:532
+#: lxc/remote.go:546
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:285 lxc/remote.go:683
+#: lxc/remote.go:299 lxc/remote.go:717
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5547,7 +5565,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1031 lxc/remote.go:1032
+#: lxc/remote.go:1065 lxc/remote.go:1066
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5643,7 +5661,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1859 lxc/auth.go:1860
+#: lxc/auth.go:2008 lxc/auth.go:2009
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5671,11 +5689,11 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:441 lxc/auth.go:442
+#: lxc/auth.go:446 lxc/auth.go:447
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:836
+#: lxc/auth.go:985
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5780,7 +5798,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:899
+#: lxc/auth.go:1048
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5790,7 +5808,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:714 lxc/remote.go:715
+#: lxc/remote.go:748 lxc/remote.go:749
 msgid "Show the default remote"
 msgstr ""
 
@@ -6002,7 +6020,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:983 lxc/remote.go:984
+#: lxc/remote.go:1017 lxc/remote.go:1018
 msgid "Switch the default remote"
 msgstr ""
 
@@ -6014,11 +6032,21 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
+#: lxc/auth.go:876
+#, c-format
+msgid "TLS identity %q (%s) pending identity token:"
+msgstr ""
+
+#: lxc/auth.go:902
+#, c-format
+msgid "TLS identity %q created with fingerprint %q"
+msgstr ""
+
 #: lxc/cluster.go:1070 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:818 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
 #: lxc/storage_volume.go:1736 lxc/warning.go:216
@@ -6037,7 +6065,7 @@ msgstr ""
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/remote.go:161 lxc/remote.go:334
+#: lxc/remote.go:161 lxc/remote.go:348
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
@@ -6193,7 +6221,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:527
+#: lxc/remote.go:541
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
@@ -6331,15 +6359,15 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:329
+#: lxc/remote.go:343
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:324
+#: lxc/remote.go:338
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr ""
 
-#: lxc/remote.go:639
+#: lxc/remote.go:653
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6382,7 +6410,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:193 lxc/remote.go:816
+#: lxc/cluster.go:193 lxc/remote.go:850
 msgid "URL"
 msgstr ""
 
@@ -6690,11 +6718,11 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:835
+#: lxc/auth.go:984
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:898
+#: lxc/auth.go:1047
 msgid "View the current identity"
 msgstr ""
 
@@ -6733,7 +6761,7 @@ msgstr ""
 
 #: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:777 lxc/remote.go:782 lxc/remote.go:787
+#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr ""
 
@@ -6765,7 +6793,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:330 lxc/auth.go:766 lxc/auth.go:897 lxc/auth.go:1748
+#: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
@@ -6798,7 +6826,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1313
+#: lxc/auth.go:1462
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6859,11 +6887,17 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:834 lxc/auth.go:1086
+#: lxc/auth.go:774
+msgid ""
+"[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
+"certificate>] [[--group <group_name>]]"
+msgstr ""
+
+#: lxc/auth.go:983 lxc/auth.go:1235
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1164 lxc/auth.go:1222 lxc/auth.go:1985
+#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:2134
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6871,13 +6905,13 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:97 lxc/auth.go:150 lxc/auth.go:200 lxc/auth.go:440
-#: lxc/auth.go:958 lxc/auth.go:1529 lxc/cluster_group.go:168
+#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:445
+#: lxc/auth.go:1107 lxc/auth.go:1678 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:515 lxc/auth.go:573
+#: lxc/auth.go:520 lxc/auth.go:578
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
@@ -6887,19 +6921,19 @@ msgstr ""
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:390
+#: lxc/auth.go:395
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1580 lxc/auth.go:1630 lxc/auth.go:1858
+#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1932
+#: lxc/auth.go:2081
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1808
+#: lxc/auth.go:1957
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -7390,7 +7424,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:806
+#: lxc/project.go:557 lxc/remote.go:840
 msgid "current"
 msgstr ""
 
@@ -7437,20 +7471,20 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/auth.go:204
+#: lxc/auth.go:209
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:962
+#: lxc/auth.go:1111
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1634
+#: lxc/auth.go:1783
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7874,7 +7908,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:531
+#: lxc/remote.go:545
 msgid "n"
 msgstr ""
 
@@ -7886,7 +7920,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:510
+#: lxc/remote.go:524
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7923,7 +7957,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:519
+#: lxc/remote.go:533
 msgid "y"
 msgstr ""
 

--- a/po/pt.po
+++ b/po/pt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-14 13:30+0000\n"
+"POT-Creation-Date: 2024-10-15 14:52+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -130,7 +130,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:214
+#: lxc/auth.go:219
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -157,7 +157,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:972
+#: lxc/auth.go:1121
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -178,7 +178,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1644
+#: lxc/auth.go:1793
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -512,15 +512,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:917 lxc/remote.go:982
+#: lxc/remote.go:951 lxc/remote.go:1016
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1030
+#: lxc/remote.go:1064
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:836
+#: lxc/remote.go:870
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -553,11 +553,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:818
+#: lxc/remote.go:852
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:817
+#: lxc/auth.go:966
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -595,11 +595,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1165 lxc/auth.go:1166
+#: lxc/auth.go:1314 lxc/auth.go:1315
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1933 lxc/auth.go:1934
+#: lxc/auth.go:2082 lxc/auth.go:2083
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -668,7 +668,7 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:516 lxc/auth.go:517
+#: lxc/auth.go:521 lxc/auth.go:522
 msgid "Add permissions to groups"
 msgstr ""
 
@@ -702,7 +702,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:648
+#: lxc/remote.go:680
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -810,7 +810,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:621
+#: lxc/remote.go:635
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -988,7 +988,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:961
+#: lxc/remote.go:995
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1054,7 +1054,7 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:509
+#: lxc/remote.go:523
 msgid "Certificate fingerprint"
 msgstr ""
 
@@ -1073,7 +1073,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:687
+#: lxc/remote.go:721
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1321,12 +1321,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:559
+#: lxc/remote.go:573
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:237 lxc/remote.go:543
+#: lxc/remote.go:237 lxc/remote.go:557
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1340,12 +1340,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:1719
+#: lxc/auth.go:306 lxc/auth.go:1868
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1058
+#: lxc/auth.go:1207
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1365,13 +1365,17 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:554
+#: lxc/remote.go:568
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
 #: lxc/network_zone.go:1536
 msgid "Couldn't find a matching entry"
+msgstr ""
+
+#: lxc/auth.go:776
+msgid "Create a TLS identity"
 msgstr ""
 
 #: lxc/cluster_group.go:169 lxc/cluster_group.go:170
@@ -1390,6 +1394,10 @@ msgstr ""
 msgid "Create an empty instance"
 msgstr ""
 
+#: lxc/auth.go:775
+msgid "Create an identity"
+msgstr ""
+
 #: lxc/launch.go:23 lxc/launch.go:24
 msgid "Create and start instances from images"
 msgstr ""
@@ -1402,11 +1410,11 @@ msgstr ""
 msgid "Create files and directories in instances"
 msgstr ""
 
-#: lxc/auth.go:98 lxc/auth.go:99
+#: lxc/auth.go:103 lxc/auth.go:104
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1530 lxc/auth.go:1531
+#: lxc/auth.go:1679 lxc/auth.go:1680
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1514,7 +1522,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
@@ -1557,7 +1565,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/auth.go:1088 lxc/auth.go:1089
+#: lxc/auth.go:1237 lxc/auth.go:1238
 msgid "Delete an identity"
 msgstr ""
 
@@ -1565,11 +1573,11 @@ msgstr ""
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/auth.go:152 lxc/auth.go:153
+#: lxc/auth.go:157 lxc/auth.go:158
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1582 lxc/auth.go:1583
+#: lxc/auth.go:1731 lxc/auth.go:1732
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1647,18 +1655,18 @@ msgstr ""
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:31 lxc/auth.go:60 lxc/auth.go:99
-#: lxc/auth.go:153 lxc/auth.go:202 lxc/auth.go:333 lxc/auth.go:393
-#: lxc/auth.go:442 lxc/auth.go:494 lxc/auth.go:517 lxc/auth.go:576
-#: lxc/auth.go:732 lxc/auth.go:769 lxc/auth.go:836 lxc/auth.go:899
-#: lxc/auth.go:960 lxc/auth.go:1089 lxc/auth.go:1143 lxc/auth.go:1166
-#: lxc/auth.go:1224 lxc/auth.go:1293 lxc/auth.go:1315 lxc/auth.go:1493
-#: lxc/auth.go:1531 lxc/auth.go:1583 lxc/auth.go:1632 lxc/auth.go:1751
-#: lxc/auth.go:1811 lxc/auth.go:1860 lxc/auth.go:1911 lxc/auth.go:1934
-#: lxc/auth.go:1987 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215
-#: lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:484
-#: lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677 lxc/cluster.go:770
-#: lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
+#: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
+#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:338 lxc/auth.go:398
+#: lxc/auth.go:447 lxc/auth.go:499 lxc/auth.go:522 lxc/auth.go:581
+#: lxc/auth.go:737 lxc/auth.go:776 lxc/auth.go:918 lxc/auth.go:985
+#: lxc/auth.go:1048 lxc/auth.go:1109 lxc/auth.go:1238 lxc/auth.go:1292
+#: lxc/auth.go:1315 lxc/auth.go:1373 lxc/auth.go:1442 lxc/auth.go:1464
+#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
+#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
+#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
+#: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
+#: lxc/cluster.go:770 lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
 #: lxc/cluster.go:1175 lxc/cluster.go:1299 lxc/cluster.go:1329
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
@@ -1729,9 +1737,9 @@ msgstr ""
 #: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
 #: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
 #: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:715
-#: lxc/remote.go:753 lxc/remote.go:839 lxc/remote.go:920 lxc/remote.go:984
-#: lxc/remote.go:1032 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
+#: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
+#: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1916,7 +1924,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:959 lxc/auth.go:960
+#: lxc/auth.go:1108 lxc/auth.go:1109
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1928,11 +1936,11 @@ msgstr ""
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/auth.go:201 lxc/auth.go:202
+#: lxc/auth.go:206 lxc/auth.go:207
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1631 lxc/auth.go:1632
+#: lxc/auth.go:1780 lxc/auth.go:1781
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2308,12 +2316,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:486
+#: lxc/remote.go:500
 #, c-format
 msgid "Failed to decode trust token: %w"
 msgstr ""
 
-#: lxc/remote.go:292
+#: lxc/remote.go:306
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2417,7 +2425,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:773 lxc/auth.go:1755
+#: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
@@ -2425,7 +2433,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:757 lxc/storage.go:657
+#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2463,7 +2471,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:821
+#: lxc/remote.go:855
 msgid "GLOBAL"
 msgstr ""
 
@@ -2475,7 +2483,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:821 lxc/auth.go:1795
+#: lxc/auth.go:970 lxc/auth.go:1944
 msgid "GROUPS"
 msgstr ""
 
@@ -2483,7 +2491,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:165 lxc/remote.go:443
+#: lxc/remote.go:165 lxc/remote.go:457
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2624,17 +2632,17 @@ msgstr ""
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: lxc/auth.go:137
+#: lxc/auth.go:142
 #, c-format
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:187
+#: lxc/auth.go:192
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:427 lxc/auth.go:1845
+#: lxc/auth.go:432 lxc/auth.go:1994
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2693,7 +2701,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:820
+#: lxc/auth.go:969
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -2725,12 +2733,16 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1567
+#: lxc/auth.go:829
+msgid "Identity creation only supported for TLS identities"
+msgstr ""
+
+#: lxc/auth.go:1716
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1617
+#: lxc/auth.go:1766
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2859,7 +2871,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1292 lxc/auth.go:1293
+#: lxc/auth.go:1441 lxc/auth.go:1442
 msgid "Inspect permissions"
 msgstr ""
 
@@ -2907,7 +2919,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:395
+#: lxc/remote.go:409
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2988,7 +3000,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:384
+#: lxc/remote.go:398
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3163,15 +3175,15 @@ msgstr ""
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:332 lxc/auth.go:333
+#: lxc/auth.go:337 lxc/auth.go:338
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:768 lxc/auth.go:769
+#: lxc/auth.go:917 lxc/auth.go:918
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1750 lxc/auth.go:1751
+#: lxc/auth.go:1899 lxc/auth.go:1900
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3324,7 +3336,7 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1314 lxc/auth.go:1315
+#: lxc/auth.go:1463 lxc/auth.go:1464
 msgid "List permissions"
 msgstr ""
 
@@ -3368,7 +3380,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:752 lxc/remote.go:753
+#: lxc/remote.go:786 lxc/remote.go:787
 msgid "List the available remotes"
 msgstr ""
 
@@ -3492,6 +3504,12 @@ msgstr ""
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
+#: lxc/auth.go:825
+msgid ""
+"Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
+"got "
+msgstr ""
+
 #: lxc/network.go:32 lxc/network.go:33
 msgid "Manage and attach instances to networks"
 msgstr ""
@@ -3520,19 +3538,19 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:59 lxc/auth.go:60 lxc/auth.go:1492 lxc/auth.go:1493
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1142 lxc/auth.go:1143
+#: lxc/auth.go:1291 lxc/auth.go:1292
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:731 lxc/auth.go:732
+#: lxc/auth.go:736 lxc/auth.go:737
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1910 lxc/auth.go:1911
+#: lxc/auth.go:2059 lxc/auth.go:2060
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3623,7 +3641,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:493 lxc/auth.go:494
+#: lxc/auth.go:498 lxc/auth.go:499
 msgid "Manage permissions"
 msgstr ""
 
@@ -3675,7 +3693,7 @@ msgstr ""
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/auth.go:30 lxc/auth.go:31
+#: lxc/auth.go:35 lxc/auth.go:36
 msgid "Manage user authorization"
 msgstr ""
 
@@ -3772,21 +3790,21 @@ msgstr ""
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:123 lxc/auth.go:177 lxc/auth.go:255 lxc/auth.go:417
-#: lxc/auth.go:466 lxc/auth.go:541 lxc/auth.go:600 lxc/auth.go:1884
+#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:260 lxc/auth.go:422
+#: lxc/auth.go:471 lxc/auth.go:546 lxc/auth.go:605 lxc/auth.go:2033
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:866 lxc/auth.go:1007 lxc/auth.go:1124 lxc/auth.go:1190
-#: lxc/auth.go:1248
+#: lxc/auth.go:820 lxc/auth.go:1015 lxc/auth.go:1156 lxc/auth.go:1273
+#: lxc/auth.go:1339 lxc/auth.go:1397
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1554 lxc/auth.go:1607 lxc/auth.go:1673 lxc/auth.go:1835
+#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1958 lxc/auth.go:2011
+#: lxc/auth.go:2107 lxc/auth.go:2160
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -4007,12 +4025,12 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:376 lxc/auth.go:819 lxc/auth.go:1794 lxc/cluster.go:192
+#: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
-#: lxc/remote.go:815 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
 msgstr ""
@@ -4039,7 +4057,7 @@ msgstr ""
 
 #: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:775 lxc/remote.go:780 lxc/remote.go:785
+#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr ""
 
@@ -4268,7 +4286,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:378
+#: lxc/remote.go:392
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4339,11 +4357,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:817
+#: lxc/remote.go:851
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:819
+#: lxc/image.go:1136 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4384,7 +4402,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:536
+#: lxc/remote.go:550
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
@@ -4401,7 +4419,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:302 lxc/auth.go:1059 lxc/auth.go:1720 lxc/cluster.go:860
+#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -4704,33 +4722,33 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:877
+#: lxc/remote.go:911
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:868 lxc/remote.go:949 lxc/remote.go:1013
-#: lxc/remote.go:1061
+#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/remote.go:1095
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:345
+#: lxc/remote.go:359
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:957
+#: lxc/remote.go:991
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:872 lxc/remote.go:953 lxc/remote.go:1065
+#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1099
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:319
+#: lxc/remote.go:333
 msgid "Remote address must not be empty"
 msgstr ""
 
@@ -4738,7 +4756,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:339
+#: lxc/remote.go:353
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4760,7 +4778,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1223 lxc/auth.go:1224
+#: lxc/auth.go:1372 lxc/auth.go:1373
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4796,7 +4814,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1986 lxc/auth.go:1987
+#: lxc/auth.go:2135 lxc/auth.go:2136
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4808,7 +4826,7 @@ msgstr ""
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:575 lxc/auth.go:576
+#: lxc/auth.go:580 lxc/auth.go:581
 msgid "Remove permissions from groups"
 msgstr ""
 
@@ -4824,7 +4842,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:919 lxc/remote.go:920
+#: lxc/remote.go:953 lxc/remote.go:954
 msgid "Remove remotes"
 msgstr ""
 
@@ -4853,11 +4871,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:392 lxc/auth.go:393
+#: lxc/auth.go:397 lxc/auth.go:398
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1810 lxc/auth.go:1811
+#: lxc/auth.go:1959 lxc/auth.go:1960
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -4881,7 +4899,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:838 lxc/remote.go:839
+#: lxc/remote.go:872 lxc/remote.go:873
 msgid "Rename remotes"
 msgstr ""
 
@@ -5026,7 +5044,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:820
+#: lxc/remote.go:854
 msgid "STATIC"
 msgstr ""
 
@@ -5067,11 +5085,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:532
+#: lxc/remote.go:546
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:285 lxc/remote.go:683
+#: lxc/remote.go:299 lxc/remote.go:717
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5282,7 +5300,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1031 lxc/remote.go:1032
+#: lxc/remote.go:1065 lxc/remote.go:1066
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5378,7 +5396,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1859 lxc/auth.go:1860
+#: lxc/auth.go:2008 lxc/auth.go:2009
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5406,11 +5424,11 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:441 lxc/auth.go:442
+#: lxc/auth.go:446 lxc/auth.go:447
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:836
+#: lxc/auth.go:985
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5515,7 +5533,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:899
+#: lxc/auth.go:1048
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5525,7 +5543,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:714 lxc/remote.go:715
+#: lxc/remote.go:748 lxc/remote.go:749
 msgid "Show the default remote"
 msgstr ""
 
@@ -5737,7 +5755,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:983 lxc/remote.go:984
+#: lxc/remote.go:1017 lxc/remote.go:1018
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5749,11 +5767,21 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
+#: lxc/auth.go:876
+#, c-format
+msgid "TLS identity %q (%s) pending identity token:"
+msgstr ""
+
+#: lxc/auth.go:902
+#, c-format
+msgid "TLS identity %q created with fingerprint %q"
+msgstr ""
+
 #: lxc/cluster.go:1070 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:818 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
 #: lxc/storage_volume.go:1736 lxc/warning.go:216
@@ -5772,7 +5800,7 @@ msgstr ""
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/remote.go:161 lxc/remote.go:334
+#: lxc/remote.go:161 lxc/remote.go:348
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
@@ -5928,7 +5956,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:527
+#: lxc/remote.go:541
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
@@ -6066,15 +6094,15 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:329
+#: lxc/remote.go:343
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:324
+#: lxc/remote.go:338
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr ""
 
-#: lxc/remote.go:639
+#: lxc/remote.go:653
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6117,7 +6145,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:193 lxc/remote.go:816
+#: lxc/cluster.go:193 lxc/remote.go:850
 msgid "URL"
 msgstr ""
 
@@ -6425,11 +6453,11 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:835
+#: lxc/auth.go:984
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:898
+#: lxc/auth.go:1047
 msgid "View the current identity"
 msgstr ""
 
@@ -6468,7 +6496,7 @@ msgstr ""
 
 #: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:777 lxc/remote.go:782 lxc/remote.go:787
+#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr ""
 
@@ -6500,7 +6528,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:330 lxc/auth.go:766 lxc/auth.go:897 lxc/auth.go:1748
+#: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
@@ -6533,7 +6561,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1313
+#: lxc/auth.go:1462
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6594,11 +6622,17 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:834 lxc/auth.go:1086
+#: lxc/auth.go:774
+msgid ""
+"[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
+"certificate>] [[--group <group_name>]]"
+msgstr ""
+
+#: lxc/auth.go:983 lxc/auth.go:1235
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1164 lxc/auth.go:1222 lxc/auth.go:1985
+#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:2134
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6606,13 +6640,13 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:97 lxc/auth.go:150 lxc/auth.go:200 lxc/auth.go:440
-#: lxc/auth.go:958 lxc/auth.go:1529 lxc/cluster_group.go:168
+#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:445
+#: lxc/auth.go:1107 lxc/auth.go:1678 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:515 lxc/auth.go:573
+#: lxc/auth.go:520 lxc/auth.go:578
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
@@ -6622,19 +6656,19 @@ msgstr ""
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:390
+#: lxc/auth.go:395
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1580 lxc/auth.go:1630 lxc/auth.go:1858
+#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1932
+#: lxc/auth.go:2081
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1808
+#: lxc/auth.go:1957
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -7125,7 +7159,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:806
+#: lxc/project.go:557 lxc/remote.go:840
 msgid "current"
 msgstr ""
 
@@ -7172,20 +7206,20 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/auth.go:204
+#: lxc/auth.go:209
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:962
+#: lxc/auth.go:1111
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1634
+#: lxc/auth.go:1783
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7609,7 +7643,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:531
+#: lxc/remote.go:545
 msgid "n"
 msgstr ""
 
@@ -7621,7 +7655,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:510
+#: lxc/remote.go:524
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7658,7 +7692,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:519
+#: lxc/remote.go:533
 msgid "y"
 msgstr ""
 

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-14 13:30+0000\n"
+"POT-Creation-Date: 2024-10-15 14:52+0100\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Renato dos Santos <renato.santos@wplex.com.br>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -204,7 +204,7 @@ msgstr ""
 "###\n"
 "### Observe que o nome é exibido mas não pode ser modificado"
 
-#: lxc/auth.go:214
+#: lxc/auth.go:219
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -231,7 +231,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:972
+#: lxc/auth.go:1121
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -252,7 +252,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1644
+#: lxc/auth.go:1793
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
@@ -773,15 +773,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:917 lxc/remote.go:982
+#: lxc/remote.go:951 lxc/remote.go:1016
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1030
+#: lxc/remote.go:1064
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:836
+#: lxc/remote.go:870
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -815,11 +815,11 @@ msgstr "ALIASES"
 msgid "ARCHITECTURE"
 msgstr "ARQUITETURA"
 
-#: lxc/remote.go:818
+#: lxc/remote.go:852
 msgid "AUTH TYPE"
 msgstr "TIPO DE AUTENTICAÇÃO"
 
-#: lxc/auth.go:817
+#: lxc/auth.go:966
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -859,11 +859,11 @@ msgstr "Ação (padrão para o GET)"
 msgid "Add a cluster member to a cluster group"
 msgstr "Nome de membro do cluster"
 
-#: lxc/auth.go:1165 lxc/auth.go:1166
+#: lxc/auth.go:1314 lxc/auth.go:1315
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1933 lxc/auth.go:1934
+#: lxc/auth.go:2082 lxc/auth.go:2083
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:516 lxc/auth.go:517
+#: lxc/auth.go:521 lxc/auth.go:522
 msgid "Add permissions to groups"
 msgstr ""
 
@@ -972,7 +972,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr "Senha de administrador para %s: "
 
-#: lxc/remote.go:648
+#: lxc/remote.go:680
 #, fuzzy, c-format
 msgid "Admin password (or token) for %s:"
 msgstr "Senha de administrador para %s: "
@@ -1088,7 +1088,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:621
+#: lxc/remote.go:635
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr "Tipo de autenticação '%s' não suportada pelo servidor"
@@ -1268,7 +1268,7 @@ msgstr "Não pode pegar um diretório sem --recursive"
 msgid "Can't read from stdin: %w"
 msgstr "Não é possível ler stdin: %s"
 
-#: lxc/remote.go:961
+#: lxc/remote.go:995
 msgid "Can't remove the default remote"
 msgstr "Não é possível remover o default remoto"
 
@@ -1335,7 +1335,7 @@ msgstr "Em cache: %s"
 msgid "Certificate add token for %s deleted"
 msgstr "Clustering ativado"
 
-#: lxc/remote.go:509
+#: lxc/remote.go:523
 #, fuzzy
 msgid "Certificate fingerprint"
 msgstr "Certificado fingerprint: %s"
@@ -1355,7 +1355,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr "Nome de membro do cluster"
 
-#: lxc/remote.go:687
+#: lxc/remote.go:721
 #, fuzzy
 msgid "Client certificate now trusted by server:"
 msgstr "Certificado do cliente armazenado no servidor: "
@@ -1615,12 +1615,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:559
+#: lxc/remote.go:573
 #, fuzzy, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "Impossível criar diretório para certificado do servidor"
 
-#: lxc/remote.go:237 lxc/remote.go:543
+#: lxc/remote.go:237 lxc/remote.go:557
 msgid "Could not create server cert dir"
 msgstr "Impossível criar diretório para certificado do servidor"
 
@@ -1634,12 +1634,12 @@ msgstr "Certificado fingerprint: %s"
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:1719
+#: lxc/auth.go:306 lxc/auth.go:1868
 #, fuzzy, c-format
 msgid "Could not parse group: %s"
 msgstr "Erro de análise de configuração: %s"
 
-#: lxc/auth.go:1058
+#: lxc/auth.go:1207
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1659,7 +1659,7 @@ msgstr "Certificado fingerprint: %s"
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:554
+#: lxc/remote.go:568
 #, fuzzy, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "Impossível criar diretório para certificado do servidor"
@@ -1667,6 +1667,11 @@ msgstr "Impossível criar diretório para certificado do servidor"
 #: lxc/network_zone.go:1536
 msgid "Couldn't find a matching entry"
 msgstr ""
+
+#: lxc/auth.go:776
+#, fuzzy
+msgid "Create a TLS identity"
+msgstr "Editar configurações de rede como YAML"
 
 #: lxc/cluster_group.go:169 lxc/cluster_group.go:170
 msgid "Create a cluster group"
@@ -1685,6 +1690,11 @@ msgstr ""
 msgid "Create an empty instance"
 msgstr ""
 
+#: lxc/auth.go:775
+#, fuzzy
+msgid "Create an identity"
+msgstr "Editar configurações de rede como YAML"
+
 #: lxc/launch.go:23 lxc/launch.go:24
 msgid "Create and start instances from images"
 msgstr ""
@@ -1698,12 +1708,12 @@ msgstr ""
 msgid "Create files and directories in instances"
 msgstr "Editar arquivos no container"
 
-#: lxc/auth.go:98 lxc/auth.go:99
+#: lxc/auth.go:103 lxc/auth.go:104
 #, fuzzy
 msgid "Create groups"
 msgstr "Criar perfis"
 
-#: lxc/auth.go:1530 lxc/auth.go:1531
+#: lxc/auth.go:1679 lxc/auth.go:1680
 #, fuzzy
 msgid "Create identity provider groups"
 msgstr "Criar novas redes"
@@ -1826,7 +1836,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
@@ -1871,7 +1881,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr "Apagar nomes alternativos da imagem"
 
-#: lxc/auth.go:1088 lxc/auth.go:1089
+#: lxc/auth.go:1237 lxc/auth.go:1238
 #, fuzzy
 msgid "Delete an identity"
 msgstr "Editar configurações de rede como YAML"
@@ -1881,12 +1891,12 @@ msgstr "Editar configurações de rede como YAML"
 msgid "Delete files in instances"
 msgstr "Editar arquivos no container"
 
-#: lxc/auth.go:152 lxc/auth.go:153
+#: lxc/auth.go:157 lxc/auth.go:158
 #, fuzzy
 msgid "Delete groups"
 msgstr "Apagar projetos"
 
-#: lxc/auth.go:1582 lxc/auth.go:1583
+#: lxc/auth.go:1731 lxc/auth.go:1732
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1973,18 +1983,18 @@ msgstr ""
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:31 lxc/auth.go:60 lxc/auth.go:99
-#: lxc/auth.go:153 lxc/auth.go:202 lxc/auth.go:333 lxc/auth.go:393
-#: lxc/auth.go:442 lxc/auth.go:494 lxc/auth.go:517 lxc/auth.go:576
-#: lxc/auth.go:732 lxc/auth.go:769 lxc/auth.go:836 lxc/auth.go:899
-#: lxc/auth.go:960 lxc/auth.go:1089 lxc/auth.go:1143 lxc/auth.go:1166
-#: lxc/auth.go:1224 lxc/auth.go:1293 lxc/auth.go:1315 lxc/auth.go:1493
-#: lxc/auth.go:1531 lxc/auth.go:1583 lxc/auth.go:1632 lxc/auth.go:1751
-#: lxc/auth.go:1811 lxc/auth.go:1860 lxc/auth.go:1911 lxc/auth.go:1934
-#: lxc/auth.go:1987 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215
-#: lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:484
-#: lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677 lxc/cluster.go:770
-#: lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
+#: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
+#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:338 lxc/auth.go:398
+#: lxc/auth.go:447 lxc/auth.go:499 lxc/auth.go:522 lxc/auth.go:581
+#: lxc/auth.go:737 lxc/auth.go:776 lxc/auth.go:918 lxc/auth.go:985
+#: lxc/auth.go:1048 lxc/auth.go:1109 lxc/auth.go:1238 lxc/auth.go:1292
+#: lxc/auth.go:1315 lxc/auth.go:1373 lxc/auth.go:1442 lxc/auth.go:1464
+#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
+#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
+#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
+#: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
+#: lxc/cluster.go:770 lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
 #: lxc/cluster.go:1175 lxc/cluster.go:1299 lxc/cluster.go:1329
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
@@ -2055,9 +2065,9 @@ msgstr ""
 #: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
 #: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
 #: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:715
-#: lxc/remote.go:753 lxc/remote.go:839 lxc/remote.go:920 lxc/remote.go:984
-#: lxc/remote.go:1032 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
+#: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
+#: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -2249,7 +2259,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:959 lxc/auth.go:960
+#: lxc/auth.go:1108 lxc/auth.go:1109
 #, fuzzy
 msgid "Edit an identity as YAML"
 msgstr "Editar configurações de rede como YAML"
@@ -2264,12 +2274,12 @@ msgstr "Editar configurações do container ou do servidor como YAML"
 msgid "Edit files in instances"
 msgstr "Editar arquivos no container"
 
-#: lxc/auth.go:201 lxc/auth.go:202
+#: lxc/auth.go:206 lxc/auth.go:207
 #, fuzzy
 msgid "Edit groups as YAML"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/auth.go:1631 lxc/auth.go:1632
+#: lxc/auth.go:1780 lxc/auth.go:1781
 #, fuzzy
 msgid "Edit identity provider groups as YAML"
 msgstr "Editar configurações de perfil como YAML"
@@ -2660,12 +2670,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr "Aceitar certificado"
 
-#: lxc/remote.go:486
+#: lxc/remote.go:500
 #, fuzzy, c-format
 msgid "Failed to decode trust token: %w"
 msgstr "Nome de membro do cluster"
 
-#: lxc/remote.go:292
+#: lxc/remote.go:306
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2770,7 +2780,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:773 lxc/auth.go:1755
+#: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
@@ -2778,7 +2788,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:757 lxc/storage.go:657
+#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2816,7 +2826,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:821
+#: lxc/remote.go:855
 msgid "GLOBAL"
 msgstr ""
 
@@ -2828,7 +2838,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:821 lxc/auth.go:1795
+#: lxc/auth.go:970 lxc/auth.go:1944
 msgid "GROUPS"
 msgstr ""
 
@@ -2836,7 +2846,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:165 lxc/remote.go:443
+#: lxc/remote.go:165 lxc/remote.go:457
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2997,17 +3007,17 @@ msgstr ""
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: lxc/auth.go:137
+#: lxc/auth.go:142
 #, fuzzy, c-format
 msgid "Group %s created"
 msgstr "Clustering ativado"
 
-#: lxc/auth.go:187
+#: lxc/auth.go:192
 #, fuzzy, c-format
 msgid "Group %s deleted"
 msgstr "Clustering ativado"
 
-#: lxc/auth.go:427 lxc/auth.go:1845
+#: lxc/auth.go:432 lxc/auth.go:1994
 #, fuzzy, c-format
 msgid "Group %s renamed to %s"
 msgstr "Dispositivo %s adicionado a %s"
@@ -3066,7 +3076,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:820
+#: lxc/auth.go:969
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -3098,12 +3108,16 @@ msgstr "IPV6"
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1567
+#: lxc/auth.go:829
+msgid "Identity creation only supported for TLS identities"
+msgstr ""
+
+#: lxc/auth.go:1716
 #, fuzzy, c-format
 msgid "Identity provider group %s created"
 msgstr "Clustering ativado"
 
-#: lxc/auth.go:1617
+#: lxc/auth.go:1766
 #, fuzzy, c-format
 msgid "Identity provider group %s deleted"
 msgstr "Clustering ativado"
@@ -3234,7 +3248,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1292 lxc/auth.go:1293
+#: lxc/auth.go:1441 lxc/auth.go:1442
 msgid "Inspect permissions"
 msgstr ""
 
@@ -3282,7 +3296,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:395
+#: lxc/remote.go:409
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3364,7 +3378,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:384
+#: lxc/remote.go:398
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3546,15 +3560,15 @@ msgstr ""
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:332 lxc/auth.go:333
+#: lxc/auth.go:337 lxc/auth.go:338
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:768 lxc/auth.go:769
+#: lxc/auth.go:917 lxc/auth.go:918
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1750 lxc/auth.go:1751
+#: lxc/auth.go:1899 lxc/auth.go:1900
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3710,7 +3724,7 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr "Criar projetos"
 
-#: lxc/auth.go:1314 lxc/auth.go:1315
+#: lxc/auth.go:1463 lxc/auth.go:1464
 msgid "List permissions"
 msgstr ""
 
@@ -3754,7 +3768,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:752 lxc/remote.go:753
+#: lxc/remote.go:786 lxc/remote.go:787
 msgid "List the available remotes"
 msgstr ""
 
@@ -3880,6 +3894,12 @@ msgstr ""
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
+#: lxc/auth.go:825
+msgid ""
+"Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
+"got "
+msgstr ""
+
 #: lxc/network.go:32 lxc/network.go:33
 msgid "Manage and attach instances to networks"
 msgstr ""
@@ -3911,21 +3931,21 @@ msgstr "Editar arquivos no container"
 msgid "Manage files in instances"
 msgstr "Editar arquivos no container"
 
-#: lxc/auth.go:59 lxc/auth.go:60 lxc/auth.go:1492 lxc/auth.go:1493
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
 #, fuzzy
 msgid "Manage groups"
 msgstr "Editar arquivos no container"
 
-#: lxc/auth.go:1142 lxc/auth.go:1143
+#: lxc/auth.go:1291 lxc/auth.go:1292
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:731 lxc/auth.go:732
+#: lxc/auth.go:736 lxc/auth.go:737
 #, fuzzy
 msgid "Manage identities"
 msgstr "Editar arquivos no container"
 
-#: lxc/auth.go:1910 lxc/auth.go:1911
+#: lxc/auth.go:2059 lxc/auth.go:2060
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -4030,7 +4050,7 @@ msgstr "Criar novas redes"
 msgid "Manage network zones"
 msgstr "Criar novas redes"
 
-#: lxc/auth.go:493 lxc/auth.go:494
+#: lxc/auth.go:498 lxc/auth.go:499
 #, fuzzy
 msgid "Manage permissions"
 msgstr "Editar arquivos no container"
@@ -4086,7 +4106,7 @@ msgstr ""
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/auth.go:30 lxc/auth.go:31
+#: lxc/auth.go:35 lxc/auth.go:36
 #, fuzzy
 msgid "Manage user authorization"
 msgstr "Nome de membro do cluster"
@@ -4190,24 +4210,24 @@ msgstr "Nome de membro do cluster"
 msgid "Missing cluster member name"
 msgstr "Nome de membro do cluster"
 
-#: lxc/auth.go:123 lxc/auth.go:177 lxc/auth.go:255 lxc/auth.go:417
-#: lxc/auth.go:466 lxc/auth.go:541 lxc/auth.go:600 lxc/auth.go:1884
+#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:260 lxc/auth.go:422
+#: lxc/auth.go:471 lxc/auth.go:546 lxc/auth.go:605 lxc/auth.go:2033
 #, fuzzy
 msgid "Missing group name"
 msgstr "Nome de membro do cluster"
 
-#: lxc/auth.go:866 lxc/auth.go:1007 lxc/auth.go:1124 lxc/auth.go:1190
-#: lxc/auth.go:1248
+#: lxc/auth.go:820 lxc/auth.go:1015 lxc/auth.go:1156 lxc/auth.go:1273
+#: lxc/auth.go:1339 lxc/auth.go:1397
 #, fuzzy
 msgid "Missing identity argument"
 msgstr "Nome de membro do cluster"
 
-#: lxc/auth.go:1554 lxc/auth.go:1607 lxc/auth.go:1673 lxc/auth.go:1835
+#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
 #, fuzzy
 msgid "Missing identity provider group name"
 msgstr "Nome de membro do cluster"
 
-#: lxc/auth.go:1958 lxc/auth.go:2011
+#: lxc/auth.go:2107 lxc/auth.go:2160
 #, fuzzy
 msgid "Missing identity provider group name argument"
 msgstr "Nome de membro do cluster"
@@ -4438,12 +4458,12 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:376 lxc/auth.go:819 lxc/auth.go:1794 lxc/cluster.go:192
+#: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
-#: lxc/remote.go:815 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
 msgstr ""
@@ -4470,7 +4490,7 @@ msgstr ""
 
 #: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:775 lxc/remote.go:780 lxc/remote.go:785
+#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr ""
 
@@ -4699,7 +4719,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:378
+#: lxc/remote.go:392
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4770,11 +4790,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:817
+#: lxc/remote.go:851
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:819
+#: lxc/image.go:1136 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4816,7 +4836,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr "Nome de membro do cluster"
 
-#: lxc/remote.go:536
+#: lxc/remote.go:550
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
@@ -4833,7 +4853,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:302 lxc/auth.go:1059 lxc/auth.go:1720 lxc/cluster.go:860
+#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -5144,33 +5164,33 @@ msgstr "Editar arquivos no container"
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:877
+#: lxc/remote.go:911
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:868 lxc/remote.go:949 lxc/remote.go:1013
-#: lxc/remote.go:1061
+#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/remote.go:1095
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:345
+#: lxc/remote.go:359
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:957
+#: lxc/remote.go:991
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:872 lxc/remote.go:953 lxc/remote.go:1065
+#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1099
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:319
+#: lxc/remote.go:333
 msgid "Remote address must not be empty"
 msgstr ""
 
@@ -5179,7 +5199,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr "Senha de administrador para %s: "
 
-#: lxc/remote.go:339
+#: lxc/remote.go:353
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -5203,7 +5223,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr "Nome de membro do cluster"
 
-#: lxc/auth.go:1223 lxc/auth.go:1224
+#: lxc/auth.go:1372 lxc/auth.go:1373
 #, fuzzy
 msgid "Remove a group from an identity"
 msgstr "Adicionar perfis aos containers"
@@ -5244,7 +5264,7 @@ msgstr "Nome de membro do cluster"
 msgid "Remove entries from a network zone record"
 msgstr "Adicionar perfis aos containers"
 
-#: lxc/auth.go:1986 lxc/auth.go:1987
+#: lxc/auth.go:2135 lxc/auth.go:2136
 #, fuzzy
 msgid "Remove identities from groups"
 msgstr "Adicionar perfis aos containers"
@@ -5257,7 +5277,7 @@ msgstr ""
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:575 lxc/auth.go:576
+#: lxc/auth.go:580 lxc/auth.go:581
 #, fuzzy
 msgid "Remove permissions from groups"
 msgstr "Adicionar perfis aos containers"
@@ -5277,7 +5297,7 @@ msgstr "Adicionar perfis aos containers"
 msgid "Remove profiles from instances"
 msgstr "Adicionar perfis aos containers"
 
-#: lxc/remote.go:919 lxc/remote.go:920
+#: lxc/remote.go:953 lxc/remote.go:954
 msgid "Remove remotes"
 msgstr ""
 
@@ -5309,11 +5329,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:392 lxc/auth.go:393
+#: lxc/auth.go:397 lxc/auth.go:398
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1810 lxc/auth.go:1811
+#: lxc/auth.go:1959 lxc/auth.go:1960
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5338,7 +5358,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:838 lxc/remote.go:839
+#: lxc/remote.go:872 lxc/remote.go:873
 msgid "Rename remotes"
 msgstr ""
 
@@ -5493,7 +5513,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:820
+#: lxc/remote.go:854
 msgid "STATIC"
 msgstr ""
 
@@ -5534,11 +5554,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:532
+#: lxc/remote.go:546
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:285 lxc/remote.go:683
+#: lxc/remote.go:299 lxc/remote.go:717
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5762,7 +5782,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1031 lxc/remote.go:1032
+#: lxc/remote.go:1065 lxc/remote.go:1066
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5865,7 +5885,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1859 lxc/auth.go:1860
+#: lxc/auth.go:2008 lxc/auth.go:2009
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5896,12 +5916,12 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr "Adicionar dispositivos aos containers ou perfis"
 
-#: lxc/auth.go:441 lxc/auth.go:442
+#: lxc/auth.go:446 lxc/auth.go:447
 #, fuzzy
 msgid "Show group configurations"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: lxc/auth.go:836
+#: lxc/auth.go:985
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -6021,7 +6041,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: lxc/auth.go:899
+#: lxc/auth.go:1048
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -6031,7 +6051,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:714 lxc/remote.go:715
+#: lxc/remote.go:748 lxc/remote.go:749
 msgid "Show the default remote"
 msgstr ""
 
@@ -6246,7 +6266,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:983 lxc/remote.go:984
+#: lxc/remote.go:1017 lxc/remote.go:1018
 msgid "Switch the default remote"
 msgstr ""
 
@@ -6258,11 +6278,21 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
+#: lxc/auth.go:876
+#, c-format
+msgid "TLS identity %q (%s) pending identity token:"
+msgstr ""
+
+#: lxc/auth.go:902
+#, fuzzy, c-format
+msgid "TLS identity %q created with fingerprint %q"
+msgstr "Certificado fingerprint: %s"
+
 #: lxc/cluster.go:1070 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:818 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
 #: lxc/storage_volume.go:1736 lxc/warning.go:216
@@ -6282,7 +6312,7 @@ msgstr "--refresh só pode ser usado com containers"
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/remote.go:161 lxc/remote.go:334
+#: lxc/remote.go:161 lxc/remote.go:348
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
@@ -6441,7 +6471,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:527
+#: lxc/remote.go:541
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
@@ -6581,16 +6611,16 @@ msgstr "Editar arquivos no container"
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:329
+#: lxc/remote.go:343
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:324
+#: lxc/remote.go:338
 #, fuzzy
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr "--refresh só pode ser usado com containers"
 
-#: lxc/remote.go:639
+#: lxc/remote.go:653
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6634,7 +6664,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:193 lxc/remote.go:816
+#: lxc/cluster.go:193 lxc/remote.go:850
 msgid "URL"
 msgstr ""
 
@@ -6969,11 +6999,11 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr "Em cache: %s"
 
-#: lxc/auth.go:835
+#: lxc/auth.go:984
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:898
+#: lxc/auth.go:1047
 msgid "View the current identity"
 msgstr ""
 
@@ -7012,7 +7042,7 @@ msgstr ""
 
 #: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:777 lxc/remote.go:782 lxc/remote.go:787
+#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr ""
 
@@ -7045,7 +7075,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr "Criar perfis"
 
-#: lxc/auth.go:330 lxc/auth.go:766 lxc/auth.go:897 lxc/auth.go:1748
+#: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
@@ -7081,7 +7111,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1313
+#: lxc/auth.go:1462
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -7152,11 +7182,17 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:834 lxc/auth.go:1086
+#: lxc/auth.go:774
+msgid ""
+"[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
+"certificate>] [[--group <group_name>]]"
+msgstr ""
+
+#: lxc/auth.go:983 lxc/auth.go:1235
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1164 lxc/auth.go:1222 lxc/auth.go:1985
+#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:2134
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -7165,14 +7201,14 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr "Criar perfis"
 
-#: lxc/auth.go:97 lxc/auth.go:150 lxc/auth.go:200 lxc/auth.go:440
-#: lxc/auth.go:958 lxc/auth.go:1529 lxc/cluster_group.go:168
+#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:445
+#: lxc/auth.go:1107 lxc/auth.go:1678 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 #, fuzzy
 msgid "[<remote>:]<group>"
 msgstr "Criar perfis"
 
-#: lxc/auth.go:515 lxc/auth.go:573
+#: lxc/auth.go:520 lxc/auth.go:578
 #, fuzzy
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
@@ -7184,22 +7220,22 @@ msgstr "Criar perfis"
 msgid "[<remote>:]<group> <new-name>"
 msgstr "Criar perfis"
 
-#: lxc/auth.go:390
+#: lxc/auth.go:395
 #, fuzzy
 msgid "[<remote>:]<group> <new_name>"
 msgstr "Criar perfis"
 
-#: lxc/auth.go:1580 lxc/auth.go:1630 lxc/auth.go:1858
+#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group>"
 msgstr "Criar perfis"
 
-#: lxc/auth.go:1932
+#: lxc/auth.go:2081
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/auth.go:1808
+#: lxc/auth.go:1957
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr "Criar perfis"
@@ -7743,7 +7779,7 @@ msgstr "Criar perfis"
 msgid "[[<remote>:]<member>]"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/project.go:557 lxc/remote.go:806
+#: lxc/project.go:557 lxc/remote.go:840
 msgid "current"
 msgstr ""
 
@@ -7790,20 +7826,20 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/auth.go:204
+#: lxc/auth.go:209
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:962
+#: lxc/auth.go:1111
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1634
+#: lxc/auth.go:1783
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -8227,7 +8263,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:531
+#: lxc/remote.go:545
 msgid "n"
 msgstr ""
 
@@ -8239,7 +8275,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:510
+#: lxc/remote.go:524
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -8276,7 +8312,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:519
+#: lxc/remote.go:533
 msgid "y"
 msgstr ""
 

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-14 13:30+0000\n"
+"POT-Creation-Date: 2024-10-15 14:52+0100\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Александр Киль <shorrey@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -208,7 +208,7 @@ msgstr ""
 "###\n"
 "### Обратите внимание, что имя отображается, но не может быть изменено"
 
-#: lxc/auth.go:214
+#: lxc/auth.go:219
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -235,7 +235,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:972
+#: lxc/auth.go:1121
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -256,7 +256,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1644
+#: lxc/auth.go:1793
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
@@ -773,15 +773,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:917 lxc/remote.go:982
+#: lxc/remote.go:951 lxc/remote.go:1016
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1030
+#: lxc/remote.go:1064
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:836
+#: lxc/remote.go:870
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -819,11 +819,11 @@ msgstr "ПСЕВДОНИМ"
 msgid "ARCHITECTURE"
 msgstr "АРХИТЕКТУРА"
 
-#: lxc/remote.go:818
+#: lxc/remote.go:852
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:817
+#: lxc/auth.go:966
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -862,11 +862,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr "Копирование образа: %s"
 
-#: lxc/auth.go:1165 lxc/auth.go:1166
+#: lxc/auth.go:1314 lxc/auth.go:1315
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1933 lxc/auth.go:1934
+#: lxc/auth.go:2082 lxc/auth.go:2083
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -938,7 +938,7 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:516 lxc/auth.go:517
+#: lxc/auth.go:521 lxc/auth.go:522
 msgid "Add permissions to groups"
 msgstr ""
 
@@ -973,7 +973,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr "Пароль администратора для %s: "
 
-#: lxc/remote.go:648
+#: lxc/remote.go:680
 #, fuzzy, c-format
 msgid "Admin password (or token) for %s:"
 msgstr "Пароль администратора для %s: "
@@ -1085,7 +1085,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:621
+#: lxc/remote.go:635
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -1266,7 +1266,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr "Невозможно прочитать из стандартного ввода: %s"
 
-#: lxc/remote.go:961
+#: lxc/remote.go:995
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1332,7 +1332,7 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr " Использование сети:"
 
-#: lxc/remote.go:509
+#: lxc/remote.go:523
 #, fuzzy
 msgid "Certificate fingerprint"
 msgstr ""
@@ -1355,7 +1355,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr "Копирование образа: %s"
 
-#: lxc/remote.go:687
+#: lxc/remote.go:721
 #, fuzzy
 msgid "Client certificate now trusted by server:"
 msgstr "Сертификат клиента хранится на сервере: "
@@ -1606,12 +1606,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:559
+#: lxc/remote.go:573
 #, fuzzy, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "Не удалось создать каталог сертификата сервера"
 
-#: lxc/remote.go:237 lxc/remote.go:543
+#: lxc/remote.go:237 lxc/remote.go:557
 msgid "Could not create server cert dir"
 msgstr "Не удалось создать каталог сертификата сервера"
 
@@ -1625,12 +1625,12 @@ msgstr "Не удалось очистить путь %s"
 msgid "Could not find certificate key file path: %s"
 msgstr "Не удалось очистить путь %s"
 
-#: lxc/auth.go:301 lxc/auth.go:1719
+#: lxc/auth.go:306 lxc/auth.go:1868
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1058
+#: lxc/auth.go:1207
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1650,13 +1650,17 @@ msgstr "Не удалось очистить путь %s"
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:554
+#: lxc/remote.go:568
 #, fuzzy, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "Не удалось создать каталог сертификата сервера"
 
 #: lxc/network_zone.go:1536
 msgid "Couldn't find a matching entry"
+msgstr ""
+
+#: lxc/auth.go:776
+msgid "Create a TLS identity"
 msgstr ""
 
 #: lxc/cluster_group.go:169 lxc/cluster_group.go:170
@@ -1677,6 +1681,11 @@ msgstr ""
 msgid "Create an empty instance"
 msgstr "Невозможно добавить имя контейнера в список"
 
+#: lxc/auth.go:775
+#, fuzzy
+msgid "Create an identity"
+msgstr "Невозможно добавить имя контейнера в список"
+
 #: lxc/launch.go:23 lxc/launch.go:24
 msgid "Create and start instances from images"
 msgstr ""
@@ -1690,12 +1699,12 @@ msgstr ""
 msgid "Create files and directories in instances"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/auth.go:98 lxc/auth.go:99
+#: lxc/auth.go:103 lxc/auth.go:104
 #, fuzzy
 msgid "Create groups"
 msgstr "Копирование образа: %s"
 
-#: lxc/auth.go:1530 lxc/auth.go:1531
+#: lxc/auth.go:1679 lxc/auth.go:1680
 #, fuzzy
 msgid "Create identity provider groups"
 msgstr "Копирование образа: %s"
@@ -1818,7 +1827,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
@@ -1861,7 +1870,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/auth.go:1088 lxc/auth.go:1089
+#: lxc/auth.go:1237 lxc/auth.go:1238
 msgid "Delete an identity"
 msgstr ""
 
@@ -1870,12 +1879,12 @@ msgstr ""
 msgid "Delete files in instances"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/auth.go:152 lxc/auth.go:153
+#: lxc/auth.go:157 lxc/auth.go:158
 #, fuzzy
 msgid "Delete groups"
 msgstr "Копирование образа: %s"
 
-#: lxc/auth.go:1582 lxc/auth.go:1583
+#: lxc/auth.go:1731 lxc/auth.go:1732
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1961,18 +1970,18 @@ msgstr ""
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:31 lxc/auth.go:60 lxc/auth.go:99
-#: lxc/auth.go:153 lxc/auth.go:202 lxc/auth.go:333 lxc/auth.go:393
-#: lxc/auth.go:442 lxc/auth.go:494 lxc/auth.go:517 lxc/auth.go:576
-#: lxc/auth.go:732 lxc/auth.go:769 lxc/auth.go:836 lxc/auth.go:899
-#: lxc/auth.go:960 lxc/auth.go:1089 lxc/auth.go:1143 lxc/auth.go:1166
-#: lxc/auth.go:1224 lxc/auth.go:1293 lxc/auth.go:1315 lxc/auth.go:1493
-#: lxc/auth.go:1531 lxc/auth.go:1583 lxc/auth.go:1632 lxc/auth.go:1751
-#: lxc/auth.go:1811 lxc/auth.go:1860 lxc/auth.go:1911 lxc/auth.go:1934
-#: lxc/auth.go:1987 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215
-#: lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:484
-#: lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677 lxc/cluster.go:770
-#: lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
+#: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
+#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:338 lxc/auth.go:398
+#: lxc/auth.go:447 lxc/auth.go:499 lxc/auth.go:522 lxc/auth.go:581
+#: lxc/auth.go:737 lxc/auth.go:776 lxc/auth.go:918 lxc/auth.go:985
+#: lxc/auth.go:1048 lxc/auth.go:1109 lxc/auth.go:1238 lxc/auth.go:1292
+#: lxc/auth.go:1315 lxc/auth.go:1373 lxc/auth.go:1442 lxc/auth.go:1464
+#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
+#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
+#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
+#: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
+#: lxc/cluster.go:770 lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
 #: lxc/cluster.go:1175 lxc/cluster.go:1299 lxc/cluster.go:1329
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
@@ -2043,9 +2052,9 @@ msgstr ""
 #: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
 #: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
 #: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:715
-#: lxc/remote.go:753 lxc/remote.go:839 lxc/remote.go:920 lxc/remote.go:984
-#: lxc/remote.go:1032 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
+#: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
+#: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -2236,7 +2245,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:959 lxc/auth.go:960
+#: lxc/auth.go:1108 lxc/auth.go:1109
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -2248,11 +2257,11 @@ msgstr ""
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/auth.go:201 lxc/auth.go:202
+#: lxc/auth.go:206 lxc/auth.go:207
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1631 lxc/auth.go:1632
+#: lxc/auth.go:1780 lxc/auth.go:1781
 #, fuzzy
 msgid "Edit identity provider groups as YAML"
 msgstr "Копирование образа: %s"
@@ -2646,12 +2655,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr "Принять сертификат"
 
-#: lxc/remote.go:486
+#: lxc/remote.go:500
 #, fuzzy, c-format
 msgid "Failed to decode trust token: %w"
 msgstr "Копирование образа: %s"
 
-#: lxc/remote.go:292
+#: lxc/remote.go:306
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2756,7 +2765,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:773 lxc/auth.go:1755
+#: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
@@ -2764,7 +2773,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:757 lxc/storage.go:657
+#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2802,7 +2811,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:821
+#: lxc/remote.go:855
 msgid "GLOBAL"
 msgstr ""
 
@@ -2814,7 +2823,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:821 lxc/auth.go:1795
+#: lxc/auth.go:970 lxc/auth.go:1944
 msgid "GROUPS"
 msgstr ""
 
@@ -2822,7 +2831,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:165 lxc/remote.go:443
+#: lxc/remote.go:165 lxc/remote.go:457
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2979,17 +2988,17 @@ msgstr ""
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: lxc/auth.go:137
+#: lxc/auth.go:142
 #, fuzzy, c-format
 msgid "Group %s created"
 msgstr " Использование сети:"
 
-#: lxc/auth.go:187
+#: lxc/auth.go:192
 #, fuzzy, c-format
 msgid "Group %s deleted"
 msgstr " Использование сети:"
 
-#: lxc/auth.go:427 lxc/auth.go:1845
+#: lxc/auth.go:432 lxc/auth.go:1994
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -3049,7 +3058,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:820
+#: lxc/auth.go:969
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -3081,12 +3090,16 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1567
+#: lxc/auth.go:829
+msgid "Identity creation only supported for TLS identities"
+msgstr ""
+
+#: lxc/auth.go:1716
 #, fuzzy, c-format
 msgid "Identity provider group %s created"
 msgstr " Использование сети:"
 
-#: lxc/auth.go:1617
+#: lxc/auth.go:1766
 #, fuzzy, c-format
 msgid "Identity provider group %s deleted"
 msgstr " Использование сети:"
@@ -3219,7 +3232,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1292 lxc/auth.go:1293
+#: lxc/auth.go:1441 lxc/auth.go:1442
 msgid "Inspect permissions"
 msgstr ""
 
@@ -3270,7 +3283,7 @@ msgstr "Имя контейнера: %s"
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:395
+#: lxc/remote.go:409
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3352,7 +3365,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:384
+#: lxc/remote.go:398
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3536,16 +3549,16 @@ msgstr ""
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:332 lxc/auth.go:333
+#: lxc/auth.go:337 lxc/auth.go:338
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:768 lxc/auth.go:769
+#: lxc/auth.go:917 lxc/auth.go:918
 #, fuzzy
 msgid "List identities"
 msgstr "Псевдонимы:"
 
-#: lxc/auth.go:1750 lxc/auth.go:1751
+#: lxc/auth.go:1899 lxc/auth.go:1900
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3702,7 +3715,7 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr "Копирование образа: %s"
 
-#: lxc/auth.go:1314 lxc/auth.go:1315
+#: lxc/auth.go:1463 lxc/auth.go:1464
 #, fuzzy
 msgid "List permissions"
 msgstr "Псевдонимы:"
@@ -3750,7 +3763,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:752 lxc/remote.go:753
+#: lxc/remote.go:786 lxc/remote.go:787
 msgid "List the available remotes"
 msgstr ""
 
@@ -3877,6 +3890,12 @@ msgstr ""
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
+#: lxc/auth.go:825
+msgid ""
+"Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
+"got "
+msgstr ""
+
 #: lxc/network.go:32 lxc/network.go:33
 msgid "Manage and attach instances to networks"
 msgstr ""
@@ -3908,21 +3927,21 @@ msgstr "Копирование образа: %s"
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:59 lxc/auth.go:60 lxc/auth.go:1492 lxc/auth.go:1493
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
 #, fuzzy
 msgid "Manage groups"
 msgstr "Копирование образа: %s"
 
-#: lxc/auth.go:1142 lxc/auth.go:1143
+#: lxc/auth.go:1291 lxc/auth.go:1292
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:731 lxc/auth.go:732
+#: lxc/auth.go:736 lxc/auth.go:737
 #, fuzzy
 msgid "Manage identities"
 msgstr "Копирование образа: %s"
 
-#: lxc/auth.go:1910 lxc/auth.go:1911
+#: lxc/auth.go:2059 lxc/auth.go:2060
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -4026,7 +4045,7 @@ msgstr "Копирование образа: %s"
 msgid "Manage network zones"
 msgstr "Копирование образа: %s"
 
-#: lxc/auth.go:493 lxc/auth.go:494
+#: lxc/auth.go:498 lxc/auth.go:499
 #, fuzzy
 msgid "Manage permissions"
 msgstr "Копирование образа: %s"
@@ -4085,7 +4104,7 @@ msgstr ""
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/auth.go:30 lxc/auth.go:31
+#: lxc/auth.go:35 lxc/auth.go:36
 #, fuzzy
 msgid "Manage user authorization"
 msgstr "Копирование образа: %s"
@@ -4189,24 +4208,24 @@ msgstr "Копирование образа: %s"
 msgid "Missing cluster member name"
 msgstr "Копирование образа: %s"
 
-#: lxc/auth.go:123 lxc/auth.go:177 lxc/auth.go:255 lxc/auth.go:417
-#: lxc/auth.go:466 lxc/auth.go:541 lxc/auth.go:600 lxc/auth.go:1884
+#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:260 lxc/auth.go:422
+#: lxc/auth.go:471 lxc/auth.go:546 lxc/auth.go:605 lxc/auth.go:2033
 #, fuzzy
 msgid "Missing group name"
 msgstr "Копирование образа: %s"
 
-#: lxc/auth.go:866 lxc/auth.go:1007 lxc/auth.go:1124 lxc/auth.go:1190
-#: lxc/auth.go:1248
+#: lxc/auth.go:820 lxc/auth.go:1015 lxc/auth.go:1156 lxc/auth.go:1273
+#: lxc/auth.go:1339 lxc/auth.go:1397
 #, fuzzy
 msgid "Missing identity argument"
 msgstr "Имя контейнера: %s"
 
-#: lxc/auth.go:1554 lxc/auth.go:1607 lxc/auth.go:1673 lxc/auth.go:1835
+#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
 #, fuzzy
 msgid "Missing identity provider group name"
 msgstr "Копирование образа: %s"
 
-#: lxc/auth.go:1958 lxc/auth.go:2011
+#: lxc/auth.go:2107 lxc/auth.go:2160
 #, fuzzy
 msgid "Missing identity provider group name argument"
 msgstr "Копирование образа: %s"
@@ -4441,12 +4460,12 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:376 lxc/auth.go:819 lxc/auth.go:1794 lxc/cluster.go:192
+#: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
-#: lxc/remote.go:815 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
 msgstr ""
@@ -4473,7 +4492,7 @@ msgstr ""
 
 #: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:775 lxc/remote.go:780 lxc/remote.go:785
+#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr ""
 
@@ -4706,7 +4725,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:378
+#: lxc/remote.go:392
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4777,11 +4796,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:817
+#: lxc/remote.go:851
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:819
+#: lxc/image.go:1136 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4823,7 +4842,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr "Копирование образа: %s"
 
-#: lxc/remote.go:536
+#: lxc/remote.go:550
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
@@ -4840,7 +4859,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:302 lxc/auth.go:1059 lxc/auth.go:1720 lxc/cluster.go:860
+#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -5147,33 +5166,33 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Refreshing the image: %s"
 msgstr "Копирование образа: %s"
 
-#: lxc/remote.go:877
+#: lxc/remote.go:911
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:868 lxc/remote.go:949 lxc/remote.go:1013
-#: lxc/remote.go:1061
+#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/remote.go:1095
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:345
+#: lxc/remote.go:359
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:957
+#: lxc/remote.go:991
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:872 lxc/remote.go:953 lxc/remote.go:1065
+#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1099
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:319
+#: lxc/remote.go:333
 msgid "Remote address must not be empty"
 msgstr ""
 
@@ -5182,7 +5201,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr "Пароль администратора для %s: "
 
-#: lxc/remote.go:339
+#: lxc/remote.go:353
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -5205,7 +5224,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr "Копирование образа: %s"
 
-#: lxc/auth.go:1223 lxc/auth.go:1224
+#: lxc/auth.go:1372 lxc/auth.go:1373
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -5244,7 +5263,7 @@ msgstr "Копирование образа: %s"
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1986 lxc/auth.go:1987
+#: lxc/auth.go:2135 lxc/auth.go:2136
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -5257,7 +5276,7 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:575 lxc/auth.go:576
+#: lxc/auth.go:580 lxc/auth.go:581
 msgid "Remove permissions from groups"
 msgstr ""
 
@@ -5274,7 +5293,7 @@ msgstr "Копирование образа: %s"
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:919 lxc/remote.go:920
+#: lxc/remote.go:953 lxc/remote.go:954
 msgid "Remove remotes"
 msgstr ""
 
@@ -5304,12 +5323,12 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:392 lxc/auth.go:393
+#: lxc/auth.go:397 lxc/auth.go:398
 #, fuzzy
 msgid "Rename groups"
 msgstr "Копирование образа: %s"
 
-#: lxc/auth.go:1810 lxc/auth.go:1811
+#: lxc/auth.go:1959 lxc/auth.go:1960
 #, fuzzy
 msgid "Rename identity provider groups"
 msgstr "Копирование образа: %s"
@@ -5335,7 +5354,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:838 lxc/remote.go:839
+#: lxc/remote.go:872 lxc/remote.go:873
 msgid "Rename remotes"
 msgstr ""
 
@@ -5489,7 +5508,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:820
+#: lxc/remote.go:854
 msgid "STATIC"
 msgstr ""
 
@@ -5530,11 +5549,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:532
+#: lxc/remote.go:546
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:285 lxc/remote.go:683
+#: lxc/remote.go:299 lxc/remote.go:717
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5753,7 +5772,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1031 lxc/remote.go:1032
+#: lxc/remote.go:1065 lxc/remote.go:1066
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5857,7 +5876,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1859 lxc/auth.go:1860
+#: lxc/auth.go:2008 lxc/auth.go:2009
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5887,12 +5906,12 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:441 lxc/auth.go:442
+#: lxc/auth.go:446 lxc/auth.go:447
 #, fuzzy
 msgid "Show group configurations"
 msgstr "Копирование образа: %s"
 
-#: lxc/auth.go:836
+#: lxc/auth.go:985
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -6009,7 +6028,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr "Копирование образа: %s"
 
-#: lxc/auth.go:899
+#: lxc/auth.go:1048
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -6019,7 +6038,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:714 lxc/remote.go:715
+#: lxc/remote.go:748 lxc/remote.go:749
 msgid "Show the default remote"
 msgstr ""
 
@@ -6238,7 +6257,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:983 lxc/remote.go:984
+#: lxc/remote.go:1017 lxc/remote.go:1018
 msgid "Switch the default remote"
 msgstr ""
 
@@ -6250,11 +6269,21 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
+#: lxc/auth.go:876
+#, c-format
+msgid "TLS identity %q (%s) pending identity token:"
+msgstr ""
+
+#: lxc/auth.go:902
+#, c-format
+msgid "TLS identity %q created with fingerprint %q"
+msgstr ""
+
 #: lxc/cluster.go:1070 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:818 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
 #: lxc/storage_volume.go:1736 lxc/warning.go:216
@@ -6273,7 +6302,7 @@ msgstr ""
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/remote.go:161 lxc/remote.go:334
+#: lxc/remote.go:161 lxc/remote.go:348
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
@@ -6429,7 +6458,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:527
+#: lxc/remote.go:541
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
@@ -6568,15 +6597,15 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:329
+#: lxc/remote.go:343
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:324
+#: lxc/remote.go:338
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr ""
 
-#: lxc/remote.go:639
+#: lxc/remote.go:653
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6620,7 +6649,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:193 lxc/remote.go:816
+#: lxc/cluster.go:193 lxc/remote.go:850
 msgid "URL"
 msgstr ""
 
@@ -6950,11 +6979,11 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:835
+#: lxc/auth.go:984
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:898
+#: lxc/auth.go:1047
 msgid "View the current identity"
 msgstr ""
 
@@ -6993,7 +7022,7 @@ msgstr ""
 
 #: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:777 lxc/remote.go:782 lxc/remote.go:787
+#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr ""
 
@@ -7033,7 +7062,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/auth.go:330 lxc/auth.go:766 lxc/auth.go:897 lxc/auth.go:1748
+#: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
@@ -7094,7 +7123,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/auth.go:1313
+#: lxc/auth.go:1462
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -7211,11 +7240,17 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/auth.go:834 lxc/auth.go:1086
+#: lxc/auth.go:774
+msgid ""
+"[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
+"certificate>] [[--group <group_name>]]"
+msgstr ""
+
+#: lxc/auth.go:983 lxc/auth.go:1235
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1164 lxc/auth.go:1222 lxc/auth.go:1985
+#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:2134
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -7227,8 +7262,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/auth.go:97 lxc/auth.go:150 lxc/auth.go:200 lxc/auth.go:440
-#: lxc/auth.go:958 lxc/auth.go:1529 lxc/cluster_group.go:168
+#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:445
+#: lxc/auth.go:1107 lxc/auth.go:1678 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 #, fuzzy
 msgid "[<remote>:]<group>"
@@ -7237,7 +7272,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/auth.go:515 lxc/auth.go:573
+#: lxc/auth.go:520 lxc/auth.go:578
 #, fuzzy
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
@@ -7255,7 +7290,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/auth.go:390
+#: lxc/auth.go:395
 #, fuzzy
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
@@ -7263,7 +7298,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/auth.go:1580 lxc/auth.go:1630 lxc/auth.go:1858
+#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
@@ -7271,7 +7306,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/auth.go:1932
+#: lxc/auth.go:2081
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
@@ -7279,7 +7314,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/auth.go:1808
+#: lxc/auth.go:1957
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
@@ -8230,7 +8265,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/project.go:557 lxc/remote.go:806
+#: lxc/project.go:557 lxc/remote.go:840
 msgid "current"
 msgstr ""
 
@@ -8277,20 +8312,20 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/auth.go:204
+#: lxc/auth.go:209
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:962
+#: lxc/auth.go:1111
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1634
+#: lxc/auth.go:1783
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -8714,7 +8749,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:531
+#: lxc/remote.go:545
 msgid "n"
 msgstr ""
 
@@ -8726,7 +8761,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:510
+#: lxc/remote.go:524
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -8763,7 +8798,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:519
+#: lxc/remote.go:533
 msgid "y"
 msgstr ""
 

--- a/po/si.po
+++ b/po/si.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-14 13:30+0000\n"
+"POT-Creation-Date: 2024-10-15 14:52+0100\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Sinhala <https://hosted.weblate.org/projects/linux-containers/"
@@ -133,7 +133,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:214
+#: lxc/auth.go:219
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -160,7 +160,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:972
+#: lxc/auth.go:1121
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -181,7 +181,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1644
+#: lxc/auth.go:1793
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -515,15 +515,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:917 lxc/remote.go:982
+#: lxc/remote.go:951 lxc/remote.go:1016
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1030
+#: lxc/remote.go:1064
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:836
+#: lxc/remote.go:870
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -556,11 +556,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:818
+#: lxc/remote.go:852
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:817
+#: lxc/auth.go:966
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -598,11 +598,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1165 lxc/auth.go:1166
+#: lxc/auth.go:1314 lxc/auth.go:1315
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1933 lxc/auth.go:1934
+#: lxc/auth.go:2082 lxc/auth.go:2083
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -671,7 +671,7 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:516 lxc/auth.go:517
+#: lxc/auth.go:521 lxc/auth.go:522
 msgid "Add permissions to groups"
 msgstr ""
 
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:648
+#: lxc/remote.go:680
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -813,7 +813,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:621
+#: lxc/remote.go:635
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -991,7 +991,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:961
+#: lxc/remote.go:995
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1057,7 +1057,7 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:509
+#: lxc/remote.go:523
 msgid "Certificate fingerprint"
 msgstr ""
 
@@ -1076,7 +1076,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:687
+#: lxc/remote.go:721
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1324,12 +1324,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:559
+#: lxc/remote.go:573
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:237 lxc/remote.go:543
+#: lxc/remote.go:237 lxc/remote.go:557
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1343,12 +1343,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:1719
+#: lxc/auth.go:306 lxc/auth.go:1868
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1058
+#: lxc/auth.go:1207
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1368,13 +1368,17 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:554
+#: lxc/remote.go:568
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
 #: lxc/network_zone.go:1536
 msgid "Couldn't find a matching entry"
+msgstr ""
+
+#: lxc/auth.go:776
+msgid "Create a TLS identity"
 msgstr ""
 
 #: lxc/cluster_group.go:169 lxc/cluster_group.go:170
@@ -1393,6 +1397,10 @@ msgstr ""
 msgid "Create an empty instance"
 msgstr ""
 
+#: lxc/auth.go:775
+msgid "Create an identity"
+msgstr ""
+
 #: lxc/launch.go:23 lxc/launch.go:24
 msgid "Create and start instances from images"
 msgstr ""
@@ -1405,11 +1413,11 @@ msgstr ""
 msgid "Create files and directories in instances"
 msgstr ""
 
-#: lxc/auth.go:98 lxc/auth.go:99
+#: lxc/auth.go:103 lxc/auth.go:104
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1530 lxc/auth.go:1531
+#: lxc/auth.go:1679 lxc/auth.go:1680
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1517,7 +1525,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
@@ -1560,7 +1568,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/auth.go:1088 lxc/auth.go:1089
+#: lxc/auth.go:1237 lxc/auth.go:1238
 msgid "Delete an identity"
 msgstr ""
 
@@ -1568,11 +1576,11 @@ msgstr ""
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/auth.go:152 lxc/auth.go:153
+#: lxc/auth.go:157 lxc/auth.go:158
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1582 lxc/auth.go:1583
+#: lxc/auth.go:1731 lxc/auth.go:1732
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1650,18 +1658,18 @@ msgstr ""
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:31 lxc/auth.go:60 lxc/auth.go:99
-#: lxc/auth.go:153 lxc/auth.go:202 lxc/auth.go:333 lxc/auth.go:393
-#: lxc/auth.go:442 lxc/auth.go:494 lxc/auth.go:517 lxc/auth.go:576
-#: lxc/auth.go:732 lxc/auth.go:769 lxc/auth.go:836 lxc/auth.go:899
-#: lxc/auth.go:960 lxc/auth.go:1089 lxc/auth.go:1143 lxc/auth.go:1166
-#: lxc/auth.go:1224 lxc/auth.go:1293 lxc/auth.go:1315 lxc/auth.go:1493
-#: lxc/auth.go:1531 lxc/auth.go:1583 lxc/auth.go:1632 lxc/auth.go:1751
-#: lxc/auth.go:1811 lxc/auth.go:1860 lxc/auth.go:1911 lxc/auth.go:1934
-#: lxc/auth.go:1987 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215
-#: lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:484
-#: lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677 lxc/cluster.go:770
-#: lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
+#: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
+#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:338 lxc/auth.go:398
+#: lxc/auth.go:447 lxc/auth.go:499 lxc/auth.go:522 lxc/auth.go:581
+#: lxc/auth.go:737 lxc/auth.go:776 lxc/auth.go:918 lxc/auth.go:985
+#: lxc/auth.go:1048 lxc/auth.go:1109 lxc/auth.go:1238 lxc/auth.go:1292
+#: lxc/auth.go:1315 lxc/auth.go:1373 lxc/auth.go:1442 lxc/auth.go:1464
+#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
+#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
+#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
+#: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
+#: lxc/cluster.go:770 lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
 #: lxc/cluster.go:1175 lxc/cluster.go:1299 lxc/cluster.go:1329
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
@@ -1732,9 +1740,9 @@ msgstr ""
 #: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
 #: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
 #: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:715
-#: lxc/remote.go:753 lxc/remote.go:839 lxc/remote.go:920 lxc/remote.go:984
-#: lxc/remote.go:1032 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
+#: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
+#: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1919,7 +1927,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:959 lxc/auth.go:960
+#: lxc/auth.go:1108 lxc/auth.go:1109
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1931,11 +1939,11 @@ msgstr ""
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/auth.go:201 lxc/auth.go:202
+#: lxc/auth.go:206 lxc/auth.go:207
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1631 lxc/auth.go:1632
+#: lxc/auth.go:1780 lxc/auth.go:1781
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2311,12 +2319,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:486
+#: lxc/remote.go:500
 #, c-format
 msgid "Failed to decode trust token: %w"
 msgstr ""
 
-#: lxc/remote.go:292
+#: lxc/remote.go:306
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2420,7 +2428,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:773 lxc/auth.go:1755
+#: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
@@ -2428,7 +2436,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:757 lxc/storage.go:657
+#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2466,7 +2474,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:821
+#: lxc/remote.go:855
 msgid "GLOBAL"
 msgstr ""
 
@@ -2478,7 +2486,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:821 lxc/auth.go:1795
+#: lxc/auth.go:970 lxc/auth.go:1944
 msgid "GROUPS"
 msgstr ""
 
@@ -2486,7 +2494,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:165 lxc/remote.go:443
+#: lxc/remote.go:165 lxc/remote.go:457
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2627,17 +2635,17 @@ msgstr ""
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: lxc/auth.go:137
+#: lxc/auth.go:142
 #, c-format
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:187
+#: lxc/auth.go:192
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:427 lxc/auth.go:1845
+#: lxc/auth.go:432 lxc/auth.go:1994
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2696,7 +2704,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:820
+#: lxc/auth.go:969
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -2728,12 +2736,16 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1567
+#: lxc/auth.go:829
+msgid "Identity creation only supported for TLS identities"
+msgstr ""
+
+#: lxc/auth.go:1716
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1617
+#: lxc/auth.go:1766
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2862,7 +2874,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1292 lxc/auth.go:1293
+#: lxc/auth.go:1441 lxc/auth.go:1442
 msgid "Inspect permissions"
 msgstr ""
 
@@ -2910,7 +2922,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:395
+#: lxc/remote.go:409
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2991,7 +3003,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:384
+#: lxc/remote.go:398
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3166,15 +3178,15 @@ msgstr ""
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:332 lxc/auth.go:333
+#: lxc/auth.go:337 lxc/auth.go:338
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:768 lxc/auth.go:769
+#: lxc/auth.go:917 lxc/auth.go:918
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1750 lxc/auth.go:1751
+#: lxc/auth.go:1899 lxc/auth.go:1900
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3327,7 +3339,7 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1314 lxc/auth.go:1315
+#: lxc/auth.go:1463 lxc/auth.go:1464
 msgid "List permissions"
 msgstr ""
 
@@ -3371,7 +3383,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:752 lxc/remote.go:753
+#: lxc/remote.go:786 lxc/remote.go:787
 msgid "List the available remotes"
 msgstr ""
 
@@ -3495,6 +3507,12 @@ msgstr ""
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
+#: lxc/auth.go:825
+msgid ""
+"Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
+"got "
+msgstr ""
+
 #: lxc/network.go:32 lxc/network.go:33
 msgid "Manage and attach instances to networks"
 msgstr ""
@@ -3523,19 +3541,19 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:59 lxc/auth.go:60 lxc/auth.go:1492 lxc/auth.go:1493
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1142 lxc/auth.go:1143
+#: lxc/auth.go:1291 lxc/auth.go:1292
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:731 lxc/auth.go:732
+#: lxc/auth.go:736 lxc/auth.go:737
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1910 lxc/auth.go:1911
+#: lxc/auth.go:2059 lxc/auth.go:2060
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3626,7 +3644,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:493 lxc/auth.go:494
+#: lxc/auth.go:498 lxc/auth.go:499
 msgid "Manage permissions"
 msgstr ""
 
@@ -3678,7 +3696,7 @@ msgstr ""
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/auth.go:30 lxc/auth.go:31
+#: lxc/auth.go:35 lxc/auth.go:36
 msgid "Manage user authorization"
 msgstr ""
 
@@ -3775,21 +3793,21 @@ msgstr ""
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:123 lxc/auth.go:177 lxc/auth.go:255 lxc/auth.go:417
-#: lxc/auth.go:466 lxc/auth.go:541 lxc/auth.go:600 lxc/auth.go:1884
+#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:260 lxc/auth.go:422
+#: lxc/auth.go:471 lxc/auth.go:546 lxc/auth.go:605 lxc/auth.go:2033
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:866 lxc/auth.go:1007 lxc/auth.go:1124 lxc/auth.go:1190
-#: lxc/auth.go:1248
+#: lxc/auth.go:820 lxc/auth.go:1015 lxc/auth.go:1156 lxc/auth.go:1273
+#: lxc/auth.go:1339 lxc/auth.go:1397
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1554 lxc/auth.go:1607 lxc/auth.go:1673 lxc/auth.go:1835
+#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1958 lxc/auth.go:2011
+#: lxc/auth.go:2107 lxc/auth.go:2160
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -4010,12 +4028,12 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:376 lxc/auth.go:819 lxc/auth.go:1794 lxc/cluster.go:192
+#: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
-#: lxc/remote.go:815 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
 msgstr ""
@@ -4042,7 +4060,7 @@ msgstr ""
 
 #: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:775 lxc/remote.go:780 lxc/remote.go:785
+#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr ""
 
@@ -4271,7 +4289,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:378
+#: lxc/remote.go:392
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4342,11 +4360,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:817
+#: lxc/remote.go:851
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:819
+#: lxc/image.go:1136 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4387,7 +4405,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:536
+#: lxc/remote.go:550
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
@@ -4404,7 +4422,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:302 lxc/auth.go:1059 lxc/auth.go:1720 lxc/cluster.go:860
+#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -4707,33 +4725,33 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:877
+#: lxc/remote.go:911
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:868 lxc/remote.go:949 lxc/remote.go:1013
-#: lxc/remote.go:1061
+#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/remote.go:1095
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:345
+#: lxc/remote.go:359
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:957
+#: lxc/remote.go:991
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:872 lxc/remote.go:953 lxc/remote.go:1065
+#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1099
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:319
+#: lxc/remote.go:333
 msgid "Remote address must not be empty"
 msgstr ""
 
@@ -4741,7 +4759,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:339
+#: lxc/remote.go:353
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4763,7 +4781,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1223 lxc/auth.go:1224
+#: lxc/auth.go:1372 lxc/auth.go:1373
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4799,7 +4817,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1986 lxc/auth.go:1987
+#: lxc/auth.go:2135 lxc/auth.go:2136
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4811,7 +4829,7 @@ msgstr ""
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:575 lxc/auth.go:576
+#: lxc/auth.go:580 lxc/auth.go:581
 msgid "Remove permissions from groups"
 msgstr ""
 
@@ -4827,7 +4845,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:919 lxc/remote.go:920
+#: lxc/remote.go:953 lxc/remote.go:954
 msgid "Remove remotes"
 msgstr ""
 
@@ -4856,11 +4874,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:392 lxc/auth.go:393
+#: lxc/auth.go:397 lxc/auth.go:398
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1810 lxc/auth.go:1811
+#: lxc/auth.go:1959 lxc/auth.go:1960
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -4884,7 +4902,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:838 lxc/remote.go:839
+#: lxc/remote.go:872 lxc/remote.go:873
 msgid "Rename remotes"
 msgstr ""
 
@@ -5029,7 +5047,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:820
+#: lxc/remote.go:854
 msgid "STATIC"
 msgstr ""
 
@@ -5070,11 +5088,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:532
+#: lxc/remote.go:546
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:285 lxc/remote.go:683
+#: lxc/remote.go:299 lxc/remote.go:717
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5285,7 +5303,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1031 lxc/remote.go:1032
+#: lxc/remote.go:1065 lxc/remote.go:1066
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5381,7 +5399,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1859 lxc/auth.go:1860
+#: lxc/auth.go:2008 lxc/auth.go:2009
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5409,11 +5427,11 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:441 lxc/auth.go:442
+#: lxc/auth.go:446 lxc/auth.go:447
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:836
+#: lxc/auth.go:985
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5518,7 +5536,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:899
+#: lxc/auth.go:1048
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5528,7 +5546,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:714 lxc/remote.go:715
+#: lxc/remote.go:748 lxc/remote.go:749
 msgid "Show the default remote"
 msgstr ""
 
@@ -5740,7 +5758,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:983 lxc/remote.go:984
+#: lxc/remote.go:1017 lxc/remote.go:1018
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5752,11 +5770,21 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
+#: lxc/auth.go:876
+#, c-format
+msgid "TLS identity %q (%s) pending identity token:"
+msgstr ""
+
+#: lxc/auth.go:902
+#, c-format
+msgid "TLS identity %q created with fingerprint %q"
+msgstr ""
+
 #: lxc/cluster.go:1070 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:818 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
 #: lxc/storage_volume.go:1736 lxc/warning.go:216
@@ -5775,7 +5803,7 @@ msgstr ""
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/remote.go:161 lxc/remote.go:334
+#: lxc/remote.go:161 lxc/remote.go:348
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
@@ -5931,7 +5959,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:527
+#: lxc/remote.go:541
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
@@ -6069,15 +6097,15 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:329
+#: lxc/remote.go:343
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:324
+#: lxc/remote.go:338
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr ""
 
-#: lxc/remote.go:639
+#: lxc/remote.go:653
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6120,7 +6148,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:193 lxc/remote.go:816
+#: lxc/cluster.go:193 lxc/remote.go:850
 msgid "URL"
 msgstr ""
 
@@ -6428,11 +6456,11 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:835
+#: lxc/auth.go:984
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:898
+#: lxc/auth.go:1047
 msgid "View the current identity"
 msgstr ""
 
@@ -6471,7 +6499,7 @@ msgstr ""
 
 #: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:777 lxc/remote.go:782 lxc/remote.go:787
+#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr ""
 
@@ -6503,7 +6531,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:330 lxc/auth.go:766 lxc/auth.go:897 lxc/auth.go:1748
+#: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
@@ -6536,7 +6564,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1313
+#: lxc/auth.go:1462
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6597,11 +6625,17 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:834 lxc/auth.go:1086
+#: lxc/auth.go:774
+msgid ""
+"[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
+"certificate>] [[--group <group_name>]]"
+msgstr ""
+
+#: lxc/auth.go:983 lxc/auth.go:1235
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1164 lxc/auth.go:1222 lxc/auth.go:1985
+#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:2134
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6609,13 +6643,13 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:97 lxc/auth.go:150 lxc/auth.go:200 lxc/auth.go:440
-#: lxc/auth.go:958 lxc/auth.go:1529 lxc/cluster_group.go:168
+#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:445
+#: lxc/auth.go:1107 lxc/auth.go:1678 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:515 lxc/auth.go:573
+#: lxc/auth.go:520 lxc/auth.go:578
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
@@ -6625,19 +6659,19 @@ msgstr ""
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:390
+#: lxc/auth.go:395
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1580 lxc/auth.go:1630 lxc/auth.go:1858
+#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1932
+#: lxc/auth.go:2081
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1808
+#: lxc/auth.go:1957
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -7128,7 +7162,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:806
+#: lxc/project.go:557 lxc/remote.go:840
 msgid "current"
 msgstr ""
 
@@ -7175,20 +7209,20 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/auth.go:204
+#: lxc/auth.go:209
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:962
+#: lxc/auth.go:1111
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1634
+#: lxc/auth.go:1783
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7612,7 +7646,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:531
+#: lxc/remote.go:545
 msgid "n"
 msgstr ""
 
@@ -7624,7 +7658,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:510
+#: lxc/remote.go:524
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7661,7 +7695,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:519
+#: lxc/remote.go:533
 msgid "y"
 msgstr ""
 

--- a/po/sl.po
+++ b/po/sl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-14 13:30+0000\n"
+"POT-Creation-Date: 2024-10-15 14:52+0100\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Slovenian <https://hosted.weblate.org/projects/linux-"
@@ -134,7 +134,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:214
+#: lxc/auth.go:219
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -161,7 +161,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:972
+#: lxc/auth.go:1121
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -182,7 +182,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1644
+#: lxc/auth.go:1793
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -516,15 +516,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:917 lxc/remote.go:982
+#: lxc/remote.go:951 lxc/remote.go:1016
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1030
+#: lxc/remote.go:1064
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:836
+#: lxc/remote.go:870
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -557,11 +557,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:818
+#: lxc/remote.go:852
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:817
+#: lxc/auth.go:966
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -599,11 +599,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1165 lxc/auth.go:1166
+#: lxc/auth.go:1314 lxc/auth.go:1315
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1933 lxc/auth.go:1934
+#: lxc/auth.go:2082 lxc/auth.go:2083
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -672,7 +672,7 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:516 lxc/auth.go:517
+#: lxc/auth.go:521 lxc/auth.go:522
 msgid "Add permissions to groups"
 msgstr ""
 
@@ -706,7 +706,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:648
+#: lxc/remote.go:680
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -814,7 +814,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:621
+#: lxc/remote.go:635
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -992,7 +992,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:961
+#: lxc/remote.go:995
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1058,7 +1058,7 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:509
+#: lxc/remote.go:523
 msgid "Certificate fingerprint"
 msgstr ""
 
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:687
+#: lxc/remote.go:721
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1325,12 +1325,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:559
+#: lxc/remote.go:573
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:237 lxc/remote.go:543
+#: lxc/remote.go:237 lxc/remote.go:557
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1344,12 +1344,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:1719
+#: lxc/auth.go:306 lxc/auth.go:1868
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1058
+#: lxc/auth.go:1207
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1369,13 +1369,17 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:554
+#: lxc/remote.go:568
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
 #: lxc/network_zone.go:1536
 msgid "Couldn't find a matching entry"
+msgstr ""
+
+#: lxc/auth.go:776
+msgid "Create a TLS identity"
 msgstr ""
 
 #: lxc/cluster_group.go:169 lxc/cluster_group.go:170
@@ -1394,6 +1398,10 @@ msgstr ""
 msgid "Create an empty instance"
 msgstr ""
 
+#: lxc/auth.go:775
+msgid "Create an identity"
+msgstr ""
+
 #: lxc/launch.go:23 lxc/launch.go:24
 msgid "Create and start instances from images"
 msgstr ""
@@ -1406,11 +1414,11 @@ msgstr ""
 msgid "Create files and directories in instances"
 msgstr ""
 
-#: lxc/auth.go:98 lxc/auth.go:99
+#: lxc/auth.go:103 lxc/auth.go:104
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1530 lxc/auth.go:1531
+#: lxc/auth.go:1679 lxc/auth.go:1680
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1518,7 +1526,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
@@ -1561,7 +1569,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/auth.go:1088 lxc/auth.go:1089
+#: lxc/auth.go:1237 lxc/auth.go:1238
 msgid "Delete an identity"
 msgstr ""
 
@@ -1569,11 +1577,11 @@ msgstr ""
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/auth.go:152 lxc/auth.go:153
+#: lxc/auth.go:157 lxc/auth.go:158
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1582 lxc/auth.go:1583
+#: lxc/auth.go:1731 lxc/auth.go:1732
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1651,18 +1659,18 @@ msgstr ""
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:31 lxc/auth.go:60 lxc/auth.go:99
-#: lxc/auth.go:153 lxc/auth.go:202 lxc/auth.go:333 lxc/auth.go:393
-#: lxc/auth.go:442 lxc/auth.go:494 lxc/auth.go:517 lxc/auth.go:576
-#: lxc/auth.go:732 lxc/auth.go:769 lxc/auth.go:836 lxc/auth.go:899
-#: lxc/auth.go:960 lxc/auth.go:1089 lxc/auth.go:1143 lxc/auth.go:1166
-#: lxc/auth.go:1224 lxc/auth.go:1293 lxc/auth.go:1315 lxc/auth.go:1493
-#: lxc/auth.go:1531 lxc/auth.go:1583 lxc/auth.go:1632 lxc/auth.go:1751
-#: lxc/auth.go:1811 lxc/auth.go:1860 lxc/auth.go:1911 lxc/auth.go:1934
-#: lxc/auth.go:1987 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215
-#: lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:484
-#: lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677 lxc/cluster.go:770
-#: lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
+#: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
+#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:338 lxc/auth.go:398
+#: lxc/auth.go:447 lxc/auth.go:499 lxc/auth.go:522 lxc/auth.go:581
+#: lxc/auth.go:737 lxc/auth.go:776 lxc/auth.go:918 lxc/auth.go:985
+#: lxc/auth.go:1048 lxc/auth.go:1109 lxc/auth.go:1238 lxc/auth.go:1292
+#: lxc/auth.go:1315 lxc/auth.go:1373 lxc/auth.go:1442 lxc/auth.go:1464
+#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
+#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
+#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
+#: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
+#: lxc/cluster.go:770 lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
 #: lxc/cluster.go:1175 lxc/cluster.go:1299 lxc/cluster.go:1329
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
@@ -1733,9 +1741,9 @@ msgstr ""
 #: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
 #: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
 #: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:715
-#: lxc/remote.go:753 lxc/remote.go:839 lxc/remote.go:920 lxc/remote.go:984
-#: lxc/remote.go:1032 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
+#: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
+#: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1920,7 +1928,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:959 lxc/auth.go:960
+#: lxc/auth.go:1108 lxc/auth.go:1109
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1932,11 +1940,11 @@ msgstr ""
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/auth.go:201 lxc/auth.go:202
+#: lxc/auth.go:206 lxc/auth.go:207
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1631 lxc/auth.go:1632
+#: lxc/auth.go:1780 lxc/auth.go:1781
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2312,12 +2320,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:486
+#: lxc/remote.go:500
 #, c-format
 msgid "Failed to decode trust token: %w"
 msgstr ""
 
-#: lxc/remote.go:292
+#: lxc/remote.go:306
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2421,7 +2429,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:773 lxc/auth.go:1755
+#: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
@@ -2429,7 +2437,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:757 lxc/storage.go:657
+#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2467,7 +2475,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:821
+#: lxc/remote.go:855
 msgid "GLOBAL"
 msgstr ""
 
@@ -2479,7 +2487,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:821 lxc/auth.go:1795
+#: lxc/auth.go:970 lxc/auth.go:1944
 msgid "GROUPS"
 msgstr ""
 
@@ -2487,7 +2495,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:165 lxc/remote.go:443
+#: lxc/remote.go:165 lxc/remote.go:457
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2628,17 +2636,17 @@ msgstr ""
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: lxc/auth.go:137
+#: lxc/auth.go:142
 #, c-format
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:187
+#: lxc/auth.go:192
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:427 lxc/auth.go:1845
+#: lxc/auth.go:432 lxc/auth.go:1994
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2697,7 +2705,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:820
+#: lxc/auth.go:969
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -2729,12 +2737,16 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1567
+#: lxc/auth.go:829
+msgid "Identity creation only supported for TLS identities"
+msgstr ""
+
+#: lxc/auth.go:1716
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1617
+#: lxc/auth.go:1766
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2863,7 +2875,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1292 lxc/auth.go:1293
+#: lxc/auth.go:1441 lxc/auth.go:1442
 msgid "Inspect permissions"
 msgstr ""
 
@@ -2911,7 +2923,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:395
+#: lxc/remote.go:409
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2992,7 +3004,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:384
+#: lxc/remote.go:398
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3167,15 +3179,15 @@ msgstr ""
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:332 lxc/auth.go:333
+#: lxc/auth.go:337 lxc/auth.go:338
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:768 lxc/auth.go:769
+#: lxc/auth.go:917 lxc/auth.go:918
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1750 lxc/auth.go:1751
+#: lxc/auth.go:1899 lxc/auth.go:1900
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3328,7 +3340,7 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1314 lxc/auth.go:1315
+#: lxc/auth.go:1463 lxc/auth.go:1464
 msgid "List permissions"
 msgstr ""
 
@@ -3372,7 +3384,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:752 lxc/remote.go:753
+#: lxc/remote.go:786 lxc/remote.go:787
 msgid "List the available remotes"
 msgstr ""
 
@@ -3496,6 +3508,12 @@ msgstr ""
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
+#: lxc/auth.go:825
+msgid ""
+"Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
+"got "
+msgstr ""
+
 #: lxc/network.go:32 lxc/network.go:33
 msgid "Manage and attach instances to networks"
 msgstr ""
@@ -3524,19 +3542,19 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:59 lxc/auth.go:60 lxc/auth.go:1492 lxc/auth.go:1493
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1142 lxc/auth.go:1143
+#: lxc/auth.go:1291 lxc/auth.go:1292
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:731 lxc/auth.go:732
+#: lxc/auth.go:736 lxc/auth.go:737
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1910 lxc/auth.go:1911
+#: lxc/auth.go:2059 lxc/auth.go:2060
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3627,7 +3645,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:493 lxc/auth.go:494
+#: lxc/auth.go:498 lxc/auth.go:499
 msgid "Manage permissions"
 msgstr ""
 
@@ -3679,7 +3697,7 @@ msgstr ""
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/auth.go:30 lxc/auth.go:31
+#: lxc/auth.go:35 lxc/auth.go:36
 msgid "Manage user authorization"
 msgstr ""
 
@@ -3776,21 +3794,21 @@ msgstr ""
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:123 lxc/auth.go:177 lxc/auth.go:255 lxc/auth.go:417
-#: lxc/auth.go:466 lxc/auth.go:541 lxc/auth.go:600 lxc/auth.go:1884
+#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:260 lxc/auth.go:422
+#: lxc/auth.go:471 lxc/auth.go:546 lxc/auth.go:605 lxc/auth.go:2033
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:866 lxc/auth.go:1007 lxc/auth.go:1124 lxc/auth.go:1190
-#: lxc/auth.go:1248
+#: lxc/auth.go:820 lxc/auth.go:1015 lxc/auth.go:1156 lxc/auth.go:1273
+#: lxc/auth.go:1339 lxc/auth.go:1397
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1554 lxc/auth.go:1607 lxc/auth.go:1673 lxc/auth.go:1835
+#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1958 lxc/auth.go:2011
+#: lxc/auth.go:2107 lxc/auth.go:2160
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -4011,12 +4029,12 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:376 lxc/auth.go:819 lxc/auth.go:1794 lxc/cluster.go:192
+#: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
-#: lxc/remote.go:815 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
 msgstr ""
@@ -4043,7 +4061,7 @@ msgstr ""
 
 #: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:775 lxc/remote.go:780 lxc/remote.go:785
+#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr ""
 
@@ -4272,7 +4290,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:378
+#: lxc/remote.go:392
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4343,11 +4361,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:817
+#: lxc/remote.go:851
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:819
+#: lxc/image.go:1136 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4388,7 +4406,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:536
+#: lxc/remote.go:550
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
@@ -4405,7 +4423,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:302 lxc/auth.go:1059 lxc/auth.go:1720 lxc/cluster.go:860
+#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -4708,33 +4726,33 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:877
+#: lxc/remote.go:911
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:868 lxc/remote.go:949 lxc/remote.go:1013
-#: lxc/remote.go:1061
+#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/remote.go:1095
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:345
+#: lxc/remote.go:359
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:957
+#: lxc/remote.go:991
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:872 lxc/remote.go:953 lxc/remote.go:1065
+#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1099
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:319
+#: lxc/remote.go:333
 msgid "Remote address must not be empty"
 msgstr ""
 
@@ -4742,7 +4760,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:339
+#: lxc/remote.go:353
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4764,7 +4782,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1223 lxc/auth.go:1224
+#: lxc/auth.go:1372 lxc/auth.go:1373
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4800,7 +4818,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1986 lxc/auth.go:1987
+#: lxc/auth.go:2135 lxc/auth.go:2136
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4812,7 +4830,7 @@ msgstr ""
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:575 lxc/auth.go:576
+#: lxc/auth.go:580 lxc/auth.go:581
 msgid "Remove permissions from groups"
 msgstr ""
 
@@ -4828,7 +4846,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:919 lxc/remote.go:920
+#: lxc/remote.go:953 lxc/remote.go:954
 msgid "Remove remotes"
 msgstr ""
 
@@ -4857,11 +4875,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:392 lxc/auth.go:393
+#: lxc/auth.go:397 lxc/auth.go:398
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1810 lxc/auth.go:1811
+#: lxc/auth.go:1959 lxc/auth.go:1960
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -4885,7 +4903,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:838 lxc/remote.go:839
+#: lxc/remote.go:872 lxc/remote.go:873
 msgid "Rename remotes"
 msgstr ""
 
@@ -5030,7 +5048,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:820
+#: lxc/remote.go:854
 msgid "STATIC"
 msgstr ""
 
@@ -5071,11 +5089,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:532
+#: lxc/remote.go:546
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:285 lxc/remote.go:683
+#: lxc/remote.go:299 lxc/remote.go:717
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5286,7 +5304,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1031 lxc/remote.go:1032
+#: lxc/remote.go:1065 lxc/remote.go:1066
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5382,7 +5400,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1859 lxc/auth.go:1860
+#: lxc/auth.go:2008 lxc/auth.go:2009
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5410,11 +5428,11 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:441 lxc/auth.go:442
+#: lxc/auth.go:446 lxc/auth.go:447
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:836
+#: lxc/auth.go:985
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5519,7 +5537,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:899
+#: lxc/auth.go:1048
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5529,7 +5547,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:714 lxc/remote.go:715
+#: lxc/remote.go:748 lxc/remote.go:749
 msgid "Show the default remote"
 msgstr ""
 
@@ -5741,7 +5759,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:983 lxc/remote.go:984
+#: lxc/remote.go:1017 lxc/remote.go:1018
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5753,11 +5771,21 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
+#: lxc/auth.go:876
+#, c-format
+msgid "TLS identity %q (%s) pending identity token:"
+msgstr ""
+
+#: lxc/auth.go:902
+#, c-format
+msgid "TLS identity %q created with fingerprint %q"
+msgstr ""
+
 #: lxc/cluster.go:1070 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:818 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
 #: lxc/storage_volume.go:1736 lxc/warning.go:216
@@ -5776,7 +5804,7 @@ msgstr ""
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/remote.go:161 lxc/remote.go:334
+#: lxc/remote.go:161 lxc/remote.go:348
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
@@ -5932,7 +5960,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:527
+#: lxc/remote.go:541
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
@@ -6070,15 +6098,15 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:329
+#: lxc/remote.go:343
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:324
+#: lxc/remote.go:338
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr ""
 
-#: lxc/remote.go:639
+#: lxc/remote.go:653
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6121,7 +6149,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:193 lxc/remote.go:816
+#: lxc/cluster.go:193 lxc/remote.go:850
 msgid "URL"
 msgstr ""
 
@@ -6429,11 +6457,11 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:835
+#: lxc/auth.go:984
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:898
+#: lxc/auth.go:1047
 msgid "View the current identity"
 msgstr ""
 
@@ -6472,7 +6500,7 @@ msgstr ""
 
 #: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:777 lxc/remote.go:782 lxc/remote.go:787
+#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr ""
 
@@ -6504,7 +6532,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:330 lxc/auth.go:766 lxc/auth.go:897 lxc/auth.go:1748
+#: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
@@ -6537,7 +6565,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1313
+#: lxc/auth.go:1462
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6598,11 +6626,17 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:834 lxc/auth.go:1086
+#: lxc/auth.go:774
+msgid ""
+"[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
+"certificate>] [[--group <group_name>]]"
+msgstr ""
+
+#: lxc/auth.go:983 lxc/auth.go:1235
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1164 lxc/auth.go:1222 lxc/auth.go:1985
+#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:2134
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6610,13 +6644,13 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:97 lxc/auth.go:150 lxc/auth.go:200 lxc/auth.go:440
-#: lxc/auth.go:958 lxc/auth.go:1529 lxc/cluster_group.go:168
+#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:445
+#: lxc/auth.go:1107 lxc/auth.go:1678 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:515 lxc/auth.go:573
+#: lxc/auth.go:520 lxc/auth.go:578
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
@@ -6626,19 +6660,19 @@ msgstr ""
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:390
+#: lxc/auth.go:395
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1580 lxc/auth.go:1630 lxc/auth.go:1858
+#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1932
+#: lxc/auth.go:2081
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1808
+#: lxc/auth.go:1957
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -7129,7 +7163,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:806
+#: lxc/project.go:557 lxc/remote.go:840
 msgid "current"
 msgstr ""
 
@@ -7176,20 +7210,20 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/auth.go:204
+#: lxc/auth.go:209
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:962
+#: lxc/auth.go:1111
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1634
+#: lxc/auth.go:1783
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7613,7 +7647,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:531
+#: lxc/remote.go:545
 msgid "n"
 msgstr ""
 
@@ -7625,7 +7659,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:510
+#: lxc/remote.go:524
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7662,7 +7696,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:519
+#: lxc/remote.go:533
 msgid "y"
 msgstr ""
 

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-14 13:30+0000\n"
+"POT-Creation-Date: 2024-10-15 14:52+0100\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Serbian <https://hosted.weblate.org/projects/linux-containers/"
@@ -134,7 +134,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:214
+#: lxc/auth.go:219
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -161,7 +161,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:972
+#: lxc/auth.go:1121
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -182,7 +182,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1644
+#: lxc/auth.go:1793
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -516,15 +516,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:917 lxc/remote.go:982
+#: lxc/remote.go:951 lxc/remote.go:1016
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1030
+#: lxc/remote.go:1064
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:836
+#: lxc/remote.go:870
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -557,11 +557,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:818
+#: lxc/remote.go:852
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:817
+#: lxc/auth.go:966
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -599,11 +599,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1165 lxc/auth.go:1166
+#: lxc/auth.go:1314 lxc/auth.go:1315
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1933 lxc/auth.go:1934
+#: lxc/auth.go:2082 lxc/auth.go:2083
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -672,7 +672,7 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:516 lxc/auth.go:517
+#: lxc/auth.go:521 lxc/auth.go:522
 msgid "Add permissions to groups"
 msgstr ""
 
@@ -706,7 +706,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:648
+#: lxc/remote.go:680
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -814,7 +814,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:621
+#: lxc/remote.go:635
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -992,7 +992,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:961
+#: lxc/remote.go:995
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1058,7 +1058,7 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:509
+#: lxc/remote.go:523
 msgid "Certificate fingerprint"
 msgstr ""
 
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:687
+#: lxc/remote.go:721
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1325,12 +1325,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:559
+#: lxc/remote.go:573
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:237 lxc/remote.go:543
+#: lxc/remote.go:237 lxc/remote.go:557
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1344,12 +1344,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:1719
+#: lxc/auth.go:306 lxc/auth.go:1868
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1058
+#: lxc/auth.go:1207
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1369,13 +1369,17 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:554
+#: lxc/remote.go:568
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
 #: lxc/network_zone.go:1536
 msgid "Couldn't find a matching entry"
+msgstr ""
+
+#: lxc/auth.go:776
+msgid "Create a TLS identity"
 msgstr ""
 
 #: lxc/cluster_group.go:169 lxc/cluster_group.go:170
@@ -1394,6 +1398,10 @@ msgstr ""
 msgid "Create an empty instance"
 msgstr ""
 
+#: lxc/auth.go:775
+msgid "Create an identity"
+msgstr ""
+
 #: lxc/launch.go:23 lxc/launch.go:24
 msgid "Create and start instances from images"
 msgstr ""
@@ -1406,11 +1414,11 @@ msgstr ""
 msgid "Create files and directories in instances"
 msgstr ""
 
-#: lxc/auth.go:98 lxc/auth.go:99
+#: lxc/auth.go:103 lxc/auth.go:104
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1530 lxc/auth.go:1531
+#: lxc/auth.go:1679 lxc/auth.go:1680
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1518,7 +1526,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
@@ -1561,7 +1569,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/auth.go:1088 lxc/auth.go:1089
+#: lxc/auth.go:1237 lxc/auth.go:1238
 msgid "Delete an identity"
 msgstr ""
 
@@ -1569,11 +1577,11 @@ msgstr ""
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/auth.go:152 lxc/auth.go:153
+#: lxc/auth.go:157 lxc/auth.go:158
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1582 lxc/auth.go:1583
+#: lxc/auth.go:1731 lxc/auth.go:1732
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1651,18 +1659,18 @@ msgstr ""
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:31 lxc/auth.go:60 lxc/auth.go:99
-#: lxc/auth.go:153 lxc/auth.go:202 lxc/auth.go:333 lxc/auth.go:393
-#: lxc/auth.go:442 lxc/auth.go:494 lxc/auth.go:517 lxc/auth.go:576
-#: lxc/auth.go:732 lxc/auth.go:769 lxc/auth.go:836 lxc/auth.go:899
-#: lxc/auth.go:960 lxc/auth.go:1089 lxc/auth.go:1143 lxc/auth.go:1166
-#: lxc/auth.go:1224 lxc/auth.go:1293 lxc/auth.go:1315 lxc/auth.go:1493
-#: lxc/auth.go:1531 lxc/auth.go:1583 lxc/auth.go:1632 lxc/auth.go:1751
-#: lxc/auth.go:1811 lxc/auth.go:1860 lxc/auth.go:1911 lxc/auth.go:1934
-#: lxc/auth.go:1987 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215
-#: lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:484
-#: lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677 lxc/cluster.go:770
-#: lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
+#: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
+#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:338 lxc/auth.go:398
+#: lxc/auth.go:447 lxc/auth.go:499 lxc/auth.go:522 lxc/auth.go:581
+#: lxc/auth.go:737 lxc/auth.go:776 lxc/auth.go:918 lxc/auth.go:985
+#: lxc/auth.go:1048 lxc/auth.go:1109 lxc/auth.go:1238 lxc/auth.go:1292
+#: lxc/auth.go:1315 lxc/auth.go:1373 lxc/auth.go:1442 lxc/auth.go:1464
+#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
+#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
+#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
+#: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
+#: lxc/cluster.go:770 lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
 #: lxc/cluster.go:1175 lxc/cluster.go:1299 lxc/cluster.go:1329
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
@@ -1733,9 +1741,9 @@ msgstr ""
 #: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
 #: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
 #: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:715
-#: lxc/remote.go:753 lxc/remote.go:839 lxc/remote.go:920 lxc/remote.go:984
-#: lxc/remote.go:1032 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
+#: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
+#: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1920,7 +1928,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:959 lxc/auth.go:960
+#: lxc/auth.go:1108 lxc/auth.go:1109
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1932,11 +1940,11 @@ msgstr ""
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/auth.go:201 lxc/auth.go:202
+#: lxc/auth.go:206 lxc/auth.go:207
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1631 lxc/auth.go:1632
+#: lxc/auth.go:1780 lxc/auth.go:1781
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2312,12 +2320,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:486
+#: lxc/remote.go:500
 #, c-format
 msgid "Failed to decode trust token: %w"
 msgstr ""
 
-#: lxc/remote.go:292
+#: lxc/remote.go:306
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2421,7 +2429,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:773 lxc/auth.go:1755
+#: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
@@ -2429,7 +2437,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:757 lxc/storage.go:657
+#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2467,7 +2475,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:821
+#: lxc/remote.go:855
 msgid "GLOBAL"
 msgstr ""
 
@@ -2479,7 +2487,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:821 lxc/auth.go:1795
+#: lxc/auth.go:970 lxc/auth.go:1944
 msgid "GROUPS"
 msgstr ""
 
@@ -2487,7 +2495,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:165 lxc/remote.go:443
+#: lxc/remote.go:165 lxc/remote.go:457
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2628,17 +2636,17 @@ msgstr ""
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: lxc/auth.go:137
+#: lxc/auth.go:142
 #, c-format
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:187
+#: lxc/auth.go:192
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:427 lxc/auth.go:1845
+#: lxc/auth.go:432 lxc/auth.go:1994
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2697,7 +2705,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:820
+#: lxc/auth.go:969
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -2729,12 +2737,16 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1567
+#: lxc/auth.go:829
+msgid "Identity creation only supported for TLS identities"
+msgstr ""
+
+#: lxc/auth.go:1716
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1617
+#: lxc/auth.go:1766
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2863,7 +2875,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1292 lxc/auth.go:1293
+#: lxc/auth.go:1441 lxc/auth.go:1442
 msgid "Inspect permissions"
 msgstr ""
 
@@ -2911,7 +2923,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:395
+#: lxc/remote.go:409
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2992,7 +3004,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:384
+#: lxc/remote.go:398
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3167,15 +3179,15 @@ msgstr ""
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:332 lxc/auth.go:333
+#: lxc/auth.go:337 lxc/auth.go:338
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:768 lxc/auth.go:769
+#: lxc/auth.go:917 lxc/auth.go:918
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1750 lxc/auth.go:1751
+#: lxc/auth.go:1899 lxc/auth.go:1900
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3328,7 +3340,7 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1314 lxc/auth.go:1315
+#: lxc/auth.go:1463 lxc/auth.go:1464
 msgid "List permissions"
 msgstr ""
 
@@ -3372,7 +3384,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:752 lxc/remote.go:753
+#: lxc/remote.go:786 lxc/remote.go:787
 msgid "List the available remotes"
 msgstr ""
 
@@ -3496,6 +3508,12 @@ msgstr ""
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
+#: lxc/auth.go:825
+msgid ""
+"Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
+"got "
+msgstr ""
+
 #: lxc/network.go:32 lxc/network.go:33
 msgid "Manage and attach instances to networks"
 msgstr ""
@@ -3524,19 +3542,19 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:59 lxc/auth.go:60 lxc/auth.go:1492 lxc/auth.go:1493
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1142 lxc/auth.go:1143
+#: lxc/auth.go:1291 lxc/auth.go:1292
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:731 lxc/auth.go:732
+#: lxc/auth.go:736 lxc/auth.go:737
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1910 lxc/auth.go:1911
+#: lxc/auth.go:2059 lxc/auth.go:2060
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3627,7 +3645,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:493 lxc/auth.go:494
+#: lxc/auth.go:498 lxc/auth.go:499
 msgid "Manage permissions"
 msgstr ""
 
@@ -3679,7 +3697,7 @@ msgstr ""
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/auth.go:30 lxc/auth.go:31
+#: lxc/auth.go:35 lxc/auth.go:36
 msgid "Manage user authorization"
 msgstr ""
 
@@ -3776,21 +3794,21 @@ msgstr ""
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:123 lxc/auth.go:177 lxc/auth.go:255 lxc/auth.go:417
-#: lxc/auth.go:466 lxc/auth.go:541 lxc/auth.go:600 lxc/auth.go:1884
+#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:260 lxc/auth.go:422
+#: lxc/auth.go:471 lxc/auth.go:546 lxc/auth.go:605 lxc/auth.go:2033
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:866 lxc/auth.go:1007 lxc/auth.go:1124 lxc/auth.go:1190
-#: lxc/auth.go:1248
+#: lxc/auth.go:820 lxc/auth.go:1015 lxc/auth.go:1156 lxc/auth.go:1273
+#: lxc/auth.go:1339 lxc/auth.go:1397
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1554 lxc/auth.go:1607 lxc/auth.go:1673 lxc/auth.go:1835
+#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1958 lxc/auth.go:2011
+#: lxc/auth.go:2107 lxc/auth.go:2160
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -4011,12 +4029,12 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:376 lxc/auth.go:819 lxc/auth.go:1794 lxc/cluster.go:192
+#: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
-#: lxc/remote.go:815 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
 msgstr ""
@@ -4043,7 +4061,7 @@ msgstr ""
 
 #: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:775 lxc/remote.go:780 lxc/remote.go:785
+#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr ""
 
@@ -4272,7 +4290,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:378
+#: lxc/remote.go:392
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4343,11 +4361,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:817
+#: lxc/remote.go:851
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:819
+#: lxc/image.go:1136 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4388,7 +4406,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:536
+#: lxc/remote.go:550
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
@@ -4405,7 +4423,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:302 lxc/auth.go:1059 lxc/auth.go:1720 lxc/cluster.go:860
+#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -4708,33 +4726,33 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:877
+#: lxc/remote.go:911
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:868 lxc/remote.go:949 lxc/remote.go:1013
-#: lxc/remote.go:1061
+#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/remote.go:1095
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:345
+#: lxc/remote.go:359
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:957
+#: lxc/remote.go:991
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:872 lxc/remote.go:953 lxc/remote.go:1065
+#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1099
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:319
+#: lxc/remote.go:333
 msgid "Remote address must not be empty"
 msgstr ""
 
@@ -4742,7 +4760,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:339
+#: lxc/remote.go:353
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4764,7 +4782,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1223 lxc/auth.go:1224
+#: lxc/auth.go:1372 lxc/auth.go:1373
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4800,7 +4818,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1986 lxc/auth.go:1987
+#: lxc/auth.go:2135 lxc/auth.go:2136
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4812,7 +4830,7 @@ msgstr ""
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:575 lxc/auth.go:576
+#: lxc/auth.go:580 lxc/auth.go:581
 msgid "Remove permissions from groups"
 msgstr ""
 
@@ -4828,7 +4846,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:919 lxc/remote.go:920
+#: lxc/remote.go:953 lxc/remote.go:954
 msgid "Remove remotes"
 msgstr ""
 
@@ -4857,11 +4875,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:392 lxc/auth.go:393
+#: lxc/auth.go:397 lxc/auth.go:398
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1810 lxc/auth.go:1811
+#: lxc/auth.go:1959 lxc/auth.go:1960
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -4885,7 +4903,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:838 lxc/remote.go:839
+#: lxc/remote.go:872 lxc/remote.go:873
 msgid "Rename remotes"
 msgstr ""
 
@@ -5030,7 +5048,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:820
+#: lxc/remote.go:854
 msgid "STATIC"
 msgstr ""
 
@@ -5071,11 +5089,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:532
+#: lxc/remote.go:546
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:285 lxc/remote.go:683
+#: lxc/remote.go:299 lxc/remote.go:717
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5286,7 +5304,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1031 lxc/remote.go:1032
+#: lxc/remote.go:1065 lxc/remote.go:1066
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5382,7 +5400,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1859 lxc/auth.go:1860
+#: lxc/auth.go:2008 lxc/auth.go:2009
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5410,11 +5428,11 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:441 lxc/auth.go:442
+#: lxc/auth.go:446 lxc/auth.go:447
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:836
+#: lxc/auth.go:985
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5519,7 +5537,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:899
+#: lxc/auth.go:1048
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5529,7 +5547,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:714 lxc/remote.go:715
+#: lxc/remote.go:748 lxc/remote.go:749
 msgid "Show the default remote"
 msgstr ""
 
@@ -5741,7 +5759,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:983 lxc/remote.go:984
+#: lxc/remote.go:1017 lxc/remote.go:1018
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5753,11 +5771,21 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
+#: lxc/auth.go:876
+#, c-format
+msgid "TLS identity %q (%s) pending identity token:"
+msgstr ""
+
+#: lxc/auth.go:902
+#, c-format
+msgid "TLS identity %q created with fingerprint %q"
+msgstr ""
+
 #: lxc/cluster.go:1070 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:818 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
 #: lxc/storage_volume.go:1736 lxc/warning.go:216
@@ -5776,7 +5804,7 @@ msgstr ""
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/remote.go:161 lxc/remote.go:334
+#: lxc/remote.go:161 lxc/remote.go:348
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
@@ -5932,7 +5960,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:527
+#: lxc/remote.go:541
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
@@ -6070,15 +6098,15 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:329
+#: lxc/remote.go:343
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:324
+#: lxc/remote.go:338
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr ""
 
-#: lxc/remote.go:639
+#: lxc/remote.go:653
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6121,7 +6149,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:193 lxc/remote.go:816
+#: lxc/cluster.go:193 lxc/remote.go:850
 msgid "URL"
 msgstr ""
 
@@ -6429,11 +6457,11 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:835
+#: lxc/auth.go:984
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:898
+#: lxc/auth.go:1047
 msgid "View the current identity"
 msgstr ""
 
@@ -6472,7 +6500,7 @@ msgstr ""
 
 #: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:777 lxc/remote.go:782 lxc/remote.go:787
+#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr ""
 
@@ -6504,7 +6532,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:330 lxc/auth.go:766 lxc/auth.go:897 lxc/auth.go:1748
+#: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
@@ -6537,7 +6565,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1313
+#: lxc/auth.go:1462
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6598,11 +6626,17 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:834 lxc/auth.go:1086
+#: lxc/auth.go:774
+msgid ""
+"[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
+"certificate>] [[--group <group_name>]]"
+msgstr ""
+
+#: lxc/auth.go:983 lxc/auth.go:1235
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1164 lxc/auth.go:1222 lxc/auth.go:1985
+#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:2134
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6610,13 +6644,13 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:97 lxc/auth.go:150 lxc/auth.go:200 lxc/auth.go:440
-#: lxc/auth.go:958 lxc/auth.go:1529 lxc/cluster_group.go:168
+#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:445
+#: lxc/auth.go:1107 lxc/auth.go:1678 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:515 lxc/auth.go:573
+#: lxc/auth.go:520 lxc/auth.go:578
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
@@ -6626,19 +6660,19 @@ msgstr ""
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:390
+#: lxc/auth.go:395
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1580 lxc/auth.go:1630 lxc/auth.go:1858
+#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1932
+#: lxc/auth.go:2081
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1808
+#: lxc/auth.go:1957
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -7129,7 +7163,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:806
+#: lxc/project.go:557 lxc/remote.go:840
 msgid "current"
 msgstr ""
 
@@ -7176,20 +7210,20 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/auth.go:204
+#: lxc/auth.go:209
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:962
+#: lxc/auth.go:1111
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1634
+#: lxc/auth.go:1783
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7613,7 +7647,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:531
+#: lxc/remote.go:545
 msgid "n"
 msgstr ""
 
@@ -7625,7 +7659,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:510
+#: lxc/remote.go:524
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7662,7 +7696,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:519
+#: lxc/remote.go:533
 msgid "y"
 msgstr ""
 

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-14 13:30+0000\n"
+"POT-Creation-Date: 2024-10-15 14:52+0100\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Swedish <https://hosted.weblate.org/projects/linux-containers/"
@@ -133,7 +133,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:214
+#: lxc/auth.go:219
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -160,7 +160,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:972
+#: lxc/auth.go:1121
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -181,7 +181,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1644
+#: lxc/auth.go:1793
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -515,15 +515,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:917 lxc/remote.go:982
+#: lxc/remote.go:951 lxc/remote.go:1016
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1030
+#: lxc/remote.go:1064
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:836
+#: lxc/remote.go:870
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -556,11 +556,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:818
+#: lxc/remote.go:852
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:817
+#: lxc/auth.go:966
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -598,11 +598,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1165 lxc/auth.go:1166
+#: lxc/auth.go:1314 lxc/auth.go:1315
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1933 lxc/auth.go:1934
+#: lxc/auth.go:2082 lxc/auth.go:2083
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -671,7 +671,7 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:516 lxc/auth.go:517
+#: lxc/auth.go:521 lxc/auth.go:522
 msgid "Add permissions to groups"
 msgstr ""
 
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:648
+#: lxc/remote.go:680
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -813,7 +813,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:621
+#: lxc/remote.go:635
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -991,7 +991,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:961
+#: lxc/remote.go:995
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1057,7 +1057,7 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:509
+#: lxc/remote.go:523
 msgid "Certificate fingerprint"
 msgstr ""
 
@@ -1076,7 +1076,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:687
+#: lxc/remote.go:721
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1324,12 +1324,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:559
+#: lxc/remote.go:573
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:237 lxc/remote.go:543
+#: lxc/remote.go:237 lxc/remote.go:557
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1343,12 +1343,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:1719
+#: lxc/auth.go:306 lxc/auth.go:1868
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1058
+#: lxc/auth.go:1207
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1368,13 +1368,17 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:554
+#: lxc/remote.go:568
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
 #: lxc/network_zone.go:1536
 msgid "Couldn't find a matching entry"
+msgstr ""
+
+#: lxc/auth.go:776
+msgid "Create a TLS identity"
 msgstr ""
 
 #: lxc/cluster_group.go:169 lxc/cluster_group.go:170
@@ -1393,6 +1397,10 @@ msgstr ""
 msgid "Create an empty instance"
 msgstr ""
 
+#: lxc/auth.go:775
+msgid "Create an identity"
+msgstr ""
+
 #: lxc/launch.go:23 lxc/launch.go:24
 msgid "Create and start instances from images"
 msgstr ""
@@ -1405,11 +1413,11 @@ msgstr ""
 msgid "Create files and directories in instances"
 msgstr ""
 
-#: lxc/auth.go:98 lxc/auth.go:99
+#: lxc/auth.go:103 lxc/auth.go:104
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1530 lxc/auth.go:1531
+#: lxc/auth.go:1679 lxc/auth.go:1680
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1517,7 +1525,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
@@ -1560,7 +1568,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/auth.go:1088 lxc/auth.go:1089
+#: lxc/auth.go:1237 lxc/auth.go:1238
 msgid "Delete an identity"
 msgstr ""
 
@@ -1568,11 +1576,11 @@ msgstr ""
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/auth.go:152 lxc/auth.go:153
+#: lxc/auth.go:157 lxc/auth.go:158
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1582 lxc/auth.go:1583
+#: lxc/auth.go:1731 lxc/auth.go:1732
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1650,18 +1658,18 @@ msgstr ""
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:31 lxc/auth.go:60 lxc/auth.go:99
-#: lxc/auth.go:153 lxc/auth.go:202 lxc/auth.go:333 lxc/auth.go:393
-#: lxc/auth.go:442 lxc/auth.go:494 lxc/auth.go:517 lxc/auth.go:576
-#: lxc/auth.go:732 lxc/auth.go:769 lxc/auth.go:836 lxc/auth.go:899
-#: lxc/auth.go:960 lxc/auth.go:1089 lxc/auth.go:1143 lxc/auth.go:1166
-#: lxc/auth.go:1224 lxc/auth.go:1293 lxc/auth.go:1315 lxc/auth.go:1493
-#: lxc/auth.go:1531 lxc/auth.go:1583 lxc/auth.go:1632 lxc/auth.go:1751
-#: lxc/auth.go:1811 lxc/auth.go:1860 lxc/auth.go:1911 lxc/auth.go:1934
-#: lxc/auth.go:1987 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215
-#: lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:484
-#: lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677 lxc/cluster.go:770
-#: lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
+#: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
+#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:338 lxc/auth.go:398
+#: lxc/auth.go:447 lxc/auth.go:499 lxc/auth.go:522 lxc/auth.go:581
+#: lxc/auth.go:737 lxc/auth.go:776 lxc/auth.go:918 lxc/auth.go:985
+#: lxc/auth.go:1048 lxc/auth.go:1109 lxc/auth.go:1238 lxc/auth.go:1292
+#: lxc/auth.go:1315 lxc/auth.go:1373 lxc/auth.go:1442 lxc/auth.go:1464
+#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
+#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
+#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
+#: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
+#: lxc/cluster.go:770 lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
 #: lxc/cluster.go:1175 lxc/cluster.go:1299 lxc/cluster.go:1329
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
@@ -1732,9 +1740,9 @@ msgstr ""
 #: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
 #: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
 #: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:715
-#: lxc/remote.go:753 lxc/remote.go:839 lxc/remote.go:920 lxc/remote.go:984
-#: lxc/remote.go:1032 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
+#: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
+#: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1919,7 +1927,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:959 lxc/auth.go:960
+#: lxc/auth.go:1108 lxc/auth.go:1109
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1931,11 +1939,11 @@ msgstr ""
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/auth.go:201 lxc/auth.go:202
+#: lxc/auth.go:206 lxc/auth.go:207
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1631 lxc/auth.go:1632
+#: lxc/auth.go:1780 lxc/auth.go:1781
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2311,12 +2319,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:486
+#: lxc/remote.go:500
 #, c-format
 msgid "Failed to decode trust token: %w"
 msgstr ""
 
-#: lxc/remote.go:292
+#: lxc/remote.go:306
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2420,7 +2428,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:773 lxc/auth.go:1755
+#: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
@@ -2428,7 +2436,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:757 lxc/storage.go:657
+#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2466,7 +2474,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:821
+#: lxc/remote.go:855
 msgid "GLOBAL"
 msgstr ""
 
@@ -2478,7 +2486,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:821 lxc/auth.go:1795
+#: lxc/auth.go:970 lxc/auth.go:1944
 msgid "GROUPS"
 msgstr ""
 
@@ -2486,7 +2494,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:165 lxc/remote.go:443
+#: lxc/remote.go:165 lxc/remote.go:457
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2627,17 +2635,17 @@ msgstr ""
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: lxc/auth.go:137
+#: lxc/auth.go:142
 #, c-format
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:187
+#: lxc/auth.go:192
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:427 lxc/auth.go:1845
+#: lxc/auth.go:432 lxc/auth.go:1994
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2696,7 +2704,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:820
+#: lxc/auth.go:969
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -2728,12 +2736,16 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1567
+#: lxc/auth.go:829
+msgid "Identity creation only supported for TLS identities"
+msgstr ""
+
+#: lxc/auth.go:1716
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1617
+#: lxc/auth.go:1766
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2862,7 +2874,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1292 lxc/auth.go:1293
+#: lxc/auth.go:1441 lxc/auth.go:1442
 msgid "Inspect permissions"
 msgstr ""
 
@@ -2910,7 +2922,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:395
+#: lxc/remote.go:409
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2991,7 +3003,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:384
+#: lxc/remote.go:398
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3166,15 +3178,15 @@ msgstr ""
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:332 lxc/auth.go:333
+#: lxc/auth.go:337 lxc/auth.go:338
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:768 lxc/auth.go:769
+#: lxc/auth.go:917 lxc/auth.go:918
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1750 lxc/auth.go:1751
+#: lxc/auth.go:1899 lxc/auth.go:1900
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3327,7 +3339,7 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1314 lxc/auth.go:1315
+#: lxc/auth.go:1463 lxc/auth.go:1464
 msgid "List permissions"
 msgstr ""
 
@@ -3371,7 +3383,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:752 lxc/remote.go:753
+#: lxc/remote.go:786 lxc/remote.go:787
 msgid "List the available remotes"
 msgstr ""
 
@@ -3495,6 +3507,12 @@ msgstr ""
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
+#: lxc/auth.go:825
+msgid ""
+"Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
+"got "
+msgstr ""
+
 #: lxc/network.go:32 lxc/network.go:33
 msgid "Manage and attach instances to networks"
 msgstr ""
@@ -3523,19 +3541,19 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:59 lxc/auth.go:60 lxc/auth.go:1492 lxc/auth.go:1493
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1142 lxc/auth.go:1143
+#: lxc/auth.go:1291 lxc/auth.go:1292
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:731 lxc/auth.go:732
+#: lxc/auth.go:736 lxc/auth.go:737
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1910 lxc/auth.go:1911
+#: lxc/auth.go:2059 lxc/auth.go:2060
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3626,7 +3644,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:493 lxc/auth.go:494
+#: lxc/auth.go:498 lxc/auth.go:499
 msgid "Manage permissions"
 msgstr ""
 
@@ -3678,7 +3696,7 @@ msgstr ""
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/auth.go:30 lxc/auth.go:31
+#: lxc/auth.go:35 lxc/auth.go:36
 msgid "Manage user authorization"
 msgstr ""
 
@@ -3775,21 +3793,21 @@ msgstr ""
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:123 lxc/auth.go:177 lxc/auth.go:255 lxc/auth.go:417
-#: lxc/auth.go:466 lxc/auth.go:541 lxc/auth.go:600 lxc/auth.go:1884
+#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:260 lxc/auth.go:422
+#: lxc/auth.go:471 lxc/auth.go:546 lxc/auth.go:605 lxc/auth.go:2033
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:866 lxc/auth.go:1007 lxc/auth.go:1124 lxc/auth.go:1190
-#: lxc/auth.go:1248
+#: lxc/auth.go:820 lxc/auth.go:1015 lxc/auth.go:1156 lxc/auth.go:1273
+#: lxc/auth.go:1339 lxc/auth.go:1397
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1554 lxc/auth.go:1607 lxc/auth.go:1673 lxc/auth.go:1835
+#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1958 lxc/auth.go:2011
+#: lxc/auth.go:2107 lxc/auth.go:2160
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -4010,12 +4028,12 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:376 lxc/auth.go:819 lxc/auth.go:1794 lxc/cluster.go:192
+#: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
-#: lxc/remote.go:815 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
 msgstr ""
@@ -4042,7 +4060,7 @@ msgstr ""
 
 #: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:775 lxc/remote.go:780 lxc/remote.go:785
+#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr ""
 
@@ -4271,7 +4289,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:378
+#: lxc/remote.go:392
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4342,11 +4360,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:817
+#: lxc/remote.go:851
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:819
+#: lxc/image.go:1136 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4387,7 +4405,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:536
+#: lxc/remote.go:550
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
@@ -4404,7 +4422,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:302 lxc/auth.go:1059 lxc/auth.go:1720 lxc/cluster.go:860
+#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -4707,33 +4725,33 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:877
+#: lxc/remote.go:911
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:868 lxc/remote.go:949 lxc/remote.go:1013
-#: lxc/remote.go:1061
+#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/remote.go:1095
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:345
+#: lxc/remote.go:359
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:957
+#: lxc/remote.go:991
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:872 lxc/remote.go:953 lxc/remote.go:1065
+#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1099
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:319
+#: lxc/remote.go:333
 msgid "Remote address must not be empty"
 msgstr ""
 
@@ -4741,7 +4759,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:339
+#: lxc/remote.go:353
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4763,7 +4781,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1223 lxc/auth.go:1224
+#: lxc/auth.go:1372 lxc/auth.go:1373
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4799,7 +4817,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1986 lxc/auth.go:1987
+#: lxc/auth.go:2135 lxc/auth.go:2136
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4811,7 +4829,7 @@ msgstr ""
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:575 lxc/auth.go:576
+#: lxc/auth.go:580 lxc/auth.go:581
 msgid "Remove permissions from groups"
 msgstr ""
 
@@ -4827,7 +4845,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:919 lxc/remote.go:920
+#: lxc/remote.go:953 lxc/remote.go:954
 msgid "Remove remotes"
 msgstr ""
 
@@ -4856,11 +4874,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:392 lxc/auth.go:393
+#: lxc/auth.go:397 lxc/auth.go:398
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1810 lxc/auth.go:1811
+#: lxc/auth.go:1959 lxc/auth.go:1960
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -4884,7 +4902,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:838 lxc/remote.go:839
+#: lxc/remote.go:872 lxc/remote.go:873
 msgid "Rename remotes"
 msgstr ""
 
@@ -5029,7 +5047,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:820
+#: lxc/remote.go:854
 msgid "STATIC"
 msgstr ""
 
@@ -5070,11 +5088,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:532
+#: lxc/remote.go:546
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:285 lxc/remote.go:683
+#: lxc/remote.go:299 lxc/remote.go:717
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5285,7 +5303,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1031 lxc/remote.go:1032
+#: lxc/remote.go:1065 lxc/remote.go:1066
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5381,7 +5399,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1859 lxc/auth.go:1860
+#: lxc/auth.go:2008 lxc/auth.go:2009
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5409,11 +5427,11 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:441 lxc/auth.go:442
+#: lxc/auth.go:446 lxc/auth.go:447
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:836
+#: lxc/auth.go:985
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5518,7 +5536,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:899
+#: lxc/auth.go:1048
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5528,7 +5546,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:714 lxc/remote.go:715
+#: lxc/remote.go:748 lxc/remote.go:749
 msgid "Show the default remote"
 msgstr ""
 
@@ -5740,7 +5758,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:983 lxc/remote.go:984
+#: lxc/remote.go:1017 lxc/remote.go:1018
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5752,11 +5770,21 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
+#: lxc/auth.go:876
+#, c-format
+msgid "TLS identity %q (%s) pending identity token:"
+msgstr ""
+
+#: lxc/auth.go:902
+#, c-format
+msgid "TLS identity %q created with fingerprint %q"
+msgstr ""
+
 #: lxc/cluster.go:1070 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:818 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
 #: lxc/storage_volume.go:1736 lxc/warning.go:216
@@ -5775,7 +5803,7 @@ msgstr ""
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/remote.go:161 lxc/remote.go:334
+#: lxc/remote.go:161 lxc/remote.go:348
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
@@ -5931,7 +5959,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:527
+#: lxc/remote.go:541
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
@@ -6069,15 +6097,15 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:329
+#: lxc/remote.go:343
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:324
+#: lxc/remote.go:338
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr ""
 
-#: lxc/remote.go:639
+#: lxc/remote.go:653
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6120,7 +6148,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:193 lxc/remote.go:816
+#: lxc/cluster.go:193 lxc/remote.go:850
 msgid "URL"
 msgstr ""
 
@@ -6428,11 +6456,11 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:835
+#: lxc/auth.go:984
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:898
+#: lxc/auth.go:1047
 msgid "View the current identity"
 msgstr ""
 
@@ -6471,7 +6499,7 @@ msgstr ""
 
 #: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:777 lxc/remote.go:782 lxc/remote.go:787
+#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr ""
 
@@ -6503,7 +6531,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:330 lxc/auth.go:766 lxc/auth.go:897 lxc/auth.go:1748
+#: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
@@ -6536,7 +6564,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1313
+#: lxc/auth.go:1462
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6597,11 +6625,17 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:834 lxc/auth.go:1086
+#: lxc/auth.go:774
+msgid ""
+"[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
+"certificate>] [[--group <group_name>]]"
+msgstr ""
+
+#: lxc/auth.go:983 lxc/auth.go:1235
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1164 lxc/auth.go:1222 lxc/auth.go:1985
+#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:2134
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6609,13 +6643,13 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:97 lxc/auth.go:150 lxc/auth.go:200 lxc/auth.go:440
-#: lxc/auth.go:958 lxc/auth.go:1529 lxc/cluster_group.go:168
+#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:445
+#: lxc/auth.go:1107 lxc/auth.go:1678 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:515 lxc/auth.go:573
+#: lxc/auth.go:520 lxc/auth.go:578
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
@@ -6625,19 +6659,19 @@ msgstr ""
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:390
+#: lxc/auth.go:395
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1580 lxc/auth.go:1630 lxc/auth.go:1858
+#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1932
+#: lxc/auth.go:2081
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1808
+#: lxc/auth.go:1957
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -7128,7 +7162,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:806
+#: lxc/project.go:557 lxc/remote.go:840
 msgid "current"
 msgstr ""
 
@@ -7175,20 +7209,20 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/auth.go:204
+#: lxc/auth.go:209
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:962
+#: lxc/auth.go:1111
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1634
+#: lxc/auth.go:1783
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7612,7 +7646,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:531
+#: lxc/remote.go:545
 msgid "n"
 msgstr ""
 
@@ -7624,7 +7658,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:510
+#: lxc/remote.go:524
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7661,7 +7695,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:519
+#: lxc/remote.go:533
 msgid "y"
 msgstr ""
 

--- a/po/te.po
+++ b/po/te.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-14 13:30+0000\n"
+"POT-Creation-Date: 2024-10-15 14:52+0100\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Telugu <https://hosted.weblate.org/projects/linux-containers/"
@@ -133,7 +133,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:214
+#: lxc/auth.go:219
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -160,7 +160,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:972
+#: lxc/auth.go:1121
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -181,7 +181,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1644
+#: lxc/auth.go:1793
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -515,15 +515,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:917 lxc/remote.go:982
+#: lxc/remote.go:951 lxc/remote.go:1016
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1030
+#: lxc/remote.go:1064
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:836
+#: lxc/remote.go:870
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -556,11 +556,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:818
+#: lxc/remote.go:852
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:817
+#: lxc/auth.go:966
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -598,11 +598,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1165 lxc/auth.go:1166
+#: lxc/auth.go:1314 lxc/auth.go:1315
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1933 lxc/auth.go:1934
+#: lxc/auth.go:2082 lxc/auth.go:2083
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -671,7 +671,7 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:516 lxc/auth.go:517
+#: lxc/auth.go:521 lxc/auth.go:522
 msgid "Add permissions to groups"
 msgstr ""
 
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:648
+#: lxc/remote.go:680
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -813,7 +813,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:621
+#: lxc/remote.go:635
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -991,7 +991,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:961
+#: lxc/remote.go:995
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1057,7 +1057,7 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:509
+#: lxc/remote.go:523
 msgid "Certificate fingerprint"
 msgstr ""
 
@@ -1076,7 +1076,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:687
+#: lxc/remote.go:721
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1324,12 +1324,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:559
+#: lxc/remote.go:573
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:237 lxc/remote.go:543
+#: lxc/remote.go:237 lxc/remote.go:557
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1343,12 +1343,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:1719
+#: lxc/auth.go:306 lxc/auth.go:1868
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1058
+#: lxc/auth.go:1207
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1368,13 +1368,17 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:554
+#: lxc/remote.go:568
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
 #: lxc/network_zone.go:1536
 msgid "Couldn't find a matching entry"
+msgstr ""
+
+#: lxc/auth.go:776
+msgid "Create a TLS identity"
 msgstr ""
 
 #: lxc/cluster_group.go:169 lxc/cluster_group.go:170
@@ -1393,6 +1397,10 @@ msgstr ""
 msgid "Create an empty instance"
 msgstr ""
 
+#: lxc/auth.go:775
+msgid "Create an identity"
+msgstr ""
+
 #: lxc/launch.go:23 lxc/launch.go:24
 msgid "Create and start instances from images"
 msgstr ""
@@ -1405,11 +1413,11 @@ msgstr ""
 msgid "Create files and directories in instances"
 msgstr ""
 
-#: lxc/auth.go:98 lxc/auth.go:99
+#: lxc/auth.go:103 lxc/auth.go:104
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1530 lxc/auth.go:1531
+#: lxc/auth.go:1679 lxc/auth.go:1680
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1517,7 +1525,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
@@ -1560,7 +1568,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/auth.go:1088 lxc/auth.go:1089
+#: lxc/auth.go:1237 lxc/auth.go:1238
 msgid "Delete an identity"
 msgstr ""
 
@@ -1568,11 +1576,11 @@ msgstr ""
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/auth.go:152 lxc/auth.go:153
+#: lxc/auth.go:157 lxc/auth.go:158
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1582 lxc/auth.go:1583
+#: lxc/auth.go:1731 lxc/auth.go:1732
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1650,18 +1658,18 @@ msgstr ""
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:31 lxc/auth.go:60 lxc/auth.go:99
-#: lxc/auth.go:153 lxc/auth.go:202 lxc/auth.go:333 lxc/auth.go:393
-#: lxc/auth.go:442 lxc/auth.go:494 lxc/auth.go:517 lxc/auth.go:576
-#: lxc/auth.go:732 lxc/auth.go:769 lxc/auth.go:836 lxc/auth.go:899
-#: lxc/auth.go:960 lxc/auth.go:1089 lxc/auth.go:1143 lxc/auth.go:1166
-#: lxc/auth.go:1224 lxc/auth.go:1293 lxc/auth.go:1315 lxc/auth.go:1493
-#: lxc/auth.go:1531 lxc/auth.go:1583 lxc/auth.go:1632 lxc/auth.go:1751
-#: lxc/auth.go:1811 lxc/auth.go:1860 lxc/auth.go:1911 lxc/auth.go:1934
-#: lxc/auth.go:1987 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215
-#: lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:484
-#: lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677 lxc/cluster.go:770
-#: lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
+#: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
+#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:338 lxc/auth.go:398
+#: lxc/auth.go:447 lxc/auth.go:499 lxc/auth.go:522 lxc/auth.go:581
+#: lxc/auth.go:737 lxc/auth.go:776 lxc/auth.go:918 lxc/auth.go:985
+#: lxc/auth.go:1048 lxc/auth.go:1109 lxc/auth.go:1238 lxc/auth.go:1292
+#: lxc/auth.go:1315 lxc/auth.go:1373 lxc/auth.go:1442 lxc/auth.go:1464
+#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
+#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
+#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
+#: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
+#: lxc/cluster.go:770 lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
 #: lxc/cluster.go:1175 lxc/cluster.go:1299 lxc/cluster.go:1329
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
@@ -1732,9 +1740,9 @@ msgstr ""
 #: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
 #: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
 #: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:715
-#: lxc/remote.go:753 lxc/remote.go:839 lxc/remote.go:920 lxc/remote.go:984
-#: lxc/remote.go:1032 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
+#: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
+#: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1919,7 +1927,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:959 lxc/auth.go:960
+#: lxc/auth.go:1108 lxc/auth.go:1109
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1931,11 +1939,11 @@ msgstr ""
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/auth.go:201 lxc/auth.go:202
+#: lxc/auth.go:206 lxc/auth.go:207
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1631 lxc/auth.go:1632
+#: lxc/auth.go:1780 lxc/auth.go:1781
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2311,12 +2319,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:486
+#: lxc/remote.go:500
 #, c-format
 msgid "Failed to decode trust token: %w"
 msgstr ""
 
-#: lxc/remote.go:292
+#: lxc/remote.go:306
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2420,7 +2428,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:773 lxc/auth.go:1755
+#: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
@@ -2428,7 +2436,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:757 lxc/storage.go:657
+#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2466,7 +2474,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:821
+#: lxc/remote.go:855
 msgid "GLOBAL"
 msgstr ""
 
@@ -2478,7 +2486,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:821 lxc/auth.go:1795
+#: lxc/auth.go:970 lxc/auth.go:1944
 msgid "GROUPS"
 msgstr ""
 
@@ -2486,7 +2494,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:165 lxc/remote.go:443
+#: lxc/remote.go:165 lxc/remote.go:457
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2627,17 +2635,17 @@ msgstr ""
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: lxc/auth.go:137
+#: lxc/auth.go:142
 #, c-format
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:187
+#: lxc/auth.go:192
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:427 lxc/auth.go:1845
+#: lxc/auth.go:432 lxc/auth.go:1994
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2696,7 +2704,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:820
+#: lxc/auth.go:969
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -2728,12 +2736,16 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1567
+#: lxc/auth.go:829
+msgid "Identity creation only supported for TLS identities"
+msgstr ""
+
+#: lxc/auth.go:1716
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1617
+#: lxc/auth.go:1766
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2862,7 +2874,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1292 lxc/auth.go:1293
+#: lxc/auth.go:1441 lxc/auth.go:1442
 msgid "Inspect permissions"
 msgstr ""
 
@@ -2910,7 +2922,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:395
+#: lxc/remote.go:409
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2991,7 +3003,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:384
+#: lxc/remote.go:398
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3166,15 +3178,15 @@ msgstr ""
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:332 lxc/auth.go:333
+#: lxc/auth.go:337 lxc/auth.go:338
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:768 lxc/auth.go:769
+#: lxc/auth.go:917 lxc/auth.go:918
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1750 lxc/auth.go:1751
+#: lxc/auth.go:1899 lxc/auth.go:1900
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3327,7 +3339,7 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1314 lxc/auth.go:1315
+#: lxc/auth.go:1463 lxc/auth.go:1464
 msgid "List permissions"
 msgstr ""
 
@@ -3371,7 +3383,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:752 lxc/remote.go:753
+#: lxc/remote.go:786 lxc/remote.go:787
 msgid "List the available remotes"
 msgstr ""
 
@@ -3495,6 +3507,12 @@ msgstr ""
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
+#: lxc/auth.go:825
+msgid ""
+"Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
+"got "
+msgstr ""
+
 #: lxc/network.go:32 lxc/network.go:33
 msgid "Manage and attach instances to networks"
 msgstr ""
@@ -3523,19 +3541,19 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:59 lxc/auth.go:60 lxc/auth.go:1492 lxc/auth.go:1493
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1142 lxc/auth.go:1143
+#: lxc/auth.go:1291 lxc/auth.go:1292
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:731 lxc/auth.go:732
+#: lxc/auth.go:736 lxc/auth.go:737
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1910 lxc/auth.go:1911
+#: lxc/auth.go:2059 lxc/auth.go:2060
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3626,7 +3644,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:493 lxc/auth.go:494
+#: lxc/auth.go:498 lxc/auth.go:499
 msgid "Manage permissions"
 msgstr ""
 
@@ -3678,7 +3696,7 @@ msgstr ""
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/auth.go:30 lxc/auth.go:31
+#: lxc/auth.go:35 lxc/auth.go:36
 msgid "Manage user authorization"
 msgstr ""
 
@@ -3775,21 +3793,21 @@ msgstr ""
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:123 lxc/auth.go:177 lxc/auth.go:255 lxc/auth.go:417
-#: lxc/auth.go:466 lxc/auth.go:541 lxc/auth.go:600 lxc/auth.go:1884
+#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:260 lxc/auth.go:422
+#: lxc/auth.go:471 lxc/auth.go:546 lxc/auth.go:605 lxc/auth.go:2033
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:866 lxc/auth.go:1007 lxc/auth.go:1124 lxc/auth.go:1190
-#: lxc/auth.go:1248
+#: lxc/auth.go:820 lxc/auth.go:1015 lxc/auth.go:1156 lxc/auth.go:1273
+#: lxc/auth.go:1339 lxc/auth.go:1397
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1554 lxc/auth.go:1607 lxc/auth.go:1673 lxc/auth.go:1835
+#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1958 lxc/auth.go:2011
+#: lxc/auth.go:2107 lxc/auth.go:2160
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -4010,12 +4028,12 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:376 lxc/auth.go:819 lxc/auth.go:1794 lxc/cluster.go:192
+#: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
-#: lxc/remote.go:815 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
 msgstr ""
@@ -4042,7 +4060,7 @@ msgstr ""
 
 #: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:775 lxc/remote.go:780 lxc/remote.go:785
+#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr ""
 
@@ -4271,7 +4289,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:378
+#: lxc/remote.go:392
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4342,11 +4360,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:817
+#: lxc/remote.go:851
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:819
+#: lxc/image.go:1136 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4387,7 +4405,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:536
+#: lxc/remote.go:550
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
@@ -4404,7 +4422,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:302 lxc/auth.go:1059 lxc/auth.go:1720 lxc/cluster.go:860
+#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -4707,33 +4725,33 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:877
+#: lxc/remote.go:911
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:868 lxc/remote.go:949 lxc/remote.go:1013
-#: lxc/remote.go:1061
+#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/remote.go:1095
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:345
+#: lxc/remote.go:359
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:957
+#: lxc/remote.go:991
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:872 lxc/remote.go:953 lxc/remote.go:1065
+#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1099
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:319
+#: lxc/remote.go:333
 msgid "Remote address must not be empty"
 msgstr ""
 
@@ -4741,7 +4759,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:339
+#: lxc/remote.go:353
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4763,7 +4781,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1223 lxc/auth.go:1224
+#: lxc/auth.go:1372 lxc/auth.go:1373
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4799,7 +4817,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1986 lxc/auth.go:1987
+#: lxc/auth.go:2135 lxc/auth.go:2136
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4811,7 +4829,7 @@ msgstr ""
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:575 lxc/auth.go:576
+#: lxc/auth.go:580 lxc/auth.go:581
 msgid "Remove permissions from groups"
 msgstr ""
 
@@ -4827,7 +4845,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:919 lxc/remote.go:920
+#: lxc/remote.go:953 lxc/remote.go:954
 msgid "Remove remotes"
 msgstr ""
 
@@ -4856,11 +4874,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:392 lxc/auth.go:393
+#: lxc/auth.go:397 lxc/auth.go:398
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1810 lxc/auth.go:1811
+#: lxc/auth.go:1959 lxc/auth.go:1960
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -4884,7 +4902,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:838 lxc/remote.go:839
+#: lxc/remote.go:872 lxc/remote.go:873
 msgid "Rename remotes"
 msgstr ""
 
@@ -5029,7 +5047,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:820
+#: lxc/remote.go:854
 msgid "STATIC"
 msgstr ""
 
@@ -5070,11 +5088,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:532
+#: lxc/remote.go:546
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:285 lxc/remote.go:683
+#: lxc/remote.go:299 lxc/remote.go:717
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5285,7 +5303,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1031 lxc/remote.go:1032
+#: lxc/remote.go:1065 lxc/remote.go:1066
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5381,7 +5399,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1859 lxc/auth.go:1860
+#: lxc/auth.go:2008 lxc/auth.go:2009
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5409,11 +5427,11 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:441 lxc/auth.go:442
+#: lxc/auth.go:446 lxc/auth.go:447
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:836
+#: lxc/auth.go:985
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5518,7 +5536,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:899
+#: lxc/auth.go:1048
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5528,7 +5546,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:714 lxc/remote.go:715
+#: lxc/remote.go:748 lxc/remote.go:749
 msgid "Show the default remote"
 msgstr ""
 
@@ -5740,7 +5758,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:983 lxc/remote.go:984
+#: lxc/remote.go:1017 lxc/remote.go:1018
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5752,11 +5770,21 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
+#: lxc/auth.go:876
+#, c-format
+msgid "TLS identity %q (%s) pending identity token:"
+msgstr ""
+
+#: lxc/auth.go:902
+#, c-format
+msgid "TLS identity %q created with fingerprint %q"
+msgstr ""
+
 #: lxc/cluster.go:1070 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:818 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
 #: lxc/storage_volume.go:1736 lxc/warning.go:216
@@ -5775,7 +5803,7 @@ msgstr ""
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/remote.go:161 lxc/remote.go:334
+#: lxc/remote.go:161 lxc/remote.go:348
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
@@ -5931,7 +5959,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:527
+#: lxc/remote.go:541
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
@@ -6069,15 +6097,15 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:329
+#: lxc/remote.go:343
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:324
+#: lxc/remote.go:338
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr ""
 
-#: lxc/remote.go:639
+#: lxc/remote.go:653
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6120,7 +6148,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:193 lxc/remote.go:816
+#: lxc/cluster.go:193 lxc/remote.go:850
 msgid "URL"
 msgstr ""
 
@@ -6428,11 +6456,11 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:835
+#: lxc/auth.go:984
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:898
+#: lxc/auth.go:1047
 msgid "View the current identity"
 msgstr ""
 
@@ -6471,7 +6499,7 @@ msgstr ""
 
 #: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:777 lxc/remote.go:782 lxc/remote.go:787
+#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr ""
 
@@ -6503,7 +6531,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:330 lxc/auth.go:766 lxc/auth.go:897 lxc/auth.go:1748
+#: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
@@ -6536,7 +6564,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1313
+#: lxc/auth.go:1462
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6597,11 +6625,17 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:834 lxc/auth.go:1086
+#: lxc/auth.go:774
+msgid ""
+"[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
+"certificate>] [[--group <group_name>]]"
+msgstr ""
+
+#: lxc/auth.go:983 lxc/auth.go:1235
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1164 lxc/auth.go:1222 lxc/auth.go:1985
+#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:2134
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6609,13 +6643,13 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:97 lxc/auth.go:150 lxc/auth.go:200 lxc/auth.go:440
-#: lxc/auth.go:958 lxc/auth.go:1529 lxc/cluster_group.go:168
+#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:445
+#: lxc/auth.go:1107 lxc/auth.go:1678 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:515 lxc/auth.go:573
+#: lxc/auth.go:520 lxc/auth.go:578
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
@@ -6625,19 +6659,19 @@ msgstr ""
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:390
+#: lxc/auth.go:395
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1580 lxc/auth.go:1630 lxc/auth.go:1858
+#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1932
+#: lxc/auth.go:2081
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1808
+#: lxc/auth.go:1957
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -7128,7 +7162,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:806
+#: lxc/project.go:557 lxc/remote.go:840
 msgid "current"
 msgstr ""
 
@@ -7175,20 +7209,20 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/auth.go:204
+#: lxc/auth.go:209
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:962
+#: lxc/auth.go:1111
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1634
+#: lxc/auth.go:1783
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7612,7 +7646,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:531
+#: lxc/remote.go:545
 msgid "n"
 msgstr ""
 
@@ -7624,7 +7658,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:510
+#: lxc/remote.go:524
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7661,7 +7695,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:519
+#: lxc/remote.go:533
 msgid "y"
 msgstr ""
 

--- a/po/th.po
+++ b/po/th.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-14 13:30+0000\n"
+"POT-Creation-Date: 2024-10-15 14:52+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -130,7 +130,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:214
+#: lxc/auth.go:219
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -157,7 +157,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:972
+#: lxc/auth.go:1121
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -178,7 +178,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1644
+#: lxc/auth.go:1793
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -512,15 +512,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:917 lxc/remote.go:982
+#: lxc/remote.go:951 lxc/remote.go:1016
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1030
+#: lxc/remote.go:1064
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:836
+#: lxc/remote.go:870
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -553,11 +553,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:818
+#: lxc/remote.go:852
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:817
+#: lxc/auth.go:966
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -595,11 +595,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1165 lxc/auth.go:1166
+#: lxc/auth.go:1314 lxc/auth.go:1315
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1933 lxc/auth.go:1934
+#: lxc/auth.go:2082 lxc/auth.go:2083
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -668,7 +668,7 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:516 lxc/auth.go:517
+#: lxc/auth.go:521 lxc/auth.go:522
 msgid "Add permissions to groups"
 msgstr ""
 
@@ -702,7 +702,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:648
+#: lxc/remote.go:680
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -810,7 +810,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:621
+#: lxc/remote.go:635
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -988,7 +988,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:961
+#: lxc/remote.go:995
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1054,7 +1054,7 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:509
+#: lxc/remote.go:523
 msgid "Certificate fingerprint"
 msgstr ""
 
@@ -1073,7 +1073,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:687
+#: lxc/remote.go:721
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1321,12 +1321,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:559
+#: lxc/remote.go:573
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:237 lxc/remote.go:543
+#: lxc/remote.go:237 lxc/remote.go:557
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1340,12 +1340,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:1719
+#: lxc/auth.go:306 lxc/auth.go:1868
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1058
+#: lxc/auth.go:1207
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1365,13 +1365,17 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:554
+#: lxc/remote.go:568
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
 #: lxc/network_zone.go:1536
 msgid "Couldn't find a matching entry"
+msgstr ""
+
+#: lxc/auth.go:776
+msgid "Create a TLS identity"
 msgstr ""
 
 #: lxc/cluster_group.go:169 lxc/cluster_group.go:170
@@ -1390,6 +1394,10 @@ msgstr ""
 msgid "Create an empty instance"
 msgstr ""
 
+#: lxc/auth.go:775
+msgid "Create an identity"
+msgstr ""
+
 #: lxc/launch.go:23 lxc/launch.go:24
 msgid "Create and start instances from images"
 msgstr ""
@@ -1402,11 +1410,11 @@ msgstr ""
 msgid "Create files and directories in instances"
 msgstr ""
 
-#: lxc/auth.go:98 lxc/auth.go:99
+#: lxc/auth.go:103 lxc/auth.go:104
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1530 lxc/auth.go:1531
+#: lxc/auth.go:1679 lxc/auth.go:1680
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1514,7 +1522,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
@@ -1557,7 +1565,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/auth.go:1088 lxc/auth.go:1089
+#: lxc/auth.go:1237 lxc/auth.go:1238
 msgid "Delete an identity"
 msgstr ""
 
@@ -1565,11 +1573,11 @@ msgstr ""
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/auth.go:152 lxc/auth.go:153
+#: lxc/auth.go:157 lxc/auth.go:158
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1582 lxc/auth.go:1583
+#: lxc/auth.go:1731 lxc/auth.go:1732
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1647,18 +1655,18 @@ msgstr ""
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:31 lxc/auth.go:60 lxc/auth.go:99
-#: lxc/auth.go:153 lxc/auth.go:202 lxc/auth.go:333 lxc/auth.go:393
-#: lxc/auth.go:442 lxc/auth.go:494 lxc/auth.go:517 lxc/auth.go:576
-#: lxc/auth.go:732 lxc/auth.go:769 lxc/auth.go:836 lxc/auth.go:899
-#: lxc/auth.go:960 lxc/auth.go:1089 lxc/auth.go:1143 lxc/auth.go:1166
-#: lxc/auth.go:1224 lxc/auth.go:1293 lxc/auth.go:1315 lxc/auth.go:1493
-#: lxc/auth.go:1531 lxc/auth.go:1583 lxc/auth.go:1632 lxc/auth.go:1751
-#: lxc/auth.go:1811 lxc/auth.go:1860 lxc/auth.go:1911 lxc/auth.go:1934
-#: lxc/auth.go:1987 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215
-#: lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:484
-#: lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677 lxc/cluster.go:770
-#: lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
+#: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
+#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:338 lxc/auth.go:398
+#: lxc/auth.go:447 lxc/auth.go:499 lxc/auth.go:522 lxc/auth.go:581
+#: lxc/auth.go:737 lxc/auth.go:776 lxc/auth.go:918 lxc/auth.go:985
+#: lxc/auth.go:1048 lxc/auth.go:1109 lxc/auth.go:1238 lxc/auth.go:1292
+#: lxc/auth.go:1315 lxc/auth.go:1373 lxc/auth.go:1442 lxc/auth.go:1464
+#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
+#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
+#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
+#: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
+#: lxc/cluster.go:770 lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
 #: lxc/cluster.go:1175 lxc/cluster.go:1299 lxc/cluster.go:1329
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
@@ -1729,9 +1737,9 @@ msgstr ""
 #: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
 #: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
 #: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:715
-#: lxc/remote.go:753 lxc/remote.go:839 lxc/remote.go:920 lxc/remote.go:984
-#: lxc/remote.go:1032 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
+#: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
+#: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1916,7 +1924,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:959 lxc/auth.go:960
+#: lxc/auth.go:1108 lxc/auth.go:1109
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1928,11 +1936,11 @@ msgstr ""
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/auth.go:201 lxc/auth.go:202
+#: lxc/auth.go:206 lxc/auth.go:207
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1631 lxc/auth.go:1632
+#: lxc/auth.go:1780 lxc/auth.go:1781
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2308,12 +2316,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:486
+#: lxc/remote.go:500
 #, c-format
 msgid "Failed to decode trust token: %w"
 msgstr ""
 
-#: lxc/remote.go:292
+#: lxc/remote.go:306
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2417,7 +2425,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:773 lxc/auth.go:1755
+#: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
@@ -2425,7 +2433,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:757 lxc/storage.go:657
+#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2463,7 +2471,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:821
+#: lxc/remote.go:855
 msgid "GLOBAL"
 msgstr ""
 
@@ -2475,7 +2483,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:821 lxc/auth.go:1795
+#: lxc/auth.go:970 lxc/auth.go:1944
 msgid "GROUPS"
 msgstr ""
 
@@ -2483,7 +2491,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:165 lxc/remote.go:443
+#: lxc/remote.go:165 lxc/remote.go:457
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2624,17 +2632,17 @@ msgstr ""
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: lxc/auth.go:137
+#: lxc/auth.go:142
 #, c-format
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:187
+#: lxc/auth.go:192
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:427 lxc/auth.go:1845
+#: lxc/auth.go:432 lxc/auth.go:1994
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2693,7 +2701,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:820
+#: lxc/auth.go:969
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -2725,12 +2733,16 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1567
+#: lxc/auth.go:829
+msgid "Identity creation only supported for TLS identities"
+msgstr ""
+
+#: lxc/auth.go:1716
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1617
+#: lxc/auth.go:1766
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2859,7 +2871,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1292 lxc/auth.go:1293
+#: lxc/auth.go:1441 lxc/auth.go:1442
 msgid "Inspect permissions"
 msgstr ""
 
@@ -2907,7 +2919,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:395
+#: lxc/remote.go:409
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2988,7 +3000,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:384
+#: lxc/remote.go:398
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3163,15 +3175,15 @@ msgstr ""
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:332 lxc/auth.go:333
+#: lxc/auth.go:337 lxc/auth.go:338
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:768 lxc/auth.go:769
+#: lxc/auth.go:917 lxc/auth.go:918
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1750 lxc/auth.go:1751
+#: lxc/auth.go:1899 lxc/auth.go:1900
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3324,7 +3336,7 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1314 lxc/auth.go:1315
+#: lxc/auth.go:1463 lxc/auth.go:1464
 msgid "List permissions"
 msgstr ""
 
@@ -3368,7 +3380,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:752 lxc/remote.go:753
+#: lxc/remote.go:786 lxc/remote.go:787
 msgid "List the available remotes"
 msgstr ""
 
@@ -3492,6 +3504,12 @@ msgstr ""
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
+#: lxc/auth.go:825
+msgid ""
+"Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
+"got "
+msgstr ""
+
 #: lxc/network.go:32 lxc/network.go:33
 msgid "Manage and attach instances to networks"
 msgstr ""
@@ -3520,19 +3538,19 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:59 lxc/auth.go:60 lxc/auth.go:1492 lxc/auth.go:1493
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1142 lxc/auth.go:1143
+#: lxc/auth.go:1291 lxc/auth.go:1292
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:731 lxc/auth.go:732
+#: lxc/auth.go:736 lxc/auth.go:737
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1910 lxc/auth.go:1911
+#: lxc/auth.go:2059 lxc/auth.go:2060
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3623,7 +3641,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:493 lxc/auth.go:494
+#: lxc/auth.go:498 lxc/auth.go:499
 msgid "Manage permissions"
 msgstr ""
 
@@ -3675,7 +3693,7 @@ msgstr ""
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/auth.go:30 lxc/auth.go:31
+#: lxc/auth.go:35 lxc/auth.go:36
 msgid "Manage user authorization"
 msgstr ""
 
@@ -3772,21 +3790,21 @@ msgstr ""
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:123 lxc/auth.go:177 lxc/auth.go:255 lxc/auth.go:417
-#: lxc/auth.go:466 lxc/auth.go:541 lxc/auth.go:600 lxc/auth.go:1884
+#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:260 lxc/auth.go:422
+#: lxc/auth.go:471 lxc/auth.go:546 lxc/auth.go:605 lxc/auth.go:2033
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:866 lxc/auth.go:1007 lxc/auth.go:1124 lxc/auth.go:1190
-#: lxc/auth.go:1248
+#: lxc/auth.go:820 lxc/auth.go:1015 lxc/auth.go:1156 lxc/auth.go:1273
+#: lxc/auth.go:1339 lxc/auth.go:1397
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1554 lxc/auth.go:1607 lxc/auth.go:1673 lxc/auth.go:1835
+#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1958 lxc/auth.go:2011
+#: lxc/auth.go:2107 lxc/auth.go:2160
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -4007,12 +4025,12 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:376 lxc/auth.go:819 lxc/auth.go:1794 lxc/cluster.go:192
+#: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
-#: lxc/remote.go:815 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
 msgstr ""
@@ -4039,7 +4057,7 @@ msgstr ""
 
 #: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:775 lxc/remote.go:780 lxc/remote.go:785
+#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr ""
 
@@ -4268,7 +4286,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:378
+#: lxc/remote.go:392
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4339,11 +4357,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:817
+#: lxc/remote.go:851
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:819
+#: lxc/image.go:1136 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4384,7 +4402,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:536
+#: lxc/remote.go:550
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
@@ -4401,7 +4419,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:302 lxc/auth.go:1059 lxc/auth.go:1720 lxc/cluster.go:860
+#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -4704,33 +4722,33 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:877
+#: lxc/remote.go:911
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:868 lxc/remote.go:949 lxc/remote.go:1013
-#: lxc/remote.go:1061
+#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/remote.go:1095
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:345
+#: lxc/remote.go:359
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:957
+#: lxc/remote.go:991
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:872 lxc/remote.go:953 lxc/remote.go:1065
+#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1099
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:319
+#: lxc/remote.go:333
 msgid "Remote address must not be empty"
 msgstr ""
 
@@ -4738,7 +4756,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:339
+#: lxc/remote.go:353
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4760,7 +4778,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1223 lxc/auth.go:1224
+#: lxc/auth.go:1372 lxc/auth.go:1373
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4796,7 +4814,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1986 lxc/auth.go:1987
+#: lxc/auth.go:2135 lxc/auth.go:2136
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4808,7 +4826,7 @@ msgstr ""
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:575 lxc/auth.go:576
+#: lxc/auth.go:580 lxc/auth.go:581
 msgid "Remove permissions from groups"
 msgstr ""
 
@@ -4824,7 +4842,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:919 lxc/remote.go:920
+#: lxc/remote.go:953 lxc/remote.go:954
 msgid "Remove remotes"
 msgstr ""
 
@@ -4853,11 +4871,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:392 lxc/auth.go:393
+#: lxc/auth.go:397 lxc/auth.go:398
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1810 lxc/auth.go:1811
+#: lxc/auth.go:1959 lxc/auth.go:1960
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -4881,7 +4899,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:838 lxc/remote.go:839
+#: lxc/remote.go:872 lxc/remote.go:873
 msgid "Rename remotes"
 msgstr ""
 
@@ -5026,7 +5044,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:820
+#: lxc/remote.go:854
 msgid "STATIC"
 msgstr ""
 
@@ -5067,11 +5085,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:532
+#: lxc/remote.go:546
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:285 lxc/remote.go:683
+#: lxc/remote.go:299 lxc/remote.go:717
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5282,7 +5300,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1031 lxc/remote.go:1032
+#: lxc/remote.go:1065 lxc/remote.go:1066
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5378,7 +5396,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1859 lxc/auth.go:1860
+#: lxc/auth.go:2008 lxc/auth.go:2009
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5406,11 +5424,11 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:441 lxc/auth.go:442
+#: lxc/auth.go:446 lxc/auth.go:447
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:836
+#: lxc/auth.go:985
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5515,7 +5533,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:899
+#: lxc/auth.go:1048
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5525,7 +5543,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:714 lxc/remote.go:715
+#: lxc/remote.go:748 lxc/remote.go:749
 msgid "Show the default remote"
 msgstr ""
 
@@ -5737,7 +5755,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:983 lxc/remote.go:984
+#: lxc/remote.go:1017 lxc/remote.go:1018
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5749,11 +5767,21 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
+#: lxc/auth.go:876
+#, c-format
+msgid "TLS identity %q (%s) pending identity token:"
+msgstr ""
+
+#: lxc/auth.go:902
+#, c-format
+msgid "TLS identity %q created with fingerprint %q"
+msgstr ""
+
 #: lxc/cluster.go:1070 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:818 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
 #: lxc/storage_volume.go:1736 lxc/warning.go:216
@@ -5772,7 +5800,7 @@ msgstr ""
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/remote.go:161 lxc/remote.go:334
+#: lxc/remote.go:161 lxc/remote.go:348
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
@@ -5928,7 +5956,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:527
+#: lxc/remote.go:541
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
@@ -6066,15 +6094,15 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:329
+#: lxc/remote.go:343
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:324
+#: lxc/remote.go:338
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr ""
 
-#: lxc/remote.go:639
+#: lxc/remote.go:653
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6117,7 +6145,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:193 lxc/remote.go:816
+#: lxc/cluster.go:193 lxc/remote.go:850
 msgid "URL"
 msgstr ""
 
@@ -6425,11 +6453,11 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:835
+#: lxc/auth.go:984
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:898
+#: lxc/auth.go:1047
 msgid "View the current identity"
 msgstr ""
 
@@ -6468,7 +6496,7 @@ msgstr ""
 
 #: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:777 lxc/remote.go:782 lxc/remote.go:787
+#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr ""
 
@@ -6500,7 +6528,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:330 lxc/auth.go:766 lxc/auth.go:897 lxc/auth.go:1748
+#: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
@@ -6533,7 +6561,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1313
+#: lxc/auth.go:1462
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6594,11 +6622,17 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:834 lxc/auth.go:1086
+#: lxc/auth.go:774
+msgid ""
+"[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
+"certificate>] [[--group <group_name>]]"
+msgstr ""
+
+#: lxc/auth.go:983 lxc/auth.go:1235
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1164 lxc/auth.go:1222 lxc/auth.go:1985
+#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:2134
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6606,13 +6640,13 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:97 lxc/auth.go:150 lxc/auth.go:200 lxc/auth.go:440
-#: lxc/auth.go:958 lxc/auth.go:1529 lxc/cluster_group.go:168
+#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:445
+#: lxc/auth.go:1107 lxc/auth.go:1678 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:515 lxc/auth.go:573
+#: lxc/auth.go:520 lxc/auth.go:578
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
@@ -6622,19 +6656,19 @@ msgstr ""
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:390
+#: lxc/auth.go:395
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1580 lxc/auth.go:1630 lxc/auth.go:1858
+#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1932
+#: lxc/auth.go:2081
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1808
+#: lxc/auth.go:1957
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -7125,7 +7159,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:806
+#: lxc/project.go:557 lxc/remote.go:840
 msgid "current"
 msgstr ""
 
@@ -7172,20 +7206,20 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/auth.go:204
+#: lxc/auth.go:209
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:962
+#: lxc/auth.go:1111
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1634
+#: lxc/auth.go:1783
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7609,7 +7643,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:531
+#: lxc/remote.go:545
 msgid "n"
 msgstr ""
 
@@ -7621,7 +7655,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:510
+#: lxc/remote.go:524
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7658,7 +7692,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:519
+#: lxc/remote.go:533
 msgid "y"
 msgstr ""
 

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-14 13:30+0000\n"
+"POT-Creation-Date: 2024-10-15 14:52+0100\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Turkish <https://hosted.weblate.org/projects/linux-containers/"
@@ -133,7 +133,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:214
+#: lxc/auth.go:219
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -160,7 +160,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:972
+#: lxc/auth.go:1121
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -181,7 +181,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1644
+#: lxc/auth.go:1793
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -515,15 +515,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:917 lxc/remote.go:982
+#: lxc/remote.go:951 lxc/remote.go:1016
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1030
+#: lxc/remote.go:1064
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:836
+#: lxc/remote.go:870
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -556,11 +556,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:818
+#: lxc/remote.go:852
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:817
+#: lxc/auth.go:966
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -598,11 +598,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1165 lxc/auth.go:1166
+#: lxc/auth.go:1314 lxc/auth.go:1315
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1933 lxc/auth.go:1934
+#: lxc/auth.go:2082 lxc/auth.go:2083
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -671,7 +671,7 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:516 lxc/auth.go:517
+#: lxc/auth.go:521 lxc/auth.go:522
 msgid "Add permissions to groups"
 msgstr ""
 
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:648
+#: lxc/remote.go:680
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -813,7 +813,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:621
+#: lxc/remote.go:635
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -991,7 +991,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:961
+#: lxc/remote.go:995
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1057,7 +1057,7 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:509
+#: lxc/remote.go:523
 msgid "Certificate fingerprint"
 msgstr ""
 
@@ -1076,7 +1076,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:687
+#: lxc/remote.go:721
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1324,12 +1324,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:559
+#: lxc/remote.go:573
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:237 lxc/remote.go:543
+#: lxc/remote.go:237 lxc/remote.go:557
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1343,12 +1343,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:1719
+#: lxc/auth.go:306 lxc/auth.go:1868
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1058
+#: lxc/auth.go:1207
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1368,13 +1368,17 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:554
+#: lxc/remote.go:568
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
 #: lxc/network_zone.go:1536
 msgid "Couldn't find a matching entry"
+msgstr ""
+
+#: lxc/auth.go:776
+msgid "Create a TLS identity"
 msgstr ""
 
 #: lxc/cluster_group.go:169 lxc/cluster_group.go:170
@@ -1393,6 +1397,10 @@ msgstr ""
 msgid "Create an empty instance"
 msgstr ""
 
+#: lxc/auth.go:775
+msgid "Create an identity"
+msgstr ""
+
 #: lxc/launch.go:23 lxc/launch.go:24
 msgid "Create and start instances from images"
 msgstr ""
@@ -1405,11 +1413,11 @@ msgstr ""
 msgid "Create files and directories in instances"
 msgstr ""
 
-#: lxc/auth.go:98 lxc/auth.go:99
+#: lxc/auth.go:103 lxc/auth.go:104
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1530 lxc/auth.go:1531
+#: lxc/auth.go:1679 lxc/auth.go:1680
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1517,7 +1525,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
@@ -1560,7 +1568,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/auth.go:1088 lxc/auth.go:1089
+#: lxc/auth.go:1237 lxc/auth.go:1238
 msgid "Delete an identity"
 msgstr ""
 
@@ -1568,11 +1576,11 @@ msgstr ""
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/auth.go:152 lxc/auth.go:153
+#: lxc/auth.go:157 lxc/auth.go:158
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1582 lxc/auth.go:1583
+#: lxc/auth.go:1731 lxc/auth.go:1732
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1650,18 +1658,18 @@ msgstr ""
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:31 lxc/auth.go:60 lxc/auth.go:99
-#: lxc/auth.go:153 lxc/auth.go:202 lxc/auth.go:333 lxc/auth.go:393
-#: lxc/auth.go:442 lxc/auth.go:494 lxc/auth.go:517 lxc/auth.go:576
-#: lxc/auth.go:732 lxc/auth.go:769 lxc/auth.go:836 lxc/auth.go:899
-#: lxc/auth.go:960 lxc/auth.go:1089 lxc/auth.go:1143 lxc/auth.go:1166
-#: lxc/auth.go:1224 lxc/auth.go:1293 lxc/auth.go:1315 lxc/auth.go:1493
-#: lxc/auth.go:1531 lxc/auth.go:1583 lxc/auth.go:1632 lxc/auth.go:1751
-#: lxc/auth.go:1811 lxc/auth.go:1860 lxc/auth.go:1911 lxc/auth.go:1934
-#: lxc/auth.go:1987 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215
-#: lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:484
-#: lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677 lxc/cluster.go:770
-#: lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
+#: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
+#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:338 lxc/auth.go:398
+#: lxc/auth.go:447 lxc/auth.go:499 lxc/auth.go:522 lxc/auth.go:581
+#: lxc/auth.go:737 lxc/auth.go:776 lxc/auth.go:918 lxc/auth.go:985
+#: lxc/auth.go:1048 lxc/auth.go:1109 lxc/auth.go:1238 lxc/auth.go:1292
+#: lxc/auth.go:1315 lxc/auth.go:1373 lxc/auth.go:1442 lxc/auth.go:1464
+#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
+#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
+#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
+#: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
+#: lxc/cluster.go:770 lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
 #: lxc/cluster.go:1175 lxc/cluster.go:1299 lxc/cluster.go:1329
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
@@ -1732,9 +1740,9 @@ msgstr ""
 #: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
 #: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
 #: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:715
-#: lxc/remote.go:753 lxc/remote.go:839 lxc/remote.go:920 lxc/remote.go:984
-#: lxc/remote.go:1032 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
+#: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
+#: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1919,7 +1927,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:959 lxc/auth.go:960
+#: lxc/auth.go:1108 lxc/auth.go:1109
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1931,11 +1939,11 @@ msgstr ""
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/auth.go:201 lxc/auth.go:202
+#: lxc/auth.go:206 lxc/auth.go:207
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1631 lxc/auth.go:1632
+#: lxc/auth.go:1780 lxc/auth.go:1781
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2311,12 +2319,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:486
+#: lxc/remote.go:500
 #, c-format
 msgid "Failed to decode trust token: %w"
 msgstr ""
 
-#: lxc/remote.go:292
+#: lxc/remote.go:306
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2420,7 +2428,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:773 lxc/auth.go:1755
+#: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
@@ -2428,7 +2436,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:757 lxc/storage.go:657
+#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2466,7 +2474,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:821
+#: lxc/remote.go:855
 msgid "GLOBAL"
 msgstr ""
 
@@ -2478,7 +2486,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:821 lxc/auth.go:1795
+#: lxc/auth.go:970 lxc/auth.go:1944
 msgid "GROUPS"
 msgstr ""
 
@@ -2486,7 +2494,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:165 lxc/remote.go:443
+#: lxc/remote.go:165 lxc/remote.go:457
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2627,17 +2635,17 @@ msgstr ""
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: lxc/auth.go:137
+#: lxc/auth.go:142
 #, c-format
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:187
+#: lxc/auth.go:192
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:427 lxc/auth.go:1845
+#: lxc/auth.go:432 lxc/auth.go:1994
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2696,7 +2704,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:820
+#: lxc/auth.go:969
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -2728,12 +2736,16 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1567
+#: lxc/auth.go:829
+msgid "Identity creation only supported for TLS identities"
+msgstr ""
+
+#: lxc/auth.go:1716
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1617
+#: lxc/auth.go:1766
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2862,7 +2874,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1292 lxc/auth.go:1293
+#: lxc/auth.go:1441 lxc/auth.go:1442
 msgid "Inspect permissions"
 msgstr ""
 
@@ -2910,7 +2922,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:395
+#: lxc/remote.go:409
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2991,7 +3003,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:384
+#: lxc/remote.go:398
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3166,15 +3178,15 @@ msgstr ""
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:332 lxc/auth.go:333
+#: lxc/auth.go:337 lxc/auth.go:338
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:768 lxc/auth.go:769
+#: lxc/auth.go:917 lxc/auth.go:918
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1750 lxc/auth.go:1751
+#: lxc/auth.go:1899 lxc/auth.go:1900
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3327,7 +3339,7 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1314 lxc/auth.go:1315
+#: lxc/auth.go:1463 lxc/auth.go:1464
 msgid "List permissions"
 msgstr ""
 
@@ -3371,7 +3383,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:752 lxc/remote.go:753
+#: lxc/remote.go:786 lxc/remote.go:787
 msgid "List the available remotes"
 msgstr ""
 
@@ -3495,6 +3507,12 @@ msgstr ""
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
+#: lxc/auth.go:825
+msgid ""
+"Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
+"got "
+msgstr ""
+
 #: lxc/network.go:32 lxc/network.go:33
 msgid "Manage and attach instances to networks"
 msgstr ""
@@ -3523,19 +3541,19 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:59 lxc/auth.go:60 lxc/auth.go:1492 lxc/auth.go:1493
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1142 lxc/auth.go:1143
+#: lxc/auth.go:1291 lxc/auth.go:1292
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:731 lxc/auth.go:732
+#: lxc/auth.go:736 lxc/auth.go:737
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1910 lxc/auth.go:1911
+#: lxc/auth.go:2059 lxc/auth.go:2060
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3626,7 +3644,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:493 lxc/auth.go:494
+#: lxc/auth.go:498 lxc/auth.go:499
 msgid "Manage permissions"
 msgstr ""
 
@@ -3678,7 +3696,7 @@ msgstr ""
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/auth.go:30 lxc/auth.go:31
+#: lxc/auth.go:35 lxc/auth.go:36
 msgid "Manage user authorization"
 msgstr ""
 
@@ -3775,21 +3793,21 @@ msgstr ""
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:123 lxc/auth.go:177 lxc/auth.go:255 lxc/auth.go:417
-#: lxc/auth.go:466 lxc/auth.go:541 lxc/auth.go:600 lxc/auth.go:1884
+#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:260 lxc/auth.go:422
+#: lxc/auth.go:471 lxc/auth.go:546 lxc/auth.go:605 lxc/auth.go:2033
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:866 lxc/auth.go:1007 lxc/auth.go:1124 lxc/auth.go:1190
-#: lxc/auth.go:1248
+#: lxc/auth.go:820 lxc/auth.go:1015 lxc/auth.go:1156 lxc/auth.go:1273
+#: lxc/auth.go:1339 lxc/auth.go:1397
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1554 lxc/auth.go:1607 lxc/auth.go:1673 lxc/auth.go:1835
+#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1958 lxc/auth.go:2011
+#: lxc/auth.go:2107 lxc/auth.go:2160
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -4010,12 +4028,12 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:376 lxc/auth.go:819 lxc/auth.go:1794 lxc/cluster.go:192
+#: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
-#: lxc/remote.go:815 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
 msgstr ""
@@ -4042,7 +4060,7 @@ msgstr ""
 
 #: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:775 lxc/remote.go:780 lxc/remote.go:785
+#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr ""
 
@@ -4271,7 +4289,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:378
+#: lxc/remote.go:392
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4342,11 +4360,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:817
+#: lxc/remote.go:851
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:819
+#: lxc/image.go:1136 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4387,7 +4405,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:536
+#: lxc/remote.go:550
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
@@ -4404,7 +4422,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:302 lxc/auth.go:1059 lxc/auth.go:1720 lxc/cluster.go:860
+#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -4707,33 +4725,33 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:877
+#: lxc/remote.go:911
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:868 lxc/remote.go:949 lxc/remote.go:1013
-#: lxc/remote.go:1061
+#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/remote.go:1095
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:345
+#: lxc/remote.go:359
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:957
+#: lxc/remote.go:991
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:872 lxc/remote.go:953 lxc/remote.go:1065
+#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1099
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:319
+#: lxc/remote.go:333
 msgid "Remote address must not be empty"
 msgstr ""
 
@@ -4741,7 +4759,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:339
+#: lxc/remote.go:353
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4763,7 +4781,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1223 lxc/auth.go:1224
+#: lxc/auth.go:1372 lxc/auth.go:1373
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4799,7 +4817,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1986 lxc/auth.go:1987
+#: lxc/auth.go:2135 lxc/auth.go:2136
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4811,7 +4829,7 @@ msgstr ""
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:575 lxc/auth.go:576
+#: lxc/auth.go:580 lxc/auth.go:581
 msgid "Remove permissions from groups"
 msgstr ""
 
@@ -4827,7 +4845,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:919 lxc/remote.go:920
+#: lxc/remote.go:953 lxc/remote.go:954
 msgid "Remove remotes"
 msgstr ""
 
@@ -4856,11 +4874,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:392 lxc/auth.go:393
+#: lxc/auth.go:397 lxc/auth.go:398
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1810 lxc/auth.go:1811
+#: lxc/auth.go:1959 lxc/auth.go:1960
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -4884,7 +4902,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:838 lxc/remote.go:839
+#: lxc/remote.go:872 lxc/remote.go:873
 msgid "Rename remotes"
 msgstr ""
 
@@ -5029,7 +5047,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:820
+#: lxc/remote.go:854
 msgid "STATIC"
 msgstr ""
 
@@ -5070,11 +5088,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:532
+#: lxc/remote.go:546
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:285 lxc/remote.go:683
+#: lxc/remote.go:299 lxc/remote.go:717
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5285,7 +5303,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1031 lxc/remote.go:1032
+#: lxc/remote.go:1065 lxc/remote.go:1066
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5381,7 +5399,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1859 lxc/auth.go:1860
+#: lxc/auth.go:2008 lxc/auth.go:2009
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5409,11 +5427,11 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:441 lxc/auth.go:442
+#: lxc/auth.go:446 lxc/auth.go:447
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:836
+#: lxc/auth.go:985
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5518,7 +5536,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:899
+#: lxc/auth.go:1048
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5528,7 +5546,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:714 lxc/remote.go:715
+#: lxc/remote.go:748 lxc/remote.go:749
 msgid "Show the default remote"
 msgstr ""
 
@@ -5740,7 +5758,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:983 lxc/remote.go:984
+#: lxc/remote.go:1017 lxc/remote.go:1018
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5752,11 +5770,21 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
+#: lxc/auth.go:876
+#, c-format
+msgid "TLS identity %q (%s) pending identity token:"
+msgstr ""
+
+#: lxc/auth.go:902
+#, c-format
+msgid "TLS identity %q created with fingerprint %q"
+msgstr ""
+
 #: lxc/cluster.go:1070 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:818 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
 #: lxc/storage_volume.go:1736 lxc/warning.go:216
@@ -5775,7 +5803,7 @@ msgstr ""
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/remote.go:161 lxc/remote.go:334
+#: lxc/remote.go:161 lxc/remote.go:348
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
@@ -5931,7 +5959,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:527
+#: lxc/remote.go:541
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
@@ -6069,15 +6097,15 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:329
+#: lxc/remote.go:343
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:324
+#: lxc/remote.go:338
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr ""
 
-#: lxc/remote.go:639
+#: lxc/remote.go:653
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6120,7 +6148,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:193 lxc/remote.go:816
+#: lxc/cluster.go:193 lxc/remote.go:850
 msgid "URL"
 msgstr ""
 
@@ -6428,11 +6456,11 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:835
+#: lxc/auth.go:984
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:898
+#: lxc/auth.go:1047
 msgid "View the current identity"
 msgstr ""
 
@@ -6471,7 +6499,7 @@ msgstr ""
 
 #: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:777 lxc/remote.go:782 lxc/remote.go:787
+#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr ""
 
@@ -6503,7 +6531,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:330 lxc/auth.go:766 lxc/auth.go:897 lxc/auth.go:1748
+#: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
@@ -6536,7 +6564,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1313
+#: lxc/auth.go:1462
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6597,11 +6625,17 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:834 lxc/auth.go:1086
+#: lxc/auth.go:774
+msgid ""
+"[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
+"certificate>] [[--group <group_name>]]"
+msgstr ""
+
+#: lxc/auth.go:983 lxc/auth.go:1235
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1164 lxc/auth.go:1222 lxc/auth.go:1985
+#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:2134
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6609,13 +6643,13 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:97 lxc/auth.go:150 lxc/auth.go:200 lxc/auth.go:440
-#: lxc/auth.go:958 lxc/auth.go:1529 lxc/cluster_group.go:168
+#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:445
+#: lxc/auth.go:1107 lxc/auth.go:1678 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:515 lxc/auth.go:573
+#: lxc/auth.go:520 lxc/auth.go:578
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
@@ -6625,19 +6659,19 @@ msgstr ""
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:390
+#: lxc/auth.go:395
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1580 lxc/auth.go:1630 lxc/auth.go:1858
+#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1932
+#: lxc/auth.go:2081
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1808
+#: lxc/auth.go:1957
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -7128,7 +7162,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:806
+#: lxc/project.go:557 lxc/remote.go:840
 msgid "current"
 msgstr ""
 
@@ -7175,20 +7209,20 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/auth.go:204
+#: lxc/auth.go:209
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:962
+#: lxc/auth.go:1111
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1634
+#: lxc/auth.go:1783
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7612,7 +7646,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:531
+#: lxc/remote.go:545
 msgid "n"
 msgstr ""
 
@@ -7624,7 +7658,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:510
+#: lxc/remote.go:524
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7661,7 +7695,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:519
+#: lxc/remote.go:533
 msgid "y"
 msgstr ""
 

--- a/po/tzm.po
+++ b/po/tzm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-14 13:30+0000\n"
+"POT-Creation-Date: 2024-10-15 14:52+0100\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Tamazight (Central Atlas) <https://hosted.weblate.org/"
@@ -133,7 +133,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:214
+#: lxc/auth.go:219
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -160,7 +160,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:972
+#: lxc/auth.go:1121
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -181,7 +181,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1644
+#: lxc/auth.go:1793
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -515,15 +515,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:917 lxc/remote.go:982
+#: lxc/remote.go:951 lxc/remote.go:1016
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1030
+#: lxc/remote.go:1064
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:836
+#: lxc/remote.go:870
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -556,11 +556,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:818
+#: lxc/remote.go:852
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:817
+#: lxc/auth.go:966
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -598,11 +598,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1165 lxc/auth.go:1166
+#: lxc/auth.go:1314 lxc/auth.go:1315
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1933 lxc/auth.go:1934
+#: lxc/auth.go:2082 lxc/auth.go:2083
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -671,7 +671,7 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:516 lxc/auth.go:517
+#: lxc/auth.go:521 lxc/auth.go:522
 msgid "Add permissions to groups"
 msgstr ""
 
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:648
+#: lxc/remote.go:680
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -813,7 +813,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:621
+#: lxc/remote.go:635
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -991,7 +991,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:961
+#: lxc/remote.go:995
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1057,7 +1057,7 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:509
+#: lxc/remote.go:523
 msgid "Certificate fingerprint"
 msgstr ""
 
@@ -1076,7 +1076,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:687
+#: lxc/remote.go:721
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1324,12 +1324,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:559
+#: lxc/remote.go:573
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:237 lxc/remote.go:543
+#: lxc/remote.go:237 lxc/remote.go:557
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1343,12 +1343,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:1719
+#: lxc/auth.go:306 lxc/auth.go:1868
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1058
+#: lxc/auth.go:1207
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1368,13 +1368,17 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:554
+#: lxc/remote.go:568
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
 #: lxc/network_zone.go:1536
 msgid "Couldn't find a matching entry"
+msgstr ""
+
+#: lxc/auth.go:776
+msgid "Create a TLS identity"
 msgstr ""
 
 #: lxc/cluster_group.go:169 lxc/cluster_group.go:170
@@ -1393,6 +1397,10 @@ msgstr ""
 msgid "Create an empty instance"
 msgstr ""
 
+#: lxc/auth.go:775
+msgid "Create an identity"
+msgstr ""
+
 #: lxc/launch.go:23 lxc/launch.go:24
 msgid "Create and start instances from images"
 msgstr ""
@@ -1405,11 +1413,11 @@ msgstr ""
 msgid "Create files and directories in instances"
 msgstr ""
 
-#: lxc/auth.go:98 lxc/auth.go:99
+#: lxc/auth.go:103 lxc/auth.go:104
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1530 lxc/auth.go:1531
+#: lxc/auth.go:1679 lxc/auth.go:1680
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1517,7 +1525,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
@@ -1560,7 +1568,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/auth.go:1088 lxc/auth.go:1089
+#: lxc/auth.go:1237 lxc/auth.go:1238
 msgid "Delete an identity"
 msgstr ""
 
@@ -1568,11 +1576,11 @@ msgstr ""
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/auth.go:152 lxc/auth.go:153
+#: lxc/auth.go:157 lxc/auth.go:158
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1582 lxc/auth.go:1583
+#: lxc/auth.go:1731 lxc/auth.go:1732
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1650,18 +1658,18 @@ msgstr ""
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:31 lxc/auth.go:60 lxc/auth.go:99
-#: lxc/auth.go:153 lxc/auth.go:202 lxc/auth.go:333 lxc/auth.go:393
-#: lxc/auth.go:442 lxc/auth.go:494 lxc/auth.go:517 lxc/auth.go:576
-#: lxc/auth.go:732 lxc/auth.go:769 lxc/auth.go:836 lxc/auth.go:899
-#: lxc/auth.go:960 lxc/auth.go:1089 lxc/auth.go:1143 lxc/auth.go:1166
-#: lxc/auth.go:1224 lxc/auth.go:1293 lxc/auth.go:1315 lxc/auth.go:1493
-#: lxc/auth.go:1531 lxc/auth.go:1583 lxc/auth.go:1632 lxc/auth.go:1751
-#: lxc/auth.go:1811 lxc/auth.go:1860 lxc/auth.go:1911 lxc/auth.go:1934
-#: lxc/auth.go:1987 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215
-#: lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:484
-#: lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677 lxc/cluster.go:770
-#: lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
+#: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
+#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:338 lxc/auth.go:398
+#: lxc/auth.go:447 lxc/auth.go:499 lxc/auth.go:522 lxc/auth.go:581
+#: lxc/auth.go:737 lxc/auth.go:776 lxc/auth.go:918 lxc/auth.go:985
+#: lxc/auth.go:1048 lxc/auth.go:1109 lxc/auth.go:1238 lxc/auth.go:1292
+#: lxc/auth.go:1315 lxc/auth.go:1373 lxc/auth.go:1442 lxc/auth.go:1464
+#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
+#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
+#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
+#: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
+#: lxc/cluster.go:770 lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
 #: lxc/cluster.go:1175 lxc/cluster.go:1299 lxc/cluster.go:1329
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
@@ -1732,9 +1740,9 @@ msgstr ""
 #: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
 #: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
 #: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:715
-#: lxc/remote.go:753 lxc/remote.go:839 lxc/remote.go:920 lxc/remote.go:984
-#: lxc/remote.go:1032 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
+#: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
+#: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1919,7 +1927,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:959 lxc/auth.go:960
+#: lxc/auth.go:1108 lxc/auth.go:1109
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1931,11 +1939,11 @@ msgstr ""
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/auth.go:201 lxc/auth.go:202
+#: lxc/auth.go:206 lxc/auth.go:207
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1631 lxc/auth.go:1632
+#: lxc/auth.go:1780 lxc/auth.go:1781
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2311,12 +2319,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:486
+#: lxc/remote.go:500
 #, c-format
 msgid "Failed to decode trust token: %w"
 msgstr ""
 
-#: lxc/remote.go:292
+#: lxc/remote.go:306
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2420,7 +2428,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:773 lxc/auth.go:1755
+#: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
@@ -2428,7 +2436,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:757 lxc/storage.go:657
+#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2466,7 +2474,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:821
+#: lxc/remote.go:855
 msgid "GLOBAL"
 msgstr ""
 
@@ -2478,7 +2486,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:821 lxc/auth.go:1795
+#: lxc/auth.go:970 lxc/auth.go:1944
 msgid "GROUPS"
 msgstr ""
 
@@ -2486,7 +2494,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:165 lxc/remote.go:443
+#: lxc/remote.go:165 lxc/remote.go:457
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2627,17 +2635,17 @@ msgstr ""
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: lxc/auth.go:137
+#: lxc/auth.go:142
 #, c-format
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:187
+#: lxc/auth.go:192
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:427 lxc/auth.go:1845
+#: lxc/auth.go:432 lxc/auth.go:1994
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2696,7 +2704,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:820
+#: lxc/auth.go:969
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -2728,12 +2736,16 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1567
+#: lxc/auth.go:829
+msgid "Identity creation only supported for TLS identities"
+msgstr ""
+
+#: lxc/auth.go:1716
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1617
+#: lxc/auth.go:1766
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2862,7 +2874,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1292 lxc/auth.go:1293
+#: lxc/auth.go:1441 lxc/auth.go:1442
 msgid "Inspect permissions"
 msgstr ""
 
@@ -2910,7 +2922,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:395
+#: lxc/remote.go:409
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2991,7 +3003,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:384
+#: lxc/remote.go:398
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3166,15 +3178,15 @@ msgstr ""
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:332 lxc/auth.go:333
+#: lxc/auth.go:337 lxc/auth.go:338
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:768 lxc/auth.go:769
+#: lxc/auth.go:917 lxc/auth.go:918
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1750 lxc/auth.go:1751
+#: lxc/auth.go:1899 lxc/auth.go:1900
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3327,7 +3339,7 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1314 lxc/auth.go:1315
+#: lxc/auth.go:1463 lxc/auth.go:1464
 msgid "List permissions"
 msgstr ""
 
@@ -3371,7 +3383,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:752 lxc/remote.go:753
+#: lxc/remote.go:786 lxc/remote.go:787
 msgid "List the available remotes"
 msgstr ""
 
@@ -3495,6 +3507,12 @@ msgstr ""
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
+#: lxc/auth.go:825
+msgid ""
+"Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
+"got "
+msgstr ""
+
 #: lxc/network.go:32 lxc/network.go:33
 msgid "Manage and attach instances to networks"
 msgstr ""
@@ -3523,19 +3541,19 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:59 lxc/auth.go:60 lxc/auth.go:1492 lxc/auth.go:1493
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1142 lxc/auth.go:1143
+#: lxc/auth.go:1291 lxc/auth.go:1292
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:731 lxc/auth.go:732
+#: lxc/auth.go:736 lxc/auth.go:737
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1910 lxc/auth.go:1911
+#: lxc/auth.go:2059 lxc/auth.go:2060
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3626,7 +3644,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:493 lxc/auth.go:494
+#: lxc/auth.go:498 lxc/auth.go:499
 msgid "Manage permissions"
 msgstr ""
 
@@ -3678,7 +3696,7 @@ msgstr ""
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/auth.go:30 lxc/auth.go:31
+#: lxc/auth.go:35 lxc/auth.go:36
 msgid "Manage user authorization"
 msgstr ""
 
@@ -3775,21 +3793,21 @@ msgstr ""
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:123 lxc/auth.go:177 lxc/auth.go:255 lxc/auth.go:417
-#: lxc/auth.go:466 lxc/auth.go:541 lxc/auth.go:600 lxc/auth.go:1884
+#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:260 lxc/auth.go:422
+#: lxc/auth.go:471 lxc/auth.go:546 lxc/auth.go:605 lxc/auth.go:2033
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:866 lxc/auth.go:1007 lxc/auth.go:1124 lxc/auth.go:1190
-#: lxc/auth.go:1248
+#: lxc/auth.go:820 lxc/auth.go:1015 lxc/auth.go:1156 lxc/auth.go:1273
+#: lxc/auth.go:1339 lxc/auth.go:1397
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1554 lxc/auth.go:1607 lxc/auth.go:1673 lxc/auth.go:1835
+#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1958 lxc/auth.go:2011
+#: lxc/auth.go:2107 lxc/auth.go:2160
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -4010,12 +4028,12 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:376 lxc/auth.go:819 lxc/auth.go:1794 lxc/cluster.go:192
+#: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
-#: lxc/remote.go:815 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
 msgstr ""
@@ -4042,7 +4060,7 @@ msgstr ""
 
 #: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:775 lxc/remote.go:780 lxc/remote.go:785
+#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr ""
 
@@ -4271,7 +4289,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:378
+#: lxc/remote.go:392
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4342,11 +4360,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:817
+#: lxc/remote.go:851
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:819
+#: lxc/image.go:1136 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4387,7 +4405,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:536
+#: lxc/remote.go:550
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
@@ -4404,7 +4422,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:302 lxc/auth.go:1059 lxc/auth.go:1720 lxc/cluster.go:860
+#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -4707,33 +4725,33 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:877
+#: lxc/remote.go:911
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:868 lxc/remote.go:949 lxc/remote.go:1013
-#: lxc/remote.go:1061
+#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/remote.go:1095
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:345
+#: lxc/remote.go:359
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:957
+#: lxc/remote.go:991
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:872 lxc/remote.go:953 lxc/remote.go:1065
+#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1099
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:319
+#: lxc/remote.go:333
 msgid "Remote address must not be empty"
 msgstr ""
 
@@ -4741,7 +4759,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:339
+#: lxc/remote.go:353
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4763,7 +4781,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1223 lxc/auth.go:1224
+#: lxc/auth.go:1372 lxc/auth.go:1373
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4799,7 +4817,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1986 lxc/auth.go:1987
+#: lxc/auth.go:2135 lxc/auth.go:2136
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4811,7 +4829,7 @@ msgstr ""
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:575 lxc/auth.go:576
+#: lxc/auth.go:580 lxc/auth.go:581
 msgid "Remove permissions from groups"
 msgstr ""
 
@@ -4827,7 +4845,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:919 lxc/remote.go:920
+#: lxc/remote.go:953 lxc/remote.go:954
 msgid "Remove remotes"
 msgstr ""
 
@@ -4856,11 +4874,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:392 lxc/auth.go:393
+#: lxc/auth.go:397 lxc/auth.go:398
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1810 lxc/auth.go:1811
+#: lxc/auth.go:1959 lxc/auth.go:1960
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -4884,7 +4902,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:838 lxc/remote.go:839
+#: lxc/remote.go:872 lxc/remote.go:873
 msgid "Rename remotes"
 msgstr ""
 
@@ -5029,7 +5047,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:820
+#: lxc/remote.go:854
 msgid "STATIC"
 msgstr ""
 
@@ -5070,11 +5088,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:532
+#: lxc/remote.go:546
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:285 lxc/remote.go:683
+#: lxc/remote.go:299 lxc/remote.go:717
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5285,7 +5303,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1031 lxc/remote.go:1032
+#: lxc/remote.go:1065 lxc/remote.go:1066
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5381,7 +5399,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1859 lxc/auth.go:1860
+#: lxc/auth.go:2008 lxc/auth.go:2009
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5409,11 +5427,11 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:441 lxc/auth.go:442
+#: lxc/auth.go:446 lxc/auth.go:447
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:836
+#: lxc/auth.go:985
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5518,7 +5536,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:899
+#: lxc/auth.go:1048
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5528,7 +5546,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:714 lxc/remote.go:715
+#: lxc/remote.go:748 lxc/remote.go:749
 msgid "Show the default remote"
 msgstr ""
 
@@ -5740,7 +5758,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:983 lxc/remote.go:984
+#: lxc/remote.go:1017 lxc/remote.go:1018
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5752,11 +5770,21 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
+#: lxc/auth.go:876
+#, c-format
+msgid "TLS identity %q (%s) pending identity token:"
+msgstr ""
+
+#: lxc/auth.go:902
+#, c-format
+msgid "TLS identity %q created with fingerprint %q"
+msgstr ""
+
 #: lxc/cluster.go:1070 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:818 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
 #: lxc/storage_volume.go:1736 lxc/warning.go:216
@@ -5775,7 +5803,7 @@ msgstr ""
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/remote.go:161 lxc/remote.go:334
+#: lxc/remote.go:161 lxc/remote.go:348
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
@@ -5931,7 +5959,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:527
+#: lxc/remote.go:541
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
@@ -6069,15 +6097,15 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:329
+#: lxc/remote.go:343
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:324
+#: lxc/remote.go:338
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr ""
 
-#: lxc/remote.go:639
+#: lxc/remote.go:653
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6120,7 +6148,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:193 lxc/remote.go:816
+#: lxc/cluster.go:193 lxc/remote.go:850
 msgid "URL"
 msgstr ""
 
@@ -6428,11 +6456,11 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:835
+#: lxc/auth.go:984
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:898
+#: lxc/auth.go:1047
 msgid "View the current identity"
 msgstr ""
 
@@ -6471,7 +6499,7 @@ msgstr ""
 
 #: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:777 lxc/remote.go:782 lxc/remote.go:787
+#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr ""
 
@@ -6503,7 +6531,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:330 lxc/auth.go:766 lxc/auth.go:897 lxc/auth.go:1748
+#: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
@@ -6536,7 +6564,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1313
+#: lxc/auth.go:1462
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6597,11 +6625,17 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:834 lxc/auth.go:1086
+#: lxc/auth.go:774
+msgid ""
+"[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
+"certificate>] [[--group <group_name>]]"
+msgstr ""
+
+#: lxc/auth.go:983 lxc/auth.go:1235
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1164 lxc/auth.go:1222 lxc/auth.go:1985
+#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:2134
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6609,13 +6643,13 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:97 lxc/auth.go:150 lxc/auth.go:200 lxc/auth.go:440
-#: lxc/auth.go:958 lxc/auth.go:1529 lxc/cluster_group.go:168
+#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:445
+#: lxc/auth.go:1107 lxc/auth.go:1678 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:515 lxc/auth.go:573
+#: lxc/auth.go:520 lxc/auth.go:578
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
@@ -6625,19 +6659,19 @@ msgstr ""
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:390
+#: lxc/auth.go:395
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1580 lxc/auth.go:1630 lxc/auth.go:1858
+#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1932
+#: lxc/auth.go:2081
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1808
+#: lxc/auth.go:1957
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -7128,7 +7162,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:806
+#: lxc/project.go:557 lxc/remote.go:840
 msgid "current"
 msgstr ""
 
@@ -7175,20 +7209,20 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/auth.go:204
+#: lxc/auth.go:209
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:962
+#: lxc/auth.go:1111
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1634
+#: lxc/auth.go:1783
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7612,7 +7646,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:531
+#: lxc/remote.go:545
 msgid "n"
 msgstr ""
 
@@ -7624,7 +7658,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:510
+#: lxc/remote.go:524
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7661,7 +7695,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:519
+#: lxc/remote.go:533
 msgid "y"
 msgstr ""
 

--- a/po/ug.po
+++ b/po/ug.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-14 13:30+0000\n"
+"POT-Creation-Date: 2024-10-15 14:52+0100\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Uyghur <https://hosted.weblate.org/projects/linux-containers/"
@@ -133,7 +133,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:214
+#: lxc/auth.go:219
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -160,7 +160,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:972
+#: lxc/auth.go:1121
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -181,7 +181,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1644
+#: lxc/auth.go:1793
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -515,15 +515,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:917 lxc/remote.go:982
+#: lxc/remote.go:951 lxc/remote.go:1016
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1030
+#: lxc/remote.go:1064
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:836
+#: lxc/remote.go:870
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -556,11 +556,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:818
+#: lxc/remote.go:852
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:817
+#: lxc/auth.go:966
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -598,11 +598,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1165 lxc/auth.go:1166
+#: lxc/auth.go:1314 lxc/auth.go:1315
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1933 lxc/auth.go:1934
+#: lxc/auth.go:2082 lxc/auth.go:2083
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -671,7 +671,7 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:516 lxc/auth.go:517
+#: lxc/auth.go:521 lxc/auth.go:522
 msgid "Add permissions to groups"
 msgstr ""
 
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:648
+#: lxc/remote.go:680
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -813,7 +813,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:621
+#: lxc/remote.go:635
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -991,7 +991,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:961
+#: lxc/remote.go:995
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1057,7 +1057,7 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:509
+#: lxc/remote.go:523
 msgid "Certificate fingerprint"
 msgstr ""
 
@@ -1076,7 +1076,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:687
+#: lxc/remote.go:721
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1324,12 +1324,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:559
+#: lxc/remote.go:573
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:237 lxc/remote.go:543
+#: lxc/remote.go:237 lxc/remote.go:557
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1343,12 +1343,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:1719
+#: lxc/auth.go:306 lxc/auth.go:1868
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1058
+#: lxc/auth.go:1207
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1368,13 +1368,17 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:554
+#: lxc/remote.go:568
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
 #: lxc/network_zone.go:1536
 msgid "Couldn't find a matching entry"
+msgstr ""
+
+#: lxc/auth.go:776
+msgid "Create a TLS identity"
 msgstr ""
 
 #: lxc/cluster_group.go:169 lxc/cluster_group.go:170
@@ -1393,6 +1397,10 @@ msgstr ""
 msgid "Create an empty instance"
 msgstr ""
 
+#: lxc/auth.go:775
+msgid "Create an identity"
+msgstr ""
+
 #: lxc/launch.go:23 lxc/launch.go:24
 msgid "Create and start instances from images"
 msgstr ""
@@ -1405,11 +1413,11 @@ msgstr ""
 msgid "Create files and directories in instances"
 msgstr ""
 
-#: lxc/auth.go:98 lxc/auth.go:99
+#: lxc/auth.go:103 lxc/auth.go:104
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1530 lxc/auth.go:1531
+#: lxc/auth.go:1679 lxc/auth.go:1680
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1517,7 +1525,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
@@ -1560,7 +1568,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/auth.go:1088 lxc/auth.go:1089
+#: lxc/auth.go:1237 lxc/auth.go:1238
 msgid "Delete an identity"
 msgstr ""
 
@@ -1568,11 +1576,11 @@ msgstr ""
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/auth.go:152 lxc/auth.go:153
+#: lxc/auth.go:157 lxc/auth.go:158
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1582 lxc/auth.go:1583
+#: lxc/auth.go:1731 lxc/auth.go:1732
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1650,18 +1658,18 @@ msgstr ""
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:31 lxc/auth.go:60 lxc/auth.go:99
-#: lxc/auth.go:153 lxc/auth.go:202 lxc/auth.go:333 lxc/auth.go:393
-#: lxc/auth.go:442 lxc/auth.go:494 lxc/auth.go:517 lxc/auth.go:576
-#: lxc/auth.go:732 lxc/auth.go:769 lxc/auth.go:836 lxc/auth.go:899
-#: lxc/auth.go:960 lxc/auth.go:1089 lxc/auth.go:1143 lxc/auth.go:1166
-#: lxc/auth.go:1224 lxc/auth.go:1293 lxc/auth.go:1315 lxc/auth.go:1493
-#: lxc/auth.go:1531 lxc/auth.go:1583 lxc/auth.go:1632 lxc/auth.go:1751
-#: lxc/auth.go:1811 lxc/auth.go:1860 lxc/auth.go:1911 lxc/auth.go:1934
-#: lxc/auth.go:1987 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215
-#: lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:484
-#: lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677 lxc/cluster.go:770
-#: lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
+#: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
+#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:338 lxc/auth.go:398
+#: lxc/auth.go:447 lxc/auth.go:499 lxc/auth.go:522 lxc/auth.go:581
+#: lxc/auth.go:737 lxc/auth.go:776 lxc/auth.go:918 lxc/auth.go:985
+#: lxc/auth.go:1048 lxc/auth.go:1109 lxc/auth.go:1238 lxc/auth.go:1292
+#: lxc/auth.go:1315 lxc/auth.go:1373 lxc/auth.go:1442 lxc/auth.go:1464
+#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
+#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
+#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
+#: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
+#: lxc/cluster.go:770 lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
 #: lxc/cluster.go:1175 lxc/cluster.go:1299 lxc/cluster.go:1329
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
@@ -1732,9 +1740,9 @@ msgstr ""
 #: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
 #: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
 #: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:715
-#: lxc/remote.go:753 lxc/remote.go:839 lxc/remote.go:920 lxc/remote.go:984
-#: lxc/remote.go:1032 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
+#: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
+#: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1919,7 +1927,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:959 lxc/auth.go:960
+#: lxc/auth.go:1108 lxc/auth.go:1109
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1931,11 +1939,11 @@ msgstr ""
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/auth.go:201 lxc/auth.go:202
+#: lxc/auth.go:206 lxc/auth.go:207
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1631 lxc/auth.go:1632
+#: lxc/auth.go:1780 lxc/auth.go:1781
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2311,12 +2319,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:486
+#: lxc/remote.go:500
 #, c-format
 msgid "Failed to decode trust token: %w"
 msgstr ""
 
-#: lxc/remote.go:292
+#: lxc/remote.go:306
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2420,7 +2428,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:773 lxc/auth.go:1755
+#: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
@@ -2428,7 +2436,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:757 lxc/storage.go:657
+#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2466,7 +2474,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:821
+#: lxc/remote.go:855
 msgid "GLOBAL"
 msgstr ""
 
@@ -2478,7 +2486,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:821 lxc/auth.go:1795
+#: lxc/auth.go:970 lxc/auth.go:1944
 msgid "GROUPS"
 msgstr ""
 
@@ -2486,7 +2494,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:165 lxc/remote.go:443
+#: lxc/remote.go:165 lxc/remote.go:457
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2627,17 +2635,17 @@ msgstr ""
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: lxc/auth.go:137
+#: lxc/auth.go:142
 #, c-format
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:187
+#: lxc/auth.go:192
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:427 lxc/auth.go:1845
+#: lxc/auth.go:432 lxc/auth.go:1994
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2696,7 +2704,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:820
+#: lxc/auth.go:969
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -2728,12 +2736,16 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1567
+#: lxc/auth.go:829
+msgid "Identity creation only supported for TLS identities"
+msgstr ""
+
+#: lxc/auth.go:1716
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1617
+#: lxc/auth.go:1766
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2862,7 +2874,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1292 lxc/auth.go:1293
+#: lxc/auth.go:1441 lxc/auth.go:1442
 msgid "Inspect permissions"
 msgstr ""
 
@@ -2910,7 +2922,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:395
+#: lxc/remote.go:409
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2991,7 +3003,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:384
+#: lxc/remote.go:398
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3166,15 +3178,15 @@ msgstr ""
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:332 lxc/auth.go:333
+#: lxc/auth.go:337 lxc/auth.go:338
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:768 lxc/auth.go:769
+#: lxc/auth.go:917 lxc/auth.go:918
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1750 lxc/auth.go:1751
+#: lxc/auth.go:1899 lxc/auth.go:1900
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3327,7 +3339,7 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1314 lxc/auth.go:1315
+#: lxc/auth.go:1463 lxc/auth.go:1464
 msgid "List permissions"
 msgstr ""
 
@@ -3371,7 +3383,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:752 lxc/remote.go:753
+#: lxc/remote.go:786 lxc/remote.go:787
 msgid "List the available remotes"
 msgstr ""
 
@@ -3495,6 +3507,12 @@ msgstr ""
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
+#: lxc/auth.go:825
+msgid ""
+"Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
+"got "
+msgstr ""
+
 #: lxc/network.go:32 lxc/network.go:33
 msgid "Manage and attach instances to networks"
 msgstr ""
@@ -3523,19 +3541,19 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:59 lxc/auth.go:60 lxc/auth.go:1492 lxc/auth.go:1493
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1142 lxc/auth.go:1143
+#: lxc/auth.go:1291 lxc/auth.go:1292
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:731 lxc/auth.go:732
+#: lxc/auth.go:736 lxc/auth.go:737
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1910 lxc/auth.go:1911
+#: lxc/auth.go:2059 lxc/auth.go:2060
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3626,7 +3644,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:493 lxc/auth.go:494
+#: lxc/auth.go:498 lxc/auth.go:499
 msgid "Manage permissions"
 msgstr ""
 
@@ -3678,7 +3696,7 @@ msgstr ""
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/auth.go:30 lxc/auth.go:31
+#: lxc/auth.go:35 lxc/auth.go:36
 msgid "Manage user authorization"
 msgstr ""
 
@@ -3775,21 +3793,21 @@ msgstr ""
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:123 lxc/auth.go:177 lxc/auth.go:255 lxc/auth.go:417
-#: lxc/auth.go:466 lxc/auth.go:541 lxc/auth.go:600 lxc/auth.go:1884
+#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:260 lxc/auth.go:422
+#: lxc/auth.go:471 lxc/auth.go:546 lxc/auth.go:605 lxc/auth.go:2033
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:866 lxc/auth.go:1007 lxc/auth.go:1124 lxc/auth.go:1190
-#: lxc/auth.go:1248
+#: lxc/auth.go:820 lxc/auth.go:1015 lxc/auth.go:1156 lxc/auth.go:1273
+#: lxc/auth.go:1339 lxc/auth.go:1397
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1554 lxc/auth.go:1607 lxc/auth.go:1673 lxc/auth.go:1835
+#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1958 lxc/auth.go:2011
+#: lxc/auth.go:2107 lxc/auth.go:2160
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -4010,12 +4028,12 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:376 lxc/auth.go:819 lxc/auth.go:1794 lxc/cluster.go:192
+#: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
-#: lxc/remote.go:815 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
 msgstr ""
@@ -4042,7 +4060,7 @@ msgstr ""
 
 #: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:775 lxc/remote.go:780 lxc/remote.go:785
+#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr ""
 
@@ -4271,7 +4289,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:378
+#: lxc/remote.go:392
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4342,11 +4360,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:817
+#: lxc/remote.go:851
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:819
+#: lxc/image.go:1136 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4387,7 +4405,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:536
+#: lxc/remote.go:550
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
@@ -4404,7 +4422,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:302 lxc/auth.go:1059 lxc/auth.go:1720 lxc/cluster.go:860
+#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -4707,33 +4725,33 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:877
+#: lxc/remote.go:911
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:868 lxc/remote.go:949 lxc/remote.go:1013
-#: lxc/remote.go:1061
+#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/remote.go:1095
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:345
+#: lxc/remote.go:359
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:957
+#: lxc/remote.go:991
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:872 lxc/remote.go:953 lxc/remote.go:1065
+#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1099
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:319
+#: lxc/remote.go:333
 msgid "Remote address must not be empty"
 msgstr ""
 
@@ -4741,7 +4759,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:339
+#: lxc/remote.go:353
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4763,7 +4781,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1223 lxc/auth.go:1224
+#: lxc/auth.go:1372 lxc/auth.go:1373
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4799,7 +4817,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1986 lxc/auth.go:1987
+#: lxc/auth.go:2135 lxc/auth.go:2136
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4811,7 +4829,7 @@ msgstr ""
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:575 lxc/auth.go:576
+#: lxc/auth.go:580 lxc/auth.go:581
 msgid "Remove permissions from groups"
 msgstr ""
 
@@ -4827,7 +4845,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:919 lxc/remote.go:920
+#: lxc/remote.go:953 lxc/remote.go:954
 msgid "Remove remotes"
 msgstr ""
 
@@ -4856,11 +4874,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:392 lxc/auth.go:393
+#: lxc/auth.go:397 lxc/auth.go:398
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1810 lxc/auth.go:1811
+#: lxc/auth.go:1959 lxc/auth.go:1960
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -4884,7 +4902,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:838 lxc/remote.go:839
+#: lxc/remote.go:872 lxc/remote.go:873
 msgid "Rename remotes"
 msgstr ""
 
@@ -5029,7 +5047,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:820
+#: lxc/remote.go:854
 msgid "STATIC"
 msgstr ""
 
@@ -5070,11 +5088,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:532
+#: lxc/remote.go:546
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:285 lxc/remote.go:683
+#: lxc/remote.go:299 lxc/remote.go:717
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5285,7 +5303,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1031 lxc/remote.go:1032
+#: lxc/remote.go:1065 lxc/remote.go:1066
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5381,7 +5399,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1859 lxc/auth.go:1860
+#: lxc/auth.go:2008 lxc/auth.go:2009
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5409,11 +5427,11 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:441 lxc/auth.go:442
+#: lxc/auth.go:446 lxc/auth.go:447
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:836
+#: lxc/auth.go:985
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5518,7 +5536,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:899
+#: lxc/auth.go:1048
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5528,7 +5546,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:714 lxc/remote.go:715
+#: lxc/remote.go:748 lxc/remote.go:749
 msgid "Show the default remote"
 msgstr ""
 
@@ -5740,7 +5758,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:983 lxc/remote.go:984
+#: lxc/remote.go:1017 lxc/remote.go:1018
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5752,11 +5770,21 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
+#: lxc/auth.go:876
+#, c-format
+msgid "TLS identity %q (%s) pending identity token:"
+msgstr ""
+
+#: lxc/auth.go:902
+#, c-format
+msgid "TLS identity %q created with fingerprint %q"
+msgstr ""
+
 #: lxc/cluster.go:1070 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:818 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
 #: lxc/storage_volume.go:1736 lxc/warning.go:216
@@ -5775,7 +5803,7 @@ msgstr ""
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/remote.go:161 lxc/remote.go:334
+#: lxc/remote.go:161 lxc/remote.go:348
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
@@ -5931,7 +5959,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:527
+#: lxc/remote.go:541
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
@@ -6069,15 +6097,15 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:329
+#: lxc/remote.go:343
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:324
+#: lxc/remote.go:338
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr ""
 
-#: lxc/remote.go:639
+#: lxc/remote.go:653
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6120,7 +6148,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:193 lxc/remote.go:816
+#: lxc/cluster.go:193 lxc/remote.go:850
 msgid "URL"
 msgstr ""
 
@@ -6428,11 +6456,11 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:835
+#: lxc/auth.go:984
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:898
+#: lxc/auth.go:1047
 msgid "View the current identity"
 msgstr ""
 
@@ -6471,7 +6499,7 @@ msgstr ""
 
 #: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:777 lxc/remote.go:782 lxc/remote.go:787
+#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr ""
 
@@ -6503,7 +6531,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:330 lxc/auth.go:766 lxc/auth.go:897 lxc/auth.go:1748
+#: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
@@ -6536,7 +6564,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1313
+#: lxc/auth.go:1462
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6597,11 +6625,17 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:834 lxc/auth.go:1086
+#: lxc/auth.go:774
+msgid ""
+"[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
+"certificate>] [[--group <group_name>]]"
+msgstr ""
+
+#: lxc/auth.go:983 lxc/auth.go:1235
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1164 lxc/auth.go:1222 lxc/auth.go:1985
+#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:2134
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6609,13 +6643,13 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:97 lxc/auth.go:150 lxc/auth.go:200 lxc/auth.go:440
-#: lxc/auth.go:958 lxc/auth.go:1529 lxc/cluster_group.go:168
+#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:445
+#: lxc/auth.go:1107 lxc/auth.go:1678 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:515 lxc/auth.go:573
+#: lxc/auth.go:520 lxc/auth.go:578
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
@@ -6625,19 +6659,19 @@ msgstr ""
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:390
+#: lxc/auth.go:395
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1580 lxc/auth.go:1630 lxc/auth.go:1858
+#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1932
+#: lxc/auth.go:2081
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1808
+#: lxc/auth.go:1957
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -7128,7 +7162,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:806
+#: lxc/project.go:557 lxc/remote.go:840
 msgid "current"
 msgstr ""
 
@@ -7175,20 +7209,20 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/auth.go:204
+#: lxc/auth.go:209
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:962
+#: lxc/auth.go:1111
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1634
+#: lxc/auth.go:1783
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7612,7 +7646,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:531
+#: lxc/remote.go:545
 msgid "n"
 msgstr ""
 
@@ -7624,7 +7658,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:510
+#: lxc/remote.go:524
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7661,7 +7695,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:519
+#: lxc/remote.go:533
 msgid "y"
 msgstr ""
 

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-14 13:30+0000\n"
+"POT-Creation-Date: 2024-10-15 14:52+0100\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Ukrainian <https://hosted.weblate.org/projects/linux-"
@@ -134,7 +134,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:214
+#: lxc/auth.go:219
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -161,7 +161,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:972
+#: lxc/auth.go:1121
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -182,7 +182,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1644
+#: lxc/auth.go:1793
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -516,15 +516,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:917 lxc/remote.go:982
+#: lxc/remote.go:951 lxc/remote.go:1016
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1030
+#: lxc/remote.go:1064
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:836
+#: lxc/remote.go:870
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -557,11 +557,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:818
+#: lxc/remote.go:852
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:817
+#: lxc/auth.go:966
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -599,11 +599,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1165 lxc/auth.go:1166
+#: lxc/auth.go:1314 lxc/auth.go:1315
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1933 lxc/auth.go:1934
+#: lxc/auth.go:2082 lxc/auth.go:2083
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -672,7 +672,7 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:516 lxc/auth.go:517
+#: lxc/auth.go:521 lxc/auth.go:522
 msgid "Add permissions to groups"
 msgstr ""
 
@@ -706,7 +706,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:648
+#: lxc/remote.go:680
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -814,7 +814,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:621
+#: lxc/remote.go:635
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -992,7 +992,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:961
+#: lxc/remote.go:995
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1058,7 +1058,7 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:509
+#: lxc/remote.go:523
 msgid "Certificate fingerprint"
 msgstr ""
 
@@ -1077,7 +1077,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:687
+#: lxc/remote.go:721
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1325,12 +1325,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:559
+#: lxc/remote.go:573
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:237 lxc/remote.go:543
+#: lxc/remote.go:237 lxc/remote.go:557
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1344,12 +1344,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:1719
+#: lxc/auth.go:306 lxc/auth.go:1868
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1058
+#: lxc/auth.go:1207
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1369,13 +1369,17 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:554
+#: lxc/remote.go:568
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
 #: lxc/network_zone.go:1536
 msgid "Couldn't find a matching entry"
+msgstr ""
+
+#: lxc/auth.go:776
+msgid "Create a TLS identity"
 msgstr ""
 
 #: lxc/cluster_group.go:169 lxc/cluster_group.go:170
@@ -1394,6 +1398,10 @@ msgstr ""
 msgid "Create an empty instance"
 msgstr ""
 
+#: lxc/auth.go:775
+msgid "Create an identity"
+msgstr ""
+
 #: lxc/launch.go:23 lxc/launch.go:24
 msgid "Create and start instances from images"
 msgstr ""
@@ -1406,11 +1414,11 @@ msgstr ""
 msgid "Create files and directories in instances"
 msgstr ""
 
-#: lxc/auth.go:98 lxc/auth.go:99
+#: lxc/auth.go:103 lxc/auth.go:104
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1530 lxc/auth.go:1531
+#: lxc/auth.go:1679 lxc/auth.go:1680
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1518,7 +1526,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
@@ -1561,7 +1569,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/auth.go:1088 lxc/auth.go:1089
+#: lxc/auth.go:1237 lxc/auth.go:1238
 msgid "Delete an identity"
 msgstr ""
 
@@ -1569,11 +1577,11 @@ msgstr ""
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/auth.go:152 lxc/auth.go:153
+#: lxc/auth.go:157 lxc/auth.go:158
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1582 lxc/auth.go:1583
+#: lxc/auth.go:1731 lxc/auth.go:1732
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1651,18 +1659,18 @@ msgstr ""
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:31 lxc/auth.go:60 lxc/auth.go:99
-#: lxc/auth.go:153 lxc/auth.go:202 lxc/auth.go:333 lxc/auth.go:393
-#: lxc/auth.go:442 lxc/auth.go:494 lxc/auth.go:517 lxc/auth.go:576
-#: lxc/auth.go:732 lxc/auth.go:769 lxc/auth.go:836 lxc/auth.go:899
-#: lxc/auth.go:960 lxc/auth.go:1089 lxc/auth.go:1143 lxc/auth.go:1166
-#: lxc/auth.go:1224 lxc/auth.go:1293 lxc/auth.go:1315 lxc/auth.go:1493
-#: lxc/auth.go:1531 lxc/auth.go:1583 lxc/auth.go:1632 lxc/auth.go:1751
-#: lxc/auth.go:1811 lxc/auth.go:1860 lxc/auth.go:1911 lxc/auth.go:1934
-#: lxc/auth.go:1987 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215
-#: lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:484
-#: lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677 lxc/cluster.go:770
-#: lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
+#: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
+#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:338 lxc/auth.go:398
+#: lxc/auth.go:447 lxc/auth.go:499 lxc/auth.go:522 lxc/auth.go:581
+#: lxc/auth.go:737 lxc/auth.go:776 lxc/auth.go:918 lxc/auth.go:985
+#: lxc/auth.go:1048 lxc/auth.go:1109 lxc/auth.go:1238 lxc/auth.go:1292
+#: lxc/auth.go:1315 lxc/auth.go:1373 lxc/auth.go:1442 lxc/auth.go:1464
+#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
+#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
+#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
+#: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
+#: lxc/cluster.go:770 lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
 #: lxc/cluster.go:1175 lxc/cluster.go:1299 lxc/cluster.go:1329
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
@@ -1733,9 +1741,9 @@ msgstr ""
 #: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
 #: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
 #: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:715
-#: lxc/remote.go:753 lxc/remote.go:839 lxc/remote.go:920 lxc/remote.go:984
-#: lxc/remote.go:1032 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
+#: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
+#: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1920,7 +1928,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:959 lxc/auth.go:960
+#: lxc/auth.go:1108 lxc/auth.go:1109
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1932,11 +1940,11 @@ msgstr ""
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/auth.go:201 lxc/auth.go:202
+#: lxc/auth.go:206 lxc/auth.go:207
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1631 lxc/auth.go:1632
+#: lxc/auth.go:1780 lxc/auth.go:1781
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2312,12 +2320,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:486
+#: lxc/remote.go:500
 #, c-format
 msgid "Failed to decode trust token: %w"
 msgstr ""
 
-#: lxc/remote.go:292
+#: lxc/remote.go:306
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2421,7 +2429,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:773 lxc/auth.go:1755
+#: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
@@ -2429,7 +2437,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:757 lxc/storage.go:657
+#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2467,7 +2475,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:821
+#: lxc/remote.go:855
 msgid "GLOBAL"
 msgstr ""
 
@@ -2479,7 +2487,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:821 lxc/auth.go:1795
+#: lxc/auth.go:970 lxc/auth.go:1944
 msgid "GROUPS"
 msgstr ""
 
@@ -2487,7 +2495,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:165 lxc/remote.go:443
+#: lxc/remote.go:165 lxc/remote.go:457
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2628,17 +2636,17 @@ msgstr ""
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: lxc/auth.go:137
+#: lxc/auth.go:142
 #, c-format
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:187
+#: lxc/auth.go:192
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:427 lxc/auth.go:1845
+#: lxc/auth.go:432 lxc/auth.go:1994
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2697,7 +2705,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:820
+#: lxc/auth.go:969
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -2729,12 +2737,16 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1567
+#: lxc/auth.go:829
+msgid "Identity creation only supported for TLS identities"
+msgstr ""
+
+#: lxc/auth.go:1716
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1617
+#: lxc/auth.go:1766
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2863,7 +2875,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1292 lxc/auth.go:1293
+#: lxc/auth.go:1441 lxc/auth.go:1442
 msgid "Inspect permissions"
 msgstr ""
 
@@ -2911,7 +2923,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:395
+#: lxc/remote.go:409
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2992,7 +3004,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:384
+#: lxc/remote.go:398
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3167,15 +3179,15 @@ msgstr ""
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:332 lxc/auth.go:333
+#: lxc/auth.go:337 lxc/auth.go:338
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:768 lxc/auth.go:769
+#: lxc/auth.go:917 lxc/auth.go:918
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1750 lxc/auth.go:1751
+#: lxc/auth.go:1899 lxc/auth.go:1900
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3328,7 +3340,7 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1314 lxc/auth.go:1315
+#: lxc/auth.go:1463 lxc/auth.go:1464
 msgid "List permissions"
 msgstr ""
 
@@ -3372,7 +3384,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:752 lxc/remote.go:753
+#: lxc/remote.go:786 lxc/remote.go:787
 msgid "List the available remotes"
 msgstr ""
 
@@ -3496,6 +3508,12 @@ msgstr ""
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
+#: lxc/auth.go:825
+msgid ""
+"Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
+"got "
+msgstr ""
+
 #: lxc/network.go:32 lxc/network.go:33
 msgid "Manage and attach instances to networks"
 msgstr ""
@@ -3524,19 +3542,19 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:59 lxc/auth.go:60 lxc/auth.go:1492 lxc/auth.go:1493
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1142 lxc/auth.go:1143
+#: lxc/auth.go:1291 lxc/auth.go:1292
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:731 lxc/auth.go:732
+#: lxc/auth.go:736 lxc/auth.go:737
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1910 lxc/auth.go:1911
+#: lxc/auth.go:2059 lxc/auth.go:2060
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3627,7 +3645,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:493 lxc/auth.go:494
+#: lxc/auth.go:498 lxc/auth.go:499
 msgid "Manage permissions"
 msgstr ""
 
@@ -3679,7 +3697,7 @@ msgstr ""
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/auth.go:30 lxc/auth.go:31
+#: lxc/auth.go:35 lxc/auth.go:36
 msgid "Manage user authorization"
 msgstr ""
 
@@ -3776,21 +3794,21 @@ msgstr ""
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:123 lxc/auth.go:177 lxc/auth.go:255 lxc/auth.go:417
-#: lxc/auth.go:466 lxc/auth.go:541 lxc/auth.go:600 lxc/auth.go:1884
+#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:260 lxc/auth.go:422
+#: lxc/auth.go:471 lxc/auth.go:546 lxc/auth.go:605 lxc/auth.go:2033
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:866 lxc/auth.go:1007 lxc/auth.go:1124 lxc/auth.go:1190
-#: lxc/auth.go:1248
+#: lxc/auth.go:820 lxc/auth.go:1015 lxc/auth.go:1156 lxc/auth.go:1273
+#: lxc/auth.go:1339 lxc/auth.go:1397
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1554 lxc/auth.go:1607 lxc/auth.go:1673 lxc/auth.go:1835
+#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1958 lxc/auth.go:2011
+#: lxc/auth.go:2107 lxc/auth.go:2160
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -4011,12 +4029,12 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:376 lxc/auth.go:819 lxc/auth.go:1794 lxc/cluster.go:192
+#: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
-#: lxc/remote.go:815 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
 msgstr ""
@@ -4043,7 +4061,7 @@ msgstr ""
 
 #: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:775 lxc/remote.go:780 lxc/remote.go:785
+#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr ""
 
@@ -4272,7 +4290,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:378
+#: lxc/remote.go:392
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4343,11 +4361,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:817
+#: lxc/remote.go:851
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:819
+#: lxc/image.go:1136 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4388,7 +4406,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:536
+#: lxc/remote.go:550
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
@@ -4405,7 +4423,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:302 lxc/auth.go:1059 lxc/auth.go:1720 lxc/cluster.go:860
+#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -4708,33 +4726,33 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:877
+#: lxc/remote.go:911
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:868 lxc/remote.go:949 lxc/remote.go:1013
-#: lxc/remote.go:1061
+#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/remote.go:1095
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:345
+#: lxc/remote.go:359
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:957
+#: lxc/remote.go:991
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:872 lxc/remote.go:953 lxc/remote.go:1065
+#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1099
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:319
+#: lxc/remote.go:333
 msgid "Remote address must not be empty"
 msgstr ""
 
@@ -4742,7 +4760,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:339
+#: lxc/remote.go:353
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4764,7 +4782,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1223 lxc/auth.go:1224
+#: lxc/auth.go:1372 lxc/auth.go:1373
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4800,7 +4818,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1986 lxc/auth.go:1987
+#: lxc/auth.go:2135 lxc/auth.go:2136
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4812,7 +4830,7 @@ msgstr ""
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:575 lxc/auth.go:576
+#: lxc/auth.go:580 lxc/auth.go:581
 msgid "Remove permissions from groups"
 msgstr ""
 
@@ -4828,7 +4846,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:919 lxc/remote.go:920
+#: lxc/remote.go:953 lxc/remote.go:954
 msgid "Remove remotes"
 msgstr ""
 
@@ -4857,11 +4875,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:392 lxc/auth.go:393
+#: lxc/auth.go:397 lxc/auth.go:398
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1810 lxc/auth.go:1811
+#: lxc/auth.go:1959 lxc/auth.go:1960
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -4885,7 +4903,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:838 lxc/remote.go:839
+#: lxc/remote.go:872 lxc/remote.go:873
 msgid "Rename remotes"
 msgstr ""
 
@@ -5030,7 +5048,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:820
+#: lxc/remote.go:854
 msgid "STATIC"
 msgstr ""
 
@@ -5071,11 +5089,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:532
+#: lxc/remote.go:546
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:285 lxc/remote.go:683
+#: lxc/remote.go:299 lxc/remote.go:717
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5286,7 +5304,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1031 lxc/remote.go:1032
+#: lxc/remote.go:1065 lxc/remote.go:1066
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5382,7 +5400,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1859 lxc/auth.go:1860
+#: lxc/auth.go:2008 lxc/auth.go:2009
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5410,11 +5428,11 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:441 lxc/auth.go:442
+#: lxc/auth.go:446 lxc/auth.go:447
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:836
+#: lxc/auth.go:985
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5519,7 +5537,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:899
+#: lxc/auth.go:1048
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5529,7 +5547,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:714 lxc/remote.go:715
+#: lxc/remote.go:748 lxc/remote.go:749
 msgid "Show the default remote"
 msgstr ""
 
@@ -5741,7 +5759,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:983 lxc/remote.go:984
+#: lxc/remote.go:1017 lxc/remote.go:1018
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5753,11 +5771,21 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
+#: lxc/auth.go:876
+#, c-format
+msgid "TLS identity %q (%s) pending identity token:"
+msgstr ""
+
+#: lxc/auth.go:902
+#, c-format
+msgid "TLS identity %q created with fingerprint %q"
+msgstr ""
+
 #: lxc/cluster.go:1070 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:818 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
 #: lxc/storage_volume.go:1736 lxc/warning.go:216
@@ -5776,7 +5804,7 @@ msgstr ""
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/remote.go:161 lxc/remote.go:334
+#: lxc/remote.go:161 lxc/remote.go:348
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
@@ -5932,7 +5960,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:527
+#: lxc/remote.go:541
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
@@ -6070,15 +6098,15 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:329
+#: lxc/remote.go:343
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:324
+#: lxc/remote.go:338
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr ""
 
-#: lxc/remote.go:639
+#: lxc/remote.go:653
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6121,7 +6149,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:193 lxc/remote.go:816
+#: lxc/cluster.go:193 lxc/remote.go:850
 msgid "URL"
 msgstr ""
 
@@ -6429,11 +6457,11 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:835
+#: lxc/auth.go:984
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:898
+#: lxc/auth.go:1047
 msgid "View the current identity"
 msgstr ""
 
@@ -6472,7 +6500,7 @@ msgstr ""
 
 #: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:777 lxc/remote.go:782 lxc/remote.go:787
+#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr ""
 
@@ -6504,7 +6532,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:330 lxc/auth.go:766 lxc/auth.go:897 lxc/auth.go:1748
+#: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
@@ -6537,7 +6565,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1313
+#: lxc/auth.go:1462
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6598,11 +6626,17 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:834 lxc/auth.go:1086
+#: lxc/auth.go:774
+msgid ""
+"[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
+"certificate>] [[--group <group_name>]]"
+msgstr ""
+
+#: lxc/auth.go:983 lxc/auth.go:1235
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1164 lxc/auth.go:1222 lxc/auth.go:1985
+#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:2134
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6610,13 +6644,13 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:97 lxc/auth.go:150 lxc/auth.go:200 lxc/auth.go:440
-#: lxc/auth.go:958 lxc/auth.go:1529 lxc/cluster_group.go:168
+#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:445
+#: lxc/auth.go:1107 lxc/auth.go:1678 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:515 lxc/auth.go:573
+#: lxc/auth.go:520 lxc/auth.go:578
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
@@ -6626,19 +6660,19 @@ msgstr ""
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:390
+#: lxc/auth.go:395
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1580 lxc/auth.go:1630 lxc/auth.go:1858
+#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1932
+#: lxc/auth.go:2081
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1808
+#: lxc/auth.go:1957
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -7129,7 +7163,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:806
+#: lxc/project.go:557 lxc/remote.go:840
 msgid "current"
 msgstr ""
 
@@ -7176,20 +7210,20 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/auth.go:204
+#: lxc/auth.go:209
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:962
+#: lxc/auth.go:1111
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1634
+#: lxc/auth.go:1783
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7613,7 +7647,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:531
+#: lxc/remote.go:545
 msgid "n"
 msgstr ""
 
@@ -7625,7 +7659,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:510
+#: lxc/remote.go:524
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7662,7 +7696,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:519
+#: lxc/remote.go:533
 msgid "y"
 msgstr ""
 

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-14 13:30+0000\n"
+"POT-Creation-Date: 2024-10-15 14:52+0100\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: 0x0916 <w@laoqinren.net>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -207,7 +207,7 @@ msgstr ""
 "###\n"
 "### Note that the name is shown but cannot be changed"
 
-#: lxc/auth.go:214
+#: lxc/auth.go:219
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -234,7 +234,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:972
+#: lxc/auth.go:1121
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -255,7 +255,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1644
+#: lxc/auth.go:1793
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
@@ -676,15 +676,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:917 lxc/remote.go:982
+#: lxc/remote.go:951 lxc/remote.go:1016
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1030
+#: lxc/remote.go:1064
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:836
+#: lxc/remote.go:870
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -717,11 +717,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:818
+#: lxc/remote.go:852
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:817
+#: lxc/auth.go:966
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -759,11 +759,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1165 lxc/auth.go:1166
+#: lxc/auth.go:1314 lxc/auth.go:1315
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1933 lxc/auth.go:1934
+#: lxc/auth.go:2082 lxc/auth.go:2083
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -832,7 +832,7 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:516 lxc/auth.go:517
+#: lxc/auth.go:521 lxc/auth.go:522
 msgid "Add permissions to groups"
 msgstr ""
 
@@ -866,7 +866,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:648
+#: lxc/remote.go:680
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -974,7 +974,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:621
+#: lxc/remote.go:635
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -1152,7 +1152,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:961
+#: lxc/remote.go:995
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1218,7 +1218,7 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:509
+#: lxc/remote.go:523
 msgid "Certificate fingerprint"
 msgstr ""
 
@@ -1237,7 +1237,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:687
+#: lxc/remote.go:721
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1485,12 +1485,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:559
+#: lxc/remote.go:573
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:237 lxc/remote.go:543
+#: lxc/remote.go:237 lxc/remote.go:557
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1504,12 +1504,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:1719
+#: lxc/auth.go:306 lxc/auth.go:1868
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1058
+#: lxc/auth.go:1207
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1529,13 +1529,17 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:554
+#: lxc/remote.go:568
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
 #: lxc/network_zone.go:1536
 msgid "Couldn't find a matching entry"
+msgstr ""
+
+#: lxc/auth.go:776
+msgid "Create a TLS identity"
 msgstr ""
 
 #: lxc/cluster_group.go:169 lxc/cluster_group.go:170
@@ -1554,6 +1558,10 @@ msgstr ""
 msgid "Create an empty instance"
 msgstr ""
 
+#: lxc/auth.go:775
+msgid "Create an identity"
+msgstr ""
+
 #: lxc/launch.go:23 lxc/launch.go:24
 msgid "Create and start instances from images"
 msgstr ""
@@ -1566,11 +1574,11 @@ msgstr ""
 msgid "Create files and directories in instances"
 msgstr ""
 
-#: lxc/auth.go:98 lxc/auth.go:99
+#: lxc/auth.go:103 lxc/auth.go:104
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1530 lxc/auth.go:1531
+#: lxc/auth.go:1679 lxc/auth.go:1680
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1678,7 +1686,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
@@ -1721,7 +1729,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/auth.go:1088 lxc/auth.go:1089
+#: lxc/auth.go:1237 lxc/auth.go:1238
 msgid "Delete an identity"
 msgstr ""
 
@@ -1729,11 +1737,11 @@ msgstr ""
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/auth.go:152 lxc/auth.go:153
+#: lxc/auth.go:157 lxc/auth.go:158
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1582 lxc/auth.go:1583
+#: lxc/auth.go:1731 lxc/auth.go:1732
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1811,18 +1819,18 @@ msgstr ""
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:31 lxc/auth.go:60 lxc/auth.go:99
-#: lxc/auth.go:153 lxc/auth.go:202 lxc/auth.go:333 lxc/auth.go:393
-#: lxc/auth.go:442 lxc/auth.go:494 lxc/auth.go:517 lxc/auth.go:576
-#: lxc/auth.go:732 lxc/auth.go:769 lxc/auth.go:836 lxc/auth.go:899
-#: lxc/auth.go:960 lxc/auth.go:1089 lxc/auth.go:1143 lxc/auth.go:1166
-#: lxc/auth.go:1224 lxc/auth.go:1293 lxc/auth.go:1315 lxc/auth.go:1493
-#: lxc/auth.go:1531 lxc/auth.go:1583 lxc/auth.go:1632 lxc/auth.go:1751
-#: lxc/auth.go:1811 lxc/auth.go:1860 lxc/auth.go:1911 lxc/auth.go:1934
-#: lxc/auth.go:1987 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215
-#: lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:484
-#: lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677 lxc/cluster.go:770
-#: lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
+#: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
+#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:338 lxc/auth.go:398
+#: lxc/auth.go:447 lxc/auth.go:499 lxc/auth.go:522 lxc/auth.go:581
+#: lxc/auth.go:737 lxc/auth.go:776 lxc/auth.go:918 lxc/auth.go:985
+#: lxc/auth.go:1048 lxc/auth.go:1109 lxc/auth.go:1238 lxc/auth.go:1292
+#: lxc/auth.go:1315 lxc/auth.go:1373 lxc/auth.go:1442 lxc/auth.go:1464
+#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
+#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
+#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
+#: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
+#: lxc/cluster.go:770 lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
 #: lxc/cluster.go:1175 lxc/cluster.go:1299 lxc/cluster.go:1329
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
@@ -1893,9 +1901,9 @@ msgstr ""
 #: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
 #: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
 #: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:715
-#: lxc/remote.go:753 lxc/remote.go:839 lxc/remote.go:920 lxc/remote.go:984
-#: lxc/remote.go:1032 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
+#: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
+#: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -2080,7 +2088,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:959 lxc/auth.go:960
+#: lxc/auth.go:1108 lxc/auth.go:1109
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -2092,11 +2100,11 @@ msgstr ""
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/auth.go:201 lxc/auth.go:202
+#: lxc/auth.go:206 lxc/auth.go:207
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1631 lxc/auth.go:1632
+#: lxc/auth.go:1780 lxc/auth.go:1781
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2472,12 +2480,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:486
+#: lxc/remote.go:500
 #, c-format
 msgid "Failed to decode trust token: %w"
 msgstr ""
 
-#: lxc/remote.go:292
+#: lxc/remote.go:306
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2581,7 +2589,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:773 lxc/auth.go:1755
+#: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
@@ -2589,7 +2597,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:757 lxc/storage.go:657
+#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2627,7 +2635,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:821
+#: lxc/remote.go:855
 msgid "GLOBAL"
 msgstr ""
 
@@ -2639,7 +2647,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:821 lxc/auth.go:1795
+#: lxc/auth.go:970 lxc/auth.go:1944
 msgid "GROUPS"
 msgstr ""
 
@@ -2647,7 +2655,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:165 lxc/remote.go:443
+#: lxc/remote.go:165 lxc/remote.go:457
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2788,17 +2796,17 @@ msgstr ""
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: lxc/auth.go:137
+#: lxc/auth.go:142
 #, c-format
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:187
+#: lxc/auth.go:192
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:427 lxc/auth.go:1845
+#: lxc/auth.go:432 lxc/auth.go:1994
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2857,7 +2865,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:820
+#: lxc/auth.go:969
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -2889,12 +2897,16 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1567
+#: lxc/auth.go:829
+msgid "Identity creation only supported for TLS identities"
+msgstr ""
+
+#: lxc/auth.go:1716
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1617
+#: lxc/auth.go:1766
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -3023,7 +3035,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1292 lxc/auth.go:1293
+#: lxc/auth.go:1441 lxc/auth.go:1442
 msgid "Inspect permissions"
 msgstr ""
 
@@ -3071,7 +3083,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:395
+#: lxc/remote.go:409
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -3152,7 +3164,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:384
+#: lxc/remote.go:398
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3327,15 +3339,15 @@ msgstr ""
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:332 lxc/auth.go:333
+#: lxc/auth.go:337 lxc/auth.go:338
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:768 lxc/auth.go:769
+#: lxc/auth.go:917 lxc/auth.go:918
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1750 lxc/auth.go:1751
+#: lxc/auth.go:1899 lxc/auth.go:1900
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3488,7 +3500,7 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1314 lxc/auth.go:1315
+#: lxc/auth.go:1463 lxc/auth.go:1464
 msgid "List permissions"
 msgstr ""
 
@@ -3532,7 +3544,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:752 lxc/remote.go:753
+#: lxc/remote.go:786 lxc/remote.go:787
 msgid "List the available remotes"
 msgstr ""
 
@@ -3656,6 +3668,12 @@ msgstr ""
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
+#: lxc/auth.go:825
+msgid ""
+"Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
+"got "
+msgstr ""
+
 #: lxc/network.go:32 lxc/network.go:33
 msgid "Manage and attach instances to networks"
 msgstr ""
@@ -3684,19 +3702,19 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:59 lxc/auth.go:60 lxc/auth.go:1492 lxc/auth.go:1493
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1142 lxc/auth.go:1143
+#: lxc/auth.go:1291 lxc/auth.go:1292
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:731 lxc/auth.go:732
+#: lxc/auth.go:736 lxc/auth.go:737
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1910 lxc/auth.go:1911
+#: lxc/auth.go:2059 lxc/auth.go:2060
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3787,7 +3805,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:493 lxc/auth.go:494
+#: lxc/auth.go:498 lxc/auth.go:499
 msgid "Manage permissions"
 msgstr ""
 
@@ -3839,7 +3857,7 @@ msgstr ""
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/auth.go:30 lxc/auth.go:31
+#: lxc/auth.go:35 lxc/auth.go:36
 msgid "Manage user authorization"
 msgstr ""
 
@@ -3936,21 +3954,21 @@ msgstr ""
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:123 lxc/auth.go:177 lxc/auth.go:255 lxc/auth.go:417
-#: lxc/auth.go:466 lxc/auth.go:541 lxc/auth.go:600 lxc/auth.go:1884
+#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:260 lxc/auth.go:422
+#: lxc/auth.go:471 lxc/auth.go:546 lxc/auth.go:605 lxc/auth.go:2033
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:866 lxc/auth.go:1007 lxc/auth.go:1124 lxc/auth.go:1190
-#: lxc/auth.go:1248
+#: lxc/auth.go:820 lxc/auth.go:1015 lxc/auth.go:1156 lxc/auth.go:1273
+#: lxc/auth.go:1339 lxc/auth.go:1397
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1554 lxc/auth.go:1607 lxc/auth.go:1673 lxc/auth.go:1835
+#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1958 lxc/auth.go:2011
+#: lxc/auth.go:2107 lxc/auth.go:2160
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -4171,12 +4189,12 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:376 lxc/auth.go:819 lxc/auth.go:1794 lxc/cluster.go:192
+#: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
-#: lxc/remote.go:815 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
 msgstr ""
@@ -4203,7 +4221,7 @@ msgstr ""
 
 #: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:775 lxc/remote.go:780 lxc/remote.go:785
+#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr ""
 
@@ -4432,7 +4450,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:378
+#: lxc/remote.go:392
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4503,11 +4521,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:817
+#: lxc/remote.go:851
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:819
+#: lxc/image.go:1136 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4548,7 +4566,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:536
+#: lxc/remote.go:550
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
@@ -4565,7 +4583,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:302 lxc/auth.go:1059 lxc/auth.go:1720 lxc/cluster.go:860
+#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -4868,33 +4886,33 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:877
+#: lxc/remote.go:911
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:868 lxc/remote.go:949 lxc/remote.go:1013
-#: lxc/remote.go:1061
+#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/remote.go:1095
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:345
+#: lxc/remote.go:359
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:957
+#: lxc/remote.go:991
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:872 lxc/remote.go:953 lxc/remote.go:1065
+#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1099
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:319
+#: lxc/remote.go:333
 msgid "Remote address must not be empty"
 msgstr ""
 
@@ -4902,7 +4920,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:339
+#: lxc/remote.go:353
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4924,7 +4942,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1223 lxc/auth.go:1224
+#: lxc/auth.go:1372 lxc/auth.go:1373
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4960,7 +4978,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1986 lxc/auth.go:1987
+#: lxc/auth.go:2135 lxc/auth.go:2136
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4972,7 +4990,7 @@ msgstr ""
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:575 lxc/auth.go:576
+#: lxc/auth.go:580 lxc/auth.go:581
 msgid "Remove permissions from groups"
 msgstr ""
 
@@ -4988,7 +5006,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:919 lxc/remote.go:920
+#: lxc/remote.go:953 lxc/remote.go:954
 msgid "Remove remotes"
 msgstr ""
 
@@ -5017,11 +5035,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:392 lxc/auth.go:393
+#: lxc/auth.go:397 lxc/auth.go:398
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1810 lxc/auth.go:1811
+#: lxc/auth.go:1959 lxc/auth.go:1960
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5045,7 +5063,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:838 lxc/remote.go:839
+#: lxc/remote.go:872 lxc/remote.go:873
 msgid "Rename remotes"
 msgstr ""
 
@@ -5190,7 +5208,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:820
+#: lxc/remote.go:854
 msgid "STATIC"
 msgstr ""
 
@@ -5231,11 +5249,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:532
+#: lxc/remote.go:546
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:285 lxc/remote.go:683
+#: lxc/remote.go:299 lxc/remote.go:717
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5446,7 +5464,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1031 lxc/remote.go:1032
+#: lxc/remote.go:1065 lxc/remote.go:1066
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5542,7 +5560,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1859 lxc/auth.go:1860
+#: lxc/auth.go:2008 lxc/auth.go:2009
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5570,11 +5588,11 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:441 lxc/auth.go:442
+#: lxc/auth.go:446 lxc/auth.go:447
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:836
+#: lxc/auth.go:985
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5679,7 +5697,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:899
+#: lxc/auth.go:1048
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5689,7 +5707,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:714 lxc/remote.go:715
+#: lxc/remote.go:748 lxc/remote.go:749
 msgid "Show the default remote"
 msgstr ""
 
@@ -5901,7 +5919,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:983 lxc/remote.go:984
+#: lxc/remote.go:1017 lxc/remote.go:1018
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5913,11 +5931,21 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
+#: lxc/auth.go:876
+#, c-format
+msgid "TLS identity %q (%s) pending identity token:"
+msgstr ""
+
+#: lxc/auth.go:902
+#, c-format
+msgid "TLS identity %q created with fingerprint %q"
+msgstr ""
+
 #: lxc/cluster.go:1070 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:818 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
 #: lxc/storage_volume.go:1736 lxc/warning.go:216
@@ -5936,7 +5964,7 @@ msgstr ""
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/remote.go:161 lxc/remote.go:334
+#: lxc/remote.go:161 lxc/remote.go:348
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
@@ -6092,7 +6120,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:527
+#: lxc/remote.go:541
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
@@ -6230,15 +6258,15 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:329
+#: lxc/remote.go:343
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:324
+#: lxc/remote.go:338
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr ""
 
-#: lxc/remote.go:639
+#: lxc/remote.go:653
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6281,7 +6309,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:193 lxc/remote.go:816
+#: lxc/cluster.go:193 lxc/remote.go:850
 msgid "URL"
 msgstr ""
 
@@ -6589,11 +6617,11 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:835
+#: lxc/auth.go:984
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:898
+#: lxc/auth.go:1047
 msgid "View the current identity"
 msgstr ""
 
@@ -6632,7 +6660,7 @@ msgstr ""
 
 #: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:777 lxc/remote.go:782 lxc/remote.go:787
+#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr ""
 
@@ -6664,7 +6692,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:330 lxc/auth.go:766 lxc/auth.go:897 lxc/auth.go:1748
+#: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
@@ -6697,7 +6725,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1313
+#: lxc/auth.go:1462
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6758,11 +6786,17 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:834 lxc/auth.go:1086
+#: lxc/auth.go:774
+msgid ""
+"[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
+"certificate>] [[--group <group_name>]]"
+msgstr ""
+
+#: lxc/auth.go:983 lxc/auth.go:1235
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1164 lxc/auth.go:1222 lxc/auth.go:1985
+#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:2134
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6770,13 +6804,13 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:97 lxc/auth.go:150 lxc/auth.go:200 lxc/auth.go:440
-#: lxc/auth.go:958 lxc/auth.go:1529 lxc/cluster_group.go:168
+#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:445
+#: lxc/auth.go:1107 lxc/auth.go:1678 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:515 lxc/auth.go:573
+#: lxc/auth.go:520 lxc/auth.go:578
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
@@ -6786,19 +6820,19 @@ msgstr ""
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:390
+#: lxc/auth.go:395
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1580 lxc/auth.go:1630 lxc/auth.go:1858
+#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1932
+#: lxc/auth.go:2081
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1808
+#: lxc/auth.go:1957
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -7289,7 +7323,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:806
+#: lxc/project.go:557 lxc/remote.go:840
 msgid "current"
 msgstr ""
 
@@ -7336,20 +7370,20 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/auth.go:204
+#: lxc/auth.go:209
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:962
+#: lxc/auth.go:1111
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1634
+#: lxc/auth.go:1783
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7773,7 +7807,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:531
+#: lxc/remote.go:545
 msgid "n"
 msgstr ""
 
@@ -7785,7 +7819,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:510
+#: lxc/remote.go:524
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7822,7 +7856,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:519
+#: lxc/remote.go:533
 msgid "y"
 msgstr ""
 

--- a/po/zh_Hant.po
+++ b/po/zh_Hant.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-14 13:30+0000\n"
+"POT-Creation-Date: 2024-10-15 14:52+0100\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Chinese (Traditional) <https://hosted.weblate.org/projects/"
@@ -133,7 +133,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:214
+#: lxc/auth.go:219
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -160,7 +160,7 @@ msgid ""
 "permissions can be modified"
 msgstr ""
 
-#: lxc/auth.go:972
+#: lxc/auth.go:1121
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -181,7 +181,7 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1644
+#: lxc/auth.go:1793
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -515,15 +515,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:917 lxc/remote.go:982
+#: lxc/remote.go:951 lxc/remote.go:1016
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:1030
+#: lxc/remote.go:1064
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:836
+#: lxc/remote.go:870
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -556,11 +556,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:818
+#: lxc/remote.go:852
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:817
+#: lxc/auth.go:966
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -598,11 +598,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1165 lxc/auth.go:1166
+#: lxc/auth.go:1314 lxc/auth.go:1315
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:1933 lxc/auth.go:1934
+#: lxc/auth.go:2082 lxc/auth.go:2083
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -671,7 +671,7 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:516 lxc/auth.go:517
+#: lxc/auth.go:521 lxc/auth.go:522
 msgid "Add permissions to groups"
 msgstr ""
 
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Admin access key: %s"
 msgstr ""
 
-#: lxc/remote.go:648
+#: lxc/remote.go:680
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -813,7 +813,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:621
+#: lxc/remote.go:635
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -991,7 +991,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:961
+#: lxc/remote.go:995
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1057,7 +1057,7 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:509
+#: lxc/remote.go:523
 msgid "Certificate fingerprint"
 msgstr ""
 
@@ -1076,7 +1076,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:687
+#: lxc/remote.go:721
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1324,12 +1324,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:559
+#: lxc/remote.go:573
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:237 lxc/remote.go:543
+#: lxc/remote.go:237 lxc/remote.go:557
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1343,12 +1343,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:301 lxc/auth.go:1719
+#: lxc/auth.go:306 lxc/auth.go:1868
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1058
+#: lxc/auth.go:1207
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1368,13 +1368,17 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:554
+#: lxc/remote.go:568
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
 
 #: lxc/network_zone.go:1536
 msgid "Couldn't find a matching entry"
+msgstr ""
+
+#: lxc/auth.go:776
+msgid "Create a TLS identity"
 msgstr ""
 
 #: lxc/cluster_group.go:169 lxc/cluster_group.go:170
@@ -1393,6 +1397,10 @@ msgstr ""
 msgid "Create an empty instance"
 msgstr ""
 
+#: lxc/auth.go:775
+msgid "Create an identity"
+msgstr ""
+
 #: lxc/launch.go:23 lxc/launch.go:24
 msgid "Create and start instances from images"
 msgstr ""
@@ -1405,11 +1413,11 @@ msgstr ""
 msgid "Create files and directories in instances"
 msgstr ""
 
-#: lxc/auth.go:98 lxc/auth.go:99
+#: lxc/auth.go:103 lxc/auth.go:104
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1530 lxc/auth.go:1531
+#: lxc/auth.go:1679 lxc/auth.go:1680
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1517,7 +1525,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:377 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
@@ -1560,7 +1568,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/auth.go:1088 lxc/auth.go:1089
+#: lxc/auth.go:1237 lxc/auth.go:1238
 msgid "Delete an identity"
 msgstr ""
 
@@ -1568,11 +1576,11 @@ msgstr ""
 msgid "Delete files in instances"
 msgstr ""
 
-#: lxc/auth.go:152 lxc/auth.go:153
+#: lxc/auth.go:157 lxc/auth.go:158
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1582 lxc/auth.go:1583
+#: lxc/auth.go:1731 lxc/auth.go:1732
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1650,18 +1658,18 @@ msgstr ""
 
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
-#: lxc/alias.go:214 lxc/auth.go:31 lxc/auth.go:60 lxc/auth.go:99
-#: lxc/auth.go:153 lxc/auth.go:202 lxc/auth.go:333 lxc/auth.go:393
-#: lxc/auth.go:442 lxc/auth.go:494 lxc/auth.go:517 lxc/auth.go:576
-#: lxc/auth.go:732 lxc/auth.go:769 lxc/auth.go:836 lxc/auth.go:899
-#: lxc/auth.go:960 lxc/auth.go:1089 lxc/auth.go:1143 lxc/auth.go:1166
-#: lxc/auth.go:1224 lxc/auth.go:1293 lxc/auth.go:1315 lxc/auth.go:1493
-#: lxc/auth.go:1531 lxc/auth.go:1583 lxc/auth.go:1632 lxc/auth.go:1751
-#: lxc/auth.go:1811 lxc/auth.go:1860 lxc/auth.go:1911 lxc/auth.go:1934
-#: lxc/auth.go:1987 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215
-#: lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:484
-#: lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677 lxc/cluster.go:770
-#: lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
+#: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
+#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:338 lxc/auth.go:398
+#: lxc/auth.go:447 lxc/auth.go:499 lxc/auth.go:522 lxc/auth.go:581
+#: lxc/auth.go:737 lxc/auth.go:776 lxc/auth.go:918 lxc/auth.go:985
+#: lxc/auth.go:1048 lxc/auth.go:1109 lxc/auth.go:1238 lxc/auth.go:1292
+#: lxc/auth.go:1315 lxc/auth.go:1373 lxc/auth.go:1442 lxc/auth.go:1464
+#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
+#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
+#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
+#: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
+#: lxc/cluster.go:770 lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
 #: lxc/cluster.go:1175 lxc/cluster.go:1299 lxc/cluster.go:1329
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
@@ -1732,9 +1740,9 @@ msgstr ""
 #: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
 #: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
 #: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
-#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:715
-#: lxc/remote.go:753 lxc/remote.go:839 lxc/remote.go:920 lxc/remote.go:984
-#: lxc/remote.go:1032 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
+#: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
+#: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
+#: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
 #: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261
 #: lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742
 #: lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30
@@ -1919,7 +1927,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:959 lxc/auth.go:960
+#: lxc/auth.go:1108 lxc/auth.go:1109
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1931,11 +1939,11 @@ msgstr ""
 msgid "Edit files in instances"
 msgstr ""
 
-#: lxc/auth.go:201 lxc/auth.go:202
+#: lxc/auth.go:206 lxc/auth.go:207
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1631 lxc/auth.go:1632
+#: lxc/auth.go:1780 lxc/auth.go:1781
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2311,12 +2319,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:486
+#: lxc/remote.go:500
 #, c-format
 msgid "Failed to decode trust token: %w"
 msgstr ""
 
-#: lxc/remote.go:292
+#: lxc/remote.go:306
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2420,7 +2428,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:337 lxc/auth.go:773 lxc/auth.go:1755
+#: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
@@ -2428,7 +2436,7 @@ msgstr ""
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:757 lxc/storage.go:657
+#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2466,7 +2474,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:821
+#: lxc/remote.go:855
 msgid "GLOBAL"
 msgstr ""
 
@@ -2478,7 +2486,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:821 lxc/auth.go:1795
+#: lxc/auth.go:970 lxc/auth.go:1944
 msgid "GROUPS"
 msgstr ""
 
@@ -2486,7 +2494,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:165 lxc/remote.go:443
+#: lxc/remote.go:165 lxc/remote.go:457
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2627,17 +2635,17 @@ msgstr ""
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
-#: lxc/auth.go:137
+#: lxc/auth.go:142
 #, c-format
 msgid "Group %s created"
 msgstr ""
 
-#: lxc/auth.go:187
+#: lxc/auth.go:192
 #, c-format
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:427 lxc/auth.go:1845
+#: lxc/auth.go:432 lxc/auth.go:1994
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2696,7 +2704,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:820
+#: lxc/auth.go:969
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -2728,12 +2736,16 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:1567
+#: lxc/auth.go:829
+msgid "Identity creation only supported for TLS identities"
+msgstr ""
+
+#: lxc/auth.go:1716
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1617
+#: lxc/auth.go:1766
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2862,7 +2874,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1292 lxc/auth.go:1293
+#: lxc/auth.go:1441 lxc/auth.go:1442
 msgid "Inspect permissions"
 msgstr ""
 
@@ -2910,7 +2922,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:395
+#: lxc/remote.go:409
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2991,7 +3003,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:384
+#: lxc/remote.go:398
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3166,15 +3178,15 @@ msgstr ""
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:332 lxc/auth.go:333
+#: lxc/auth.go:337 lxc/auth.go:338
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:768 lxc/auth.go:769
+#: lxc/auth.go:917 lxc/auth.go:918
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1750 lxc/auth.go:1751
+#: lxc/auth.go:1899 lxc/auth.go:1900
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3327,7 +3339,7 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1314 lxc/auth.go:1315
+#: lxc/auth.go:1463 lxc/auth.go:1464
 msgid "List permissions"
 msgstr ""
 
@@ -3371,7 +3383,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:752 lxc/remote.go:753
+#: lxc/remote.go:786 lxc/remote.go:787
 msgid "List the available remotes"
 msgstr ""
 
@@ -3495,6 +3507,12 @@ msgstr ""
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
+#: lxc/auth.go:825
+msgid ""
+"Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
+"got "
+msgstr ""
+
 #: lxc/network.go:32 lxc/network.go:33
 msgid "Manage and attach instances to networks"
 msgstr ""
@@ -3523,19 +3541,19 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:59 lxc/auth.go:60 lxc/auth.go:1492 lxc/auth.go:1493
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1142 lxc/auth.go:1143
+#: lxc/auth.go:1291 lxc/auth.go:1292
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:731 lxc/auth.go:732
+#: lxc/auth.go:736 lxc/auth.go:737
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:1910 lxc/auth.go:1911
+#: lxc/auth.go:2059 lxc/auth.go:2060
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3626,7 +3644,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:493 lxc/auth.go:494
+#: lxc/auth.go:498 lxc/auth.go:499
 msgid "Manage permissions"
 msgstr ""
 
@@ -3678,7 +3696,7 @@ msgstr ""
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/auth.go:30 lxc/auth.go:31
+#: lxc/auth.go:35 lxc/auth.go:36
 msgid "Manage user authorization"
 msgstr ""
 
@@ -3775,21 +3793,21 @@ msgstr ""
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:123 lxc/auth.go:177 lxc/auth.go:255 lxc/auth.go:417
-#: lxc/auth.go:466 lxc/auth.go:541 lxc/auth.go:600 lxc/auth.go:1884
+#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:260 lxc/auth.go:422
+#: lxc/auth.go:471 lxc/auth.go:546 lxc/auth.go:605 lxc/auth.go:2033
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:866 lxc/auth.go:1007 lxc/auth.go:1124 lxc/auth.go:1190
-#: lxc/auth.go:1248
+#: lxc/auth.go:820 lxc/auth.go:1015 lxc/auth.go:1156 lxc/auth.go:1273
+#: lxc/auth.go:1339 lxc/auth.go:1397
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1554 lxc/auth.go:1607 lxc/auth.go:1673 lxc/auth.go:1835
+#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:1958 lxc/auth.go:2011
+#: lxc/auth.go:2107 lxc/auth.go:2160
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -4010,12 +4028,12 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:376 lxc/auth.go:819 lxc/auth.go:1794 lxc/cluster.go:192
+#: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
-#: lxc/remote.go:815 lxc/storage.go:715 lxc/storage_bucket.go:512
+#: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
 msgstr ""
@@ -4042,7 +4060,7 @@ msgstr ""
 
 #: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:775 lxc/remote.go:780 lxc/remote.go:785
+#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr ""
 
@@ -4271,7 +4289,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:378
+#: lxc/remote.go:392
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4342,11 +4360,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:817
+#: lxc/remote.go:851
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:819
+#: lxc/image.go:1136 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4387,7 +4405,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:536
+#: lxc/remote.go:550
 msgid "Please type 'y', 'n' or the fingerprint: "
 msgstr ""
 
@@ -4404,7 +4422,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:302 lxc/auth.go:1059 lxc/auth.go:1720 lxc/cluster.go:860
+#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -4707,33 +4725,33 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:877
+#: lxc/remote.go:911
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:868 lxc/remote.go:949 lxc/remote.go:1013
-#: lxc/remote.go:1061
+#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/remote.go:1095
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:345
+#: lxc/remote.go:359
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:957
+#: lxc/remote.go:991
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:872 lxc/remote.go:953 lxc/remote.go:1065
+#: lxc/remote.go:906 lxc/remote.go:987 lxc/remote.go:1099
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:319
+#: lxc/remote.go:333
 msgid "Remote address must not be empty"
 msgstr ""
 
@@ -4741,7 +4759,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:339
+#: lxc/remote.go:353
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4763,7 +4781,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1223 lxc/auth.go:1224
+#: lxc/auth.go:1372 lxc/auth.go:1373
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4799,7 +4817,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:1986 lxc/auth.go:1987
+#: lxc/auth.go:2135 lxc/auth.go:2136
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4811,7 +4829,7 @@ msgstr ""
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:575 lxc/auth.go:576
+#: lxc/auth.go:580 lxc/auth.go:581
 msgid "Remove permissions from groups"
 msgstr ""
 
@@ -4827,7 +4845,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:919 lxc/remote.go:920
+#: lxc/remote.go:953 lxc/remote.go:954
 msgid "Remove remotes"
 msgstr ""
 
@@ -4856,11 +4874,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:392 lxc/auth.go:393
+#: lxc/auth.go:397 lxc/auth.go:398
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1810 lxc/auth.go:1811
+#: lxc/auth.go:1959 lxc/auth.go:1960
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -4884,7 +4902,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:838 lxc/remote.go:839
+#: lxc/remote.go:872 lxc/remote.go:873
 msgid "Rename remotes"
 msgstr ""
 
@@ -5029,7 +5047,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:820
+#: lxc/remote.go:854
 msgid "STATIC"
 msgstr ""
 
@@ -5070,11 +5088,11 @@ msgstr ""
 msgid "Server authentication type (tls or oidc)"
 msgstr ""
 
-#: lxc/remote.go:532
+#: lxc/remote.go:546
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:285 lxc/remote.go:683
+#: lxc/remote.go:299 lxc/remote.go:717
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -5285,7 +5303,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:1031 lxc/remote.go:1032
+#: lxc/remote.go:1065 lxc/remote.go:1066
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5381,7 +5399,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:1859 lxc/auth.go:1860
+#: lxc/auth.go:2008 lxc/auth.go:2009
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5409,11 +5427,11 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:441 lxc/auth.go:442
+#: lxc/auth.go:446 lxc/auth.go:447
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:836
+#: lxc/auth.go:985
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5518,7 +5536,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:899
+#: lxc/auth.go:1048
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5528,7 +5546,7 @@ msgid ""
 "that are granted via identity provider group mappings. \n"
 msgstr ""
 
-#: lxc/remote.go:714 lxc/remote.go:715
+#: lxc/remote.go:748 lxc/remote.go:749
 msgid "Show the default remote"
 msgstr ""
 
@@ -5740,7 +5758,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:983 lxc/remote.go:984
+#: lxc/remote.go:1017 lxc/remote.go:1018
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5752,11 +5770,21 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
+#: lxc/auth.go:876
+#, c-format
+msgid "TLS identity %q (%s) pending identity token:"
+msgstr ""
+
+#: lxc/auth.go:902
+#, c-format
+msgid "TLS identity %q created with fingerprint %q"
+msgstr ""
+
 #: lxc/cluster.go:1070 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:818 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:26 lxc/operation.go:172
 #: lxc/storage_volume.go:1736 lxc/warning.go:216
@@ -5775,7 +5803,7 @@ msgstr ""
 msgid "Target path must be a directory"
 msgstr ""
 
-#: lxc/remote.go:161 lxc/remote.go:334
+#: lxc/remote.go:161 lxc/remote.go:348
 msgid ""
 "The --accept-certificate flag is not supported when adding a remote using a "
 "trust token"
@@ -5931,7 +5959,7 @@ msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr ""
 
-#: lxc/remote.go:527
+#: lxc/remote.go:541
 msgid ""
 "The provided fingerprint does not match the server certificate fingerprint"
 msgstr ""
@@ -6069,15 +6097,15 @@ msgstr ""
 msgid "Transmit policy"
 msgstr ""
 
-#: lxc/remote.go:329
+#: lxc/remote.go:343
 msgid "Trust token cannot be used for public remotes"
 msgstr ""
 
-#: lxc/remote.go:324
+#: lxc/remote.go:338
 msgid "Trust token cannot be used with OIDC authentication"
 msgstr ""
 
-#: lxc/remote.go:639
+#: lxc/remote.go:653
 #, c-format
 msgid "Trust token for %s: "
 msgstr ""
@@ -6120,7 +6148,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:193 lxc/remote.go:816
+#: lxc/cluster.go:193 lxc/remote.go:850
 msgid "URL"
 msgstr ""
 
@@ -6428,11 +6456,11 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:835
+#: lxc/auth.go:984
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:898
+#: lxc/auth.go:1047
 msgid "View the current identity"
 msgstr ""
 
@@ -6471,7 +6499,7 @@ msgstr ""
 
 #: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:777 lxc/remote.go:782 lxc/remote.go:787
+#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr ""
 
@@ -6503,7 +6531,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:330 lxc/auth.go:766 lxc/auth.go:897 lxc/auth.go:1748
+#: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
@@ -6536,7 +6564,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1313
+#: lxc/auth.go:1462
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6597,11 +6625,17 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:834 lxc/auth.go:1086
+#: lxc/auth.go:774
+msgid ""
+"[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
+"certificate>] [[--group <group_name>]]"
+msgstr ""
+
+#: lxc/auth.go:983 lxc/auth.go:1235
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1164 lxc/auth.go:1222 lxc/auth.go:1985
+#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:2134
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6609,13 +6643,13 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:97 lxc/auth.go:150 lxc/auth.go:200 lxc/auth.go:440
-#: lxc/auth.go:958 lxc/auth.go:1529 lxc/cluster_group.go:168
+#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:445
+#: lxc/auth.go:1107 lxc/auth.go:1678 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:515 lxc/auth.go:573
+#: lxc/auth.go:520 lxc/auth.go:578
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
@@ -6625,19 +6659,19 @@ msgstr ""
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:390
+#: lxc/auth.go:395
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1580 lxc/auth.go:1630 lxc/auth.go:1858
+#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:1932
+#: lxc/auth.go:2081
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1808
+#: lxc/auth.go:1957
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -7128,7 +7162,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:806
+#: lxc/project.go:557 lxc/remote.go:840
 msgid "current"
 msgstr ""
 
@@ -7175,20 +7209,20 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/auth.go:204
+#: lxc/auth.go:209
 msgid ""
 "lxc auth group edit <group> < group.yaml\n"
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:962
+#: lxc/auth.go:1111
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1634
+#: lxc/auth.go:1783
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7612,7 +7646,7 @@ msgid ""
 "the configuration from \"config.yaml\"."
 msgstr ""
 
-#: lxc/remote.go:531
+#: lxc/remote.go:545
 msgid "n"
 msgstr ""
 
@@ -7624,7 +7658,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:510
+#: lxc/remote.go:524
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7661,7 +7695,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:519
+#: lxc/remote.go:533
 msgid "y"
 msgstr ""
 

--- a/shared/api/auth.go
+++ b/shared/api/auth.go
@@ -105,6 +105,32 @@ type IdentityPut struct {
 	Groups []string `json:"groups" yaml:"groups"`
 }
 
+// IdentitiesTLSPost contains required information for the creation of a TLS identity.
+//
+// swagger:model
+//
+// API extension: access_management_tls.
+type IdentitiesTLSPost struct {
+	// Name associated with the identity
+	// Example: foo
+	Name string `json:"name" yaml:"name"`
+
+	// Trust token (used to add an untrusted client)
+	// Example: blah
+	TrustToken string `json:"trust_token" yaml:"trust_token"`
+
+	// Whether to create a certificate add token
+	// Example: true
+	Token bool `json:"token" yaml:"token"`
+
+	// The PEM encoded x509 certificate of the identity
+	Certificate string `json:"certificate" yaml:"certificate"`
+
+	// Groups is the list of groups for which the identity is a member.
+	// Example: ["foo", "bar"]
+	Groups []string `json:"groups" yaml:"groups"`
+}
+
 // AuthGroup is the type for a LXD group.
 //
 // swagger:model

--- a/shared/api/auth.go
+++ b/shared/api/auth.go
@@ -15,6 +15,12 @@ const (
 	// IdentityTypeCertificateClientUnrestricted represents identities that authenticate using TLS and are privileged.
 	IdentityTypeCertificateClientUnrestricted = "Client certificate (unrestricted)"
 
+	// IdentityTypeCertificateClient represents identities that authenticate using TLS and whose permissions are managed via group membership.
+	IdentityTypeCertificateClient = "Client certificate"
+
+	// IdentityTypeCertificateClientPending represents identities for which a token has been issued but who have not yet authenticated with LXD.
+	IdentityTypeCertificateClientPending = "Client certificate (pending)"
+
 	// IdentityTypeCertificateServer represents cluster member authentication.
 	IdentityTypeCertificateServer = "Server certificate"
 

--- a/shared/api/certificate.go
+++ b/shared/api/certificate.go
@@ -184,6 +184,12 @@ type CertificateAddToken struct {
 	// The token's expiry date.
 	// Example: 2021-03-23T17:38:37.753398689-04:00
 	ExpiresAt time.Time `json:"expires_at" yaml:"expires_at"`
+
+	// Type is an indicator for which API (certificates or identities) to send the token.
+	// Example: Client certificate
+	//
+	// API extension: access_management_tls
+	Type string `json:"type" yaml:"type"`
 }
 
 // String encodes the certificate add token as JSON and then base64.

--- a/shared/cert.go
+++ b/shared/cert.go
@@ -434,7 +434,7 @@ func GenerateMemCert(client bool, options CertOptions) ([]byte, []byte, error) {
 func ParseCert(cert []byte) (*x509.Certificate, error) {
 	certBlock, _ := pem.Decode(cert)
 	if certBlock == nil {
-		return nil, fmt.Errorf("Invalid certificate file")
+		return nil, fmt.Errorf("Invalid PEM block")
 	}
 
 	return x509.ParseCertificate(certBlock.Bytes)

--- a/test/suites/auth.sh
+++ b/test/suites/auth.sh
@@ -105,19 +105,28 @@ test_authorization() {
   lxc auth identity list --format csv | grep -Fq "tls,Client certificate,test-user,${tls_identity_fingerprint},test-group"
 
   # Test `lxc auth identity info`
-  expected=$(cat << EOF
-groups:
-- test-group
-authentication_method: oidc
+  expectedOIDCInfo="authentication_method: oidc
 type: OIDC client
 id: test-user@example.com
 name: ' '
+groups:
+- test-group
 effective_groups:
 - test-group
-effective_permissions: []
-EOF
-)
-  lxc auth identity info oidc: | grep -Fz "${expected}"
+effective_permissions: []"
+  [ "$(lxc auth identity info oidc:)" = "${expectedOIDCInfo}" ]
+
+  expectedTLSInfo="authentication_method: tls
+type: Client certificate
+id: ${tls_identity_fingerprint}
+name: test-user
+groups:
+- test-group
+effective_groups:
+- test-group
+effective_permissions: []"
+  [ "$(LXD_CONF="${LXD_CONF2}" lxc auth identity info tls:)" = "${expectedTLSInfo}" ]
+
 
   # Identity permissions.
   ! lxc auth group permission add test-group identity test-user@example.com can_view || false # Missing authentication method

--- a/test/suites/auth.sh
+++ b/test/suites/auth.sh
@@ -138,10 +138,10 @@ EOF
   lxc auth group permission remove test-group server project_manager
 
   # Perform access checks
-  fine_grained_authorization
+  fine_grained_authorization "oidc"
 
   # Perform access check compatibility with project feature flags
-  auth_project_features
+  auth_project_features "oidc"
 
   # The OIDC identity should be able to delete themselves without any permissions.
   lxc auth identity group remove oidc/test-user@example.com test-group
@@ -161,40 +161,42 @@ EOF
 
 
 fine_grained_authorization() {
+  remote="${1}"
+
   echo "==> Checking permissions for member of group with no permissions..."
-  user_is_not_server_admin
-  user_is_not_server_operator
-  user_is_not_project_manager
-  user_is_not_project_operator
+  user_is_not_server_admin "${remote}"
+  user_is_not_server_operator "${remote}"
+  user_is_not_project_manager "${remote}"
+  user_is_not_project_operator "${remote}"
 
   # Give the test-group the `admin` entitlement on entity type `server`.
   lxc auth group permission add test-group server admin
 
   echo "==> Checking permissions for member of group with admin entitlement on server..."
-  user_is_server_admin
-  user_is_server_operator
-  user_can_edit_projects
-  user_is_project_operator
+  user_is_server_admin "${remote}"
+  user_is_server_operator "${remote}"
+  user_can_edit_projects "${remote}"
+  user_is_project_operator "${remote}"
 
   # Give the test-group the `project_manager` entitlement on entity type `server`.
   lxc auth group permission remove test-group server admin
   lxc auth group permission add test-group server project_manager
 
   echo "==> Checking permissions for member of group with project_manager entitlement on server..."
-  user_is_not_server_admin
-  user_is_server_operator
-  user_can_edit_projects
-  user_is_project_operator
+  user_is_not_server_admin "${remote}"
+  user_is_server_operator "${remote}"
+  user_can_edit_projects "${remote}"
+  user_is_project_operator "${remote}"
 
   # Give the test-group the `operator` entitlement on the default project.
   lxc auth group permission remove test-group server project_manager
   lxc auth group permission add test-group project default operator
 
   echo "==> Checking permissions for member of group with operator entitlement on default project..."
-  user_is_not_server_admin
-  user_is_not_server_operator
-  user_is_not_project_manager
-  user_is_project_operator
+  user_is_not_server_admin "${remote}"
+  user_is_not_server_operator "${remote}"
+  user_is_not_project_manager "${remote}"
+  user_is_project_operator "${remote}"
 
   lxc auth group permission remove test-group project default operator
 
@@ -213,12 +215,12 @@ fine_grained_authorization() {
   lxc auth group permission add test-group project default can_view_events
 
   echo "==> Checking permissions for member of group with user entitlement on instance user-foo in default project..."
-  user_is_instance_user user-foo # Pass instance name into test as we don't have permission to create one.
+  user_is_instance_user "${remote}" user-foo # Pass instance name into test as we don't have permission to create one.
   lxc delete user-foo --force # Must clean this up now as subsequent tests assume a clean project.
-  user_is_not_server_admin
-  user_is_not_server_operator
-  user_is_not_project_manager
-  user_is_not_project_operator
+  user_is_not_server_admin "${remote}"
+  user_is_not_server_operator "${remote}"
+  user_is_not_project_manager "${remote}"
+  user_is_not_project_operator "${remote}"
 
   lxc auth group permission remove test-group project default can_view_events
 
@@ -230,33 +232,33 @@ fine_grained_authorization() {
   lxc query --wait -X POST -d '{\"type_code\": 0, \"message\": \"authorization warning\"}' /internal/testing/warnings
 
   # Check we are not able to view warnings currently
-  ! lxc_remote warning list oidc: || false
+  ! lxc_remote warning list "${remote}:" || false
 
   # Add "can_view_warnings" permission to group.
   lxc auth group permission add test-group server can_view_warnings
 
   # Check we can view the warning we just created.
-  [ "$(lxc_remote query oidc:/1.0/warnings?recursion=1 | jq -r '[.[] | select(.last_message == "authorization warning")] | length')" = 1 ]
+  [ "$(lxc_remote query "${remote}:/1.0/warnings?recursion=1" | jq -r '[.[] | select(.last_message == "authorization warning")] | length')" = 1 ]
 
   lxc auth group permission remove test-group server can_view_warnings
 
   # Check we are not able to view any server config currently.
   # Here we explicitly a setting that contains an actual password.
   lxc config set loki.auth.password bar
-  [ "$(lxc_remote query oidc:/1.0 | jq '.config | length')" = 0 ]
-  [ "$(lxc_remote query oidc:/1.0 | jq -r '.config."loki.auth.password"')" = "null" ]
+  [ "$(lxc_remote query "${remote}:/1.0" | jq '.config | length')" = 0 ]
+  [ "$(lxc_remote query "${remote}:/1.0" | jq -r '.config."loki.auth.password"')" = "null" ]
 
   # Check we are not able to set any server config currently.
-  ! lxc_remote config set oidc: loki.auth.password bar2 || false
+  ! lxc_remote config set "${remote}:" loki.auth.password bar2 || false
 
   # Add "can_edit" permission to group.
   lxc auth group permission add test-group server can_edit
 
   # Check we can view the server's config.
-  [ "$(lxc_remote query oidc:/1.0 | jq -r '.config."loki.auth.password"')" = "bar" ]
+  [ "$(lxc_remote query "${remote}:/1.0" | jq -r '.config."loki.auth.password"')" = "bar" ]
 
   # Check we can modify the server's config.
-  lxc_remote config set oidc: loki.auth.password bar2
+  lxc_remote config set "${remote}:" loki.auth.password bar2
 
   lxc auth group permission remove test-group server can_edit
   lxc config unset loki.auth.password
@@ -264,61 +266,68 @@ fine_grained_authorization() {
   # Check we are not able to view any storage pool config currently.
   lxc storage create test-pool dir
   lxc storage set test-pool user.foo bar
-  [ "$(lxc_remote query oidc:/1.0/storage-pools/test-pool | jq '.config | length')" = 0 ]
-  [ "$(lxc_remote query oidc:/1.0/storage-pools/test-pool | jq -r '.config."user.foo"')" = "null" ]
+  [ "$(lxc_remote query "${remote}:/1.0/storage-pools/test-pool" | jq '.config | length')" = 0 ]
+  [ "$(lxc_remote query "${remote}:/1.0/storage-pools/test-pool" | jq -r '.config."user.foo"')" = "null" ]
 
   # Add "can_edit" permission to storage pool.
   lxc auth group permission add test-group storage_pool test-pool can_edit
 
   # Check we can view the storage pool's config.
-  [ "$(lxc_remote query oidc:/1.0/storage-pools/test-pool | jq -r '.config."user.foo"')" = "bar" ]
+  [ "$(lxc_remote query "${remote}:/1.0/storage-pools/test-pool" | jq -r '.config."user.foo"')" = "bar" ]
 
   lxc auth group permission remove test-group storage_pool test-pool can_edit
   lxc storage delete test-pool
 }
 
 user_is_not_server_admin() {
+  remote="${1}"
+
   # Can always see server info (type-bound public access https://openfga.dev/docs/modeling/public-access).
-  lxc_remote info oidc: > /dev/null
+  lxc_remote info "${remote}:" > /dev/null
 
   # Cannot see any config.
-  ! lxc_remote info oidc: | grep -Fq 'core.https_address' || false
+  ! lxc_remote info "${remote}:" | grep -Fq 'core.https_address' || false
 
   # Cannot set any config.
-  ! lxc_remote config set oidc: core.proxy_https=https://example.com || false
+  ! lxc_remote config set "${remote}:" core.proxy_https=https://example.com || false
 
   # Should still be able to list storage pools but not be able to see any storage pool config or delete.
-  [ "$(lxc_remote storage list oidc: -f csv | wc -l)" = 1 ]
+  [ "$(lxc_remote storage list "${remote}:" -f csv | wc -l)" = 1 ]
   lxc_remote storage create test-pool dir
-  ! lxc_remote storage set oidc:test-pool rsync.compression=true || false
-  ! lxc_remote storage show oidc:test-pool | grep -Fq 'source:' || false
-  ! lxc_remote storage delete oidc:test-pool || false
+  ! lxc_remote storage set "${remote}:test-pool" rsync.compression=true || false
+  ! lxc_remote storage show "${remote}:test-pool" | grep -Fq 'source:' || false
+  ! lxc_remote storage delete "${remote}:test-pool" || false
   lxc_remote storage delete test-pool
 
   # Should not be able to create a storage pool.
-  ! lxc_remote storage create oidc:test dir || false
+  ! lxc_remote storage create "${remote}:test" dir || false
 
   # Should not be able to see certificates
-  [ "$(lxc_remote config trust list oidc: -f csv | wc -l)" = 0 ]
+  [ "$(lxc_remote config trust list "${remote}:" -f csv | wc -l)" = 0 ]
 
   # Cannot edit certificates.
   fingerprint="$(lxc config trust list -f csv | cut -d, -f4)"
-  ! lxc config trust show "${fingerprint}" | sed -e "s/restricted: false/restricted: true/" | lxc_remote config trust edit "oidc:${fingerprint}" || false
+  ! lxc config trust show "${fingerprint}" | sed -e "s/restricted: false/restricted: true/" | lxc_remote config trust edit "${remote}:${fingerprint}" || false
 }
 
 user_is_not_server_operator() {
+  remote="${1}"
+
   # Should not be able to create a project.
-  ! lxc_remote project create oidc:new-project || false
+  ! lxc_remote project create "${remote}:new-project" || false
 }
 
 user_is_server_admin() {
+  remote="${1}"
+
   # Should be able to see server config.
-  lxc_remote info oidc: | grep -Fq 'core.https_address'
+  lxc_remote info "${remote}:" | grep -Fq 'core.https_address'
 
   # Should be able to add/remove certificates.
   gen_cert openfga-test
+  # shellcheck disable=SC2153
   test_cert_fingerprint="$(cert_fingerprint "${LXD_CONF}/openfga-test.crt")"
-  certificate_add_token="$(lxc_remote config trust add oidc: --name test --quiet)"
+  certificate_add_token="$(lxc_remote config trust add "${remote}:" --name test --quiet)"
   mv "${LXD_CONF}/client.crt" "${LXD_CONF}/client.crt.bak"
   mv "${LXD_CONF}/client.key" "${LXD_CONF}/client.key.bak"
   mv "${LXD_CONF}/openfga-test.crt" "${LXD_CONF}/client.crt"
@@ -326,142 +335,156 @@ user_is_server_admin() {
   lxc_remote remote add test-remote "${certificate_add_token}"
   mv "${LXD_CONF}/client.crt.bak" "${LXD_CONF}/client.crt"
   mv "${LXD_CONF}/client.key.bak" "${LXD_CONF}/client.key"
-  lxc_remote config trust remove "oidc:${test_cert_fingerprint}"
+  lxc_remote config trust remove "${remote}:${test_cert_fingerprint}"
   lxc_remote remote remove test-remote
 
   # Should be able to create/edit/delete a storage pool.
-  lxc_remote storage create oidc:test-pool dir
-  lxc_remote storage set oidc:test-pool rsync.compression=true
-  lxc_remote storage show oidc:test-pool | grep -Fq 'rsync.compression:'
-  lxc_remote storage delete oidc:test-pool
+  lxc_remote storage create "${remote}:test-pool" dir
+  lxc_remote storage set "${remote}:test-pool" rsync.compression=true
+  lxc_remote storage show "${remote}:test-pool" | grep -Fq 'rsync.compression:'
+  lxc_remote storage delete "${remote}:test-pool"
 }
 
 user_is_server_operator() {
+  remote="${1}"
+
   # Should be able to see projects.
-  lxc_remote project list oidc: -f csv | grep -Fq 'default'
+  lxc_remote project list "${remote}:" -f csv | grep -Fq 'default'
 
   # Should be able to create/edit/delete a project.
-  lxc_remote project create oidc:test-project
-  lxc_remote project show oidc:test-project | sed -e 's/description: ""/description: "Test Project"/' | lxc_remote project edit oidc:test-project
-  lxc_remote project delete oidc:test-project
+  lxc_remote project create "${remote}:test-project"
+  lxc_remote project show "${remote}:test-project" | sed -e 's/description: ""/description: "Test Project"/' | lxc_remote project edit "${remote}:test-project"
+  lxc_remote project delete "${remote}:test-project"
 }
 
 user_can_edit_projects() {
-  lxc_remote project set oidc:default user.foo bar
-  lxc_remote project unset oidc:default user.foo
+  remote="${1}"
+
+  lxc_remote project set "${remote}:default" user.foo bar
+  lxc_remote project unset "${remote}:default" user.foo
 }
 
 user_is_not_project_manager() {
-  ! lxc_remote project set oidc:default user.foo bar || false
-  ! lxc_remote project unset oidc:default user.foo || false
+  remote="${1}"
+
+  ! lxc_remote project set "${remote}:default" user.foo bar || false
+  ! lxc_remote project unset "${remote}:default" user.foo || false
 }
 
 user_is_project_operator() {
+  remote="${1}"
+
     # Should be able to create/edit/delete project level resources
-    lxc_remote profile create oidc:test-profile
-    lxc_remote profile device add oidc:test-profile eth0 none
-    lxc_remote profile delete oidc:test-profile
-    lxc_remote network create oidc:test-network
-    lxc_remote network set oidc:test-network bridge.mtu=1500
-    lxc_remote network delete oidc:test-network
-    lxc_remote network acl create oidc:test-network-acl
-    lxc_remote network acl delete oidc:test-network-acl
-    lxc_remote network zone create oidc:test-network-zone
-    lxc_remote network zone delete oidc:test-network-zone
-    pool_name="$(lxc_remote storage list oidc: -f csv | cut -d, -f1)"
-    lxc_remote storage volume create "oidc:${pool_name}" test-volume
-    lxc_remote query oidc:/1.0/storage-volumes | grep -F "/1.0/storage-pools/${pool_name}/volumes/custom/test-volume"
-    lxc_remote query oidc:/1.0/storage-volumes/custom | grep -F "/1.0/storage-pools/${pool_name}/volumes/custom/test-volume"
-    lxc_remote storage volume delete "oidc:${pool_name}" test-volume
-    lxc_remote launch testimage oidc:operator-foo
-    LXC_LOCAL='' lxc_remote exec oidc:operator-foo -- echo "bar"
-    lxc_remote delete oidc:operator-foo --force
+    lxc_remote profile create "${remote}:test-profile"
+    lxc_remote profile device add "${remote}:test-profile" eth0 none
+    lxc_remote profile delete "${remote}:test-profile"
+    lxc_remote network create "${remote}:test-network"
+    lxc_remote network set "${remote}:test-network" bridge.mtu=1500
+    lxc_remote network delete "${remote}:test-network"
+    lxc_remote network acl create "${remote}:test-network-acl"
+    lxc_remote network acl delete "${remote}:test-network-acl"
+    lxc_remote network zone create "${remote}:test-network-zone"
+    lxc_remote network zone delete "${remote}:test-network-zone"
+    pool_name="$(lxc_remote storage list "${remote}:" -f csv | cut -d, -f1)"
+    lxc_remote storage volume create "${remote}:${pool_name}" test-volume
+    lxc_remote query "${remote}:/1.0/storage-volumes" | grep -F "/1.0/storage-pools/${pool_name}/volumes/custom/test-volume"
+    lxc_remote query "${remote}:/1.0/storage-volumes/custom" | grep -F "/1.0/storage-pools/${pool_name}/volumes/custom/test-volume"
+    lxc_remote storage volume delete "${remote}:${pool_name}" test-volume
+    lxc_remote launch testimage "${remote}:operator-foo"
+    LXC_LOCAL='' lxc_remote exec "${remote}:operator-foo" -- echo "bar"
+    lxc_remote delete "${remote}:operator-foo" --force
 }
 
 user_is_not_project_operator() {
+  remote="${1}"
+
   # Project list will not fail but there will be no output.
-  [ "$(lxc project list oidc: -f csv | wc -l)" = 0 ]
-  ! lxc project show oidc:default || false
+  [ "$(lxc project list "${remote}:" -f csv | wc -l)" = 0 ]
+  ! lxc project show "${remote}:default" || false
 
   # Should not be able to see or create any instances.
   lxc_remote init testimage c1
-  [ "$(lxc_remote list oidc: -f csv | wc -l)" = 0 ]
-  [ "$(lxc_remote list oidc: -f csv --all-projects | wc -l)" = 0 ]
-  ! lxc_remote init testimage oidc:test-instance || false
+  [ "$(lxc_remote list "${remote}:" -f csv | wc -l)" = 0 ]
+  [ "$(lxc_remote list "${remote}:" -f csv --all-projects | wc -l)" = 0 ]
+  ! lxc_remote init testimage "${remote}:test-instance" || false
   lxc_remote delete c1 -f
 
   # Should not be able to see network allocations.
-  [ "$(lxc_remote network list-allocations oidc: -f csv | wc -l)" = 0 ]
-  [ "$(lxc_remote network list-allocations oidc: --all-projects -f csv | wc -l)" = 0 ]
+  [ "$(lxc_remote network list-allocations "${remote}:" -f csv | wc -l)" = 0 ]
+  [ "$(lxc_remote network list-allocations "${remote}:" --all-projects -f csv | wc -l)" = 0 ]
 
   # Should not be able to see or create networks.
-  [ "$(lxc_remote network list oidc: -f csv | wc -l)" = 0 ]
-  ! lxc_remote network create oidc:test-network || false
+  [ "$(lxc_remote network list "${remote}:" -f csv | wc -l)" = 0 ]
+  ! lxc_remote network create "${remote}:test-network" || false
 
   # Should not be able to see or create network ACLs.
   lxc_remote network acl create acl1
-  [ "$(lxc_remote network acl list oidc: -f csv | wc -l)" = 0 ]
-  ! lxc_remote network acl create oidc:test-acl || false
+  [ "$(lxc_remote network acl list "${remote}:" -f csv | wc -l)" = 0 ]
+  ! lxc_remote network acl create "${remote}:test-acl" || false
   lxc_remote network acl delete acl1
 
   # Should not be able to see or create network zones.
   lxc_remote network zone create zone1
-  [ "$(lxc_remote network zone list oidc: -f csv | wc -l)" = 0 ]
-  ! lxc_remote network zone create oidc:test-zone || false
+  [ "$(lxc_remote network zone list "${remote}:" -f csv | wc -l)" = 0 ]
+  ! lxc_remote network zone create "${remote}:test-zone" || false
   lxc_remote network zone delete zone1
 
   # Should not be able to see or create profiles.
-  [ "$(lxc_remote profile list oidc: -f csv | wc -l)" = 0 ]
-  ! lxc_remote profile create oidc:test-profile || false
+  [ "$(lxc_remote profile list "${remote}:" -f csv | wc -l)" = 0 ]
+  ! lxc_remote profile create "${remote}:test-profile" || false
 
   # Should not be able to see or create image aliases
   test_image_fingerprint="$(lxc_remote image info testimage | awk '/^Fingerprint/ {print $2}')"
-  [ "$(lxc_remote image alias list oidc: -f csv | wc -l)" = 0 ]
-  ! lxc_remote image alias create oidc:testimage2 "${test_image_fingerprint}" || false
+  [ "$(lxc_remote image alias list "${remote}:" -f csv | wc -l)" = 0 ]
+  ! lxc_remote image alias create "${remote}:testimage2" "${test_image_fingerprint}" || false
 
   # Should not be able to see or create storage pool volumes.
-  pool_name="$(lxc_remote storage list oidc: -f csv | cut -d, -f1)"
+  pool_name="$(lxc_remote storage list "${remote}:" -f csv | cut -d, -f1)"
   lxc_remote storage volume create "${pool_name}" vol1
-  [ "$(lxc_remote storage volume list "oidc:${pool_name}" -f csv | wc -l)" = 0 ]
-  [ "$(lxc_remote storage volume list "oidc:${pool_name}" --all-projects -f csv | wc -l)" = 0 ]
-  [ "$(lxc_remote storage volume list "oidc:" -f csv | wc -l)" = 0 ]
-  [ "$(lxc_remote storage volume list "oidc:" --all-projects -f csv | wc -l)" = 0 ]
-  ! lxc_remote storage volume create "oidc:${pool_name}" test-volume || false
+  [ "$(lxc_remote storage volume list "${remote}:${pool_name}" -f csv | wc -l)" = 0 ]
+  [ "$(lxc_remote storage volume list "${remote}:${pool_name}" --all-projects -f csv | wc -l)" = 0 ]
+  [ "$(lxc_remote storage volume list "${remote}:" -f csv | wc -l)" = 0 ]
+  [ "$(lxc_remote storage volume list "${remote}:" --all-projects -f csv | wc -l)" = 0 ]
+  ! lxc_remote storage volume create "${remote}:${pool_name}" test-volume || false
   lxc_remote storage volume delete "${pool_name}" vol1
 
   # Should not be able to see any operations.
-  [ "$(lxc_remote operation list oidc: -f csv | wc -l)" = 0 ]
-  [ "$(lxc_remote operation list oidc: --all-projects -f csv | wc -l)" = 0 ]
+  [ "$(lxc_remote operation list "${remote}:" -f csv | wc -l)" = 0 ]
+  [ "$(lxc_remote operation list "${remote}:" --all-projects -f csv | wc -l)" = 0 ]
 
   # Image list will still work but none will be shown because none are public.
-  [ "$(lxc_remote image list oidc: -f csv | wc -l)" = 0 ]
+  [ "$(lxc_remote image list "${remote}:" -f csv | wc -l)" = 0 ]
 
   # Image edit will fail. Note that this fails with "not found" because we fail to resolve the alias (image is not public
   # so it is not returned from the DB).
-  ! lxc_remote image set-property oidc:testimage requirements.secureboot true || false
+  ! lxc_remote image set-property "${remote}:testimage" requirements.secureboot true || false
   test_image_fingerprint_short="$(echo "${test_image_fingerprint}" | cut -c1-12)"
-  ! lxc_remote image set-property "oidc:${test_image_fingerprint_short}" requirements.secureboot true || false
+  ! lxc_remote image set-property "${remote}:${test_image_fingerprint_short}" requirements.secureboot true || false
 
   # Should be able to list public images.
   lxc_remote image show testimage | sed -e "s/public: false/public: true/" | lxc_remote image edit testimage
-  lxc_remote image list oidc: -f csv | grep -Fq "${test_image_fingerprint_short}"
+  lxc_remote image list "${remote}:" -f csv | grep -Fq "${test_image_fingerprint_short}"
   lxc_remote image show testimage | sed -e "s/public: true/public: false/" | lxc_remote image edit testimage
 }
 
 user_is_instance_user() {
-  instance_name="${1}"
+  remote="${1}"
+  instance_name="${2}"
 
   # Check we can still interact with the instance.
   touch "${TEST_DIR}/tmp"
-  lxc_remote file push "${TEST_DIR}/tmp" "oidc:${instance_name}/root/tmpfile.txt"
-  LXC_LOCAL='' lxc_remote exec "oidc:${instance_name}" -- rm /root/tmpfile.txt
+  lxc_remote file push "${TEST_DIR}/tmp" "${remote}:${instance_name}/root/tmpfile.txt"
+  LXC_LOCAL='' lxc_remote exec "${remote}:${instance_name}" -- rm /root/tmpfile.txt
   rm "${TEST_DIR}/tmp"
 
   # We can't edit the instance though
-  ! lxc_remote config set "oidc:${instance_name}" user.fizz=buzz || false
+  ! lxc_remote config set "${remote}:${instance_name}" user.fizz=buzz || false
 }
 
 auth_project_features() {
+  ensure_import_testimage
+  remote="${1}"
+
   # test-group must have no permissions to start the test.
   [ "$(lxc query /1.0/auth/groups/test-group | jq '.permissions | length')" -eq 0 ]
 
@@ -469,78 +492,78 @@ auth_project_features() {
   lxc project create blah
 
   # Validate view with no permissions
-  [ "$(lxc_remote project list oidc: --format csv | wc -l)" -eq 0 ]
+  [ "$(lxc_remote project list "${remote}:" --format csv | wc -l)" -eq 0 ]
 
   # Allow operator permissions on project blah
   lxc auth group permission add test-group project blah operator
 
   # Confirm we can still view storage pools
-  [ "$(lxc_remote storage list oidc: --format csv | wc -l)" = 1 ]
+  [ "$(lxc_remote storage list "${remote}:" --format csv | wc -l)" = 1 ]
 
   # Confirm we cannot view storage pool configuration
-  pool_name="$(lxc_remote storage list oidc: --format csv | cut -d, -f1)"
-  [ "$(lxc_remote storage get "oidc:${pool_name}" source)" = "" ]
+  pool_name="$(lxc_remote storage list "${remote}:" --format csv | cut -d, -f1)"
+  [ "$(lxc_remote storage get "${remote}:${pool_name}" source)" = "" ]
 
   # Validate restricted view
-  ! lxc_remote project list oidc: --format csv | grep -w ^default || false
-  lxc_remote project list oidc: --format csv | grep -w ^blah
+  ! lxc_remote project list "${remote}:" --format csv | grep -w ^default || false
+  lxc_remote project list "${remote}:" --format csv | grep -w ^blah
 
   # Validate that the restricted caller cannot edit or delete the project.
-  ! lxc_remote project set oidc:blah user.foo=bar || false
-  ! lxc_remote project delete oidc:blah || false
+  ! lxc_remote project set "${remote}:blah" user.foo=bar || false
+  ! lxc_remote project delete "${remote}:blah" || false
 
   # Validate restricted caller cannot create projects.
-  ! lxc_remote project create oidc:blah1 || false
+  ! lxc_remote project create "${remote}:blah1" || false
 
   # Validate restricted caller cannot see resources in projects they do not have access to (the call will not fail, but
   # the lists should be empty
-  [ "$(lxc_remote list oidc: --project default --format csv)" = "" ]
-  [ "$(lxc_remote profile list oidc: --project default --format csv)" = "" ]
-  [ "$(lxc_remote network list oidc: --project default --format csv)" = "" ]
-  [ "$(lxc_remote operation list oidc: --project default --format csv)" = "" ]
-  [ "$(lxc_remote network zone list oidc: --project default --format csv)" = "" ]
-  [ "$(lxc_remote storage volume list "oidc:${pool_name}" --project default --format csv)" = "" ]
-  [ "$(lxc_remote storage bucket list "oidc:${pool_name}" --project default --format csv)" = "" ]
+  [ "$(lxc_remote list "${remote}:" --project default --format csv)" = "" ]
+  [ "$(lxc_remote profile list "${remote}:" --project default --format csv)" = "" ]
+  [ "$(lxc_remote network list "${remote}:" --project default --format csv)" = "" ]
+  [ "$(lxc_remote operation list "${remote}:" --project default --format csv)" = "" ]
+  [ "$(lxc_remote network zone list "${remote}:" --project default --format csv)" = "" ]
+  [ "$(lxc_remote storage volume list "${remote}:${pool_name}" --project default --format csv)" = "" ]
+  [ "$(lxc_remote storage bucket list "${remote}:${pool_name}" --project default --format csv)" = "" ]
 
   ### Validate images.
   test_image_fingerprint="$(lxc image info testimage --project default | awk '/^Fingerprint/ {print $2}')"
 
   # We can always list images, but there are no public images in the default project now, so the list should be empty.
-  [ "$(lxc_remote image list oidc: --project default --format csv)" = "" ]
-  ! lxc_remote image show oidc:testimage --project default || false
+  [ "$(lxc_remote image list "${remote}:" --project default --format csv)" = "" ]
+  ! lxc_remote image show "${remote}:testimage" --project default || false
 
   # Set the image to public and ensure we can view it.
   lxc image show testimage --project default | sed -e "s/public: false/public: true/" | lxc image edit testimage --project default
-  [ "$(lxc_remote image list oidc: --project default --format csv | wc -l)" = 1 ]
-  lxc_remote image show oidc:testimage --project default
+  [ "$(lxc_remote image list "${remote}:" --project default --format csv | wc -l)" = 1 ]
+  lxc_remote image show "${remote}:testimage" --project default
 
   # Check we can export the public image:
-  lxc image export oidc:testimage "${TEST_DIR}/" --project default
+  lxc image export "${remote}:testimage" "${TEST_DIR}/" --project default
   [ "${test_image_fingerprint}" = "$(sha256sum "${TEST_DIR}/${test_image_fingerprint}.tar.xz" | cut -d' ' -f1)" ]
 
   # While the image is public, copy it to the blah project and create an alias for it.
-  lxc_remote image copy oidc:testimage oidc: --project default --target-project blah
-  lxc_remote image alias create oidc:testimage "${test_image_fingerprint}" --project blah
+  lxc_remote image copy "${remote}:testimage" "${remote}:" --project default --target-project blah
+  lxc_remote image alias create "${remote}:testimage" "${test_image_fingerprint}" --project blah
 
   # Restore privacy on the test image in the default project.
   lxc image show testimage --project default | sed -e "s/public: true/public: false/" | lxc image edit testimage --project default
 
   # Set up a profile in the blah project. Additionally ensures project operator can edit profiles.
-  lxc profile show default | lxc_remote profile edit oidc:default --project blah
+  lxc profile show default | lxc_remote profile edit "${remote}:default" --project blah
 
   # Create an instance (using the test image copied from the default project while it was public).
-  lxc_remote init testimage oidc:blah-instance --project blah
+  lxc_remote init testimage "${remote}:blah-instance" --project blah
 
   # Create a custom volume.
-  lxc_remote storage volume create "oidc:${pool_name}" blah-volume --project blah
+  lxc_remote storage volume create "${remote}:${pool_name}" blah-volume --project blah
 
   # There should now be two volume URLs, one instance, one image, and one profile URL in the used-by list.
-  [ "$(lxc_remote project list oidc: --format csv | cut -d, -f9)" = "5" ]
+  [ "$(lxc_remote project list "${remote}:" --format csv | cut -d, -f9)" = "5" ]
 
   # Delete resources in project blah so that we can modify project features.
-  lxc_remote delete oidc:blah-instance --project blah
-  lxc_remote storage volume delete "oidc:${pool_name}" blah-volume --project blah
-  lxc_remote image delete "oidc:${test_image_fingerprint}" --project blah
+  lxc_remote delete "${remote}:blah-instance" --project blah
+  lxc_remote storage volume delete "${remote}:${pool_name}" blah-volume --project blah
+  lxc_remote image delete "${remote}:${test_image_fingerprint}" --project blah
 
   # Ensure we can create and view resources that are not enabled for the project (e.g. their effective project is
   # the default project).
@@ -551,42 +574,42 @@ auth_project_features() {
   lxc project unset blah features.images
 
   # The test image in the default project *not* should be visible by default via project blah.
-  ! lxc_remote image info "oidc:${test_image_fingerprint}" --project blah || false
-  ! lxc_remote image show "oidc:${test_image_fingerprint}" --project blah || false
+  ! lxc_remote image info "${remote}:${test_image_fingerprint}" --project blah || false
+  ! lxc_remote image show "${remote}:${test_image_fingerprint}" --project blah || false
   test_image_fingerprint_short="$(echo "${test_image_fingerprint}" | cut -c1-12)"
-  ! lxc_remote image list oidc: --project blah | grep -F "${test_image_fingerprint_short}" || false
+  ! lxc_remote image list "${remote}:" --project blah | grep -F "${test_image_fingerprint_short}" || false
 
   # Make the images in the default project viewable to members of test-group
   lxc auth group permission add test-group project default can_view_images
 
   # The test image in the default project should now be visible via project blah.
-  lxc_remote image info "oidc:${test_image_fingerprint}" --project blah
-  lxc_remote image show "oidc:${test_image_fingerprint}" --project blah
-  lxc_remote image list oidc: --project blah | grep -F "${test_image_fingerprint_short}"
+  lxc_remote image info "${remote}:${test_image_fingerprint}" --project blah
+  lxc_remote image show "${remote}:${test_image_fingerprint}" --project blah
+  lxc_remote image list "${remote}:" --project blah | grep -F "${test_image_fingerprint_short}"
 
   # Members of test-group can view it via project default. (This is true even though they do not have can_view on project default).
-  lxc_remote image info "oidc:${test_image_fingerprint}" --project default
-  lxc_remote image show "oidc:${test_image_fingerprint}" --project default
-  lxc_remote image list oidc: --project default | grep -F "${test_image_fingerprint_short}"
+  lxc_remote image info "${remote}:${test_image_fingerprint}" --project default
+  lxc_remote image show "${remote}:${test_image_fingerprint}" --project default
+  lxc_remote image list "${remote}:" --project default | grep -F "${test_image_fingerprint_short}"
 
   # Members of test-group cannot edit the image.
-  ! lxc_remote image set-property "oidc:${test_image_fingerprint}" requirements.secureboot true --project blah || false
-  ! lxc_remote image unset-property "oidc:${test_image_fingerprint}" requirements.secureboot --project blah || false
+  ! lxc_remote image set-property "${remote}:${test_image_fingerprint}" requirements.secureboot true --project blah || false
+  ! lxc_remote image unset-property "${remote}:${test_image_fingerprint}" requirements.secureboot --project blah || false
 
   # Members of test-group cannot delete the image.
-  ! lxc_remote image delete "oidc:${test_image_fingerprint}" --project blah || false
+  ! lxc_remote image delete "${remote}:${test_image_fingerprint}" --project blah || false
 
   # Delete it anyway to test that we can import a new one.
   lxc image delete "${test_image_fingerprint}" --project default
 
   # Members of test-group can create images.
-  lxc_remote image import "${TEST_DIR}/${test_image_fingerprint}.tar.xz" oidc: --project blah
-  lxc_remote image alias create oidc:testimage "${test_image_fingerprint}" --project blah
+  lxc_remote image import "${TEST_DIR}/${test_image_fingerprint}.tar.xz" "${remote}:" --project blah
+  lxc_remote image alias create "${remote}:testimage" "${test_image_fingerprint}" --project blah
 
   # We can view the image we've created via project blah (whose effective project is default) because we've granted the
   # group permission to view all images in the default project.
-  lxc_remote image show "oidc:${test_image_fingerprint}" --project blah
-  lxc_remote image show "oidc:${test_image_fingerprint}" --project default
+  lxc_remote image show "${remote}:${test_image_fingerprint}" --project blah
+  lxc_remote image show "${remote}:${test_image_fingerprint}" --project default
 
   # Image clean up
   lxc image delete "${test_image_fingerprint}" --project default
@@ -600,41 +623,41 @@ auth_project_features() {
   lxc network create "${networkName}" --project default
 
   # The network we created in the default project is not visible in project blah.
-  ! lxc_remote network show "oidc:${networkName}" --project blah || false
-  ! lxc_remote network list oidc: --project blah | grep -F "${networkName}" || false
+  ! lxc_remote network show "${remote}:${networkName}" --project blah || false
+  ! lxc_remote network list "${remote}:" --project blah | grep -F "${networkName}" || false
 
   # Make networks in the default project viewable to members of test-group
   lxc auth group permission add test-group project default can_view_networks
 
   # The network we created in the default project is now visible in project blah.
-  lxc_remote network show "oidc:${networkName}" --project blah
-  lxc_remote network list oidc: --project blah | grep -F "${networkName}"
+  lxc_remote network show "${remote}:${networkName}" --project blah
+  lxc_remote network list "${remote}:" --project blah | grep -F "${networkName}"
 
   # Members of test-group can view it via project default.
-  lxc_remote network show "oidc:${networkName}" --project default
-  lxc_remote network list oidc: --project default | grep -F "${networkName}"
+  lxc_remote network show "${remote}:${networkName}" --project default
+  lxc_remote network list "${remote}:" --project default | grep -F "${networkName}"
 
   # Members of test-group cannot edit the network.
-  ! lxc_remote network set "oidc:${networkName}" user.foo=bar --project blah || false
+  ! lxc_remote network set "${remote}:${networkName}" user.foo=bar --project blah || false
 
   # Members of test-group cannot delete the network.
-  ! lxc_remote network delete "oidc:${networkName}" --project blah || false
+  ! lxc_remote network delete "${remote}:${networkName}" --project blah || false
 
   # Create a network in the blah project.
-  lxc_remote network create oidc:blah-network --project blah
+  lxc_remote network create "${remote}:blah-network" --project blah
 
   # The network is visible only because we have granted view access on networks in the default project.
-  lxc_remote network show oidc:blah-network --project blah
-  lxc_remote network list oidc: --project blah | grep blah-network
+  lxc_remote network show "${remote}:blah-network" --project blah
+  lxc_remote network list "${remote}:" --project blah | grep blah-network
 
   # Members of test-group can view it via the default project.
-  lxc_remote network show oidc:blah-network --project default
+  lxc_remote network show "${remote}:blah-network" --project default
 
   # Members of test-group cannot edit the network.
-  ! lxc_remote network set oidc:blah-network user.foo=bar --project blah || false
+  ! lxc_remote network set "${remote}:blah-network" user.foo=bar --project blah || false
 
   # Members of test-group cannot delete the network.
-  ! lxc_remote network delete oidc:blah-network --project blah || false
+  ! lxc_remote network delete "${remote}:blah-network" --project blah || false
 
   # Network clean up
   lxc network delete "${networkName}" --project blah
@@ -648,35 +671,35 @@ auth_project_features() {
   lxc network zone create "${zoneName}" --project default
 
   # The network zone we created in the default project is *not* visible in project blah.
-  ! lxc_remote network zone show "oidc:${zoneName}" --project blah || false
-  ! lxc_remote network zone list oidc: --project blah | grep -F "${zoneName}" || false
+  ! lxc_remote network zone show "${remote}:${zoneName}" --project blah || false
+  ! lxc_remote network zone list "${remote}:" --project blah | grep -F "${zoneName}" || false
 
   # Allow view access to network zones in the default project.
   lxc auth group permission add test-group project default can_view_network_zones
 
   # Members of test-group can now view the network zone via the default project and via the blah project.
-  lxc_remote network zone show "oidc:${zoneName}" --project default
-  lxc_remote network zone list oidc: --project default | grep -F "${zoneName}"
-  lxc_remote network zone show "oidc:${zoneName}" --project blah
-  lxc_remote network zone list oidc: --project blah | grep -F "${zoneName}"
+  lxc_remote network zone show "${remote}:${zoneName}" --project default
+  lxc_remote network zone list "${remote}:" --project default | grep -F "${zoneName}"
+  lxc_remote network zone show "${remote}:${zoneName}" --project blah
+  lxc_remote network zone list "${remote}:" --project blah | grep -F "${zoneName}"
 
   # Members of test-group cannot edit the network zone.
-  ! lxc_remote network zone set "oidc:${zoneName}" user.foo=bar --project blah || false
+  ! lxc_remote network zone set "${remote}:${zoneName}" user.foo=bar --project blah || false
 
   # Members of test-group can delete the network zone.
-  ! lxc_remote network zone delete "oidc:${zoneName}" --project blah || false
+  ! lxc_remote network zone delete "${remote}:${zoneName}" --project blah || false
 
   # Create a network zone in the blah project.
-  lxc_remote network zone create oidc:blah-zone --project blah
+  lxc_remote network zone create "${remote}:blah-zone" --project blah
 
   # Network zone is visible to members of test-group in project blah (because they can view network zones in the default project).
-  lxc_remote network zone show oidc:blah-zone --project blah
-  lxc_remote network zone list oidc: --project blah | grep blah-zone
-  lxc_remote network zone show oidc:blah-zone --project default
-  lxc_remote network zone list oidc: --project default | grep blah-zone
+  lxc_remote network zone show "${remote}:blah-zone" --project blah
+  lxc_remote network zone list "${remote}:" --project blah | grep blah-zone
+  lxc_remote network zone show "${remote}:blah-zone" --project default
+  lxc_remote network zone list "${remote}:" --project default | grep blah-zone
 
   # Members of test-group cannot delete the network zone.
-  ! lxc_remote network zone delete oidc:blah-zone --project blah || false
+  ! lxc_remote network zone delete "${remote}:blah-zone" --project blah || false
 
   # Network zone clean up
   lxc network zone delete "${zoneName}" --project blah
@@ -693,35 +716,35 @@ auth_project_features() {
   lxc profile create "${profileName}" --project default
 
   # The profile we created in the default project is not visible in project blah.
-  ! lxc_remote profile show "oidc:${profileName}" --project blah || false
-  ! lxc_remote profile list oidc: --project blah | grep -F "${profileName}" || false
+  ! lxc_remote profile show "${remote}:${profileName}" --project blah || false
+  ! lxc_remote profile list "${remote}:" --project blah | grep -F "${profileName}" || false
 
   # Grant members of test-group permission to view profiles in the default project
   lxc auth group permission add test-group project default can_view_profiles
 
   # The profile we just created is now visible via the default project and via the blah project
-  lxc_remote profile show "oidc:${profileName}" --project default
-  lxc_remote profile list oidc: --project default | grep -F "${profileName}"
-  lxc_remote profile show "oidc:${profileName}" --project blah
-  lxc_remote profile list oidc: --project blah | grep -F "${profileName}"
+  lxc_remote profile show "${remote}:${profileName}" --project default
+  lxc_remote profile list "${remote}:" --project default | grep -F "${profileName}"
+  lxc_remote profile show "${remote}:${profileName}" --project blah
+  lxc_remote profile list "${remote}:" --project blah | grep -F "${profileName}"
 
   # Members of test-group cannot edit the profile.
-  ! lxc_remote profile set "oidc:${profileName}" user.foo=bar --project blah || false
+  ! lxc_remote profile set "${remote}:${profileName}" user.foo=bar --project blah || false
 
   # Members of test-group cannot delete the profile.
-  ! lxc_remote profile delete "oidc:${profileName}" --project blah || false
+  ! lxc_remote profile delete "${remote}:${profileName}" --project blah || false
 
   # Create a profile in the blah project.
-  lxc_remote profile create oidc:blah-profile --project blah
+  lxc_remote profile create "${remote}:blah-profile" --project blah
 
   # Profile is visible to members of test-group in project blah and project default.
-  lxc_remote profile show oidc:blah-profile --project blah
-  lxc_remote profile list oidc: --project blah | grep blah-profile
-  lxc_remote profile show oidc:blah-profile --project default
-  lxc_remote profile list oidc: --project default | grep blah-profile
+  lxc_remote profile show "${remote}:blah-profile" --project blah
+  lxc_remote profile list "${remote}:" --project blah | grep blah-profile
+  lxc_remote profile show "${remote}:blah-profile" --project default
+  lxc_remote profile list "${remote}:" --project default | grep blah-profile
 
   # Members of test-group cannot delete the profile.
-  ! lxc_remote profile delete oidc:blah-profile --project blah || false
+  ! lxc_remote profile delete "${remote}:blah-profile" --project blah || false
 
   # Profile clean up
   lxc profile delete "${profileName}" --project blah
@@ -738,35 +761,35 @@ auth_project_features() {
   lxc storage volume create "${pool_name}" "${volName}" --project default
 
   # The storage volume we created in the default project is not visible in project blah.
-  ! lxc_remote storage volume show "oidc:${pool_name}" "${volName}" --project blah || false
-  ! lxc_remote storage volume list "oidc:${pool_name}" --project blah | grep -F "${volName}" || false
+  ! lxc_remote storage volume show "${remote}:${pool_name}" "${volName}" --project blah || false
+  ! lxc_remote storage volume list "${remote}:${pool_name}" --project blah | grep -F "${volName}" || false
 
   # Grant members of test-group permission to view storage volumes in project default
   lxc auth group permission add test-group project default can_view_storage_volumes
 
   # Members of test-group can't view it via project default and project blah.
-  lxc_remote storage volume show "oidc:${pool_name}" "${volName}" --project default
-  lxc_remote storage volume list "oidc:${pool_name}" --project default | grep -F "${volName}"
-  lxc_remote storage volume show "oidc:${pool_name}" "${volName}" --project blah
-  lxc_remote storage volume list "oidc:${pool_name}" --project blah | grep -F "${volName}"
+  lxc_remote storage volume show "${remote}:${pool_name}" "${volName}" --project default
+  lxc_remote storage volume list "${remote}:${pool_name}" --project default | grep -F "${volName}"
+  lxc_remote storage volume show "${remote}:${pool_name}" "${volName}" --project blah
+  lxc_remote storage volume list "${remote}:${pool_name}" --project blah | grep -F "${volName}"
 
   # Members of test-group cannot edit the storage volume.
-  ! lxc_remote storage volume set "oidc:${pool_name}" "${volName}" user.foo=bar --project blah || false
+  ! lxc_remote storage volume set "${remote}:${pool_name}" "${volName}" user.foo=bar --project blah || false
 
   # Members of test-group cannot delete the storage volume.
-  ! lxc_remote storage volume delete "oidc:${pool_name}" "${volName}" --project blah || false
+  ! lxc_remote storage volume delete "${remote}:${pool_name}" "${volName}" --project blah || false
 
   # Create a storage volume in the blah project.
-  lxc_remote storage volume create "oidc:${pool_name}" blah-volume --project blah
+  lxc_remote storage volume create "${remote}:${pool_name}" blah-volume --project blah
 
   # Storage volume is visible to members of test-group in project blah (because they can view volumes in the default project).
-  lxc_remote storage volume show "oidc:${pool_name}" blah-volume --project blah
-  lxc_remote storage volume list "oidc:${pool_name}" --project blah | grep blah-volume
-  lxc_remote storage volume show "oidc:${pool_name}" blah-volume --project default
-  lxc_remote storage volume list "oidc:${pool_name}" --project default | grep blah-volume
+  lxc_remote storage volume show "${remote}:${pool_name}" blah-volume --project blah
+  lxc_remote storage volume list "${remote}:${pool_name}" --project blah | grep blah-volume
+  lxc_remote storage volume show "${remote}:${pool_name}" blah-volume --project default
+  lxc_remote storage volume list "${remote}:${pool_name}" --project default | grep blah-volume
 
   # Members of test-group cannot delete the storage volume.
-  ! lxc_remote storage volume delete "oidc:${pool_name}" blah-volume --project blah || false
+  ! lxc_remote storage volume delete "${remote}:${pool_name}" blah-volume --project blah || false
 
   # Storage volume clean up
   lxc storage volume delete "${pool_name}" "${volName}"
@@ -786,37 +809,38 @@ auth_project_features() {
   lxc storage bucket create s3 "${bucketName}" --project default
 
   # The storage bucket we created in the default project is not visible in project blah.
-  ! lxc_remote storage bucket show oidc:s3 "${bucketName}" --project blah || false
-  ! lxc_remote storage bucket list oidc:s3 --project blah | grep -F "${bucketName}" || false
+  ! lxc_remote storage bucket show "${remote}:s3" "${bucketName}" --project blah || false
+  ! lxc_remote storage bucket list "${remote}:s3" --project blah | grep -F "${bucketName}" || false
 
   # Grant view permission on storage buckets in project default to members of test-group
   lxc auth group permission add test-group project default can_view_storage_buckets
 
   # Members of test-group can now view the bucket via project default and project blah.
-  lxc_remote storage bucket show oidc:s3 "${bucketName}" --project default
-  lxc_remote storage bucket list oidc:s3 --project default | grep -F "${bucketName}"
-  lxc_remote storage bucket show oidc:s3 "${bucketName}" --project blah
-  lxc_remote storage bucket list oidc:s3 --project blah | grep -F "${bucketName}"
+  lxc_remote storage bucket show "${remote}:s3" "${bucketName}" --project default
+  lxc_remote storage bucket list "${remote}:s3" --project default | grep -F "${bucketName}"
+  lxc_remote storage bucket show "${remote}:s3" "${bucketName}" --project blah
+  lxc_remote storage bucket list "${remote}:s3" --project blah | grep -F "${bucketName}"
 
   # Members of test-group cannot edit the storage bucket.
-  ! lxc_remote storage bucket set oidc:s3 "${bucketName}" user.foo=bar --project blah || false
+  ! lxc_remote storage bucket set "${remote}:s3" "${bucketName}" user.foo=bar --project blah || false
 
   # Members of test-group cannot delete the storage bucket.
-  ! lxc_remote storage bucket delete oidc:s3 "${bucketName}" --project blah || false
+  ! lxc_remote storage bucket delete "${remote}:s3" "${bucketName}" --project blah || false
 
   # Create a storage bucket in the blah project.
-  lxc_remote storage bucket create oidc:s3 blah-bucket --project blah
+  lxc_remote storage bucket create "${remote}:s3" blah-bucket --project blah
 
   # Storage bucket is visible to members of test-group in project blah (because they can view buckets in the default project).
-  lxc_remote storage bucket show oidc:s3 blah-bucket --project blah
-  lxc_remote storage bucket list oidc:s3 --project blah | grep blah-bucket
+  lxc_remote storage bucket show "${remote}:s3" blah-bucket --project blah
+  lxc_remote storage bucket list "${remote}:s3" --project blah | grep blah-bucket
 
   # Members of test-group cannot delete the storage bucket.
-  ! lxc_remote storage bucket delete oidc:s3 blah-bucket --project blah || false
+  ! lxc_remote storage bucket delete "${remote}:s3" blah-bucket --project blah || false
 
   # Cleanup storage buckets
   lxc storage bucket delete s3 blah-bucket --project blah
   lxc storage bucket delete s3 "${bucketName}" --project blah
+  lxc auth group permission remove test-group project default can_view_storage_buckets
   delete_object_storage_pool s3
 
   # General clean up

--- a/test/suites/auth.sh
+++ b/test/suites/auth.sh
@@ -170,9 +170,11 @@ effective_permissions: []"
 
   # Perform access checks
   fine_grained_authorization "oidc"
+  LXD_CONF="${LXD_CONF2}" fine_grained_authorization "tls"
 
   # Perform access check compatibility with project feature flags
   auth_project_features "oidc"
+  LXD_CONF="${LXD_CONF2}" auth_project_features "tls"
 
   # The OIDC identity should be able to delete themselves without any permissions.
   lxc auth identity group remove oidc/test-user@example.com test-group

--- a/test/suites/pki.sh
+++ b/test/suites/pki.sh
@@ -27,6 +27,7 @@ test_pki() {
         ./easyrsa gen-crl
         ./easyrsa build-client-full restricted nopass
         ./easyrsa build-client-full unrestricted nopass
+        ./easyrsa build-client-full fine-grained nopass
         ./easyrsa build-client-full ca-trusted nopass
         ./easyrsa build-client-full prior-revoked nopass
         mkdir keys
@@ -177,6 +178,71 @@ test_pki() {
     ! lxc_remote remote add pki-lxd "${LXD5_ADDR}" --token "${token}" || false
     [ "$(lxc config trust list --format csv | wc -l)" = 1 ]
 
+    ### Fine-grained TLS identity with `core.trust_ca_certificates` disabled.
+
+    # Set up the client config
+    cp "${TEST_DIR}/pki/keys/fine-grained.crt" "${LXD_CONF}/client.crt"
+    cp "${TEST_DIR}/pki/keys/fine-grained.key" "${LXD_CONF}/client.key"
+    cat "${LXD_CONF}/client.crt" "${LXD_CONF}/client.key" > "${LXD_CONF}/client.pem"
+    fingerprint="$(cert_fingerprint "${LXD_CONF}/client.crt")"
+
+    # Try adding remote using an incorrect token. This should fail even though the client certificate
+    # has been signed by the CA because `core.trust_ca_certificates` is not enabled.
+    ! lxc_remote remote add pki-lxd "${LXD5_ADDR}" --token=bar || false
+
+    # Add remote using the correct token.
+    # This should work because the client certificate is signed by the CA.
+    token="$(lxc auth identity create tls/foo --quiet)"
+    lxc_remote remote add pki-lxd "${LXD5_ADDR}" --token "${token}"
+
+    # Should be shown in `identity list` because `core.trust_ca_certificates` is disabled.
+    lxc_remote auth identity list pki-lxd: --format csv | grep -F "tls,Client certificate,foo,${fingerprint}"
+
+    # Should not be shown `lxc config trust list` because it is a fine-grained identity that can't be managed via this subcommand.
+    [ "$(lxc config trust list --format csv | wc -l)" = 1 ]
+
+    # The identity is not a member of any groups, so should not be able to view server config
+    ! lxc_remote info pki-lxd: | grep -F 'core.https_address' || false
+    ! curl -s --cert "${LXD_CONF}/client.pem" --cacert "${LXD5_DIR}/server.crt" "https://${LXD5_ADDR}/1.0" | jq -e '.metadata.config."core.https_address"' || false
+
+    # Enable `core.trust_ca_certificates`.
+    lxc config set core.trust_ca_certificates true
+
+    # The identity is not a member of any groups, so should not be able to view server config even though `core.trust_ca_certificates` is now enabled.
+    ! lxc_remote info pki-lxd: | grep -F 'core.https_address' || false
+    ! curl -s --cert "${LXD_CONF}/client.pem" --cacert "${LXD5_DIR}/server.crt" "https://${LXD5_ADDR}/1.0" | jq -e '.metadata.config."core.https_address"' || false
+
+    # Revoke the client certificate
+    cd "${TEST_DIR}/pki" && "${TEST_DIR}/pki/easyrsa" --batch revoke fine-grained keyCompromise && "${TEST_DIR}/pki/easyrsa" gen-crl && cd -
+
+    # Restart LXD with the revoked certificate in the CRL.
+    shutdown_lxd "${LXD5_DIR}"
+    cp "${TEST_DIR}/pki/pki/crl.pem" "${LXD5_DIR}/ca.crl"
+    respawn_lxd "${LXD5_DIR}" true
+
+    # Revoked certificate no longer has access even though it is in the trust store.
+    lxc_remote info pki-lxd: | grep -F 'auth: untrusted'
+    ! lxc_remote ls pki-lxd: || false
+    [ "$(curl -s --cert "${LXD_CONF}/client.pem" --cacert "${LXD5_DIR}/server.crt" "https://${LXD5_ADDR}/1.0/instances" | jq -e -r '.error')" = "not authorized" ]
+
+    # Remove cert from truststore.
+    lxc auth identity delete "tls/${fingerprint}"
+    lxc_remote remote remove pki-lxd
+
+    # Unset `core.trust_ca_certificates`.
+    lxc config unset core.trust_ca_certificates
+
+    # The certificate is now revoked, we can create a pending identity.
+    token="$(lxc auth identity create tls/bar --quiet)"
+    lxc auth identity list --format csv | grep -F 'tls,Client certificate (pending),bar'
+    # But adding the remote will not work
+    ! lxc_remote remote add pki-lxd "${LXD5_ADDR}" --token "${token}" || false
+    # And the identity should still be pending.
+    lxc auth identity list --format csv | grep -F 'tls,Client certificate (pending),bar'
+
+    # The pending TLS identity can be deleted
+    lxc auth identity delete tls/bar
+
     ### CA signed certificate with `core.trust_ca_certificates` enabled.
 
     # NOTE: These certificates cannot be restricted/unrestricted because no trust store entries are created for them.
@@ -253,6 +319,14 @@ test_pki() {
     token="$(lxc config trust add --name foo -q)"
     ! lxc_remote remote add pki-lxd "${LXD5_ADDR}" --token "${token}" || false
     [ "$(lxc config trust list --format csv | wc -l)" = 1 ]
+
+    # The revoked certificate is not valid when an identity token is used either.
+    token="$(lxc auth identity create tls/bar --quiet)"
+    lxc auth identity list --format csv | grep -F 'tls,Client certificate (pending),bar'
+    ! lxc_remote remote add pki-lxd "${LXD5_ADDR}" --token "${token}" || false
+    lxc auth identity list --format csv | grep -F 'tls,Client certificate (pending),bar'
+    lxc auth identity delete tls/bar
+
 
     # Try adding a remote using a revoked client certificate, and an incorrect token.
     # This should fail, as if the certificate is revoked and token is wrong then no access should be allowed.


### PR DESCRIPTION
Implements creation and subsequent authentication/authorization of fine-grained TLS identities.

Depends on https://github.com/canonical/lxd/pull/14191

Still to do:
- [x] Documentation