### PR TITLE
Storage: Add support for online disk growing of `zfs` and `lvm` block volumes (from Incus)

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -2520,3 +2520,11 @@ contains the total available logical CPUs available when LXD started.
 ## `vm_limits_cpu_pin_strategy`
 
 Adds a new {config:option}`instance-resource-limits:limits.cpu.pin_strategy` configuration option for virtual machines. This option controls the CPU pinning strategy. When set to `none`, CPU auto pinning is disabled. When set to `auto`, CPU auto pinning is enabled.
+
+## `vm_zfs_storage_disk_live_resize`
+
+This enables resizing of virtual machine `zfs` disks without requiring a restart for the changes to take effect.
+
+## `vm_lvm_storage_disk_live_resize`
+
+This enables resizing of virtual machine `lvm` disks without requiring a restart for the changes to take effect.

--- a/doc/reference/storage_drivers.md
+++ b/doc/reference/storage_drivers.md
@@ -44,6 +44,7 @@ Restore from older snapshots (not latest)   | ✅        | ✅   | ✅     | ❌
 Storage quotas                              | ✅[^5]    | ✅   | ✅     | ✅     | ✅       | ✅     | ✅          | ✅
 Available on `lxd init`                     | ✅        | ✅   | ✅     | ✅     | ✅       | ❌     | ❌          | ❌
 Object storage                              | ✅        | ✅   | ✅     | ✅     | ❌       | ❌     | ✅          | ❌
+Online growing of disks                | ❌        | ❌   | ✅     | ✅     | ❌       | ❌     | ❌          | ❌
 
 [^1]: Volumes of type `block` will fall back to non-optimized transfer when migrating to an older LXD server that doesn't yet support the `RBD_AND_RSYNC` migration type.
 [^2]: Requires {config:option}`storage-lvm-pool-conf:lvm.use_thinpool` to be enabled. Only when refreshing local volumes.

--- a/lxd/cluster/connect.go
+++ b/lxd/cluster/connect.go
@@ -16,10 +16,16 @@ import (
 	"github.com/canonical/lxd/lxd/instance/instancetype"
 	"github.com/canonical/lxd/lxd/request"
 	"github.com/canonical/lxd/lxd/state"
+	storagePools "github.com/canonical/lxd/lxd/storage"
 	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/api"
 	"github.com/canonical/lxd/shared/version"
 )
+
+// Set references.
+func init() {
+	storagePools.ConnectIfInstanceIsRemote = ConnectIfInstanceIsRemote
+}
 
 // Connect is a convenience around lxd.ConnectLXD that configures the client
 // with the correct parameters for node-to-node communication.

--- a/lxd/device/config/device_runconfig.go
+++ b/lxd/device/config/device_runconfig.go
@@ -30,6 +30,7 @@ type MountEntryItem struct {
 	PassNo     int         // Used by fsck(8) to determine the order in which filesystem checks are done at boot time. Defaults to zero (don't fsck) if not present.
 	OwnerShift string      // Ownership shifting mode, use constants MountOwnerShiftNone, MountOwnerShiftStatic or MountOwnerShiftDynamic.
 	Limits     *DiskLimits // Disk limits.
+	Size       int64       // Expected disk size in bytes.
 }
 
 // RootFSEntryItem represents the root filesystem options for an Instance.

--- a/lxd/instance/drivers/qmp/commands.go
+++ b/lxd/instance/drivers/qmp/commands.go
@@ -1015,6 +1015,24 @@ func (m *Monitor) Eject(id string) error {
 	return nil
 }
 
+// UpdateBlockSize updates the size of a disk.
+func (m *Monitor) UpdateBlockSize(id string) error {
+	var args struct {
+		NodeName string `json:"node-name"`
+		Size     int64  `json:"size"`
+	}
+
+	args.NodeName = id
+	args.Size = 1
+
+	err := m.run("block_resize", args, nil)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // SetBlockThrottle applies an I/O limit on a disk.
 func (m *Monitor) SetBlockThrottle(id string, bytesRead int, bytesWrite int, iopsRead int, iopsWrite int) error {
 	var args struct {

--- a/lxd/storage/drivers/driver_lvm_utils.go
+++ b/lxd/storage/drivers/driver_lvm_utils.go
@@ -590,27 +590,27 @@ func (d *lvm) copyThinpoolVolume(vol, srcVol Volume, srcSnapshots []string, refr
 	}
 
 	if volExists {
-		if refresh {
-			newVolDevPath := d.lvmDevPath(d.config["lvm.vg_name"], vol.volType, vol.contentType, vol.name)
-			tmpVolName := vol.name + tmpVolSuffix
-			tmpVolDevPath := d.lvmDevPath(d.config["lvm.vg_name"], vol.volType, vol.contentType, tmpVolName)
-
-			// Rename existing volume to temporary new name so we can revert if needed.
-			err := d.renameLogicalVolume(newVolDevPath, tmpVolDevPath)
-			if err != nil {
-				return fmt.Errorf("Error temporarily renaming original LVM logical volume: %w", err)
-			}
-
-			// Record this volume to be removed at the very end.
-			removeVols = append(removeVols, tmpVolName)
-
-			revert.Add(func() {
-				// Rename the original volume back to the original name.
-				_ = d.renameLogicalVolume(tmpVolDevPath, newVolDevPath)
-			})
-		} else {
+		if !refresh {
 			return fmt.Errorf("LVM volume already exists %q", vol.name)
 		}
+
+		newVolDevPath := d.lvmDevPath(d.config["lvm.vg_name"], vol.volType, vol.contentType, vol.name)
+		tmpVolName := vol.name + tmpVolSuffix
+		tmpVolDevPath := d.lvmDevPath(d.config["lvm.vg_name"], vol.volType, vol.contentType, tmpVolName)
+
+		// Rename existing volume to temporary new name so we can revert if needed.
+		err := d.renameLogicalVolume(newVolDevPath, tmpVolDevPath)
+		if err != nil {
+			return fmt.Errorf("Error temporarily renaming original LVM logical volume: %w", err)
+		}
+
+		// Record this volume to be removed at the very end.
+		removeVols = append(removeVols, tmpVolName)
+
+		revert.Add(func() {
+			// Rename the original volume back to the original name.
+			_ = d.renameLogicalVolume(tmpVolDevPath, newVolDevPath)
+		})
 	} else {
 		volPath := vol.MountPath()
 		err := vol.EnsureMountPath()

--- a/lxd/storage/drivers/driver_lvm_utils.go
+++ b/lxd/storage/drivers/driver_lvm_utils.go
@@ -693,7 +693,7 @@ func (d *lvm) logicalVolumeSize(volDevPath string) (int64, error) {
 	return strconv.ParseInt(output, 10, 64)
 }
 
-func (d *lvm) thinPoolVolumeUsage(volDevPath string) (uint64, uint64, error) {
+func (d *lvm) thinPoolVolumeUsage(volDevPath string) (totalSize uint64, usedSize uint64, err error) {
 	args := []string{
 		volDevPath,
 		"--noheadings",
@@ -718,7 +718,7 @@ func (d *lvm) thinPoolVolumeUsage(volDevPath string) (uint64, uint64, error) {
 		return 0, 0, fmt.Errorf("Failed parsing thin volume total size (%q): %w", parts[0], err)
 	}
 
-	totalSize := total
+	totalSize = total
 
 	// Used percentage is not available if thin volume isn't activated.
 	if parts[1] == "" {
@@ -740,7 +740,7 @@ func (d *lvm) thinPoolVolumeUsage(volDevPath string) (uint64, uint64, error) {
 		}
 	}
 
-	usedSize := uint64(float64(total) * ((dataPerc + metaPerc) / 100))
+	usedSize = uint64(float64(total) * ((dataPerc + metaPerc) / 100))
 
 	return totalSize, usedSize, nil
 }

--- a/lxd/storage/drivers/driver_zfs_volumes.go
+++ b/lxd/storage/drivers/driver_zfs_volumes.go
@@ -1837,10 +1837,6 @@ func (d *zfs) SetVolumeQuota(vol Volume, size string, allowUnsafeResize bool, op
 				if sizeBytes < oldVolSizeBytes {
 					return fmt.Errorf("Block volumes cannot be shrunk: %w", ErrCannotBeShrunk)
 				}
-
-				if inUse {
-					return ErrInUse // We don't allow online resizing of block volumes.
-				}
 			}
 
 			err = d.setDatasetProperties(d.dataset(vol, false), fmt.Sprintf("volsize=%d", sizeBytes))

--- a/lxd/storage/utils.go
+++ b/lxd/storage/utils.go
@@ -1105,11 +1105,12 @@ func VolumeUsedByExclusiveRemoteInstancesWithProfiles(s *state.State, poolName s
 	// Find if volume is attached to a remote instance.
 	var remoteInstance *db.InstanceArgs
 	err = VolumeUsedByInstanceDevices(s, poolName, projectName, vol, true, func(dbInst db.InstanceArgs, project api.Project, usedByDevices []string) error {
-		if dbInst.Node != s.ServerName {
-			remoteInstance = &dbInst
-			return db.ErrListStop // Stop the search, this volume is attached to a remote instance.
+		if dbInst.Node == s.ServerName {
+			remoteInstance = nil
+			return db.ErrListStop // Stop the search if the volume is attached to the local system.
 		}
 
+		remoteInstance = &dbInst
 		return nil
 	})
 	if err != nil && err != db.ErrListStop {

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -423,6 +423,8 @@ var APIExtensions = []string{
 	"network_ovn_uplink_vlan",
 	"state_logical_cpus",
 	"vm_limits_cpu_pin_strategy",
+	"vm_zfs_storage_disk_live_resize",
+	"vm_lvm_storage_disk_live_resize",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
This PR adds support for resizing (growing) VM disks without rebooting, when using ZFS or LVM storage backends.

Resolves https://github.com/canonical/lxd/issues/13311.