### PR TITLE
Storage: Use the `Net*` response variables for PowerFlex pool stats

### DIFF
--- a/lxd/storage/drivers/driver_powerflex.go
+++ b/lxd/storage/drivers/driver_powerflex.go
@@ -311,9 +311,11 @@ func (d *powerflex) GetResources() (*api.ResourcesStoragePool, error) {
 		return nil, err
 	}
 
+	used := stats.NetCapacityInUseInKb * 1024
+
 	res := &api.ResourcesStoragePool{}
-	res.Space.Total = stats.MaxCapacityInKb * 1000
-	res.Space.Used = stats.CapacityInUseInKb * 1000
+	res.Space.Total = stats.NetUnusedCapacityInKb*1024 + used
+	res.Space.Used = used
 
 	return res, nil
 }

--- a/lxd/storage/drivers/driver_powerflex_utils.go
+++ b/lxd/storage/drivers/driver_powerflex_utils.go
@@ -108,8 +108,10 @@ type powerFlexStoragePool struct {
 
 // powerFlexStoragePoolStatistics represents the statistics of a storage pool in PowerFlex.
 type powerFlexStoragePoolStatistics struct {
-	MaxCapacityInKb   uint64 `json:"maxCapacityInKb"`
-	CapacityInUseInKb uint64 `json:"capacityInUseInKb"`
+	// Unused usable storage capacity.
+	NetUnusedCapacityInKb uint64 `json:"netUnusedCapacityInKb"`
+	// Actual used storage capacity.
+	NetCapacityInUseInKb uint64 `json:"netCapacityInUseInKb"`
 }
 
 // powerFlexProtectionDomain represents a protection domain in PowerFlex.


### PR DESCRIPTION
This allows showing the actual usable storage capacity after PowerFlex interal data duplication.

Furthermore the factor is changed to 1024 as the returned value is in KiB and not KB as suggested by the name of the variables. The values are now identical to what is reported in PowerFlex UI even though in the UI the units are written in TB/GB instead of TiB/GiB:

![Screenshot from 2024-10-07 14-05-41](https://github.com/user-attachments/assets/40762be9-978d-432c-a881-c5aa776cc9e4)

![Screenshot from 2024-10-07 13-46-00](https://github.com/user-attachments/assets/290b207b-d6a7-47ca-9de5-54ba4d958e95)
