### PR TITLE
lxd: Include CAP_SYS_ADMIN in rsync AppArmor profile

### DIFF
--- a/lxd/apparmor/rsync.go
+++ b/lxd/apparmor/rsync.go
@@ -29,6 +29,7 @@ profile "{{ .name }}" flags=(attach_disconnected,mediate_deleted) {
   capability fsetid,
   capability mknod,
   capability setfcap,
+  capability sys_admin,
 
   unix (connect, send, receive) type=stream,
 


### PR DESCRIPTION
The `CAP_SYS_ADMIN` cap is required for rsync to write to files using security.* xattrs. In order to preserve these xattrs and ensure proper updates when these xattrs are present, we must include this capability in the rsync AppArmor profile.

Related: https://github.com/canonical/lxd/issues/13707.