### PR TITLE
Remove workaround for sphinx-tabs warnings

### DIFF
--- a/doc/custom_conf.py
+++ b/doc/custom_conf.py
@@ -6,10 +6,6 @@ import yaml
 from git import Repo
 import filecmp
 
-# XXX: workaround for https://github.com/executablebooks/sphinx-tabs/issues/197
-import warnings
-warnings.filterwarnings("ignore", message='The str interface for _JavaScript objects is deprecated. Use js.filename instead.')
-
 # Custom configuration for the Sphinx documentation builder.
 # All configuration specific to your project should be done in this file.
 #

--- a/doc/custom_conf.py
+++ b/doc/custom_conf.py
@@ -8,7 +8,7 @@ import filecmp
 
 # XXX: workaround for https://github.com/executablebooks/sphinx-tabs/issues/197
 import warnings
-warnings.filterwarnings("ignore", message='RemovedInSphinx90Warning: ')
+warnings.filterwarnings("ignore", message='The str interface for _JavaScript objects is deprecated. Use js.filename instead.')
 
 # Custom configuration for the Sphinx documentation builder.
 # All configuration specific to your project should be done in this file.


### PR DESCRIPTION
`sphinx-tabs` version 3.4.7 was released addressing the root cause so we no longer need to ignore those warnings.