### PR TITLE
github: stop scanning Python through CodeQL

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -45,7 +45,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'go', 'python' ]
+        language: [ 'go' ]
         # CodeQL supports [ 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'swift' ]
         # Use only 'java-kotlin' to analyze code written in Java, Kotlin or both
         # Use only 'javascript-typescript' to analyze code written in JavaScript, TypeScript or both


### PR DESCRIPTION
The repo has very few lines of python codes and they are all related to testing bits that very rarely change. Not worth spending ~1300 minutes of CI per month.