### PR TITLE
Revert "github: Workaround GHA download artifact bug"

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -320,12 +320,6 @@ jobs:
           ls -lR /home/runner/go/bin/
           chmod uog+x /home/runner/go/bin/*
 
-      - name: Symlink dqlite lib
-        run: |
-          # Workaround for GHA upload-artifact bug
-          # https://github.com/actions/upload-artifact/pull/625
-          ln -s /home/runner/go/bin/dqlite/libs/libdqlite.so.0.0.1 /home/runner/go/bin/dqlite/libs/libdqlite.so.0
-
       - name: Setup MicroCeph
         if: ${{ matrix.backend == 'ceph' }}
         uses: ./.github/actions/setup-microceph
@@ -395,12 +389,6 @@ jobs:
           name: system-test-deps
           merge-multiple: true
           path: /home/runner/go/bin
-
-      - name: Symlink dqlite lib
-        run: |
-            # Workaround for GHA upload-artifact bug
-            # https://github.com/actions/upload-artifact/pull/625
-            ln -s /home/runner/go/bin/dqlite/libs/libdqlite.so.0.0.1 /home/runner/go/bin/dqlite/libs/libdqlite.so.0
 
       - name: Install build dependencies
         uses: ./.github/actions/install-lxd-builddeps


### PR DESCRIPTION
This reverts commit 2acc480e4926697a61931ae57a8b14a173290fce now that https://github.com/actions/upload-artifact/releases/tag/v4.4.2 contains a fix.