### PR TITLE
github: only run CodeQL (go) on PRs and on weekly schedule

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,6 +13,12 @@ name: "CodeQL"
 
 on:
   pull_request:
+    paths-ignore:
+      - '.github/**'
+      - 'doc/**'
+      - 'po/**'
+      - 'tests/**'
+      - '**.md'
   schedule:
     - cron: '19 20 * * 5'
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,10 +12,6 @@
 name: "CodeQL"
 
 on:
-  push:
-    branches:
-      - main
-      - stable-*
   pull_request:
   schedule:
     - cron: '19 20 * * 5'


### PR DESCRIPTION
Suggested-by: Thomas Parrott <thomas.parrott@canonical.com>