### PR TITLE
lxd-user: Add callhook support for container stop hooks

### DIFF
--- a/lxd-user/callhook/callhook.go
+++ b/lxd-user/callhook/callhook.go
@@ -1,0 +1,97 @@
+package callhook
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/canonical/lxd/client"
+	"github.com/canonical/lxd/shared/api"
+)
+
+// ParseArgs parses callhook request into constituent parts.
+func ParseArgs(args []string) (lxdPath string, projectName string, instanceRef string, hook string, cdiHooksFiles []string, err error) {
+	argsLen := len(args)
+
+	if argsLen < 2 {
+		return "", "", "", "", nil, errors.New("Missing required arguments")
+	}
+
+	lxdPath = args[0]
+
+	if argsLen == 3 {
+		instanceRef = args[1]
+		hook = args[2]
+	} else if argsLen == 4 {
+		projectName = args[1]
+		instanceRef = args[2]
+		hook = args[3]
+	} else if argsLen >= 5 {
+		projectName = args[1]
+		instanceRef = args[2]
+		hook = args[3]
+		cdiHooksFiles = make([]string, len(args[4:]))
+		copy(cdiHooksFiles, args[4:])
+	}
+
+	return lxdPath, projectName, instanceRef, hook, cdiHooksFiles, nil
+}
+
+// HandleContainerHook passes the callhook request to the LXD server via the UNIX socket.
+func HandleContainerHook(lxdPath string, projectName string, instanceRef string, hook string) error {
+	// Connect to LXD.
+	socket := os.Getenv("LXD_SOCKET")
+	if socket == "" {
+		socket = filepath.Join(lxdPath, "unix.socket")
+	}
+
+	// Detect stop target.
+	var target string
+	if hook == "stop" || hook == "stopns" {
+		target = os.Getenv("LXC_TARGET")
+		if target == "" {
+			target = "unknown"
+		}
+	}
+
+	// Timeout hook request to LXD after 30s.
+	ctx, done := context.WithTimeout(context.Background(), time.Second*30)
+	defer done()
+
+	// Setup the request to LXD.
+	lxdArgs := lxd.ConnectionArgs{
+		SkipGetServer: true,
+	}
+
+	d, err := lxd.ConnectLXDUnixWithContext(ctx, socket, &lxdArgs)
+	if err != nil {
+		return err
+	}
+
+	u := api.NewURL().Path("internal", "containers", instanceRef, "on"+hook)
+	u.WithQuery("target", target)
+
+	if projectName != "" {
+		u.WithQuery("project", projectName)
+	}
+
+	if hook == "stopns" {
+		u.WithQuery("netns", os.Getenv("LXC_NET_NS"))
+	}
+
+	_, _, err = d.RawQuery("GET", u.String(), nil, "")
+	if err != nil {
+		return err
+	}
+
+	// If the container is rebooting, we purposefully tell LXC that this hook failed so that
+	// it won't reboot the container, which lets LXD start it again in the OnStop function.
+	// Other hook types can return without error safely.
+	if hook == "stop" && target == "reboot" {
+		return errors.New("Reboot must be handled by LXD")
+	}
+
+	return nil
+}

--- a/lxd-user/main.go
+++ b/lxd-user/main.go
@@ -34,6 +34,10 @@ func main() {
 	app.PersistentFlags().BoolVar(&globalCmd.flagVersion, "version", false, "Print version number")
 	app.PersistentFlags().BoolVarP(&globalCmd.flagHelp, "help", "h", false, "Print help")
 
+	// callhook sub-command
+	callhookCmd := cmdCallhook{global: &globalCmd}
+	app.AddCommand(callhookCmd.Command())
+
 	// Version handling
 	app.SetVersionTemplate("{{.Version}}\n")
 	app.Version = version.Version

--- a/lxd-user/main_callhook.go
+++ b/lxd-user/main_callhook.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/canonical/lxd/lxd-user/callhook"
+)
+
+type cmdCallhook struct {
+	global *cmdGlobal
+}
+
+// Command returns a cobra command for `lxd callhook`.
+func (c *cmdCallhook) Command() *cobra.Command {
+	cmd := &cobra.Command{}
+	cmd.Use = "callhook <path> [<instance id>|<instance project> <instance name>] <hook>"
+	cmd.Short = "Call container lifecycle hook in LXD"
+	cmd.Long = `Description:
+  Call container lifecycle hook in LXD
+
+  This internal command notifies LXD about a container lifecycle event
+  (stopns, stop) and blocks until LXD has processed it.
+`
+	cmd.RunE = c.Run
+	cmd.Hidden = true
+
+	return cmd
+}
+
+// Run executes the `lxd callhook` command.
+func (c *cmdCallhook) Run(cmd *cobra.Command, args []string) error {
+	// Only root should run this.
+	if os.Geteuid() != 0 {
+		return fmt.Errorf("This must be run as root")
+	}
+
+	// Parse request.
+	lxdPath, projectName, instanceRef, hook, _, err := callhook.ParseArgs(args)
+	if err != nil {
+		_ = cmd.Help()
+		if len(args) == 0 {
+			return nil
+		}
+
+		return err
+	}
+
+	// Handle stop hooks.
+	return callhook.HandleContainerHook(lxdPath, projectName, instanceRef, hook)
+}


### PR DESCRIPTION
- Adds ability for lxd-user to handle container stop hook requests.
- Uses a context rather than a go routine for 30s timeout.
- Adds `callhook` package used from both `lxd-user` and `lxd` to avoid duplication.
- Uses URL builder rather than crafting URLs manually.

Related to https://github.com/canonical/lxd/issues/13331

Depends on https://github.com/canonical/lxd-pkg-snap/pull/564