### PR TITLE
lxd: Change token pruning task to hourly.

### DIFF
--- a/lxd/tokens.go
+++ b/lxd/tokens.go
@@ -71,5 +71,5 @@ func autoRemoveExpiredTokensTask(d *Daemon) (task.Func, task.Schedule) {
 		autoRemoveExpiredTokens(ctx, d.State())
 	}
 
-	return f, task.Every(time.Minute)
+	return f, task.Every(time.Hour)
 }


### PR DESCRIPTION
This task is running every minute but doesn't need to, because token expiry is checked at the time of use. Additionally, a comment where the task is added to the daemon specifies that it runs hourly.