### PR TITLE
API: Add support for fetching images across all projects (from Incus)

### DIFF
--- a/client/interfaces.go
+++ b/client/interfaces.go
@@ -243,6 +243,7 @@ type InstanceServer interface {
 	UpdateImageAlias(name string, alias api.ImageAliasesEntryPut, ETag string) (err error)
 	RenameImageAlias(name string, alias api.ImageAliasesEntryPost) (err error)
 	DeleteImageAlias(name string) (err error)
+	GetImagesAllProjects() (images []api.Image, err error)
 
 	// Network functions ("network" API extension)
 	GetNetworkNames() (names []string, err error)

--- a/client/interfaces.go
+++ b/client/interfaces.go
@@ -244,6 +244,7 @@ type InstanceServer interface {
 	RenameImageAlias(name string, alias api.ImageAliasesEntryPost) (err error)
 	DeleteImageAlias(name string) (err error)
 	GetImagesAllProjects() (images []api.Image, err error)
+	GetImagesAllProjectsWithFilter(filters []string) (images []api.Image, err error)
 
 	// Network functions ("network" API extension)
 	GetNetworkNames() (names []string, err error)

--- a/client/lxd_images.go
+++ b/client/lxd_images.go
@@ -51,6 +51,29 @@ func (r *ProtocolLXD) GetImagesAllProjects() ([]api.Image, error) {
 	return images, nil
 }
 
+// GetImagesAllProjectsWithFilter returns a filtered list of images across all projects as Image structs.
+func (r *ProtocolLXD) GetImagesAllProjectsWithFilter(filters []string) ([]api.Image, error) {
+	err := r.CheckExtension("api_filtering")
+	if err != nil {
+		return nil, err
+	}
+
+	images := []api.Image{}
+
+	err = r.CheckExtension("images_all_projects")
+	if err != nil {
+		return nil, err
+	}
+
+	u := api.NewURL().Path("images").WithQuery("recursion", "1").WithQuery("all-projects", "true").WithQuery("filter", parseFilters(filters))
+	_, err = r.queryStruct("GET", u.String(), nil, "", &images)
+	if err != nil {
+		return nil, err
+	}
+
+	return images, nil
+}
+
 // GetImagesWithFilter returns a filtered list of available images as Image structs.
 func (r *ProtocolLXD) GetImagesWithFilter(filters []string) ([]api.Image, error) {
 	err := r.CheckExtension("api_filtering")

--- a/client/lxd_images.go
+++ b/client/lxd_images.go
@@ -33,6 +33,24 @@ func (r *ProtocolLXD) GetImages() ([]api.Image, error) {
 	return images, nil
 }
 
+// GetImagesAllProjects returns a list of images across all projects as Image structs.
+func (r *ProtocolLXD) GetImagesAllProjects() ([]api.Image, error) {
+	images := []api.Image{}
+
+	err := r.CheckExtension("images_all_projects")
+	if err != nil {
+		return nil, err
+	}
+
+	u := api.NewURL().Path("images").WithQuery("recursion", "1").WithQuery("all-projects", "true")
+	_, err = r.queryStruct("GET", u.String(), nil, "", &images)
+	if err != nil {
+		return nil, err
+	}
+
+	return images, nil
+}
+
 // GetImagesWithFilter returns a filtered list of available images as Image structs.
 func (r *ProtocolLXD) GetImagesWithFilter(filters []string) ([]api.Image, error) {
 	err := r.CheckExtension("api_filtering")

--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -2519,3 +2519,7 @@ Adds a new {config:option}`instance-resource-limits:limits.cpu.pin_strategy` con
 ## `gpu_cdi`
 
 Adds support for using the Container Device Interface (CDI) specification to configure GPU passthrough in LXD containers. The `id` field of GPU devices now accepts CDI identifiers (for example, `{VENDOR_DOMAIN_NAME}/gpu=gpu{INDEX}`) for containers, in addition to DRM card IDs. This enables GPU passthrough for devices that don't use PCI addressing (like NVIDIA Tegra iGPUs) and provides a more flexible way to identify and configure GPU devices.
+
+## `images_all_projects`
+
+This adds support for listing images across all projects using the `all-projects` parameter in `GET /1.0/images` requests.

--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -987,6 +987,11 @@ definitions:
                     type: string
                 type: array
                 x-go-name: Profiles
+            project:
+                description: Project name
+                example: project1
+                type: string
+                x-go-name: Project
             properties:
                 additionalProperties:
                     type: string
@@ -9019,6 +9024,10 @@ paths:
                   in: query
                   name: filter
                   type: string
+                - description: Retrieve images from all projects
+                  in: query
+                  name: all-projects
+                  type: boolean
             produces:
                 - application/json
             responses:
@@ -9770,6 +9779,10 @@ paths:
                   in: query
                   name: filter
                   type: string
+                - description: Retrieve images from all projects
+                  in: query
+                  name: all-projects
+                  type: boolean
             produces:
                 - application/json
             responses:
@@ -9858,6 +9871,10 @@ paths:
                   in: query
                   name: filter
                   type: string
+                - description: Retrieve images from all projects
+                  in: query
+                  name: all-projects
+                  type: boolean
             produces:
                 - application/json
             responses:
@@ -9906,6 +9923,11 @@ paths:
                   in: query
                   name: filter
                   type: string
+                - description: Retrieve images from all projects
+                  example: default
+                  in: query
+                  name: all-projects
+                  type: boolean
             produces:
                 - application/json
             responses:

--- a/lxd/db/images.go
+++ b/lxd/db/images.go
@@ -401,6 +401,7 @@ func (c *ClusterTx) GetImageByFingerprintPrefix(ctx context.Context, fingerprint
 	image.Cached = object.Cached
 	image.Public = object.Public
 	image.AutoUpdate = object.AutoUpdate
+	image.Project = object.Project
 
 	err = c.imageFill(
 		ctx, object.ID, &image,

--- a/po/ar.po
+++ b/po/ar.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-11-18 20:34-0300\n"
+"POT-Creation-Date: 2024-11-21 15:57-0700\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -420,7 +420,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1168
+#: lxc/image.go:1180
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -541,11 +541,11 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1133
+#: lxc/image.go:1144
 msgid "ALIASES"
 msgstr ""
 
@@ -766,7 +766,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:342 lxc/rebuild.go:131
+#: lxc/init.go:343 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -871,7 +871,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1169,7 +1169,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1595
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1595
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1499,7 +1499,7 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:186
+#: lxc/init.go:182
 #, c-format
 msgid "Creating %s"
 msgstr ""
@@ -1509,7 +1509,7 @@ msgstr ""
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: lxc/init.go:184
+#: lxc/init.go:180
 msgid "Creating the instance"
 msgstr ""
 
@@ -1523,7 +1523,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -1690,8 +1690,8 @@ msgstr ""
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1090 lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574
-#: lxc/image.go:1638 lxc/image.go:1701 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
+#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1836,7 +1836,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:402
+#: lxc/init.go:403
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1877,6 +1877,10 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
+#: lxc/image.go:1119
+msgid "Display images from all projects"
+msgstr ""
+
 #: lxc/list.go:135
 msgid "Display instances from all projects"
 msgstr ""
@@ -1885,7 +1889,7 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:100
+#: lxc/main.go:99
 msgid "Don't show progress information"
 msgstr ""
 
@@ -2020,7 +2024,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1772
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2193,7 +2197,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
+#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2397,7 +2401,7 @@ msgstr ""
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:96
+#: lxc/main.go:95
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -2428,7 +2432,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2503,7 +2507,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1573 lxc/image.go:1574
+#: lxc/image.go:1606 lxc/image.go:1607
 msgid "Get image properties"
 msgstr ""
 
@@ -2759,7 +2763,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:405
+#: lxc/main.go:404
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2781,7 +2785,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1489
+#: lxc/image.go:1522
 msgid "Image already up to date."
 msgstr ""
 
@@ -2797,11 +2801,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1444
+#: lxc/image.go:364 lxc/image.go:1477
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1670
+#: lxc/image.go:444 lxc/image.go:1703
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2811,7 +2815,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1520
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2892,7 +2896,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:413
+#: lxc/init.go:414
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2991,7 +2995,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:507
+#: lxc/main.go:506
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3084,12 +3088,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/init.go:180
+#: lxc/init.go:176
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: lxc/init.go:178
+#: lxc/init.go:174
 msgid "Launching the instance"
 msgstr ""
 
@@ -3198,11 +3202,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1089
+#: lxc/image.go:1090
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid ""
 "List images\n"
 "\n"
@@ -3223,6 +3227,7 @@ msgid ""
 "    F - Fingerprint (long)\n"
 "    p - Whether image is public\n"
 "    d - Description\n"
+"    e - Project\n"
 "    a - Architecture\n"
 "    s - Size\n"
 "    u - Upload date\n"
@@ -4319,7 +4324,7 @@ msgstr ""
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:96
 msgid "Override the source project"
 msgstr ""
 
@@ -4361,7 +4366,8 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:567 lxc/storage_volume.go:1762 lxc/warning.go:213
+#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1762
+#: lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4369,7 +4375,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:853
+#: lxc/image.go:1145 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4385,7 +4391,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:368
+#: lxc/main.go:367
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4444,7 +4450,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:95
+#: lxc/main.go:94
 msgid "Print help"
 msgstr ""
 
@@ -4452,7 +4458,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:94
+#: lxc/main.go:93
 msgid "Print version number"
 msgstr ""
 
@@ -4549,7 +4555,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1621
+#: lxc/image.go:1654
 msgid "Property not found"
 msgstr ""
 
@@ -4679,7 +4685,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4716,7 +4722,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1416 lxc/image.go:1417
+#: lxc/image.go:1449 lxc/image.go:1450
 msgid "Refresh images"
 msgstr ""
 
@@ -4725,7 +4731,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1453
+#: lxc/image.go:1486
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4988,7 +4994,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:356
+#: lxc/init.go:357
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5021,7 +5027,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1139
+#: lxc/image.go:1146
 msgid "SIZE"
 msgstr ""
 
@@ -5144,7 +5150,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1637 lxc/image.go:1638
+#: lxc/image.go:1670 lxc/image.go:1671
 msgid "Set image properties"
 msgstr ""
 
@@ -5396,11 +5402,11 @@ msgstr ""
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: lxc/main.go:98
+#: lxc/main.go:97
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:99
+#: lxc/main.go:98
 msgid "Show all information messages"
 msgstr ""
 
@@ -5449,7 +5455,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1507 lxc/image.go:1508
+#: lxc/image.go:1540 lxc/image.go:1541
 msgid "Show image properties"
 msgstr ""
 
@@ -5469,7 +5475,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:272 lxc/main.go:273
+#: lxc/main.go:271 lxc/main.go:272
 msgid "Show less common commands"
 msgstr ""
 
@@ -5793,7 +5799,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1736 lxc/warning.go:216
@@ -5864,7 +5870,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:434
+#: lxc/init.go:435
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -6010,7 +6016,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:299
+#: lxc/main.go:298
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6034,11 +6040,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:436
+#: lxc/init.go:437
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:435
+#: lxc/init.go:436
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6046,7 +6052,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:411
+#: lxc/main.go:410
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6153,7 +6159,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1140
+#: lxc/image.go:1148
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6199,7 +6205,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1778
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1778
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6241,7 +6247,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1700 lxc/image.go:1701
+#: lxc/image.go:1733 lxc/image.go:1734
 msgid "Unset image properties"
 msgstr ""
 
@@ -6411,7 +6417,7 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/main.go:101
+#: lxc/main.go:100
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -6565,7 +6571,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1087 lxc/list.go:46
+#: lxc/image.go:1088 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6684,15 +6690,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1572 lxc/image.go:1699
+#: lxc/image.go:1605 lxc/image.go:1732
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1636
+#: lxc/image.go:1669
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6712,7 +6718,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1415
+#: lxc/image.go:334 lxc/image.go:1448
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -7667,7 +7673,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
+#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
 msgid "no"
 msgstr ""
 
@@ -7713,6 +7719,6 @@ msgid "y"
 msgstr ""
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1194
+#: lxc/image.go:1206
 msgid "yes"
 msgstr ""

--- a/po/ber.po
+++ b/po/ber.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-11-18 20:34-0300\n"
+"POT-Creation-Date: 2024-11-21 15:57-0700\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Berber <https://hosted.weblate.org/projects/linux-containers/"
@@ -423,7 +423,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1168
+#: lxc/image.go:1180
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -544,11 +544,11 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1133
+#: lxc/image.go:1144
 msgid "ALIASES"
 msgstr ""
 
@@ -769,7 +769,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:342 lxc/rebuild.go:131
+#: lxc/init.go:343 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1172,7 +1172,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1595
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1595
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1502,7 +1502,7 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:186
+#: lxc/init.go:182
 #, c-format
 msgid "Creating %s"
 msgstr ""
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: lxc/init.go:184
+#: lxc/init.go:180
 msgid "Creating the instance"
 msgstr ""
 
@@ -1526,7 +1526,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -1693,8 +1693,8 @@ msgstr ""
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1090 lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574
-#: lxc/image.go:1638 lxc/image.go:1701 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
+#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:402
+#: lxc/init.go:403
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1880,6 +1880,10 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
+#: lxc/image.go:1119
+msgid "Display images from all projects"
+msgstr ""
+
 #: lxc/list.go:135
 msgid "Display instances from all projects"
 msgstr ""
@@ -1888,7 +1892,7 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:100
+#: lxc/main.go:99
 msgid "Don't show progress information"
 msgstr ""
 
@@ -2023,7 +2027,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1772
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2196,7 +2200,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
+#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2400,7 +2404,7 @@ msgstr ""
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:96
+#: lxc/main.go:95
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -2431,7 +2435,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2506,7 +2510,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1573 lxc/image.go:1574
+#: lxc/image.go:1606 lxc/image.go:1607
 msgid "Get image properties"
 msgstr ""
 
@@ -2762,7 +2766,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:405
+#: lxc/main.go:404
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2784,7 +2788,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1489
+#: lxc/image.go:1522
 msgid "Image already up to date."
 msgstr ""
 
@@ -2800,11 +2804,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1444
+#: lxc/image.go:364 lxc/image.go:1477
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1670
+#: lxc/image.go:444 lxc/image.go:1703
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2814,7 +2818,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1520
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2895,7 +2899,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:413
+#: lxc/init.go:414
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2994,7 +2998,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:507
+#: lxc/main.go:506
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3087,12 +3091,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/init.go:180
+#: lxc/init.go:176
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: lxc/init.go:178
+#: lxc/init.go:174
 msgid "Launching the instance"
 msgstr ""
 
@@ -3201,11 +3205,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1089
+#: lxc/image.go:1090
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid ""
 "List images\n"
 "\n"
@@ -3226,6 +3230,7 @@ msgid ""
 "    F - Fingerprint (long)\n"
 "    p - Whether image is public\n"
 "    d - Description\n"
+"    e - Project\n"
 "    a - Architecture\n"
 "    s - Size\n"
 "    u - Upload date\n"
@@ -4322,7 +4327,7 @@ msgstr ""
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:96
 msgid "Override the source project"
 msgstr ""
 
@@ -4364,7 +4369,8 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:567 lxc/storage_volume.go:1762 lxc/warning.go:213
+#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1762
+#: lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4372,7 +4378,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:853
+#: lxc/image.go:1145 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4388,7 +4394,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:368
+#: lxc/main.go:367
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4447,7 +4453,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:95
+#: lxc/main.go:94
 msgid "Print help"
 msgstr ""
 
@@ -4455,7 +4461,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:94
+#: lxc/main.go:93
 msgid "Print version number"
 msgstr ""
 
@@ -4552,7 +4558,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1621
+#: lxc/image.go:1654
 msgid "Property not found"
 msgstr ""
 
@@ -4682,7 +4688,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4719,7 +4725,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1416 lxc/image.go:1417
+#: lxc/image.go:1449 lxc/image.go:1450
 msgid "Refresh images"
 msgstr ""
 
@@ -4728,7 +4734,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1453
+#: lxc/image.go:1486
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4991,7 +4997,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:356
+#: lxc/init.go:357
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5024,7 +5030,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1139
+#: lxc/image.go:1146
 msgid "SIZE"
 msgstr ""
 
@@ -5147,7 +5153,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1637 lxc/image.go:1638
+#: lxc/image.go:1670 lxc/image.go:1671
 msgid "Set image properties"
 msgstr ""
 
@@ -5399,11 +5405,11 @@ msgstr ""
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: lxc/main.go:98
+#: lxc/main.go:97
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:99
+#: lxc/main.go:98
 msgid "Show all information messages"
 msgstr ""
 
@@ -5452,7 +5458,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1507 lxc/image.go:1508
+#: lxc/image.go:1540 lxc/image.go:1541
 msgid "Show image properties"
 msgstr ""
 
@@ -5472,7 +5478,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:272 lxc/main.go:273
+#: lxc/main.go:271 lxc/main.go:272
 msgid "Show less common commands"
 msgstr ""
 
@@ -5796,7 +5802,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1736 lxc/warning.go:216
@@ -5867,7 +5873,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:434
+#: lxc/init.go:435
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -6013,7 +6019,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:299
+#: lxc/main.go:298
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6037,11 +6043,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:436
+#: lxc/init.go:437
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:435
+#: lxc/init.go:436
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6049,7 +6055,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:411
+#: lxc/main.go:410
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6156,7 +6162,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1140
+#: lxc/image.go:1148
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6202,7 +6208,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1778
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1778
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6244,7 +6250,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1700 lxc/image.go:1701
+#: lxc/image.go:1733 lxc/image.go:1734
 msgid "Unset image properties"
 msgstr ""
 
@@ -6414,7 +6420,7 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/main.go:101
+#: lxc/main.go:100
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -6568,7 +6574,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1087 lxc/list.go:46
+#: lxc/image.go:1088 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6687,15 +6693,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1572 lxc/image.go:1699
+#: lxc/image.go:1605 lxc/image.go:1732
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1636
+#: lxc/image.go:1669
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6715,7 +6721,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1415
+#: lxc/image.go:334 lxc/image.go:1448
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -7670,7 +7676,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
+#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
 msgid "no"
 msgstr ""
 
@@ -7716,6 +7722,6 @@ msgid "y"
 msgstr ""
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1194
+#: lxc/image.go:1206
 msgid "yes"
 msgstr ""

--- a/po/bg.po
+++ b/po/bg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-11-18 20:34-0300\n"
+"POT-Creation-Date: 2024-11-21 15:57-0700\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Bulgarian <https://hosted.weblate.org/projects/linux-"
@@ -423,7 +423,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1168
+#: lxc/image.go:1180
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -544,11 +544,11 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1133
+#: lxc/image.go:1144
 msgid "ALIASES"
 msgstr ""
 
@@ -769,7 +769,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:342 lxc/rebuild.go:131
+#: lxc/init.go:343 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1172,7 +1172,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1595
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1595
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1502,7 +1502,7 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:186
+#: lxc/init.go:182
 #, c-format
 msgid "Creating %s"
 msgstr ""
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: lxc/init.go:184
+#: lxc/init.go:180
 msgid "Creating the instance"
 msgstr ""
 
@@ -1526,7 +1526,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -1693,8 +1693,8 @@ msgstr ""
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1090 lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574
-#: lxc/image.go:1638 lxc/image.go:1701 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
+#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:402
+#: lxc/init.go:403
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1880,6 +1880,10 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
+#: lxc/image.go:1119
+msgid "Display images from all projects"
+msgstr ""
+
 #: lxc/list.go:135
 msgid "Display instances from all projects"
 msgstr ""
@@ -1888,7 +1892,7 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:100
+#: lxc/main.go:99
 msgid "Don't show progress information"
 msgstr ""
 
@@ -2023,7 +2027,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1772
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2196,7 +2200,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
+#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2400,7 +2404,7 @@ msgstr ""
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:96
+#: lxc/main.go:95
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -2431,7 +2435,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2506,7 +2510,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1573 lxc/image.go:1574
+#: lxc/image.go:1606 lxc/image.go:1607
 msgid "Get image properties"
 msgstr ""
 
@@ -2762,7 +2766,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:405
+#: lxc/main.go:404
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2784,7 +2788,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1489
+#: lxc/image.go:1522
 msgid "Image already up to date."
 msgstr ""
 
@@ -2800,11 +2804,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1444
+#: lxc/image.go:364 lxc/image.go:1477
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1670
+#: lxc/image.go:444 lxc/image.go:1703
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2814,7 +2818,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1520
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2895,7 +2899,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:413
+#: lxc/init.go:414
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2994,7 +2998,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:507
+#: lxc/main.go:506
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3087,12 +3091,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/init.go:180
+#: lxc/init.go:176
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: lxc/init.go:178
+#: lxc/init.go:174
 msgid "Launching the instance"
 msgstr ""
 
@@ -3201,11 +3205,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1089
+#: lxc/image.go:1090
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid ""
 "List images\n"
 "\n"
@@ -3226,6 +3230,7 @@ msgid ""
 "    F - Fingerprint (long)\n"
 "    p - Whether image is public\n"
 "    d - Description\n"
+"    e - Project\n"
 "    a - Architecture\n"
 "    s - Size\n"
 "    u - Upload date\n"
@@ -4322,7 +4327,7 @@ msgstr ""
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:96
 msgid "Override the source project"
 msgstr ""
 
@@ -4364,7 +4369,8 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:567 lxc/storage_volume.go:1762 lxc/warning.go:213
+#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1762
+#: lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4372,7 +4378,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:853
+#: lxc/image.go:1145 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4388,7 +4394,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:368
+#: lxc/main.go:367
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4447,7 +4453,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:95
+#: lxc/main.go:94
 msgid "Print help"
 msgstr ""
 
@@ -4455,7 +4461,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:94
+#: lxc/main.go:93
 msgid "Print version number"
 msgstr ""
 
@@ -4552,7 +4558,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1621
+#: lxc/image.go:1654
 msgid "Property not found"
 msgstr ""
 
@@ -4682,7 +4688,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4719,7 +4725,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1416 lxc/image.go:1417
+#: lxc/image.go:1449 lxc/image.go:1450
 msgid "Refresh images"
 msgstr ""
 
@@ -4728,7 +4734,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1453
+#: lxc/image.go:1486
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4991,7 +4997,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:356
+#: lxc/init.go:357
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5024,7 +5030,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1139
+#: lxc/image.go:1146
 msgid "SIZE"
 msgstr ""
 
@@ -5147,7 +5153,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1637 lxc/image.go:1638
+#: lxc/image.go:1670 lxc/image.go:1671
 msgid "Set image properties"
 msgstr ""
 
@@ -5399,11 +5405,11 @@ msgstr ""
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: lxc/main.go:98
+#: lxc/main.go:97
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:99
+#: lxc/main.go:98
 msgid "Show all information messages"
 msgstr ""
 
@@ -5452,7 +5458,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1507 lxc/image.go:1508
+#: lxc/image.go:1540 lxc/image.go:1541
 msgid "Show image properties"
 msgstr ""
 
@@ -5472,7 +5478,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:272 lxc/main.go:273
+#: lxc/main.go:271 lxc/main.go:272
 msgid "Show less common commands"
 msgstr ""
 
@@ -5796,7 +5802,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1736 lxc/warning.go:216
@@ -5867,7 +5873,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:434
+#: lxc/init.go:435
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -6013,7 +6019,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:299
+#: lxc/main.go:298
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6037,11 +6043,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:436
+#: lxc/init.go:437
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:435
+#: lxc/init.go:436
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6049,7 +6055,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:411
+#: lxc/main.go:410
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6156,7 +6162,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1140
+#: lxc/image.go:1148
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6202,7 +6208,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1778
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1778
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6244,7 +6250,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1700 lxc/image.go:1701
+#: lxc/image.go:1733 lxc/image.go:1734
 msgid "Unset image properties"
 msgstr ""
 
@@ -6414,7 +6420,7 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/main.go:101
+#: lxc/main.go:100
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -6568,7 +6574,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1087 lxc/list.go:46
+#: lxc/image.go:1088 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6687,15 +6693,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1572 lxc/image.go:1699
+#: lxc/image.go:1605 lxc/image.go:1732
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1636
+#: lxc/image.go:1669
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6715,7 +6721,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1415
+#: lxc/image.go:334 lxc/image.go:1448
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -7670,7 +7676,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
+#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
 msgid "no"
 msgstr ""
 
@@ -7716,6 +7722,6 @@ msgid "y"
 msgstr ""
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1194
+#: lxc/image.go:1206
 msgid "yes"
 msgstr ""

--- a/po/ca.po
+++ b/po/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-11-18 20:34-0300\n"
+"POT-Creation-Date: 2024-11-21 15:57-0700\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Catalan <https://hosted.weblate.org/projects/linux-containers/"
@@ -423,7 +423,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1168
+#: lxc/image.go:1180
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -544,11 +544,11 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1133
+#: lxc/image.go:1144
 msgid "ALIASES"
 msgstr ""
 
@@ -769,7 +769,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:342 lxc/rebuild.go:131
+#: lxc/init.go:343 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1172,7 +1172,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1595
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1595
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1502,7 +1502,7 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:186
+#: lxc/init.go:182
 #, c-format
 msgid "Creating %s"
 msgstr ""
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: lxc/init.go:184
+#: lxc/init.go:180
 msgid "Creating the instance"
 msgstr ""
 
@@ -1526,7 +1526,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -1693,8 +1693,8 @@ msgstr ""
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1090 lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574
-#: lxc/image.go:1638 lxc/image.go:1701 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
+#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:402
+#: lxc/init.go:403
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1880,6 +1880,10 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
+#: lxc/image.go:1119
+msgid "Display images from all projects"
+msgstr ""
+
 #: lxc/list.go:135
 msgid "Display instances from all projects"
 msgstr ""
@@ -1888,7 +1892,7 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:100
+#: lxc/main.go:99
 msgid "Don't show progress information"
 msgstr ""
 
@@ -2023,7 +2027,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1772
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2196,7 +2200,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
+#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2400,7 +2404,7 @@ msgstr ""
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:96
+#: lxc/main.go:95
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -2431,7 +2435,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2506,7 +2510,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1573 lxc/image.go:1574
+#: lxc/image.go:1606 lxc/image.go:1607
 msgid "Get image properties"
 msgstr ""
 
@@ -2762,7 +2766,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:405
+#: lxc/main.go:404
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2784,7 +2788,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1489
+#: lxc/image.go:1522
 msgid "Image already up to date."
 msgstr ""
 
@@ -2800,11 +2804,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1444
+#: lxc/image.go:364 lxc/image.go:1477
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1670
+#: lxc/image.go:444 lxc/image.go:1703
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2814,7 +2818,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1520
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2895,7 +2899,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:413
+#: lxc/init.go:414
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2994,7 +2998,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:507
+#: lxc/main.go:506
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3087,12 +3091,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/init.go:180
+#: lxc/init.go:176
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: lxc/init.go:178
+#: lxc/init.go:174
 msgid "Launching the instance"
 msgstr ""
 
@@ -3201,11 +3205,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1089
+#: lxc/image.go:1090
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid ""
 "List images\n"
 "\n"
@@ -3226,6 +3230,7 @@ msgid ""
 "    F - Fingerprint (long)\n"
 "    p - Whether image is public\n"
 "    d - Description\n"
+"    e - Project\n"
 "    a - Architecture\n"
 "    s - Size\n"
 "    u - Upload date\n"
@@ -4322,7 +4327,7 @@ msgstr ""
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:96
 msgid "Override the source project"
 msgstr ""
 
@@ -4364,7 +4369,8 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:567 lxc/storage_volume.go:1762 lxc/warning.go:213
+#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1762
+#: lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4372,7 +4378,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:853
+#: lxc/image.go:1145 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4388,7 +4394,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:368
+#: lxc/main.go:367
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4447,7 +4453,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:95
+#: lxc/main.go:94
 msgid "Print help"
 msgstr ""
 
@@ -4455,7 +4461,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:94
+#: lxc/main.go:93
 msgid "Print version number"
 msgstr ""
 
@@ -4552,7 +4558,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1621
+#: lxc/image.go:1654
 msgid "Property not found"
 msgstr ""
 
@@ -4682,7 +4688,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4719,7 +4725,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1416 lxc/image.go:1417
+#: lxc/image.go:1449 lxc/image.go:1450
 msgid "Refresh images"
 msgstr ""
 
@@ -4728,7 +4734,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1453
+#: lxc/image.go:1486
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4991,7 +4997,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:356
+#: lxc/init.go:357
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5024,7 +5030,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1139
+#: lxc/image.go:1146
 msgid "SIZE"
 msgstr ""
 
@@ -5147,7 +5153,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1637 lxc/image.go:1638
+#: lxc/image.go:1670 lxc/image.go:1671
 msgid "Set image properties"
 msgstr ""
 
@@ -5399,11 +5405,11 @@ msgstr ""
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: lxc/main.go:98
+#: lxc/main.go:97
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:99
+#: lxc/main.go:98
 msgid "Show all information messages"
 msgstr ""
 
@@ -5452,7 +5458,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1507 lxc/image.go:1508
+#: lxc/image.go:1540 lxc/image.go:1541
 msgid "Show image properties"
 msgstr ""
 
@@ -5472,7 +5478,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:272 lxc/main.go:273
+#: lxc/main.go:271 lxc/main.go:272
 msgid "Show less common commands"
 msgstr ""
 
@@ -5796,7 +5802,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1736 lxc/warning.go:216
@@ -5867,7 +5873,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:434
+#: lxc/init.go:435
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -6013,7 +6019,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:299
+#: lxc/main.go:298
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6037,11 +6043,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:436
+#: lxc/init.go:437
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:435
+#: lxc/init.go:436
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6049,7 +6055,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:411
+#: lxc/main.go:410
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6156,7 +6162,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1140
+#: lxc/image.go:1148
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6202,7 +6208,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1778
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1778
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6244,7 +6250,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1700 lxc/image.go:1701
+#: lxc/image.go:1733 lxc/image.go:1734
 msgid "Unset image properties"
 msgstr ""
 
@@ -6414,7 +6420,7 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/main.go:101
+#: lxc/main.go:100
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -6568,7 +6574,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1087 lxc/list.go:46
+#: lxc/image.go:1088 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6687,15 +6693,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1572 lxc/image.go:1699
+#: lxc/image.go:1605 lxc/image.go:1732
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1636
+#: lxc/image.go:1669
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6715,7 +6721,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1415
+#: lxc/image.go:334 lxc/image.go:1448
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -7670,7 +7676,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
+#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
 msgid "no"
 msgstr ""
 
@@ -7716,6 +7722,6 @@ msgid "y"
 msgstr ""
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1194
+#: lxc/image.go:1206
 msgid "yes"
 msgstr ""

--- a/po/cs.po
+++ b/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-11-18 20:34-0300\n"
+"POT-Creation-Date: 2024-11-21 15:57-0700\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Czech <https://hosted.weblate.org/projects/linux-containers/"
@@ -423,7 +423,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1168
+#: lxc/image.go:1180
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -544,11 +544,11 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1133
+#: lxc/image.go:1144
 msgid "ALIASES"
 msgstr ""
 
@@ -769,7 +769,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:342 lxc/rebuild.go:131
+#: lxc/init.go:343 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1172,7 +1172,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1595
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1595
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1502,7 +1502,7 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:186
+#: lxc/init.go:182
 #, c-format
 msgid "Creating %s"
 msgstr ""
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: lxc/init.go:184
+#: lxc/init.go:180
 msgid "Creating the instance"
 msgstr ""
 
@@ -1526,7 +1526,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -1693,8 +1693,8 @@ msgstr ""
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1090 lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574
-#: lxc/image.go:1638 lxc/image.go:1701 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
+#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:402
+#: lxc/init.go:403
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1880,6 +1880,10 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
+#: lxc/image.go:1119
+msgid "Display images from all projects"
+msgstr ""
+
 #: lxc/list.go:135
 msgid "Display instances from all projects"
 msgstr ""
@@ -1888,7 +1892,7 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:100
+#: lxc/main.go:99
 msgid "Don't show progress information"
 msgstr ""
 
@@ -2023,7 +2027,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1772
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2196,7 +2200,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
+#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2400,7 +2404,7 @@ msgstr ""
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:96
+#: lxc/main.go:95
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -2431,7 +2435,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2506,7 +2510,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1573 lxc/image.go:1574
+#: lxc/image.go:1606 lxc/image.go:1607
 msgid "Get image properties"
 msgstr ""
 
@@ -2762,7 +2766,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:405
+#: lxc/main.go:404
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2784,7 +2788,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1489
+#: lxc/image.go:1522
 msgid "Image already up to date."
 msgstr ""
 
@@ -2800,11 +2804,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1444
+#: lxc/image.go:364 lxc/image.go:1477
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1670
+#: lxc/image.go:444 lxc/image.go:1703
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2814,7 +2818,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1520
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2895,7 +2899,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:413
+#: lxc/init.go:414
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2994,7 +2998,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:507
+#: lxc/main.go:506
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3087,12 +3091,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/init.go:180
+#: lxc/init.go:176
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: lxc/init.go:178
+#: lxc/init.go:174
 msgid "Launching the instance"
 msgstr ""
 
@@ -3201,11 +3205,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1089
+#: lxc/image.go:1090
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid ""
 "List images\n"
 "\n"
@@ -3226,6 +3230,7 @@ msgid ""
 "    F - Fingerprint (long)\n"
 "    p - Whether image is public\n"
 "    d - Description\n"
+"    e - Project\n"
 "    a - Architecture\n"
 "    s - Size\n"
 "    u - Upload date\n"
@@ -4322,7 +4327,7 @@ msgstr ""
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:96
 msgid "Override the source project"
 msgstr ""
 
@@ -4364,7 +4369,8 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:567 lxc/storage_volume.go:1762 lxc/warning.go:213
+#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1762
+#: lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4372,7 +4378,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:853
+#: lxc/image.go:1145 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4388,7 +4394,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:368
+#: lxc/main.go:367
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4447,7 +4453,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:95
+#: lxc/main.go:94
 msgid "Print help"
 msgstr ""
 
@@ -4455,7 +4461,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:94
+#: lxc/main.go:93
 msgid "Print version number"
 msgstr ""
 
@@ -4552,7 +4558,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1621
+#: lxc/image.go:1654
 msgid "Property not found"
 msgstr ""
 
@@ -4682,7 +4688,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4719,7 +4725,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1416 lxc/image.go:1417
+#: lxc/image.go:1449 lxc/image.go:1450
 msgid "Refresh images"
 msgstr ""
 
@@ -4728,7 +4734,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1453
+#: lxc/image.go:1486
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4991,7 +4997,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:356
+#: lxc/init.go:357
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5024,7 +5030,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1139
+#: lxc/image.go:1146
 msgid "SIZE"
 msgstr ""
 
@@ -5147,7 +5153,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1637 lxc/image.go:1638
+#: lxc/image.go:1670 lxc/image.go:1671
 msgid "Set image properties"
 msgstr ""
 
@@ -5399,11 +5405,11 @@ msgstr ""
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: lxc/main.go:98
+#: lxc/main.go:97
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:99
+#: lxc/main.go:98
 msgid "Show all information messages"
 msgstr ""
 
@@ -5452,7 +5458,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1507 lxc/image.go:1508
+#: lxc/image.go:1540 lxc/image.go:1541
 msgid "Show image properties"
 msgstr ""
 
@@ -5472,7 +5478,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:272 lxc/main.go:273
+#: lxc/main.go:271 lxc/main.go:272
 msgid "Show less common commands"
 msgstr ""
 
@@ -5796,7 +5802,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1736 lxc/warning.go:216
@@ -5867,7 +5873,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:434
+#: lxc/init.go:435
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -6013,7 +6019,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:299
+#: lxc/main.go:298
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6037,11 +6043,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:436
+#: lxc/init.go:437
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:435
+#: lxc/init.go:436
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6049,7 +6055,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:411
+#: lxc/main.go:410
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6156,7 +6162,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1140
+#: lxc/image.go:1148
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6202,7 +6208,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1778
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1778
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6244,7 +6250,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1700 lxc/image.go:1701
+#: lxc/image.go:1733 lxc/image.go:1734
 msgid "Unset image properties"
 msgstr ""
 
@@ -6414,7 +6420,7 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/main.go:101
+#: lxc/main.go:100
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -6568,7 +6574,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1087 lxc/list.go:46
+#: lxc/image.go:1088 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6687,15 +6693,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1572 lxc/image.go:1699
+#: lxc/image.go:1605 lxc/image.go:1732
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1636
+#: lxc/image.go:1669
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6715,7 +6721,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1415
+#: lxc/image.go:334 lxc/image.go:1448
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -7670,7 +7676,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
+#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
 msgid "no"
 msgstr ""
 
@@ -7716,6 +7722,6 @@ msgid "y"
 msgstr ""
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1194
+#: lxc/image.go:1206
 msgid "yes"
 msgstr ""

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-11-18 20:34-0300\n"
+"POT-Creation-Date: 2024-11-21 15:57-0700\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Krombel <krombel@krombel.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/linux-containers/"
@@ -672,7 +672,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr "%d (ID: %d, Online: %v, NUMA-Knoten: %v)"
 
-#: lxc/image.go:1168
+#: lxc/image.go:1180
 #, c-format
 msgid "%s (%d more)"
 msgstr "%s (%d mehr)"
@@ -808,11 +808,11 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr "ALIAS"
 
-#: lxc/image.go:1133
+#: lxc/image.go:1144
 msgid "ALIASES"
 msgstr "ALIASES"
 
@@ -1046,7 +1046,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:342 lxc/rebuild.go:131
+#: lxc/init.go:343 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -1159,7 +1159,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "Alternatives config Verzeichnis."
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1595
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1595
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr "Spalten"
@@ -1834,7 +1834,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Created: %s"
 msgstr "Erstellt: %s"
 
-#: lxc/init.go:186
+#: lxc/init.go:182
 #, c-format
 msgid "Creating %s"
 msgstr "Erstelle %s"
@@ -1844,7 +1844,7 @@ msgstr "Erstelle %s"
 msgid "Creating %s: %%s"
 msgstr "Erstelle %s"
 
-#: lxc/init.go:184
+#: lxc/init.go:180
 #, fuzzy
 msgid "Creating the instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -1859,7 +1859,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -2037,8 +2037,8 @@ msgstr ""
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1090 lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574
-#: lxc/image.go:1638 lxc/image.go:1701 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
+#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -2191,7 +2191,7 @@ msgstr ""
 "Optionen:\n"
 "\n"
 
-#: lxc/init.go:402
+#: lxc/init.go:403
 #, fuzzy
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
@@ -2237,6 +2237,11 @@ msgstr " Prozessorauslastung:"
 msgid "Disks:"
 msgstr " Prozessorauslastung:"
 
+#: lxc/image.go:1119
+#, fuzzy
+msgid "Display images from all projects"
+msgstr "Herunterfahren des Containers erzwingen."
+
 #: lxc/list.go:135
 #, fuzzy
 msgid "Display instances from all projects"
@@ -2246,7 +2251,7 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:100
+#: lxc/main.go:99
 msgid "Don't show progress information"
 msgstr ""
 
@@ -2398,7 +2403,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1772
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2585,7 +2590,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
+#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr "FINGERABDRUCK"
@@ -2793,7 +2798,7 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:96
+#: lxc/main.go:95
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -2824,7 +2829,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2901,7 +2906,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1573 lxc/image.go:1574
+#: lxc/image.go:1606 lxc/image.go:1607
 msgid "Get image properties"
 msgstr ""
 
@@ -3179,7 +3184,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:405
+#: lxc/main.go:404
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -3202,7 +3207,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/image.go:1489
+#: lxc/image.go:1522
 msgid "Image already up to date."
 msgstr ""
 
@@ -3218,11 +3223,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1444
+#: lxc/image.go:364 lxc/image.go:1477
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1670
+#: lxc/image.go:444 lxc/image.go:1703
 #, fuzzy, c-format
 msgid "Image identifier missing: %s"
 msgstr "Abbild mit Fingerabdruck %s importiert\n"
@@ -3232,7 +3237,7 @@ msgstr "Abbild mit Fingerabdruck %s importiert\n"
 msgid "Image imported with fingerprint: %s"
 msgstr "Abbild mit Fingerabdruck %s importiert\n"
 
-#: lxc/image.go:1487
+#: lxc/image.go:1520
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3317,7 +3322,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:413
+#: lxc/init.go:414
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -3418,7 +3423,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:507
+#: lxc/main.go:506
 #, fuzzy
 msgid "Invalid number of arguments"
 msgstr "ungültiges Argument %s"
@@ -3517,12 +3522,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/init.go:180
+#: lxc/init.go:176
 #, fuzzy, c-format
 msgid "Launching %s"
 msgstr "Erstelle %s"
 
-#: lxc/init.go:178
+#: lxc/init.go:174
 #, fuzzy
 msgid "Launching the instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -3640,11 +3645,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1089
+#: lxc/image.go:1090
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid ""
 "List images\n"
 "\n"
@@ -3665,6 +3670,7 @@ msgid ""
 "    F - Fingerprint (long)\n"
 "    p - Whether image is public\n"
 "    d - Description\n"
+"    e - Project\n"
 "    a - Architecture\n"
 "    s - Size\n"
 "    u - Upload date\n"
@@ -4860,7 +4866,7 @@ msgstr "Profil %s gelöscht\n"
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:96
 msgid "Override the source project"
 msgstr ""
 
@@ -4902,7 +4908,8 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:567 lxc/storage_volume.go:1762 lxc/warning.go:213
+#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1762
+#: lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4910,7 +4917,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:853
+#: lxc/image.go:1145 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4926,7 +4933,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:368
+#: lxc/main.go:367
 #, fuzzy, c-format
 msgid "Password for %s: "
 msgstr "Administrator Passwort für %s: "
@@ -4989,7 +4996,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:95
+#: lxc/main.go:94
 msgid "Print help"
 msgstr ""
 
@@ -4997,7 +5004,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:94
+#: lxc/main.go:93
 msgid "Print version number"
 msgstr ""
 
@@ -5100,7 +5107,7 @@ msgstr ""
 msgid "Properties:"
 msgstr "Eigenschaften:\n"
 
-#: lxc/image.go:1621
+#: lxc/image.go:1654
 msgid "Property not found"
 msgstr ""
 
@@ -5233,7 +5240,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -5273,7 +5280,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/image.go:1416 lxc/image.go:1417
+#: lxc/image.go:1449 lxc/image.go:1450
 msgid "Refresh images"
 msgstr ""
 
@@ -5282,7 +5289,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/image.go:1453
+#: lxc/image.go:1486
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5572,7 +5579,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/init.go:356
+#: lxc/init.go:357
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5608,7 +5615,7 @@ msgstr "Fehlerhafte Profil URL %s"
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1139
+#: lxc/image.go:1146
 msgid "SIZE"
 msgstr ""
 
@@ -5736,7 +5743,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1637 lxc/image.go:1638
+#: lxc/image.go:1670 lxc/image.go:1671
 msgid "Set image properties"
 msgstr ""
 
@@ -6010,11 +6017,11 @@ msgstr ""
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: lxc/main.go:98
+#: lxc/main.go:97
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:99
+#: lxc/main.go:98
 msgid "Show all information messages"
 msgstr ""
 
@@ -6067,7 +6074,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1507 lxc/image.go:1508
+#: lxc/image.go:1540 lxc/image.go:1541
 msgid "Show image properties"
 msgstr ""
 
@@ -6091,7 +6098,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Show instance or server information"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/main.go:272 lxc/main.go:273
+#: lxc/main.go:271 lxc/main.go:272
 msgid "Show less common commands"
 msgstr ""
 
@@ -6439,7 +6446,7 @@ msgstr "Abbild mit Fingerabdruck %s importiert\n"
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1736 lxc/warning.go:216
@@ -6515,7 +6522,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:434
+#: lxc/init.go:435
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -6665,7 +6672,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:299
+#: lxc/main.go:298
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6691,11 +6698,11 @@ msgstr "Wartezeit bevor der Container gestoppt wird."
 msgid "Timestamps:"
 msgstr "Zeitstempel:\n"
 
-#: lxc/init.go:436
+#: lxc/init.go:437
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:435
+#: lxc/init.go:436
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6703,7 +6710,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:411
+#: lxc/main.go:410
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6812,7 +6819,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1140
+#: lxc/image.go:1148
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6859,7 +6866,7 @@ msgstr "Unbekannter Befehl %s für Abbild"
 msgid "Unknown channel type for client %q: %s"
 msgstr "Unbekannter Befehl %s für Abbild"
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1778
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1778
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6905,7 +6912,7 @@ msgstr "nicht alle Profile der Quelle sind am Ziel vorhanden."
 msgid "Unset device configuration keys"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/image.go:1700 lxc/image.go:1701
+#: lxc/image.go:1733 lxc/image.go:1734
 msgid "Unset image properties"
 msgstr ""
 
@@ -7099,7 +7106,7 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/main.go:101
+#: lxc/main.go:100
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -7296,7 +7303,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/image.go:1087 lxc/list.go:46
+#: lxc/image.go:1088 lxc/list.go:46
 #, fuzzy
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
@@ -7517,7 +7524,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
 #, fuzzy
 msgid "[<remote>:]<image>"
 msgstr ""
@@ -7526,7 +7533,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/image.go:1572 lxc/image.go:1699
+#: lxc/image.go:1605 lxc/image.go:1732
 #, fuzzy
 msgid "[<remote>:]<image> <key>"
 msgstr ""
@@ -7535,7 +7542,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/image.go:1636
+#: lxc/image.go:1669
 #, fuzzy
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
@@ -7575,7 +7582,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/image.go:334 lxc/image.go:1415
+#: lxc/image.go:334 lxc/image.go:1448
 #, fuzzy
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
@@ -8998,7 +9005,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
+#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
 msgid "no"
 msgstr ""
 
@@ -9044,7 +9051,7 @@ msgid "y"
 msgstr ""
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1194
+#: lxc/image.go:1206
 msgid "yes"
 msgstr ""
 

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-11-18 20:34-0300\n"
+"POT-Creation-Date: 2024-11-21 15:57-0700\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/linux-containers/"
@@ -423,7 +423,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1168
+#: lxc/image.go:1180
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -544,11 +544,11 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1133
+#: lxc/image.go:1144
 msgid "ALIASES"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:342 lxc/rebuild.go:131
+#: lxc/init.go:343 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -877,7 +877,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1176,7 +1176,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1595
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1595
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1509,7 +1509,7 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:186
+#: lxc/init.go:182
 #, c-format
 msgid "Creating %s"
 msgstr ""
@@ -1519,7 +1519,7 @@ msgstr ""
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: lxc/init.go:184
+#: lxc/init.go:180
 msgid "Creating the instance"
 msgstr ""
 
@@ -1533,7 +1533,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -1705,8 +1705,8 @@ msgstr ""
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1090 lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574
-#: lxc/image.go:1638 lxc/image.go:1701 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
+#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1852,7 +1852,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:402
+#: lxc/init.go:403
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1896,6 +1896,10 @@ msgstr "  Χρήση CPU:"
 msgid "Disks:"
 msgstr "  Χρήση CPU:"
 
+#: lxc/image.go:1119
+msgid "Display images from all projects"
+msgstr ""
+
 #: lxc/list.go:135
 msgid "Display instances from all projects"
 msgstr ""
@@ -1904,7 +1908,7 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:100
+#: lxc/main.go:99
 msgid "Don't show progress information"
 msgstr ""
 
@@ -2045,7 +2049,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1772
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2218,7 +2222,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
+#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2422,7 +2426,7 @@ msgstr ""
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:96
+#: lxc/main.go:95
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -2453,7 +2457,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2528,7 +2532,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1573 lxc/image.go:1574
+#: lxc/image.go:1606 lxc/image.go:1607
 msgid "Get image properties"
 msgstr ""
 
@@ -2797,7 +2801,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:405
+#: lxc/main.go:404
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2819,7 +2823,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1489
+#: lxc/image.go:1522
 msgid "Image already up to date."
 msgstr ""
 
@@ -2835,11 +2839,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1444
+#: lxc/image.go:364 lxc/image.go:1477
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1670
+#: lxc/image.go:444 lxc/image.go:1703
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2849,7 +2853,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1520
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2930,7 +2934,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:413
+#: lxc/init.go:414
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -3029,7 +3033,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:507
+#: lxc/main.go:506
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3122,12 +3126,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/init.go:180
+#: lxc/init.go:176
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: lxc/init.go:178
+#: lxc/init.go:174
 msgid "Launching the instance"
 msgstr ""
 
@@ -3238,11 +3242,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1089
+#: lxc/image.go:1090
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid ""
 "List images\n"
 "\n"
@@ -3263,6 +3267,7 @@ msgid ""
 "    F - Fingerprint (long)\n"
 "    p - Whether image is public\n"
 "    d - Description\n"
+"    e - Project\n"
 "    a - Architecture\n"
 "    s - Size\n"
 "    u - Upload date\n"
@@ -4386,7 +4391,7 @@ msgstr ""
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:96
 msgid "Override the source project"
 msgstr ""
 
@@ -4428,7 +4433,8 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:567 lxc/storage_volume.go:1762 lxc/warning.go:213
+#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1762
+#: lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4436,7 +4442,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:853
+#: lxc/image.go:1145 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4452,7 +4458,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:368
+#: lxc/main.go:367
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4512,7 +4518,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:95
+#: lxc/main.go:94
 msgid "Print help"
 msgstr ""
 
@@ -4520,7 +4526,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:94
+#: lxc/main.go:93
 msgid "Print version number"
 msgstr ""
 
@@ -4617,7 +4623,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1621
+#: lxc/image.go:1654
 msgid "Property not found"
 msgstr ""
 
@@ -4747,7 +4753,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4784,7 +4790,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1416 lxc/image.go:1417
+#: lxc/image.go:1449 lxc/image.go:1450
 msgid "Refresh images"
 msgstr ""
 
@@ -4793,7 +4799,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1453
+#: lxc/image.go:1486
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5061,7 +5067,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:356
+#: lxc/init.go:357
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5095,7 +5101,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1139
+#: lxc/image.go:1146
 msgid "SIZE"
 msgstr ""
 
@@ -5219,7 +5225,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1637 lxc/image.go:1638
+#: lxc/image.go:1670 lxc/image.go:1671
 msgid "Set image properties"
 msgstr ""
 
@@ -5483,11 +5489,11 @@ msgstr ""
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: lxc/main.go:98
+#: lxc/main.go:97
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:99
+#: lxc/main.go:98
 msgid "Show all information messages"
 msgstr ""
 
@@ -5538,7 +5544,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1507 lxc/image.go:1508
+#: lxc/image.go:1540 lxc/image.go:1541
 msgid "Show image properties"
 msgstr ""
 
@@ -5558,7 +5564,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:272 lxc/main.go:273
+#: lxc/main.go:271 lxc/main.go:272
 msgid "Show less common commands"
 msgstr ""
 
@@ -5891,7 +5897,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1736 lxc/warning.go:216
@@ -5962,7 +5968,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:434
+#: lxc/init.go:435
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -6109,7 +6115,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:299
+#: lxc/main.go:298
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6133,11 +6139,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:436
+#: lxc/init.go:437
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:435
+#: lxc/init.go:436
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6145,7 +6151,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:411
+#: lxc/main.go:410
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6252,7 +6258,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1140
+#: lxc/image.go:1148
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6298,7 +6304,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1778
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1778
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6341,7 +6347,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1700 lxc/image.go:1701
+#: lxc/image.go:1733 lxc/image.go:1734
 msgid "Unset image properties"
 msgstr ""
 
@@ -6527,7 +6533,7 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/main.go:101
+#: lxc/main.go:100
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -6681,7 +6687,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1087 lxc/list.go:46
+#: lxc/image.go:1088 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6800,15 +6806,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1572 lxc/image.go:1699
+#: lxc/image.go:1605 lxc/image.go:1732
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1636
+#: lxc/image.go:1669
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6828,7 +6834,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1415
+#: lxc/image.go:334 lxc/image.go:1448
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -7783,7 +7789,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
+#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
 msgid "no"
 msgstr ""
 
@@ -7829,7 +7835,7 @@ msgid "y"
 msgstr ""
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1194
+#: lxc/image.go:1206
 msgid "yes"
 msgstr ""
 

--- a/po/eo.po
+++ b/po/eo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-11-18 20:34-0300\n"
+"POT-Creation-Date: 2024-11-21 15:57-0700\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Esperanto <https://hosted.weblate.org/projects/linux-"
@@ -423,7 +423,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1168
+#: lxc/image.go:1180
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -544,11 +544,11 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1133
+#: lxc/image.go:1144
 msgid "ALIASES"
 msgstr ""
 
@@ -769,7 +769,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:342 lxc/rebuild.go:131
+#: lxc/init.go:343 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1172,7 +1172,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1595
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1595
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1502,7 +1502,7 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:186
+#: lxc/init.go:182
 #, c-format
 msgid "Creating %s"
 msgstr ""
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: lxc/init.go:184
+#: lxc/init.go:180
 msgid "Creating the instance"
 msgstr ""
 
@@ -1526,7 +1526,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -1693,8 +1693,8 @@ msgstr ""
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1090 lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574
-#: lxc/image.go:1638 lxc/image.go:1701 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
+#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:402
+#: lxc/init.go:403
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1880,6 +1880,10 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
+#: lxc/image.go:1119
+msgid "Display images from all projects"
+msgstr ""
+
 #: lxc/list.go:135
 msgid "Display instances from all projects"
 msgstr ""
@@ -1888,7 +1892,7 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:100
+#: lxc/main.go:99
 msgid "Don't show progress information"
 msgstr ""
 
@@ -2023,7 +2027,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1772
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2196,7 +2200,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
+#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2400,7 +2404,7 @@ msgstr ""
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:96
+#: lxc/main.go:95
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -2431,7 +2435,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2506,7 +2510,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1573 lxc/image.go:1574
+#: lxc/image.go:1606 lxc/image.go:1607
 msgid "Get image properties"
 msgstr ""
 
@@ -2762,7 +2766,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:405
+#: lxc/main.go:404
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2784,7 +2788,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1489
+#: lxc/image.go:1522
 msgid "Image already up to date."
 msgstr ""
 
@@ -2800,11 +2804,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1444
+#: lxc/image.go:364 lxc/image.go:1477
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1670
+#: lxc/image.go:444 lxc/image.go:1703
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2814,7 +2818,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1520
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2895,7 +2899,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:413
+#: lxc/init.go:414
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2994,7 +2998,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:507
+#: lxc/main.go:506
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3087,12 +3091,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/init.go:180
+#: lxc/init.go:176
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: lxc/init.go:178
+#: lxc/init.go:174
 msgid "Launching the instance"
 msgstr ""
 
@@ -3201,11 +3205,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1089
+#: lxc/image.go:1090
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid ""
 "List images\n"
 "\n"
@@ -3226,6 +3230,7 @@ msgid ""
 "    F - Fingerprint (long)\n"
 "    p - Whether image is public\n"
 "    d - Description\n"
+"    e - Project\n"
 "    a - Architecture\n"
 "    s - Size\n"
 "    u - Upload date\n"
@@ -4322,7 +4327,7 @@ msgstr ""
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:96
 msgid "Override the source project"
 msgstr ""
 
@@ -4364,7 +4369,8 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:567 lxc/storage_volume.go:1762 lxc/warning.go:213
+#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1762
+#: lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4372,7 +4378,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:853
+#: lxc/image.go:1145 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4388,7 +4394,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:368
+#: lxc/main.go:367
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4447,7 +4453,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:95
+#: lxc/main.go:94
 msgid "Print help"
 msgstr ""
 
@@ -4455,7 +4461,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:94
+#: lxc/main.go:93
 msgid "Print version number"
 msgstr ""
 
@@ -4552,7 +4558,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1621
+#: lxc/image.go:1654
 msgid "Property not found"
 msgstr ""
 
@@ -4682,7 +4688,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4719,7 +4725,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1416 lxc/image.go:1417
+#: lxc/image.go:1449 lxc/image.go:1450
 msgid "Refresh images"
 msgstr ""
 
@@ -4728,7 +4734,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1453
+#: lxc/image.go:1486
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4991,7 +4997,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:356
+#: lxc/init.go:357
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5024,7 +5030,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1139
+#: lxc/image.go:1146
 msgid "SIZE"
 msgstr ""
 
@@ -5147,7 +5153,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1637 lxc/image.go:1638
+#: lxc/image.go:1670 lxc/image.go:1671
 msgid "Set image properties"
 msgstr ""
 
@@ -5399,11 +5405,11 @@ msgstr ""
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: lxc/main.go:98
+#: lxc/main.go:97
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:99
+#: lxc/main.go:98
 msgid "Show all information messages"
 msgstr ""
 
@@ -5452,7 +5458,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1507 lxc/image.go:1508
+#: lxc/image.go:1540 lxc/image.go:1541
 msgid "Show image properties"
 msgstr ""
 
@@ -5472,7 +5478,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:272 lxc/main.go:273
+#: lxc/main.go:271 lxc/main.go:272
 msgid "Show less common commands"
 msgstr ""
 
@@ -5796,7 +5802,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1736 lxc/warning.go:216
@@ -5867,7 +5873,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:434
+#: lxc/init.go:435
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -6013,7 +6019,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:299
+#: lxc/main.go:298
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6037,11 +6043,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:436
+#: lxc/init.go:437
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:435
+#: lxc/init.go:436
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6049,7 +6055,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:411
+#: lxc/main.go:410
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6156,7 +6162,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1140
+#: lxc/image.go:1148
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6202,7 +6208,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1778
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1778
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6244,7 +6250,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1700 lxc/image.go:1701
+#: lxc/image.go:1733 lxc/image.go:1734
 msgid "Unset image properties"
 msgstr ""
 
@@ -6414,7 +6420,7 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/main.go:101
+#: lxc/main.go:100
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -6568,7 +6574,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1087 lxc/list.go:46
+#: lxc/image.go:1088 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6687,15 +6693,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1572 lxc/image.go:1699
+#: lxc/image.go:1605 lxc/image.go:1732
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1636
+#: lxc/image.go:1669
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6715,7 +6721,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1415
+#: lxc/image.go:334 lxc/image.go:1448
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -7670,7 +7676,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
+#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
 msgid "no"
 msgstr ""
 
@@ -7716,6 +7722,6 @@ msgid "y"
 msgstr ""
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1194
+#: lxc/image.go:1206
 msgid "yes"
 msgstr ""

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-11-18 20:34-0300\n"
+"POT-Creation-Date: 2024-11-21 15:57-0700\n"
 "PO-Revision-Date: 2023-06-16 20:55+0000\n"
 "Last-Translator: Francisco Serrador <fserrador@gmail.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -660,7 +660,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1168
+#: lxc/image.go:1180
 #, c-format
 msgid "%s (%d more)"
 msgstr "%s (%d más)"
@@ -787,11 +787,11 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr "ALIAS"
 
-#: lxc/image.go:1133
+#: lxc/image.go:1144
 msgid "ALIASES"
 msgstr "ALIASES"
 
@@ -1017,7 +1017,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:342 lxc/rebuild.go:131
+#: lxc/init.go:343 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -1123,7 +1123,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "Nombre del contenedor es: %s"
@@ -1428,7 +1428,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1595
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1595
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr "Columnas"
@@ -1771,7 +1771,7 @@ msgstr ""
 msgid "Created: %s"
 msgstr "Creado: %s"
 
-#: lxc/init.go:186
+#: lxc/init.go:182
 #, c-format
 msgid "Creating %s"
 msgstr "Creando %s"
@@ -1781,7 +1781,7 @@ msgstr "Creando %s"
 msgid "Creating %s: %%s"
 msgstr "Creando %s"
 
-#: lxc/init.go:184
+#: lxc/init.go:180
 #, fuzzy
 msgid "Creating the instance"
 msgstr "Creando el contenedor"
@@ -1796,7 +1796,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -1969,8 +1969,8 @@ msgstr ""
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1090 lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574
-#: lxc/image.go:1638 lxc/image.go:1701 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
+#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -2117,7 +2117,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr "Dispositivo: %s"
 
-#: lxc/init.go:402
+#: lxc/init.go:403
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -2158,6 +2158,11 @@ msgstr "Disco:"
 msgid "Disks:"
 msgstr "Discos:"
 
+#: lxc/image.go:1119
+#, fuzzy
+msgid "Display images from all projects"
+msgstr "No se puede proveer el nombre del container a la lista"
+
 #: lxc/list.go:135
 #, fuzzy
 msgid "Display instances from all projects"
@@ -2167,7 +2172,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:100
+#: lxc/main.go:99
 msgid "Don't show progress information"
 msgstr ""
 
@@ -2309,7 +2314,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1772
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2486,7 +2491,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
+#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr "HUELLA DIGITAL"
@@ -2691,7 +2696,7 @@ msgstr "Creando el contenedor"
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:96
+#: lxc/main.go:95
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -2722,7 +2727,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2798,7 +2803,7 @@ msgstr "Aliases:"
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1573 lxc/image.go:1574
+#: lxc/image.go:1606 lxc/image.go:1607
 msgid "Get image properties"
 msgstr ""
 
@@ -3070,7 +3075,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:405
+#: lxc/main.go:404
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -3092,7 +3097,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1489
+#: lxc/image.go:1522
 msgid "Image already up to date."
 msgstr ""
 
@@ -3108,11 +3113,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1444
+#: lxc/image.go:364 lxc/image.go:1477
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1670
+#: lxc/image.go:444 lxc/image.go:1703
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -3122,7 +3127,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1520
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3206,7 +3211,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr "Nombre del contenedor es obligatorio"
 
-#: lxc/init.go:413
+#: lxc/init.go:414
 #, fuzzy, c-format
 msgid "Instance name is: %s"
 msgstr "Nombre del contenedor es: %s"
@@ -3307,7 +3312,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:507
+#: lxc/main.go:506
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3401,12 +3406,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/init.go:180
+#: lxc/init.go:176
 #, fuzzy, c-format
 msgid "Launching %s"
 msgstr "Creando %s"
 
-#: lxc/init.go:178
+#: lxc/init.go:174
 #, fuzzy
 msgid "Launching the instance"
 msgstr "Creando el contenedor"
@@ -3524,11 +3529,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1089
+#: lxc/image.go:1090
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid ""
 "List images\n"
 "\n"
@@ -3549,6 +3554,7 @@ msgid ""
 "    F - Fingerprint (long)\n"
 "    p - Whether image is public\n"
 "    d - Description\n"
+"    e - Project\n"
 "    a - Architecture\n"
 "    s - Size\n"
 "    u - Upload date\n"
@@ -4686,7 +4692,7 @@ msgstr ""
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:96
 msgid "Override the source project"
 msgstr ""
 
@@ -4728,7 +4734,8 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:567 lxc/storage_volume.go:1762 lxc/warning.go:213
+#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1762
+#: lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4736,7 +4743,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:853
+#: lxc/image.go:1145 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4752,7 +4759,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:368
+#: lxc/main.go:367
 #, fuzzy, c-format
 msgid "Password for %s: "
 msgstr "Contraseña admin para %s:"
@@ -4812,7 +4819,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:95
+#: lxc/main.go:94
 msgid "Print help"
 msgstr ""
 
@@ -4820,7 +4827,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:94
+#: lxc/main.go:93
 msgid "Print version number"
 msgstr ""
 
@@ -4921,7 +4928,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1621
+#: lxc/image.go:1654
 msgid "Property not found"
 msgstr ""
 
@@ -5051,7 +5058,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -5090,7 +5097,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1416 lxc/image.go:1417
+#: lxc/image.go:1449 lxc/image.go:1450
 msgid "Refresh images"
 msgstr ""
 
@@ -5099,7 +5106,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/image.go:1453
+#: lxc/image.go:1486
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr "Refrescando la imagen: %s"
@@ -5373,7 +5380,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:356
+#: lxc/init.go:357
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5409,7 +5416,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1139
+#: lxc/image.go:1146
 msgid "SIZE"
 msgstr ""
 
@@ -5534,7 +5541,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1637 lxc/image.go:1638
+#: lxc/image.go:1670 lxc/image.go:1671
 msgid "Set image properties"
 msgstr ""
 
@@ -5798,11 +5805,11 @@ msgstr ""
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: lxc/main.go:98
+#: lxc/main.go:97
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:99
+#: lxc/main.go:98
 msgid "Show all information messages"
 msgstr ""
 
@@ -5853,7 +5860,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1507 lxc/image.go:1508
+#: lxc/image.go:1540 lxc/image.go:1541
 msgid "Show image properties"
 msgstr ""
 
@@ -5874,7 +5881,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:272 lxc/main.go:273
+#: lxc/main.go:271 lxc/main.go:272
 msgid "Show less common commands"
 msgstr ""
 
@@ -6208,7 +6215,7 @@ msgstr "Contenedor publicado con huella digital: %s"
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1736 lxc/warning.go:216
@@ -6281,7 +6288,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:434
+#: lxc/init.go:435
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -6429,7 +6436,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr "El directorio importado no está disponible en esta plataforma"
 
-#: lxc/main.go:299
+#: lxc/main.go:298
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6453,11 +6460,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:436
+#: lxc/init.go:437
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:435
+#: lxc/init.go:436
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6465,7 +6472,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:411
+#: lxc/main.go:410
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6574,7 +6581,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1140
+#: lxc/image.go:1148
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6620,7 +6627,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1778
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1778
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6664,7 +6671,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1700 lxc/image.go:1701
+#: lxc/image.go:1733 lxc/image.go:1734
 msgid "Unset image properties"
 msgstr ""
 
@@ -6851,7 +6858,7 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/main.go:101
+#: lxc/main.go:100
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -7012,7 +7019,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:] [<cert>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/image.go:1087 lxc/list.go:46
+#: lxc/image.go:1088 lxc/list.go:46
 #, fuzzy
 msgid "[<remote>:] [<filter>...]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7155,17 +7162,17 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
 #, fuzzy
 msgid "[<remote>:]<image>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/image.go:1572 lxc/image.go:1699
+#: lxc/image.go:1605 lxc/image.go:1732
 #, fuzzy
 msgid "[<remote>:]<image> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/image.go:1636
+#: lxc/image.go:1669
 #, fuzzy
 msgid "[<remote>:]<image> <key> <value>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7190,7 +7197,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<image> [<target>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/image.go:334 lxc/image.go:1415
+#: lxc/image.go:334 lxc/image.go:1448
 #, fuzzy
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -8252,7 +8259,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
+#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
 msgid "no"
 msgstr ""
 
@@ -8298,7 +8305,7 @@ msgid "y"
 msgstr ""
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1194
+#: lxc/image.go:1206
 msgid "yes"
 msgstr ""
 

--- a/po/fa.po
+++ b/po/fa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-11-18 20:34-0300\n"
+"POT-Creation-Date: 2024-11-21 15:57-0700\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Persian <https://hosted.weblate.org/projects/linux-containers/"
@@ -423,7 +423,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1168
+#: lxc/image.go:1180
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -544,11 +544,11 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1133
+#: lxc/image.go:1144
 msgid "ALIASES"
 msgstr ""
 
@@ -769,7 +769,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:342 lxc/rebuild.go:131
+#: lxc/init.go:343 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1172,7 +1172,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1595
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1595
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1502,7 +1502,7 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:186
+#: lxc/init.go:182
 #, c-format
 msgid "Creating %s"
 msgstr ""
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: lxc/init.go:184
+#: lxc/init.go:180
 msgid "Creating the instance"
 msgstr ""
 
@@ -1526,7 +1526,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -1693,8 +1693,8 @@ msgstr ""
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1090 lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574
-#: lxc/image.go:1638 lxc/image.go:1701 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
+#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:402
+#: lxc/init.go:403
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1880,6 +1880,10 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
+#: lxc/image.go:1119
+msgid "Display images from all projects"
+msgstr ""
+
 #: lxc/list.go:135
 msgid "Display instances from all projects"
 msgstr ""
@@ -1888,7 +1892,7 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:100
+#: lxc/main.go:99
 msgid "Don't show progress information"
 msgstr ""
 
@@ -2023,7 +2027,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1772
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2196,7 +2200,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
+#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2400,7 +2404,7 @@ msgstr ""
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:96
+#: lxc/main.go:95
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -2431,7 +2435,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2506,7 +2510,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1573 lxc/image.go:1574
+#: lxc/image.go:1606 lxc/image.go:1607
 msgid "Get image properties"
 msgstr ""
 
@@ -2762,7 +2766,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:405
+#: lxc/main.go:404
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2784,7 +2788,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1489
+#: lxc/image.go:1522
 msgid "Image already up to date."
 msgstr ""
 
@@ -2800,11 +2804,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1444
+#: lxc/image.go:364 lxc/image.go:1477
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1670
+#: lxc/image.go:444 lxc/image.go:1703
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2814,7 +2818,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1520
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2895,7 +2899,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:413
+#: lxc/init.go:414
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2994,7 +2998,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:507
+#: lxc/main.go:506
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3087,12 +3091,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/init.go:180
+#: lxc/init.go:176
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: lxc/init.go:178
+#: lxc/init.go:174
 msgid "Launching the instance"
 msgstr ""
 
@@ -3201,11 +3205,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1089
+#: lxc/image.go:1090
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid ""
 "List images\n"
 "\n"
@@ -3226,6 +3230,7 @@ msgid ""
 "    F - Fingerprint (long)\n"
 "    p - Whether image is public\n"
 "    d - Description\n"
+"    e - Project\n"
 "    a - Architecture\n"
 "    s - Size\n"
 "    u - Upload date\n"
@@ -4322,7 +4327,7 @@ msgstr ""
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:96
 msgid "Override the source project"
 msgstr ""
 
@@ -4364,7 +4369,8 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:567 lxc/storage_volume.go:1762 lxc/warning.go:213
+#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1762
+#: lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4372,7 +4378,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:853
+#: lxc/image.go:1145 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4388,7 +4394,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:368
+#: lxc/main.go:367
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4447,7 +4453,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:95
+#: lxc/main.go:94
 msgid "Print help"
 msgstr ""
 
@@ -4455,7 +4461,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:94
+#: lxc/main.go:93
 msgid "Print version number"
 msgstr ""
 
@@ -4552,7 +4558,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1621
+#: lxc/image.go:1654
 msgid "Property not found"
 msgstr ""
 
@@ -4682,7 +4688,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4719,7 +4725,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1416 lxc/image.go:1417
+#: lxc/image.go:1449 lxc/image.go:1450
 msgid "Refresh images"
 msgstr ""
 
@@ -4728,7 +4734,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1453
+#: lxc/image.go:1486
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4991,7 +4997,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:356
+#: lxc/init.go:357
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5024,7 +5030,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1139
+#: lxc/image.go:1146
 msgid "SIZE"
 msgstr ""
 
@@ -5147,7 +5153,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1637 lxc/image.go:1638
+#: lxc/image.go:1670 lxc/image.go:1671
 msgid "Set image properties"
 msgstr ""
 
@@ -5399,11 +5405,11 @@ msgstr ""
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: lxc/main.go:98
+#: lxc/main.go:97
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:99
+#: lxc/main.go:98
 msgid "Show all information messages"
 msgstr ""
 
@@ -5452,7 +5458,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1507 lxc/image.go:1508
+#: lxc/image.go:1540 lxc/image.go:1541
 msgid "Show image properties"
 msgstr ""
 
@@ -5472,7 +5478,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:272 lxc/main.go:273
+#: lxc/main.go:271 lxc/main.go:272
 msgid "Show less common commands"
 msgstr ""
 
@@ -5796,7 +5802,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1736 lxc/warning.go:216
@@ -5867,7 +5873,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:434
+#: lxc/init.go:435
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -6013,7 +6019,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:299
+#: lxc/main.go:298
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6037,11 +6043,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:436
+#: lxc/init.go:437
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:435
+#: lxc/init.go:436
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6049,7 +6055,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:411
+#: lxc/main.go:410
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6156,7 +6162,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1140
+#: lxc/image.go:1148
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6202,7 +6208,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1778
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1778
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6244,7 +6250,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1700 lxc/image.go:1701
+#: lxc/image.go:1733 lxc/image.go:1734
 msgid "Unset image properties"
 msgstr ""
 
@@ -6414,7 +6420,7 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/main.go:101
+#: lxc/main.go:100
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -6568,7 +6574,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1087 lxc/list.go:46
+#: lxc/image.go:1088 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6687,15 +6693,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1572 lxc/image.go:1699
+#: lxc/image.go:1605 lxc/image.go:1732
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1636
+#: lxc/image.go:1669
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6715,7 +6721,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1415
+#: lxc/image.go:334 lxc/image.go:1448
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -7670,7 +7676,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
+#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
 msgid "no"
 msgstr ""
 
@@ -7716,6 +7722,6 @@ msgid "y"
 msgstr ""
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1194
+#: lxc/image.go:1206
 msgid "yes"
 msgstr ""

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-11-18 20:34-0300\n"
+"POT-Creation-Date: 2024-11-21 15:57-0700\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/linux-containers/"
@@ -423,7 +423,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1168
+#: lxc/image.go:1180
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -544,11 +544,11 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1133
+#: lxc/image.go:1144
 msgid "ALIASES"
 msgstr ""
 
@@ -769,7 +769,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:342 lxc/rebuild.go:131
+#: lxc/init.go:343 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1172,7 +1172,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1595
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1595
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1502,7 +1502,7 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:186
+#: lxc/init.go:182
 #, c-format
 msgid "Creating %s"
 msgstr ""
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: lxc/init.go:184
+#: lxc/init.go:180
 msgid "Creating the instance"
 msgstr ""
 
@@ -1526,7 +1526,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -1693,8 +1693,8 @@ msgstr ""
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1090 lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574
-#: lxc/image.go:1638 lxc/image.go:1701 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
+#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:402
+#: lxc/init.go:403
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1880,6 +1880,10 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
+#: lxc/image.go:1119
+msgid "Display images from all projects"
+msgstr ""
+
 #: lxc/list.go:135
 msgid "Display instances from all projects"
 msgstr ""
@@ -1888,7 +1892,7 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:100
+#: lxc/main.go:99
 msgid "Don't show progress information"
 msgstr ""
 
@@ -2023,7 +2027,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1772
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2196,7 +2200,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
+#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2400,7 +2404,7 @@ msgstr ""
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:96
+#: lxc/main.go:95
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -2431,7 +2435,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2506,7 +2510,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1573 lxc/image.go:1574
+#: lxc/image.go:1606 lxc/image.go:1607
 msgid "Get image properties"
 msgstr ""
 
@@ -2762,7 +2766,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:405
+#: lxc/main.go:404
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2784,7 +2788,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1489
+#: lxc/image.go:1522
 msgid "Image already up to date."
 msgstr ""
 
@@ -2800,11 +2804,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1444
+#: lxc/image.go:364 lxc/image.go:1477
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1670
+#: lxc/image.go:444 lxc/image.go:1703
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2814,7 +2818,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1520
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2895,7 +2899,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:413
+#: lxc/init.go:414
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2994,7 +2998,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:507
+#: lxc/main.go:506
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3087,12 +3091,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/init.go:180
+#: lxc/init.go:176
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: lxc/init.go:178
+#: lxc/init.go:174
 msgid "Launching the instance"
 msgstr ""
 
@@ -3201,11 +3205,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1089
+#: lxc/image.go:1090
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid ""
 "List images\n"
 "\n"
@@ -3226,6 +3230,7 @@ msgid ""
 "    F - Fingerprint (long)\n"
 "    p - Whether image is public\n"
 "    d - Description\n"
+"    e - Project\n"
 "    a - Architecture\n"
 "    s - Size\n"
 "    u - Upload date\n"
@@ -4322,7 +4327,7 @@ msgstr ""
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:96
 msgid "Override the source project"
 msgstr ""
 
@@ -4364,7 +4369,8 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:567 lxc/storage_volume.go:1762 lxc/warning.go:213
+#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1762
+#: lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4372,7 +4378,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:853
+#: lxc/image.go:1145 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4388,7 +4394,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:368
+#: lxc/main.go:367
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4447,7 +4453,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:95
+#: lxc/main.go:94
 msgid "Print help"
 msgstr ""
 
@@ -4455,7 +4461,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:94
+#: lxc/main.go:93
 msgid "Print version number"
 msgstr ""
 
@@ -4552,7 +4558,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1621
+#: lxc/image.go:1654
 msgid "Property not found"
 msgstr ""
 
@@ -4682,7 +4688,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4719,7 +4725,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1416 lxc/image.go:1417
+#: lxc/image.go:1449 lxc/image.go:1450
 msgid "Refresh images"
 msgstr ""
 
@@ -4728,7 +4734,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1453
+#: lxc/image.go:1486
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4991,7 +4997,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:356
+#: lxc/init.go:357
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5024,7 +5030,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1139
+#: lxc/image.go:1146
 msgid "SIZE"
 msgstr ""
 
@@ -5147,7 +5153,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1637 lxc/image.go:1638
+#: lxc/image.go:1670 lxc/image.go:1671
 msgid "Set image properties"
 msgstr ""
 
@@ -5399,11 +5405,11 @@ msgstr ""
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: lxc/main.go:98
+#: lxc/main.go:97
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:99
+#: lxc/main.go:98
 msgid "Show all information messages"
 msgstr ""
 
@@ -5452,7 +5458,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1507 lxc/image.go:1508
+#: lxc/image.go:1540 lxc/image.go:1541
 msgid "Show image properties"
 msgstr ""
 
@@ -5472,7 +5478,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:272 lxc/main.go:273
+#: lxc/main.go:271 lxc/main.go:272
 msgid "Show less common commands"
 msgstr ""
 
@@ -5796,7 +5802,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1736 lxc/warning.go:216
@@ -5867,7 +5873,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:434
+#: lxc/init.go:435
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -6013,7 +6019,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:299
+#: lxc/main.go:298
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6037,11 +6043,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:436
+#: lxc/init.go:437
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:435
+#: lxc/init.go:436
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6049,7 +6055,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:411
+#: lxc/main.go:410
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6156,7 +6162,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1140
+#: lxc/image.go:1148
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6202,7 +6208,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1778
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1778
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6244,7 +6250,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1700 lxc/image.go:1701
+#: lxc/image.go:1733 lxc/image.go:1734
 msgid "Unset image properties"
 msgstr ""
 
@@ -6414,7 +6420,7 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/main.go:101
+#: lxc/main.go:100
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -6568,7 +6574,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1087 lxc/list.go:46
+#: lxc/image.go:1088 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6687,15 +6693,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1572 lxc/image.go:1699
+#: lxc/image.go:1605 lxc/image.go:1732
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1636
+#: lxc/image.go:1669
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6715,7 +6721,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1415
+#: lxc/image.go:334 lxc/image.go:1448
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -7670,7 +7676,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
+#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
 msgid "no"
 msgstr ""
 
@@ -7716,6 +7722,6 @@ msgid "y"
 msgstr ""
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1194
+#: lxc/image.go:1206
 msgid "yes"
 msgstr ""

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-11-18 20:34-0300\n"
+"POT-Creation-Date: 2024-11-21 15:57-0700\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Wivik <seb+weblate@zedas.fr>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/linux-containers/"
@@ -669,7 +669,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr "%d (id: %d, online: %v, NUMA node: %v)"
 
-#: lxc/image.go:1168
+#: lxc/image.go:1180
 #, c-format
 msgid "%s (%d more)"
 msgstr "%s (%d de plus)"
@@ -804,11 +804,11 @@ msgstr "<cible>"
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr "ALIAS"
 
-#: lxc/image.go:1133
+#: lxc/image.go:1144
 #, fuzzy
 msgid "ALIASES"
 msgstr "ALIAS"
@@ -1050,7 +1050,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:342 lxc/rebuild.go:131
+#: lxc/init.go:343 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -1162,7 +1162,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "Clé de configuration invalide"
@@ -1468,7 +1468,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1595
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1595
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr "Colonnes"
@@ -1854,7 +1854,7 @@ msgstr "L'arrêt du conteneur a échoué !"
 msgid "Created: %s"
 msgstr "Créé : %s"
 
-#: lxc/init.go:186
+#: lxc/init.go:182
 #, c-format
 msgid "Creating %s"
 msgstr "Création de %s"
@@ -1864,7 +1864,7 @@ msgstr "Création de %s"
 msgid "Creating %s: %%s"
 msgstr "Création de %s"
 
-#: lxc/init.go:184
+#: lxc/init.go:180
 #, fuzzy
 msgid "Creating the instance"
 msgstr "Création du conteneur"
@@ -1879,7 +1879,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -2063,8 +2063,8 @@ msgstr "Récupération de l'image : %s"
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1090 lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574
-#: lxc/image.go:1638 lxc/image.go:1701 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
+#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -2212,7 +2212,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr "Serveur distant : %s"
 
-#: lxc/init.go:402
+#: lxc/init.go:403
 #, fuzzy
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr "pas d'image, conteneur ou instantané affecté sur ce serveur"
@@ -2257,6 +2257,11 @@ msgstr "  Disque utilisé :"
 msgid "Disks:"
 msgstr "  Disque utilisé :"
 
+#: lxc/image.go:1119
+#, fuzzy
+msgid "Display images from all projects"
+msgstr "Forcer le conteneur à s'arrêter"
+
 #: lxc/list.go:135
 #, fuzzy
 msgid "Display instances from all projects"
@@ -2267,7 +2272,7 @@ msgstr "Forcer le conteneur à s'arrêter"
 msgid "Don't require user confirmation for using --force"
 msgstr "Requérir une confirmation de l'utilisateur"
 
-#: lxc/main.go:100
+#: lxc/main.go:99
 msgid "Don't show progress information"
 msgstr ""
 
@@ -2420,7 +2425,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr "Clé de configuration invalide"
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1772
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2618,7 +2623,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr "NOM"
 
-#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
+#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr "EMPREINTE"
@@ -2828,7 +2833,7 @@ msgstr "Forcer le conteneur à s'arrêter"
 msgid "Force the removal of running instances"
 msgstr "Forcer la suppression des conteneurs arrêtés"
 
-#: lxc/main.go:96
+#: lxc/main.go:95
 msgid "Force using the local unix socket"
 msgstr "Forcer l'utilisation de la socket unix locale"
 
@@ -2859,7 +2864,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2935,7 +2940,7 @@ msgstr "Création du conteneur"
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1573 lxc/image.go:1574
+#: lxc/image.go:1606 lxc/image.go:1607
 msgid "Get image properties"
 msgstr ""
 
@@ -3217,7 +3222,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:405
+#: lxc/main.go:404
 #, fuzzy
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
@@ -3243,7 +3248,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
 
-#: lxc/image.go:1489
+#: lxc/image.go:1522
 msgid "Image already up to date."
 msgstr ""
 
@@ -3260,11 +3265,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr "Image copiée avec succès !"
 
-#: lxc/image.go:364 lxc/image.go:1444
+#: lxc/image.go:364 lxc/image.go:1477
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1670
+#: lxc/image.go:444 lxc/image.go:1703
 #, fuzzy, c-format
 msgid "Image identifier missing: %s"
 msgstr "Image importée avec l'empreinte : %s"
@@ -3274,7 +3279,7 @@ msgstr "Image importée avec l'empreinte : %s"
 msgid "Image imported with fingerprint: %s"
 msgstr "Image importée avec l'empreinte : %s"
 
-#: lxc/image.go:1487
+#: lxc/image.go:1520
 #, fuzzy
 msgid "Image refreshed successfully!"
 msgstr "Image copiée avec succès !"
@@ -3363,7 +3368,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr "Le nom du conteneur est obligatoire"
 
-#: lxc/init.go:413
+#: lxc/init.go:414
 #, fuzzy, c-format
 msgid "Instance name is: %s"
 msgstr "Le nom du conteneur est : %s"
@@ -3464,7 +3469,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:507
+#: lxc/main.go:506
 #, fuzzy
 msgid "Invalid number of arguments"
 msgstr "nombre d'arguments incorrect pour la sous-comande"
@@ -3560,12 +3565,12 @@ msgstr "Dernière utilisation : %s"
 msgid "Last used: never"
 msgstr "Dernière utilisation : jamais"
 
-#: lxc/init.go:180
+#: lxc/init.go:176
 #, fuzzy, c-format
 msgid "Launching %s"
 msgstr "Création de %s"
 
-#: lxc/init.go:178
+#: lxc/init.go:174
 #, fuzzy
 msgid "Launching the instance"
 msgstr "Création du conteneur"
@@ -3683,11 +3688,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1089
+#: lxc/image.go:1090
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid ""
 "List images\n"
 "\n"
@@ -3708,6 +3713,7 @@ msgid ""
 "    F - Fingerprint (long)\n"
 "    p - Whether image is public\n"
 "    d - Description\n"
+"    e - Project\n"
 "    a - Architecture\n"
 "    s - Size\n"
 "    u - Upload date\n"
@@ -4961,7 +4967,7 @@ msgstr "Le réseau %s a été supprimé"
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:96
 #, fuzzy
 msgid "Override the source project"
 msgstr "impossible de supprimer le serveur distant par défaut"
@@ -5004,7 +5010,8 @@ msgstr ""
 msgid "PROFILES"
 msgstr "PROFILS"
 
-#: lxc/list.go:567 lxc/storage_volume.go:1762 lxc/warning.go:213
+#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1762
+#: lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -5012,7 +5019,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr "PROTOCOLE"
 
-#: lxc/image.go:1136 lxc/remote.go:853
+#: lxc/image.go:1145 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr "PUBLIC"
 
@@ -5029,7 +5036,7 @@ msgstr "Paquets émis"
 msgid "Partitions:"
 msgstr "Options :"
 
-#: lxc/main.go:368
+#: lxc/main.go:367
 #, fuzzy, c-format
 msgid "Password for %s: "
 msgstr "Mot de passe administrateur pour %s : "
@@ -5093,7 +5100,7 @@ msgstr "Appuyer sur Entrée pour ouvrir à nouveau l'éditeur"
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:95
+#: lxc/main.go:94
 msgid "Print help"
 msgstr ""
 
@@ -5101,7 +5108,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:94
+#: lxc/main.go:93
 msgid "Print version number"
 msgstr ""
 
@@ -5203,7 +5210,7 @@ msgstr ""
 msgid "Properties:"
 msgstr "Propriétés :"
 
-#: lxc/image.go:1621
+#: lxc/image.go:1654
 msgid "Property not found"
 msgstr ""
 
@@ -5336,7 +5343,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -5378,7 +5385,7 @@ msgstr "Pousser ou récupérer des fichiers récursivement"
 msgid "Refresh and update the existing storage volume copies"
 msgstr "Copie de l'image : %s"
 
-#: lxc/image.go:1416 lxc/image.go:1417
+#: lxc/image.go:1449 lxc/image.go:1450
 #, fuzzy
 msgid "Refresh images"
 msgstr "Récupération de l'image : %s"
@@ -5388,7 +5395,7 @@ msgstr "Récupération de l'image : %s"
 msgid "Refreshing instance: %s"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
 
-#: lxc/image.go:1453
+#: lxc/image.go:1486
 #, fuzzy, c-format
 msgid "Refreshing the image: %s"
 msgstr "Récupération de l'image : %s"
@@ -5696,7 +5703,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
 
-#: lxc/init.go:356
+#: lxc/init.go:357
 #, c-format
 msgid "Retrieving image: %s"
 msgstr "Récupération de l'image : %s"
@@ -5732,7 +5739,7 @@ msgstr "Rendre l'image publique"
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1139
+#: lxc/image.go:1146
 msgid "SIZE"
 msgstr "TAILLE"
 
@@ -5863,7 +5870,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1637 lxc/image.go:1638
+#: lxc/image.go:1670 lxc/image.go:1671
 msgid "Set image properties"
 msgstr ""
 
@@ -6139,11 +6146,11 @@ msgstr ""
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: lxc/main.go:98
+#: lxc/main.go:97
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:99
+#: lxc/main.go:98
 msgid "Show all information messages"
 msgstr ""
 
@@ -6196,7 +6203,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1507 lxc/image.go:1508
+#: lxc/image.go:1540 lxc/image.go:1541
 msgid "Show image properties"
 msgstr ""
 
@@ -6220,7 +6227,7 @@ msgstr "Afficher la configuration étendue"
 msgid "Show instance or server information"
 msgstr "Afficher des informations supplémentaires"
 
-#: lxc/main.go:272 lxc/main.go:273
+#: lxc/main.go:271 lxc/main.go:272
 #, fuzzy
 msgid "Show less common commands"
 msgstr "Afficher les commandes moins communes"
@@ -6577,7 +6584,7 @@ msgstr "Image importée avec l'empreinte : %s"
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1736 lxc/warning.go:216
@@ -6655,7 +6662,7 @@ msgstr ""
 "Le conteneur est en cours d'exécution. Utiliser --force pour qu'il soit "
 "arrêté et redémarré."
 
-#: lxc/init.go:434
+#: lxc/init.go:435
 #, fuzzy
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
@@ -6806,7 +6813,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr "L'importation de répertoire n'est pas disponible sur cette plateforme"
 
-#: lxc/main.go:299
+#: lxc/main.go:298
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6831,12 +6838,12 @@ msgstr "Temps d'attente du conteneur avant de le tuer"
 msgid "Timestamps:"
 msgstr "Horodatage :"
 
-#: lxc/init.go:436
+#: lxc/init.go:437
 #, fuzzy
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr "Pour attacher un réseau à un conteneur, utiliser : lxc network attach"
 
-#: lxc/init.go:435
+#: lxc/init.go:436
 msgid "To create a new network, use: lxc network create"
 msgstr "Pour créer un réseau, utiliser : lxc network create"
 
@@ -6844,7 +6851,7 @@ msgstr "Pour créer un réseau, utiliser : lxc network create"
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:411
+#: lxc/main.go:410
 #, fuzzy
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
@@ -6956,7 +6963,7 @@ msgstr "Type : éphémère"
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1140
+#: lxc/image.go:1148
 msgid "UPLOAD DATE"
 msgstr "DATE DE PUBLICATION"
 
@@ -7003,7 +7010,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1778
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1778
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -7049,7 +7056,7 @@ msgstr "tous les profils de la source n'existent pas sur la cible"
 msgid "Unset device configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/image.go:1700 lxc/image.go:1701
+#: lxc/image.go:1733 lxc/image.go:1734
 msgid "Unset image properties"
 msgstr ""
 
@@ -7246,7 +7253,7 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/main.go:101
+#: lxc/main.go:100
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -7444,7 +7451,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/image.go:1087 lxc/list.go:46
+#: lxc/image.go:1088 lxc/list.go:46
 #, fuzzy
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
@@ -7680,7 +7687,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
 #, fuzzy
 msgid "[<remote>:]<image>"
 msgstr ""
@@ -7692,7 +7699,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/image.go:1572 lxc/image.go:1699
+#: lxc/image.go:1605 lxc/image.go:1732
 #, fuzzy
 msgid "[<remote>:]<image> <key>"
 msgstr ""
@@ -7704,7 +7711,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/image.go:1636
+#: lxc/image.go:1669
 #, fuzzy
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
@@ -7744,7 +7751,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/image.go:334 lxc/image.go:1415
+#: lxc/image.go:334 lxc/image.go:1448
 #, fuzzy
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
@@ -9280,7 +9287,7 @@ msgstr "non"
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
+#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
 msgid "no"
 msgstr "non"
 
@@ -9326,7 +9333,7 @@ msgid "y"
 msgstr "o"
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1194
+#: lxc/image.go:1206
 msgid "yes"
 msgstr "oui"
 

--- a/po/he.po
+++ b/po/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-11-18 20:34-0300\n"
+"POT-Creation-Date: 2024-11-21 15:57-0700\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hebrew <https://hosted.weblate.org/projects/linux-containers/"
@@ -424,7 +424,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1168
+#: lxc/image.go:1180
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -545,11 +545,11 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1133
+#: lxc/image.go:1144
 msgid "ALIASES"
 msgstr ""
 
@@ -770,7 +770,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:342 lxc/rebuild.go:131
+#: lxc/init.go:343 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -875,7 +875,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1173,7 +1173,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1595
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1595
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1503,7 +1503,7 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:186
+#: lxc/init.go:182
 #, c-format
 msgid "Creating %s"
 msgstr ""
@@ -1513,7 +1513,7 @@ msgstr ""
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: lxc/init.go:184
+#: lxc/init.go:180
 msgid "Creating the instance"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -1694,8 +1694,8 @@ msgstr ""
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1090 lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574
-#: lxc/image.go:1638 lxc/image.go:1701 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
+#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1840,7 +1840,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:402
+#: lxc/init.go:403
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1881,6 +1881,10 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
+#: lxc/image.go:1119
+msgid "Display images from all projects"
+msgstr ""
+
 #: lxc/list.go:135
 msgid "Display instances from all projects"
 msgstr ""
@@ -1889,7 +1893,7 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:100
+#: lxc/main.go:99
 msgid "Don't show progress information"
 msgstr ""
 
@@ -2024,7 +2028,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1772
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2197,7 +2201,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
+#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2401,7 +2405,7 @@ msgstr ""
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:96
+#: lxc/main.go:95
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -2432,7 +2436,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2507,7 +2511,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1573 lxc/image.go:1574
+#: lxc/image.go:1606 lxc/image.go:1607
 msgid "Get image properties"
 msgstr ""
 
@@ -2763,7 +2767,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:405
+#: lxc/main.go:404
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2785,7 +2789,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1489
+#: lxc/image.go:1522
 msgid "Image already up to date."
 msgstr ""
 
@@ -2801,11 +2805,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1444
+#: lxc/image.go:364 lxc/image.go:1477
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1670
+#: lxc/image.go:444 lxc/image.go:1703
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2815,7 +2819,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1520
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2896,7 +2900,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:413
+#: lxc/init.go:414
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2995,7 +2999,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:507
+#: lxc/main.go:506
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3088,12 +3092,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/init.go:180
+#: lxc/init.go:176
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: lxc/init.go:178
+#: lxc/init.go:174
 msgid "Launching the instance"
 msgstr ""
 
@@ -3202,11 +3206,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1089
+#: lxc/image.go:1090
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid ""
 "List images\n"
 "\n"
@@ -3227,6 +3231,7 @@ msgid ""
 "    F - Fingerprint (long)\n"
 "    p - Whether image is public\n"
 "    d - Description\n"
+"    e - Project\n"
 "    a - Architecture\n"
 "    s - Size\n"
 "    u - Upload date\n"
@@ -4323,7 +4328,7 @@ msgstr ""
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:96
 msgid "Override the source project"
 msgstr ""
 
@@ -4365,7 +4370,8 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:567 lxc/storage_volume.go:1762 lxc/warning.go:213
+#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1762
+#: lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4373,7 +4379,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:853
+#: lxc/image.go:1145 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4389,7 +4395,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:368
+#: lxc/main.go:367
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4448,7 +4454,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:95
+#: lxc/main.go:94
 msgid "Print help"
 msgstr ""
 
@@ -4456,7 +4462,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:94
+#: lxc/main.go:93
 msgid "Print version number"
 msgstr ""
 
@@ -4553,7 +4559,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1621
+#: lxc/image.go:1654
 msgid "Property not found"
 msgstr ""
 
@@ -4683,7 +4689,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4720,7 +4726,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1416 lxc/image.go:1417
+#: lxc/image.go:1449 lxc/image.go:1450
 msgid "Refresh images"
 msgstr ""
 
@@ -4729,7 +4735,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1453
+#: lxc/image.go:1486
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4992,7 +4998,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:356
+#: lxc/init.go:357
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5025,7 +5031,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1139
+#: lxc/image.go:1146
 msgid "SIZE"
 msgstr ""
 
@@ -5148,7 +5154,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1637 lxc/image.go:1638
+#: lxc/image.go:1670 lxc/image.go:1671
 msgid "Set image properties"
 msgstr ""
 
@@ -5400,11 +5406,11 @@ msgstr ""
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: lxc/main.go:98
+#: lxc/main.go:97
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:99
+#: lxc/main.go:98
 msgid "Show all information messages"
 msgstr ""
 
@@ -5453,7 +5459,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1507 lxc/image.go:1508
+#: lxc/image.go:1540 lxc/image.go:1541
 msgid "Show image properties"
 msgstr ""
 
@@ -5473,7 +5479,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:272 lxc/main.go:273
+#: lxc/main.go:271 lxc/main.go:272
 msgid "Show less common commands"
 msgstr ""
 
@@ -5797,7 +5803,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1736 lxc/warning.go:216
@@ -5868,7 +5874,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:434
+#: lxc/init.go:435
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -6014,7 +6020,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:299
+#: lxc/main.go:298
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6038,11 +6044,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:436
+#: lxc/init.go:437
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:435
+#: lxc/init.go:436
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6050,7 +6056,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:411
+#: lxc/main.go:410
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6157,7 +6163,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1140
+#: lxc/image.go:1148
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6203,7 +6209,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1778
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1778
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6245,7 +6251,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1700 lxc/image.go:1701
+#: lxc/image.go:1733 lxc/image.go:1734
 msgid "Unset image properties"
 msgstr ""
 
@@ -6415,7 +6421,7 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/main.go:101
+#: lxc/main.go:100
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -6569,7 +6575,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1087 lxc/list.go:46
+#: lxc/image.go:1088 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6688,15 +6694,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1572 lxc/image.go:1699
+#: lxc/image.go:1605 lxc/image.go:1732
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1636
+#: lxc/image.go:1669
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6716,7 +6722,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1415
+#: lxc/image.go:334 lxc/image.go:1448
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -7671,7 +7677,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
+#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
 msgid "no"
 msgstr ""
 
@@ -7717,6 +7723,6 @@ msgid "y"
 msgstr ""
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1194
+#: lxc/image.go:1206
 msgid "yes"
 msgstr ""

--- a/po/hi.po
+++ b/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-11-18 20:34-0300\n"
+"POT-Creation-Date: 2024-11-21 15:57-0700\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hindi <https://hosted.weblate.org/projects/linux-containers/"
@@ -423,7 +423,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1168
+#: lxc/image.go:1180
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -544,11 +544,11 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1133
+#: lxc/image.go:1144
 msgid "ALIASES"
 msgstr ""
 
@@ -769,7 +769,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:342 lxc/rebuild.go:131
+#: lxc/init.go:343 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1172,7 +1172,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1595
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1595
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1502,7 +1502,7 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:186
+#: lxc/init.go:182
 #, c-format
 msgid "Creating %s"
 msgstr ""
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: lxc/init.go:184
+#: lxc/init.go:180
 msgid "Creating the instance"
 msgstr ""
 
@@ -1526,7 +1526,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -1693,8 +1693,8 @@ msgstr ""
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1090 lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574
-#: lxc/image.go:1638 lxc/image.go:1701 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
+#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:402
+#: lxc/init.go:403
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1880,6 +1880,10 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
+#: lxc/image.go:1119
+msgid "Display images from all projects"
+msgstr ""
+
 #: lxc/list.go:135
 msgid "Display instances from all projects"
 msgstr ""
@@ -1888,7 +1892,7 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:100
+#: lxc/main.go:99
 msgid "Don't show progress information"
 msgstr ""
 
@@ -2023,7 +2027,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1772
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2196,7 +2200,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
+#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2400,7 +2404,7 @@ msgstr ""
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:96
+#: lxc/main.go:95
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -2431,7 +2435,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2506,7 +2510,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1573 lxc/image.go:1574
+#: lxc/image.go:1606 lxc/image.go:1607
 msgid "Get image properties"
 msgstr ""
 
@@ -2762,7 +2766,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:405
+#: lxc/main.go:404
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2784,7 +2788,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1489
+#: lxc/image.go:1522
 msgid "Image already up to date."
 msgstr ""
 
@@ -2800,11 +2804,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1444
+#: lxc/image.go:364 lxc/image.go:1477
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1670
+#: lxc/image.go:444 lxc/image.go:1703
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2814,7 +2818,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1520
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2895,7 +2899,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:413
+#: lxc/init.go:414
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2994,7 +2998,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:507
+#: lxc/main.go:506
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3087,12 +3091,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/init.go:180
+#: lxc/init.go:176
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: lxc/init.go:178
+#: lxc/init.go:174
 msgid "Launching the instance"
 msgstr ""
 
@@ -3201,11 +3205,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1089
+#: lxc/image.go:1090
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid ""
 "List images\n"
 "\n"
@@ -3226,6 +3230,7 @@ msgid ""
 "    F - Fingerprint (long)\n"
 "    p - Whether image is public\n"
 "    d - Description\n"
+"    e - Project\n"
 "    a - Architecture\n"
 "    s - Size\n"
 "    u - Upload date\n"
@@ -4322,7 +4327,7 @@ msgstr ""
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:96
 msgid "Override the source project"
 msgstr ""
 
@@ -4364,7 +4369,8 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:567 lxc/storage_volume.go:1762 lxc/warning.go:213
+#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1762
+#: lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4372,7 +4378,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:853
+#: lxc/image.go:1145 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4388,7 +4394,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:368
+#: lxc/main.go:367
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4447,7 +4453,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:95
+#: lxc/main.go:94
 msgid "Print help"
 msgstr ""
 
@@ -4455,7 +4461,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:94
+#: lxc/main.go:93
 msgid "Print version number"
 msgstr ""
 
@@ -4552,7 +4558,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1621
+#: lxc/image.go:1654
 msgid "Property not found"
 msgstr ""
 
@@ -4682,7 +4688,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4719,7 +4725,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1416 lxc/image.go:1417
+#: lxc/image.go:1449 lxc/image.go:1450
 msgid "Refresh images"
 msgstr ""
 
@@ -4728,7 +4734,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1453
+#: lxc/image.go:1486
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4991,7 +4997,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:356
+#: lxc/init.go:357
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5024,7 +5030,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1139
+#: lxc/image.go:1146
 msgid "SIZE"
 msgstr ""
 
@@ -5147,7 +5153,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1637 lxc/image.go:1638
+#: lxc/image.go:1670 lxc/image.go:1671
 msgid "Set image properties"
 msgstr ""
 
@@ -5399,11 +5405,11 @@ msgstr ""
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: lxc/main.go:98
+#: lxc/main.go:97
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:99
+#: lxc/main.go:98
 msgid "Show all information messages"
 msgstr ""
 
@@ -5452,7 +5458,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1507 lxc/image.go:1508
+#: lxc/image.go:1540 lxc/image.go:1541
 msgid "Show image properties"
 msgstr ""
 
@@ -5472,7 +5478,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:272 lxc/main.go:273
+#: lxc/main.go:271 lxc/main.go:272
 msgid "Show less common commands"
 msgstr ""
 
@@ -5796,7 +5802,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1736 lxc/warning.go:216
@@ -5867,7 +5873,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:434
+#: lxc/init.go:435
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -6013,7 +6019,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:299
+#: lxc/main.go:298
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6037,11 +6043,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:436
+#: lxc/init.go:437
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:435
+#: lxc/init.go:436
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6049,7 +6055,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:411
+#: lxc/main.go:410
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6156,7 +6162,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1140
+#: lxc/image.go:1148
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6202,7 +6208,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1778
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1778
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6244,7 +6250,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1700 lxc/image.go:1701
+#: lxc/image.go:1733 lxc/image.go:1734
 msgid "Unset image properties"
 msgstr ""
 
@@ -6414,7 +6420,7 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/main.go:101
+#: lxc/main.go:100
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -6568,7 +6574,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1087 lxc/list.go:46
+#: lxc/image.go:1088 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6687,15 +6693,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1572 lxc/image.go:1699
+#: lxc/image.go:1605 lxc/image.go:1732
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1636
+#: lxc/image.go:1669
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6715,7 +6721,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1415
+#: lxc/image.go:334 lxc/image.go:1448
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -7670,7 +7676,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
+#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
 msgid "no"
 msgstr ""
 
@@ -7716,6 +7722,6 @@ msgid "y"
 msgstr ""
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1194
+#: lxc/image.go:1206
 msgid "yes"
 msgstr ""

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-11-18 20:34-0300\n"
+"POT-Creation-Date: 2024-11-21 15:57-0700\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Indonesian <https://hosted.weblate.org/projects/linux-"
@@ -423,7 +423,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1168
+#: lxc/image.go:1180
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -544,11 +544,11 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1133
+#: lxc/image.go:1144
 msgid "ALIASES"
 msgstr ""
 
@@ -769,7 +769,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:342 lxc/rebuild.go:131
+#: lxc/init.go:343 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1172,7 +1172,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1595
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1595
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1502,7 +1502,7 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:186
+#: lxc/init.go:182
 #, c-format
 msgid "Creating %s"
 msgstr ""
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: lxc/init.go:184
+#: lxc/init.go:180
 msgid "Creating the instance"
 msgstr ""
 
@@ -1526,7 +1526,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -1693,8 +1693,8 @@ msgstr ""
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1090 lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574
-#: lxc/image.go:1638 lxc/image.go:1701 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
+#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:402
+#: lxc/init.go:403
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1880,6 +1880,10 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
+#: lxc/image.go:1119
+msgid "Display images from all projects"
+msgstr ""
+
 #: lxc/list.go:135
 msgid "Display instances from all projects"
 msgstr ""
@@ -1888,7 +1892,7 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:100
+#: lxc/main.go:99
 msgid "Don't show progress information"
 msgstr ""
 
@@ -2023,7 +2027,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1772
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2196,7 +2200,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
+#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2400,7 +2404,7 @@ msgstr ""
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:96
+#: lxc/main.go:95
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -2431,7 +2435,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2506,7 +2510,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1573 lxc/image.go:1574
+#: lxc/image.go:1606 lxc/image.go:1607
 msgid "Get image properties"
 msgstr ""
 
@@ -2762,7 +2766,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:405
+#: lxc/main.go:404
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2784,7 +2788,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1489
+#: lxc/image.go:1522
 msgid "Image already up to date."
 msgstr ""
 
@@ -2800,11 +2804,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1444
+#: lxc/image.go:364 lxc/image.go:1477
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1670
+#: lxc/image.go:444 lxc/image.go:1703
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2814,7 +2818,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1520
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2895,7 +2899,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:413
+#: lxc/init.go:414
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2994,7 +2998,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:507
+#: lxc/main.go:506
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3087,12 +3091,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/init.go:180
+#: lxc/init.go:176
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: lxc/init.go:178
+#: lxc/init.go:174
 msgid "Launching the instance"
 msgstr ""
 
@@ -3201,11 +3205,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1089
+#: lxc/image.go:1090
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid ""
 "List images\n"
 "\n"
@@ -3226,6 +3230,7 @@ msgid ""
 "    F - Fingerprint (long)\n"
 "    p - Whether image is public\n"
 "    d - Description\n"
+"    e - Project\n"
 "    a - Architecture\n"
 "    s - Size\n"
 "    u - Upload date\n"
@@ -4322,7 +4327,7 @@ msgstr ""
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:96
 msgid "Override the source project"
 msgstr ""
 
@@ -4364,7 +4369,8 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:567 lxc/storage_volume.go:1762 lxc/warning.go:213
+#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1762
+#: lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4372,7 +4378,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:853
+#: lxc/image.go:1145 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4388,7 +4394,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:368
+#: lxc/main.go:367
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4447,7 +4453,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:95
+#: lxc/main.go:94
 msgid "Print help"
 msgstr ""
 
@@ -4455,7 +4461,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:94
+#: lxc/main.go:93
 msgid "Print version number"
 msgstr ""
 
@@ -4552,7 +4558,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1621
+#: lxc/image.go:1654
 msgid "Property not found"
 msgstr ""
 
@@ -4682,7 +4688,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4719,7 +4725,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1416 lxc/image.go:1417
+#: lxc/image.go:1449 lxc/image.go:1450
 msgid "Refresh images"
 msgstr ""
 
@@ -4728,7 +4734,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1453
+#: lxc/image.go:1486
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4991,7 +4997,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:356
+#: lxc/init.go:357
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5024,7 +5030,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1139
+#: lxc/image.go:1146
 msgid "SIZE"
 msgstr ""
 
@@ -5147,7 +5153,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1637 lxc/image.go:1638
+#: lxc/image.go:1670 lxc/image.go:1671
 msgid "Set image properties"
 msgstr ""
 
@@ -5399,11 +5405,11 @@ msgstr ""
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: lxc/main.go:98
+#: lxc/main.go:97
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:99
+#: lxc/main.go:98
 msgid "Show all information messages"
 msgstr ""
 
@@ -5452,7 +5458,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1507 lxc/image.go:1508
+#: lxc/image.go:1540 lxc/image.go:1541
 msgid "Show image properties"
 msgstr ""
 
@@ -5472,7 +5478,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:272 lxc/main.go:273
+#: lxc/main.go:271 lxc/main.go:272
 msgid "Show less common commands"
 msgstr ""
 
@@ -5796,7 +5802,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1736 lxc/warning.go:216
@@ -5867,7 +5873,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:434
+#: lxc/init.go:435
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -6013,7 +6019,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:299
+#: lxc/main.go:298
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6037,11 +6043,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:436
+#: lxc/init.go:437
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:435
+#: lxc/init.go:436
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6049,7 +6055,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:411
+#: lxc/main.go:410
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6156,7 +6162,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1140
+#: lxc/image.go:1148
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6202,7 +6208,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1778
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1778
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6244,7 +6250,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1700 lxc/image.go:1701
+#: lxc/image.go:1733 lxc/image.go:1734
 msgid "Unset image properties"
 msgstr ""
 
@@ -6414,7 +6420,7 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/main.go:101
+#: lxc/main.go:100
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -6568,7 +6574,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1087 lxc/list.go:46
+#: lxc/image.go:1088 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6687,15 +6693,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1572 lxc/image.go:1699
+#: lxc/image.go:1605 lxc/image.go:1732
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1636
+#: lxc/image.go:1669
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6715,7 +6721,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1415
+#: lxc/image.go:334 lxc/image.go:1448
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -7670,7 +7676,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
+#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
 msgid "no"
 msgstr ""
 
@@ -7716,6 +7722,6 @@ msgid "y"
 msgstr ""
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1194
+#: lxc/image.go:1206
 msgid "yes"
 msgstr ""

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-11-18 20:34-0300\n"
+"POT-Creation-Date: 2024-11-21 15:57-0700\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Luigi Operoso <brokenpip3@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/linux-containers/"
@@ -665,7 +665,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1168
+#: lxc/image.go:1180
 #, c-format
 msgid "%s (%d more)"
 msgstr "%s (altri %d)"
@@ -789,11 +789,11 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr "ALIAS"
 
-#: lxc/image.go:1133
+#: lxc/image.go:1144
 msgid "ALIASES"
 msgstr "ALIAS"
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:342 lxc/rebuild.go:131
+#: lxc/init.go:343 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -1125,7 +1125,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "Proprietà errata: %s"
@@ -1426,7 +1426,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1595
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1595
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr "Colonne"
@@ -1767,7 +1767,7 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:186
+#: lxc/init.go:182
 #, c-format
 msgid "Creating %s"
 msgstr "Creazione di %s in corso"
@@ -1777,7 +1777,7 @@ msgstr "Creazione di %s in corso"
 msgid "Creating %s: %%s"
 msgstr "Creazione di %s in corso"
 
-#: lxc/init.go:184
+#: lxc/init.go:180
 #, fuzzy
 msgid "Creating the instance"
 msgstr "Creazione del container in corso"
@@ -1792,7 +1792,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -1964,8 +1964,8 @@ msgstr ""
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1090 lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574
-#: lxc/image.go:1638 lxc/image.go:1701 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
+#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -2112,7 +2112,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:402
+#: lxc/init.go:403
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -2155,6 +2155,11 @@ msgstr "Utilizzo disco:"
 msgid "Disks:"
 msgstr "Utilizzo disco:"
 
+#: lxc/image.go:1119
+#, fuzzy
+msgid "Display images from all projects"
+msgstr "Creazione del container in corso"
+
 #: lxc/list.go:135
 #, fuzzy
 msgid "Display instances from all projects"
@@ -2164,7 +2169,7 @@ msgstr "Creazione del container in corso"
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:100
+#: lxc/main.go:99
 msgid "Don't show progress information"
 msgstr ""
 
@@ -2306,7 +2311,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1772
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2482,7 +2487,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
+#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2688,7 +2693,7 @@ msgstr "Creazione del container in corso"
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:96
+#: lxc/main.go:95
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -2719,7 +2724,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2795,7 +2800,7 @@ msgstr "Creazione del container in corso"
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1573 lxc/image.go:1574
+#: lxc/image.go:1606 lxc/image.go:1607
 msgid "Get image properties"
 msgstr ""
 
@@ -3062,7 +3067,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:405
+#: lxc/main.go:404
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -3085,7 +3090,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr "Creazione del container in corso"
 
-#: lxc/image.go:1489
+#: lxc/image.go:1522
 msgid "Image already up to date."
 msgstr ""
 
@@ -3101,11 +3106,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1444
+#: lxc/image.go:364 lxc/image.go:1477
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1670
+#: lxc/image.go:444 lxc/image.go:1703
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -3115,7 +3120,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1520
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3198,7 +3203,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:413
+#: lxc/init.go:414
 #, fuzzy, c-format
 msgid "Instance name is: %s"
 msgstr "Il nome del container è: %s"
@@ -3299,7 +3304,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:507
+#: lxc/main.go:506
 #, fuzzy
 msgid "Invalid number of arguments"
 msgstr "numero errato di argomenti del sottocomando"
@@ -3394,12 +3399,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/init.go:180
+#: lxc/init.go:176
 #, fuzzy, c-format
 msgid "Launching %s"
 msgstr "Creazione di %s in corso"
 
-#: lxc/init.go:178
+#: lxc/init.go:174
 #, fuzzy
 msgid "Launching the instance"
 msgstr "Creazione del container in corso"
@@ -3517,11 +3522,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1089
+#: lxc/image.go:1090
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid ""
 "List images\n"
 "\n"
@@ -3542,6 +3547,7 @@ msgid ""
 "    F - Fingerprint (long)\n"
 "    p - Whether image is public\n"
 "    d - Description\n"
+"    e - Project\n"
 "    a - Architecture\n"
 "    s - Size\n"
 "    u - Upload date\n"
@@ -4686,7 +4692,7 @@ msgstr ""
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:96
 msgid "Override the source project"
 msgstr ""
 
@@ -4728,7 +4734,8 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:567 lxc/storage_volume.go:1762 lxc/warning.go:213
+#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1762
+#: lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4736,7 +4743,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:853
+#: lxc/image.go:1145 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4752,7 +4759,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:368
+#: lxc/main.go:367
 #, fuzzy, c-format
 msgid "Password for %s: "
 msgstr "Password amministratore per %s: "
@@ -4813,7 +4820,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:95
+#: lxc/main.go:94
 msgid "Print help"
 msgstr ""
 
@@ -4821,7 +4828,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:94
+#: lxc/main.go:93
 msgid "Print version number"
 msgstr ""
 
@@ -4920,7 +4927,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1621
+#: lxc/image.go:1654
 msgid "Property not found"
 msgstr ""
 
@@ -5051,7 +5058,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -5090,7 +5097,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1416 lxc/image.go:1417
+#: lxc/image.go:1449 lxc/image.go:1450
 msgid "Refresh images"
 msgstr ""
 
@@ -5099,7 +5106,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr "Creazione del container in corso"
 
-#: lxc/image.go:1453
+#: lxc/image.go:1486
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5374,7 +5381,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:356
+#: lxc/init.go:357
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5410,7 +5417,7 @@ msgstr "Creazione del container in corso"
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1139
+#: lxc/image.go:1146
 msgid "SIZE"
 msgstr ""
 
@@ -5535,7 +5542,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1637 lxc/image.go:1638
+#: lxc/image.go:1670 lxc/image.go:1671
 msgid "Set image properties"
 msgstr ""
 
@@ -5795,11 +5802,11 @@ msgstr ""
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: lxc/main.go:98
+#: lxc/main.go:97
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:99
+#: lxc/main.go:98
 msgid "Show all information messages"
 msgstr ""
 
@@ -5850,7 +5857,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1507 lxc/image.go:1508
+#: lxc/image.go:1540 lxc/image.go:1541
 msgid "Show image properties"
 msgstr ""
 
@@ -5871,7 +5878,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:272 lxc/main.go:273
+#: lxc/main.go:271 lxc/main.go:272
 msgid "Show less common commands"
 msgstr ""
 
@@ -6207,7 +6214,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1736 lxc/warning.go:216
@@ -6279,7 +6286,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:434
+#: lxc/init.go:435
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -6428,7 +6435,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr "Import da directory non disponibile su questa piattaforma"
 
-#: lxc/main.go:299
+#: lxc/main.go:298
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6452,11 +6459,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:436
+#: lxc/init.go:437
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:435
+#: lxc/init.go:436
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6464,7 +6471,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:411
+#: lxc/main.go:410
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6572,7 +6579,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1140
+#: lxc/image.go:1148
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6619,7 +6626,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1778
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1778
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6664,7 +6671,7 @@ msgstr "non tutti i profili dell'origine esistono nella destinazione"
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1700 lxc/image.go:1701
+#: lxc/image.go:1733 lxc/image.go:1734
 msgid "Unset image properties"
 msgstr ""
 
@@ -6846,7 +6853,7 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/main.go:101
+#: lxc/main.go:100
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -7010,7 +7017,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:] [<cert>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/image.go:1087 lxc/list.go:46
+#: lxc/image.go:1088 lxc/list.go:46
 #, fuzzy
 msgid "[<remote>:] [<filter>...]"
 msgstr "Creazione del container in corso"
@@ -7153,17 +7160,17 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr "Creazione del container in corso"
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
 #, fuzzy
 msgid "[<remote>:]<image>"
 msgstr "Creazione del container in corso"
 
-#: lxc/image.go:1572 lxc/image.go:1699
+#: lxc/image.go:1605 lxc/image.go:1732
 #, fuzzy
 msgid "[<remote>:]<image> <key>"
 msgstr "Creazione del container in corso"
 
-#: lxc/image.go:1636
+#: lxc/image.go:1669
 #, fuzzy
 msgid "[<remote>:]<image> <key> <value>"
 msgstr "Creazione del container in corso"
@@ -7188,7 +7195,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<image> [<target>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/image.go:334 lxc/image.go:1415
+#: lxc/image.go:334 lxc/image.go:1448
 #, fuzzy
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr "Creazione del container in corso"
@@ -8251,7 +8258,7 @@ msgstr "no"
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
+#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
 msgid "no"
 msgstr "no"
 
@@ -8297,7 +8304,7 @@ msgid "y"
 msgstr ""
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1194
+#: lxc/image.go:1206
 msgid "yes"
 msgstr "si"
 

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-11-18 20:34-0300\n"
+"POT-Creation-Date: 2024-11-21 15:57-0700\n"
 "PO-Revision-Date: 2023-03-10 15:14+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/linux-"
@@ -657,7 +657,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr "%d (id: %d, オンライン: %v, NUMA ノード: %v)"
 
-#: lxc/image.go:1168
+#: lxc/image.go:1180
 #, c-format
 msgid "%s (%d more)"
 msgstr "%s (他%d個)"
@@ -780,11 +780,11 @@ msgstr "<target>"
 msgid "ADDRESS"
 msgstr "IP ADDRESS"
 
-#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr "ALIAS"
 
-#: lxc/image.go:1133
+#: lxc/image.go:1144
 msgid "ALIASES"
 msgstr "ALIASES"
 
@@ -1027,7 +1027,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr "どちらもみつかりませんでした。raw SPICE ソケットはこちらにあります:"
 
-#: lxc/init.go:342 lxc/rebuild.go:131
+#: lxc/init.go:343 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr "VMを要求しましたが、イメージタイプがコンテナです"
 
@@ -1138,7 +1138,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr "不適切なキー/値のペア: %s"
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "不適切な キー=値 のペア: %s"
@@ -1442,7 +1442,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr "クラスタリングが有効になりました"
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1595
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1595
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr "カラムレイアウト"
@@ -1800,7 +1800,7 @@ msgstr "プロファイルを適用しないインスタンスを作成します
 msgid "Created: %s"
 msgstr "作成日時: %s"
 
-#: lxc/init.go:186
+#: lxc/init.go:182
 #, c-format
 msgid "Creating %s"
 msgstr "%s を作成中"
@@ -1810,7 +1810,7 @@ msgstr "%s を作成中"
 msgid "Creating %s: %%s"
 msgstr "%s を作成中"
 
-#: lxc/init.go:184
+#: lxc/init.go:180
 msgid "Creating the instance"
 msgstr "インスタンスを作成中"
 
@@ -1824,7 +1824,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr "DEFAULT TARGET ADDRESS"
 
 #: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -1994,8 +1994,8 @@ msgstr "警告を削除します"
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1090 lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574
-#: lxc/image.go:1638 lxc/image.go:1701 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
+#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -2144,7 +2144,7 @@ msgstr "プロファイルのデバイスは個々のインスタンスでは取
 msgid "Device: %s"
 msgstr "デバイス: %s"
 
-#: lxc/init.go:402
+#: lxc/init.go:403
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 "サーバから変更されたイメージ、インスタンス、スナップショットを取得できません"
@@ -2187,6 +2187,11 @@ msgstr "ディスク:"
 msgid "Disks:"
 msgstr "ディスク:"
 
+#: lxc/image.go:1119
+#, fuzzy
+msgid "Display images from all projects"
+msgstr "すべてのプロジェクトのインスタンスを表示します"
+
 #: lxc/list.go:135
 msgid "Display instances from all projects"
 msgstr "すべてのプロジェクトのインスタンスを表示します"
@@ -2195,7 +2200,7 @@ msgstr "すべてのプロジェクトのインスタンスを表示します"
 msgid "Don't require user confirmation for using --force"
 msgstr "--force を使う際にユーザーの確認を必要としない"
 
-#: lxc/main.go:100
+#: lxc/main.go:99
 msgid "Don't show progress information"
 msgstr "進捗情報を表示しません"
 
@@ -2336,7 +2341,7 @@ msgstr "ストレージボリュームの設定をYAMLで編集します"
 msgid "Edit trust configurations as YAML"
 msgstr "信頼済みクライアント設定をYAMLで編集します"
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1772
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2535,7 +2540,7 @@ msgstr "FAILURE DOMAIN"
 msgid "FILENAME"
 msgstr "FILENAME"
 
-#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
+#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr "FINGERPRINT"
@@ -2740,7 +2745,7 @@ msgstr "インスタンスを強制停止します"
 msgid "Force the removal of running instances"
 msgstr "稼働中のインスタンスを強制的に削除します"
 
-#: lxc/main.go:96
+#: lxc/main.go:95
 msgid "Force using the local unix socket"
 msgstr "強制的にローカルのUNIXソケットを使います"
 
@@ -2786,7 +2791,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2862,7 +2867,7 @@ msgstr "インスタンスからファイルをマウントします"
 msgid "Get a summary of resource allocations"
 msgstr "リソース割当の状況を表示します"
 
-#: lxc/image.go:1573 lxc/image.go:1574
+#: lxc/image.go:1606 lxc/image.go:1607
 msgid "Get image properties"
 msgstr "イメージのプロパティを取得します"
 
@@ -3133,7 +3138,7 @@ msgstr ""
 "存在するスナップショット名の場合は既存のスナップショットを削除したあとに新し"
 "いスナップショットを作成します"
 
-#: lxc/main.go:405
+#: lxc/main.go:404
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -3155,7 +3160,7 @@ msgstr "コピー中にファイルが更新された場合のエラーを無視
 msgid "Ignore the instance state"
 msgstr "インスタンスの状態を無視します"
 
-#: lxc/image.go:1489
+#: lxc/image.go:1522
 msgid "Image already up to date."
 msgstr "イメージは更新済みです。"
 
@@ -3171,11 +3176,11 @@ msgstr "イメージの失効日（フォーマット: rfc3339）"
 msgid "Image exported successfully!"
 msgstr "イメージのエクスポートが成功しました!"
 
-#: lxc/image.go:364 lxc/image.go:1444
+#: lxc/image.go:364 lxc/image.go:1477
 msgid "Image identifier missing"
 msgstr "イメージ名を指定してください"
 
-#: lxc/image.go:444 lxc/image.go:1670
+#: lxc/image.go:444 lxc/image.go:1703
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr "イメージ名を指定してください: %s"
@@ -3185,7 +3190,7 @@ msgstr "イメージ名を指定してください: %s"
 msgid "Image imported with fingerprint: %s"
 msgstr "イメージは以下のフィンガープリントでインポートされました: %s"
 
-#: lxc/image.go:1487
+#: lxc/image.go:1520
 msgid "Image refreshed successfully!"
 msgstr "イメージの更新が成功しました!"
 
@@ -3274,7 +3279,7 @@ msgstr "クライアント %q に対するインスタンスが切断されま�
 msgid "Instance name is mandatory"
 msgstr "インスタンス名を指定する必要があります"
 
-#: lxc/init.go:413
+#: lxc/init.go:414
 #, c-format
 msgid "Instance name is: %s"
 msgstr "インスタンス名: %s"
@@ -3382,7 +3387,7 @@ msgstr ""
 "新しいスナップショット名が不正です。親のボリュームはソースと同じでなければな"
 "りません"
 
-#: lxc/main.go:507
+#: lxc/main.go:506
 msgid "Invalid number of arguments"
 msgstr "引数の数が不正です"
 
@@ -3477,12 +3482,12 @@ msgstr "最終使用: %s"
 msgid "Last used: never"
 msgstr "最終使用: 未使用"
 
-#: lxc/init.go:180
+#: lxc/init.go:176
 #, fuzzy, c-format
 msgid "Launching %s"
 msgstr "%s を作成中"
 
-#: lxc/init.go:178
+#: lxc/init.go:174
 #, fuzzy
 msgid "Launching the instance"
 msgstr "インスタンスを作成中"
@@ -3598,11 +3603,12 @@ msgstr ""
 "指定するフィルタはイメージのハッシュ値の一部でもイメージのエイリアスの一部で"
 "も構いません。\n"
 
-#: lxc/image.go:1089
+#: lxc/image.go:1090
 msgid "List images"
 msgstr "イメージを一覧表示します"
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
+#, fuzzy
 msgid ""
 "List images\n"
 "\n"
@@ -3623,6 +3629,7 @@ msgid ""
 "    F - Fingerprint (long)\n"
 "    p - Whether image is public\n"
 "    d - Description\n"
+"    e - Project\n"
 "    a - Architecture\n"
 "    s - Size\n"
 "    u - Upload date\n"
@@ -4907,7 +4914,7 @@ msgstr "バックグラウンド操作 %s を削除しました"
 msgid "Optimized Storage"
 msgstr "最適化されたストレージ"
 
-#: lxc/main.go:97
+#: lxc/main.go:96
 msgid "Override the source project"
 msgstr "プロジェクトを指定します"
 
@@ -4949,7 +4956,8 @@ msgstr "PROCESSES"
 msgid "PROFILES"
 msgstr "PROFILES"
 
-#: lxc/list.go:567 lxc/storage_volume.go:1762 lxc/warning.go:213
+#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1762
+#: lxc/warning.go:213
 msgid "PROJECT"
 msgstr "PROJECT"
 
@@ -4957,7 +4965,7 @@ msgstr "PROJECT"
 msgid "PROTOCOL"
 msgstr "PROTOCOL"
 
-#: lxc/image.go:1136 lxc/remote.go:853
+#: lxc/image.go:1145 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr "PUBLIC"
 
@@ -4973,7 +4981,7 @@ msgstr "送信パケット"
 msgid "Partitions:"
 msgstr "パーティション:"
 
-#: lxc/main.go:368
+#: lxc/main.go:367
 #, c-format
 msgid "Password for %s: "
 msgstr "%s のパスワード: "
@@ -5035,7 +5043,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr "Pretty レンダリング（--format=pretty の短縮系）"
 
-#: lxc/main.go:95
+#: lxc/main.go:94
 msgid "Print help"
 msgstr "ヘルプを表示します"
 
@@ -5043,7 +5051,7 @@ msgstr "ヘルプを表示します"
 msgid "Print the raw response"
 msgstr "レスポンスをそのまま表示します"
 
-#: lxc/main.go:94
+#: lxc/main.go:93
 msgid "Print version number"
 msgstr "バージョン番号を表示します"
 
@@ -5140,7 +5148,7 @@ msgstr "リモートで使用するプロジェクト"
 msgid "Properties:"
 msgstr "プロパティ:"
 
-#: lxc/image.go:1621
+#: lxc/image.go:1654
 msgid "Property not found"
 msgstr "プロパティが見つかりません"
 
@@ -5273,7 +5281,7 @@ msgstr "ファイル %s をコンテナ %s 内にコピーします: %%s"
 msgid "Query path must start with /"
 msgstr "query のパスは / で始める必要があります"
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
 msgid "Query virtual machine images"
 msgstr "仮想マシンイメージを対象にします"
 
@@ -5312,7 +5320,7 @@ msgstr "再帰的にファイルを転送します"
 msgid "Refresh and update the existing storage volume copies"
 msgstr "既存のストレージボリュームのコピーの再読込と更新"
 
-#: lxc/image.go:1416 lxc/image.go:1417
+#: lxc/image.go:1449 lxc/image.go:1450
 msgid "Refresh images"
 msgstr "イメージを更新します"
 
@@ -5321,7 +5329,7 @@ msgstr "イメージを更新します"
 msgid "Refreshing instance: %s"
 msgstr "インスタンスの更新中: %s"
 
-#: lxc/image.go:1453
+#: lxc/image.go:1486
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr "イメージの更新中: %s"
@@ -5598,7 +5606,7 @@ msgstr "証明書の使用を1つ以上のプロジェクトに制限します"
 msgid "Retrieve the container's console log"
 msgstr "インスタンスのコンソールログを取得します"
 
-#: lxc/init.go:356
+#: lxc/init.go:357
 #, c-format
 msgid "Retrieving image: %s"
 msgstr "イメージの取得中: %s"
@@ -5632,7 +5640,7 @@ msgstr "すべてのインスタンスに対してコマンドを実行します
 msgid "SEVERITY"
 msgstr "SEVERITY"
 
-#: lxc/image.go:1139
+#: lxc/image.go:1146
 msgid "SIZE"
 msgstr "SIZE"
 
@@ -5765,7 +5773,7 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 
-#: lxc/image.go:1637 lxc/image.go:1638
+#: lxc/image.go:1670 lxc/image.go:1671
 msgid "Set image properties"
 msgstr "イメージのプロパティを設定します"
 
@@ -6079,11 +6087,11 @@ msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 "マウントの代わりに address:port で SSH SFTP リスナーをセットアップします"
 
-#: lxc/main.go:98
+#: lxc/main.go:97
 msgid "Show all debug messages"
 msgstr "デバッグメッセージをすべて表示します"
 
-#: lxc/main.go:99
+#: lxc/main.go:98
 msgid "Show all information messages"
 msgstr "詳細な情報を出力します"
 
@@ -6133,7 +6141,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1507 lxc/image.go:1508
+#: lxc/image.go:1540 lxc/image.go:1541
 msgid "Show image properties"
 msgstr "イメージのプロパティを表示します"
 
@@ -6154,7 +6162,7 @@ msgstr "インスタンスもしくはサーバの設定を表示します"
 msgid "Show instance or server information"
 msgstr "インスタンスもしくはサーバの情報を表示します"
 
-#: lxc/main.go:272 lxc/main.go:273
+#: lxc/main.go:271 lxc/main.go:272
 msgid "Show less common commands"
 msgstr "全てのコマンドを表示します (主なコマンドだけではなく)"
 
@@ -6478,7 +6486,7 @@ msgstr "イメージは以下のフィンガープリントでインポートさ
 msgid "TOKEN"
 msgstr "TOKEN"
 
-#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1736 lxc/warning.go:216
@@ -6552,7 +6560,7 @@ msgstr ""
 "インスタンスは現在実行中です。停止して、再起動するために --force を使用してく"
 "ださい"
 
-#: lxc/init.go:434
+#: lxc/init.go:435
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr "起動しようとしたインスタンスに接続されているネットワークがありません。"
 
@@ -6706,7 +6714,7 @@ msgstr "LXD サーバはすでにクラスターに属しています"
 msgid "This LXD server is not available on the network"
 msgstr "この LXD サーバはネットワークから利用できません"
 
-#: lxc/main.go:299
+#: lxc/main.go:298
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6739,13 +6747,13 @@ msgstr "インスタンスがクリーンにシャットダウンするまで待
 msgid "Timestamps:"
 msgstr "タイムスタンプ:"
 
-#: lxc/init.go:436
+#: lxc/init.go:437
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 "インスタンスにネットワークを接続するには、lxc network attach を使用してくださ"
 "い"
 
-#: lxc/init.go:435
+#: lxc/init.go:436
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 "新しいネットワークを作成するには、lxc network create を使用してください"
@@ -6754,7 +6762,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr "コンソールから切り離すには <ctrl>+a q を押します"
 
-#: lxc/main.go:411
+#: lxc/main.go:410
 #, fuzzy
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
@@ -6870,7 +6878,7 @@ msgstr "タイプ: %s (ephemeral)"
 msgid "UNLIMITED"
 msgstr "UNLIMITED"
 
-#: lxc/image.go:1140
+#: lxc/image.go:1148
 msgid "UPLOAD DATE"
 msgstr "UPLOAD DATE"
 
@@ -6916,7 +6924,7 @@ msgstr "未知の証明書タイプ %q"
 msgid "Unknown channel type for client %q: %s"
 msgstr "クライアント %q の未知のチャンネルタイプ: %s"
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1778
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1778
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6959,7 +6967,7 @@ msgstr "移動先のインスタンスのすべてのプロファイルを削除
 msgid "Unset device configuration keys"
 msgstr "デバイスの設定を削除します"
 
-#: lxc/image.go:1700 lxc/image.go:1701
+#: lxc/image.go:1733 lxc/image.go:1734
 msgid "Unset image properties"
 msgstr "イメージのプロパティを削除します"
 
@@ -7142,7 +7150,7 @@ msgstr ""
 "最適化された形でストレージドライバを使います (同様のプール上にのみリストアで"
 "きます)"
 
-#: lxc/main.go:101
+#: lxc/main.go:100
 msgid "Use with help or --help to view sub-commands"
 msgstr "サブコマンドを見るには help もしくは --help を使ってください"
 
@@ -7304,7 +7312,7 @@ msgstr "[<remote>:] <name>"
 msgid "[<remote>:] [<cert>]"
 msgstr "[<remote>:] [<cert>]"
 
-#: lxc/image.go:1087 lxc/list.go:46
+#: lxc/image.go:1088 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr "[<remote>:] [<filter>...]"
 
@@ -7428,15 +7436,15 @@ msgstr "[<remote>:]<member> <group>"
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr "[<remote>:]<group> <new-name>"
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
 msgid "[<remote>:]<image>"
 msgstr "[<remote>:]<image>"
 
-#: lxc/image.go:1572 lxc/image.go:1699
+#: lxc/image.go:1605 lxc/image.go:1732
 msgid "[<remote>:]<image> <key>"
 msgstr "[<remote>:]<image> <key>"
 
-#: lxc/image.go:1636
+#: lxc/image.go:1669
 msgid "[<remote>:]<image> <key> <value>"
 msgstr "[<remote>:]<image> <key> <value>"
 
@@ -7457,7 +7465,7 @@ msgstr "[<remote>:]<image> [<remote>:][<name>]"
 msgid "[<remote>:]<image> [<target>]"
 msgstr "[<remote>:]<image> [<target>]"
 
-#: lxc/image.go:334 lxc/image.go:1415
+#: lxc/image.go:334 lxc/image.go:1448
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr "[<remote>:]<image> [[<remote>:]<image>...]"
 
@@ -8648,7 +8656,7 @@ msgstr "n"
 msgid "name"
 msgstr "名前"
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
+#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
 msgid "no"
 msgstr "no"
 
@@ -8696,7 +8704,7 @@ msgid "y"
 msgstr "y"
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1194
+#: lxc/image.go:1206
 msgid "yes"
 msgstr "yes"
 

--- a/po/ka.po
+++ b/po/ka.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-11-18 20:34-0300\n"
+"POT-Creation-Date: 2024-11-21 15:57-0700\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -420,7 +420,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1168
+#: lxc/image.go:1180
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -541,11 +541,11 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1133
+#: lxc/image.go:1144
 msgid "ALIASES"
 msgstr ""
 
@@ -766,7 +766,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:342 lxc/rebuild.go:131
+#: lxc/init.go:343 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -871,7 +871,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1169,7 +1169,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1595
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1595
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1499,7 +1499,7 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:186
+#: lxc/init.go:182
 #, c-format
 msgid "Creating %s"
 msgstr ""
@@ -1509,7 +1509,7 @@ msgstr ""
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: lxc/init.go:184
+#: lxc/init.go:180
 msgid "Creating the instance"
 msgstr ""
 
@@ -1523,7 +1523,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -1690,8 +1690,8 @@ msgstr ""
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1090 lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574
-#: lxc/image.go:1638 lxc/image.go:1701 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
+#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1836,7 +1836,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:402
+#: lxc/init.go:403
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1877,6 +1877,10 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
+#: lxc/image.go:1119
+msgid "Display images from all projects"
+msgstr ""
+
 #: lxc/list.go:135
 msgid "Display instances from all projects"
 msgstr ""
@@ -1885,7 +1889,7 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:100
+#: lxc/main.go:99
 msgid "Don't show progress information"
 msgstr ""
 
@@ -2020,7 +2024,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1772
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2193,7 +2197,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
+#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2397,7 +2401,7 @@ msgstr ""
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:96
+#: lxc/main.go:95
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -2428,7 +2432,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2503,7 +2507,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1573 lxc/image.go:1574
+#: lxc/image.go:1606 lxc/image.go:1607
 msgid "Get image properties"
 msgstr ""
 
@@ -2759,7 +2763,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:405
+#: lxc/main.go:404
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2781,7 +2785,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1489
+#: lxc/image.go:1522
 msgid "Image already up to date."
 msgstr ""
 
@@ -2797,11 +2801,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1444
+#: lxc/image.go:364 lxc/image.go:1477
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1670
+#: lxc/image.go:444 lxc/image.go:1703
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2811,7 +2815,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1520
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2892,7 +2896,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:413
+#: lxc/init.go:414
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2991,7 +2995,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:507
+#: lxc/main.go:506
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3084,12 +3088,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/init.go:180
+#: lxc/init.go:176
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: lxc/init.go:178
+#: lxc/init.go:174
 msgid "Launching the instance"
 msgstr ""
 
@@ -3198,11 +3202,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1089
+#: lxc/image.go:1090
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid ""
 "List images\n"
 "\n"
@@ -3223,6 +3227,7 @@ msgid ""
 "    F - Fingerprint (long)\n"
 "    p - Whether image is public\n"
 "    d - Description\n"
+"    e - Project\n"
 "    a - Architecture\n"
 "    s - Size\n"
 "    u - Upload date\n"
@@ -4319,7 +4324,7 @@ msgstr ""
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:96
 msgid "Override the source project"
 msgstr ""
 
@@ -4361,7 +4366,8 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:567 lxc/storage_volume.go:1762 lxc/warning.go:213
+#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1762
+#: lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4369,7 +4375,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:853
+#: lxc/image.go:1145 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4385,7 +4391,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:368
+#: lxc/main.go:367
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4444,7 +4450,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:95
+#: lxc/main.go:94
 msgid "Print help"
 msgstr ""
 
@@ -4452,7 +4458,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:94
+#: lxc/main.go:93
 msgid "Print version number"
 msgstr ""
 
@@ -4549,7 +4555,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1621
+#: lxc/image.go:1654
 msgid "Property not found"
 msgstr ""
 
@@ -4679,7 +4685,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4716,7 +4722,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1416 lxc/image.go:1417
+#: lxc/image.go:1449 lxc/image.go:1450
 msgid "Refresh images"
 msgstr ""
 
@@ -4725,7 +4731,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1453
+#: lxc/image.go:1486
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4988,7 +4994,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:356
+#: lxc/init.go:357
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5021,7 +5027,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1139
+#: lxc/image.go:1146
 msgid "SIZE"
 msgstr ""
 
@@ -5144,7 +5150,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1637 lxc/image.go:1638
+#: lxc/image.go:1670 lxc/image.go:1671
 msgid "Set image properties"
 msgstr ""
 
@@ -5396,11 +5402,11 @@ msgstr ""
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: lxc/main.go:98
+#: lxc/main.go:97
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:99
+#: lxc/main.go:98
 msgid "Show all information messages"
 msgstr ""
 
@@ -5449,7 +5455,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1507 lxc/image.go:1508
+#: lxc/image.go:1540 lxc/image.go:1541
 msgid "Show image properties"
 msgstr ""
 
@@ -5469,7 +5475,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:272 lxc/main.go:273
+#: lxc/main.go:271 lxc/main.go:272
 msgid "Show less common commands"
 msgstr ""
 
@@ -5793,7 +5799,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1736 lxc/warning.go:216
@@ -5864,7 +5870,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:434
+#: lxc/init.go:435
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -6010,7 +6016,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:299
+#: lxc/main.go:298
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6034,11 +6040,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:436
+#: lxc/init.go:437
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:435
+#: lxc/init.go:436
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6046,7 +6052,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:411
+#: lxc/main.go:410
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6153,7 +6159,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1140
+#: lxc/image.go:1148
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6199,7 +6205,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1778
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1778
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6241,7 +6247,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1700 lxc/image.go:1701
+#: lxc/image.go:1733 lxc/image.go:1734
 msgid "Unset image properties"
 msgstr ""
 
@@ -6411,7 +6417,7 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/main.go:101
+#: lxc/main.go:100
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -6565,7 +6571,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1087 lxc/list.go:46
+#: lxc/image.go:1088 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6684,15 +6690,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1572 lxc/image.go:1699
+#: lxc/image.go:1605 lxc/image.go:1732
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1636
+#: lxc/image.go:1669
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6712,7 +6718,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1415
+#: lxc/image.go:334 lxc/image.go:1448
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -7667,7 +7673,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
+#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
 msgid "no"
 msgstr ""
 
@@ -7713,6 +7719,6 @@ msgid "y"
 msgstr ""
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1194
+#: lxc/image.go:1206
 msgid "yes"
 msgstr ""

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-11-18 20:34-0300\n"
+"POT-Creation-Date: 2024-11-21 15:57-0700\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Korean <https://hosted.weblate.org/projects/linux-containers/"
@@ -423,7 +423,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1168
+#: lxc/image.go:1180
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -544,11 +544,11 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1133
+#: lxc/image.go:1144
 msgid "ALIASES"
 msgstr ""
 
@@ -769,7 +769,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:342 lxc/rebuild.go:131
+#: lxc/init.go:343 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1172,7 +1172,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1595
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1595
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1502,7 +1502,7 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:186
+#: lxc/init.go:182
 #, c-format
 msgid "Creating %s"
 msgstr ""
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: lxc/init.go:184
+#: lxc/init.go:180
 msgid "Creating the instance"
 msgstr ""
 
@@ -1526,7 +1526,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -1693,8 +1693,8 @@ msgstr ""
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1090 lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574
-#: lxc/image.go:1638 lxc/image.go:1701 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
+#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:402
+#: lxc/init.go:403
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1880,6 +1880,10 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
+#: lxc/image.go:1119
+msgid "Display images from all projects"
+msgstr ""
+
 #: lxc/list.go:135
 msgid "Display instances from all projects"
 msgstr ""
@@ -1888,7 +1892,7 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:100
+#: lxc/main.go:99
 msgid "Don't show progress information"
 msgstr ""
 
@@ -2023,7 +2027,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1772
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2196,7 +2200,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
+#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2400,7 +2404,7 @@ msgstr ""
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:96
+#: lxc/main.go:95
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -2431,7 +2435,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2506,7 +2510,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1573 lxc/image.go:1574
+#: lxc/image.go:1606 lxc/image.go:1607
 msgid "Get image properties"
 msgstr ""
 
@@ -2762,7 +2766,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:405
+#: lxc/main.go:404
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2784,7 +2788,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1489
+#: lxc/image.go:1522
 msgid "Image already up to date."
 msgstr ""
 
@@ -2800,11 +2804,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1444
+#: lxc/image.go:364 lxc/image.go:1477
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1670
+#: lxc/image.go:444 lxc/image.go:1703
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2814,7 +2818,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1520
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2895,7 +2899,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:413
+#: lxc/init.go:414
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2994,7 +2998,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:507
+#: lxc/main.go:506
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3087,12 +3091,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/init.go:180
+#: lxc/init.go:176
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: lxc/init.go:178
+#: lxc/init.go:174
 msgid "Launching the instance"
 msgstr ""
 
@@ -3201,11 +3205,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1089
+#: lxc/image.go:1090
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid ""
 "List images\n"
 "\n"
@@ -3226,6 +3230,7 @@ msgid ""
 "    F - Fingerprint (long)\n"
 "    p - Whether image is public\n"
 "    d - Description\n"
+"    e - Project\n"
 "    a - Architecture\n"
 "    s - Size\n"
 "    u - Upload date\n"
@@ -4322,7 +4327,7 @@ msgstr ""
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:96
 msgid "Override the source project"
 msgstr ""
 
@@ -4364,7 +4369,8 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:567 lxc/storage_volume.go:1762 lxc/warning.go:213
+#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1762
+#: lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4372,7 +4378,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:853
+#: lxc/image.go:1145 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4388,7 +4394,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:368
+#: lxc/main.go:367
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4447,7 +4453,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:95
+#: lxc/main.go:94
 msgid "Print help"
 msgstr ""
 
@@ -4455,7 +4461,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:94
+#: lxc/main.go:93
 msgid "Print version number"
 msgstr ""
 
@@ -4552,7 +4558,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1621
+#: lxc/image.go:1654
 msgid "Property not found"
 msgstr ""
 
@@ -4682,7 +4688,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4719,7 +4725,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1416 lxc/image.go:1417
+#: lxc/image.go:1449 lxc/image.go:1450
 msgid "Refresh images"
 msgstr ""
 
@@ -4728,7 +4734,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1453
+#: lxc/image.go:1486
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4991,7 +4997,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:356
+#: lxc/init.go:357
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5024,7 +5030,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1139
+#: lxc/image.go:1146
 msgid "SIZE"
 msgstr ""
 
@@ -5147,7 +5153,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1637 lxc/image.go:1638
+#: lxc/image.go:1670 lxc/image.go:1671
 msgid "Set image properties"
 msgstr ""
 
@@ -5399,11 +5405,11 @@ msgstr ""
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: lxc/main.go:98
+#: lxc/main.go:97
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:99
+#: lxc/main.go:98
 msgid "Show all information messages"
 msgstr ""
 
@@ -5452,7 +5458,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1507 lxc/image.go:1508
+#: lxc/image.go:1540 lxc/image.go:1541
 msgid "Show image properties"
 msgstr ""
 
@@ -5472,7 +5478,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:272 lxc/main.go:273
+#: lxc/main.go:271 lxc/main.go:272
 msgid "Show less common commands"
 msgstr ""
 
@@ -5796,7 +5802,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1736 lxc/warning.go:216
@@ -5867,7 +5873,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:434
+#: lxc/init.go:435
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -6013,7 +6019,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:299
+#: lxc/main.go:298
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6037,11 +6043,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:436
+#: lxc/init.go:437
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:435
+#: lxc/init.go:436
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6049,7 +6055,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:411
+#: lxc/main.go:410
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6156,7 +6162,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1140
+#: lxc/image.go:1148
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6202,7 +6208,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1778
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1778
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6244,7 +6250,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1700 lxc/image.go:1701
+#: lxc/image.go:1733 lxc/image.go:1734
 msgid "Unset image properties"
 msgstr ""
 
@@ -6414,7 +6420,7 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/main.go:101
+#: lxc/main.go:100
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -6568,7 +6574,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1087 lxc/list.go:46
+#: lxc/image.go:1088 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6687,15 +6693,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1572 lxc/image.go:1699
+#: lxc/image.go:1605 lxc/image.go:1732
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1636
+#: lxc/image.go:1669
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6715,7 +6721,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1415
+#: lxc/image.go:334 lxc/image.go:1448
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -7670,7 +7676,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
+#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
 msgid "no"
 msgstr ""
 
@@ -7716,6 +7722,6 @@ msgid "y"
 msgstr ""
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1194
+#: lxc/image.go:1206
 msgid "yes"
 msgstr ""

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-        "POT-Creation-Date: 2024-11-18 20:34-0300\n"
+        "POT-Creation-Date: 2024-11-21 15:57-0700\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -391,7 +391,7 @@ msgstr  ""
 msgid   "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr  ""
 
-#: lxc/image.go:1168
+#: lxc/image.go:1180
 #, c-format
 msgid   "%s (%d more)"
 msgstr  ""
@@ -510,11 +510,11 @@ msgstr  ""
 msgid   "ADDRESS"
 msgstr  ""
 
-#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
 msgid   "ALIAS"
 msgstr  ""
 
-#: lxc/image.go:1133
+#: lxc/image.go:1144
 msgid   "ALIASES"
 msgstr  ""
 
@@ -728,7 +728,7 @@ msgstr  ""
 msgid   "As neither could be found, the raw SPICE socket can be found at:"
 msgstr  ""
 
-#: lxc/init.go:342 lxc/rebuild.go:131
+#: lxc/init.go:343 lxc/rebuild.go:131
 msgid   "Asked for a VM but image is of type container"
 msgstr  ""
 
@@ -830,7 +830,7 @@ msgstr  ""
 msgid   "Bad key/value pair: %s"
 msgstr  ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
 #, c-format
 msgid   "Bad key=value pair: %q"
 msgstr  ""
@@ -1100,7 +1100,7 @@ msgstr  ""
 msgid   "Clustering enabled"
 msgstr  ""
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1595 lxc/warning.go:93
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1595 lxc/warning.go:93
 msgid   "Columns"
 msgstr  ""
 
@@ -1412,7 +1412,7 @@ msgstr  ""
 msgid   "Created: %s"
 msgstr  ""
 
-#: lxc/init.go:186
+#: lxc/init.go:182
 #, c-format
 msgid   "Creating %s"
 msgstr  ""
@@ -1422,7 +1422,7 @@ msgstr  ""
 msgid   "Creating %s: %%s"
 msgstr  ""
 
-#: lxc/init.go:184
+#: lxc/init.go:180
 msgid   "Creating the instance"
 msgstr  ""
 
@@ -1435,7 +1435,7 @@ msgstr  ""
 msgid   "DEFAULT TARGET ADDRESS"
 msgstr  ""
 
-#: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504 lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086 lxc/network_acl.go:157 lxc/network_forward.go:157 lxc/network_load_balancer.go:160 lxc/network_peer.go:149 lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173 lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723 lxc/storage_bucket.go:513 lxc/storage_bucket.go:833 lxc/storage_volume.go:1738
+#: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504 lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086 lxc/network_acl.go:157 lxc/network_forward.go:157 lxc/network_load_balancer.go:160 lxc/network_peer.go:149 lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173 lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723 lxc/storage_bucket.go:513 lxc/storage_bucket.go:833 lxc/storage_volume.go:1738
 msgid   "DESCRIPTION"
 msgstr  ""
 
@@ -1559,7 +1559,7 @@ msgstr  ""
 msgid   "Delete warning"
 msgstr  ""
 
-#: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159 lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104 lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:338 lxc/auth.go:398 lxc/auth.go:447 lxc/auth.go:499 lxc/auth.go:522 lxc/auth.go:581 lxc/auth.go:737 lxc/auth.go:776 lxc/auth.go:918 lxc/auth.go:985 lxc/auth.go:1048 lxc/auth.go:1109 lxc/auth.go:1238 lxc/auth.go:1292 lxc/auth.go:1315 lxc/auth.go:1373 lxc/auth.go:1442 lxc/auth.go:1464 lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781 lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060 lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677 lxc/cluster.go:770 lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087 lxc/cluster.go:1175 lxc/cluster.go:1299 lxc/cluster.go:1329 lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170 lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440 lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663 lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51 lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:955 lxc/config.go:995 lxc/config.go:1050 lxc/config.go:1141 lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:25 lxc/config_device.go:79 lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409 lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634 lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28 lxc/config_metadata.go:56 lxc/config_metadata.go:189 lxc/config_template.go:28 lxc/config_template.go:68 lxc/config_template.go:119 lxc/config_template.go:173 lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34 lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135 lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689 lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090 lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638 lxc/image.go:1701 lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1005 lxc/network.go:1106 lxc/network.go:1185 lxc/network.go:1245 lxc/network.go:1341 lxc/network.go:1413 lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731 lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:53 lxc/network_forward.go:33 lxc/network_forward.go:90 lxc/network_forward.go:179 lxc/network_forward.go:256 lxc/network_forward.go:404 lxc/network_forward.go:489 lxc/network_forward.go:599 lxc/network_forward.go:646 lxc/network_forward.go:800 lxc/network_forward.go:874 lxc/network_forward.go:889 lxc/network_forward.go:970 lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476 lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935 lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1121 lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236 lxc/network_peer.go:360 lxc/network_peer.go:445 lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:165 lxc/network_zone.go:228 lxc/network_zone.go:301 lxc/network_zone.go:396 lxc/network_zone.go:484 lxc/network_zone.go:527 lxc/network_zone.go:654 lxc/network_zone.go:710 lxc/network_zone.go:767 lxc/network_zone.go:845 lxc/network_zone.go:909 lxc/network_zone.go:985 lxc/network_zone.go:1083 lxc/network_zone.go:1172 lxc/network_zone.go:1219 lxc/network_zone.go:1349 lxc/network_zone.go:1410 lxc/network_zone.go:1425 lxc/network_zone.go:1483 lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180 lxc/profile.go:271 lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493 lxc/profile.go:629 lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860 lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31 lxc/project.go:95 lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472 lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789 lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749 lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018 lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250 lxc/storage_bucket.go:383 lxc/storage_bucket.go:459 lxc/storage_bucket.go:536 lxc/storage_bucket.go:630 lxc/storage_bucket.go:699 lxc/storage_bucket.go:733 lxc/storage_bucket.go:774 lxc/storage_bucket.go:853 lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158 lxc/storage_volume.go:58 lxc/storage_volume.go:169 lxc/storage_volume.go:283 lxc/storage_volume.go:390 lxc/storage_volume.go:611 lxc/storage_volume.go:720 lxc/storage_volume.go:807 lxc/storage_volume.go:905 lxc/storage_volume.go:1002 lxc/storage_volume.go:1223 lxc/storage_volume.go:1354 lxc/storage_volume.go:1513 lxc/storage_volume.go:1597 lxc/storage_volume.go:1850 lxc/storage_volume.go:1949 lxc/storage_volume.go:2076 lxc/storage_volume.go:2234 lxc/storage_volume.go:2355 lxc/storage_volume.go:2417 lxc/storage_volume.go:2553 lxc/storage_volume.go:2636 lxc/storage_volume.go:2802 lxc/version.go:22 lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
+#: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159 lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104 lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:338 lxc/auth.go:398 lxc/auth.go:447 lxc/auth.go:499 lxc/auth.go:522 lxc/auth.go:581 lxc/auth.go:737 lxc/auth.go:776 lxc/auth.go:918 lxc/auth.go:985 lxc/auth.go:1048 lxc/auth.go:1109 lxc/auth.go:1238 lxc/auth.go:1292 lxc/auth.go:1315 lxc/auth.go:1373 lxc/auth.go:1442 lxc/auth.go:1464 lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781 lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060 lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677 lxc/cluster.go:770 lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087 lxc/cluster.go:1175 lxc/cluster.go:1299 lxc/cluster.go:1329 lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170 lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440 lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663 lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51 lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:955 lxc/config.go:995 lxc/config.go:1050 lxc/config.go:1141 lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:25 lxc/config_device.go:79 lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409 lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634 lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28 lxc/config_metadata.go:56 lxc/config_metadata.go:189 lxc/config_template.go:28 lxc/config_template.go:68 lxc/config_template.go:119 lxc/config_template.go:173 lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34 lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135 lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689 lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948 lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607 lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1005 lxc/network.go:1106 lxc/network.go:1185 lxc/network.go:1245 lxc/network.go:1341 lxc/network.go:1413 lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731 lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:53 lxc/network_forward.go:33 lxc/network_forward.go:90 lxc/network_forward.go:179 lxc/network_forward.go:256 lxc/network_forward.go:404 lxc/network_forward.go:489 lxc/network_forward.go:599 lxc/network_forward.go:646 lxc/network_forward.go:800 lxc/network_forward.go:874 lxc/network_forward.go:889 lxc/network_forward.go:970 lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476 lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935 lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1121 lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236 lxc/network_peer.go:360 lxc/network_peer.go:445 lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:165 lxc/network_zone.go:228 lxc/network_zone.go:301 lxc/network_zone.go:396 lxc/network_zone.go:484 lxc/network_zone.go:527 lxc/network_zone.go:654 lxc/network_zone.go:710 lxc/network_zone.go:767 lxc/network_zone.go:845 lxc/network_zone.go:909 lxc/network_zone.go:985 lxc/network_zone.go:1083 lxc/network_zone.go:1172 lxc/network_zone.go:1219 lxc/network_zone.go:1349 lxc/network_zone.go:1410 lxc/network_zone.go:1425 lxc/network_zone.go:1483 lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180 lxc/profile.go:271 lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493 lxc/profile.go:629 lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860 lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31 lxc/project.go:95 lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472 lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789 lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749 lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018 lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250 lxc/storage_bucket.go:383 lxc/storage_bucket.go:459 lxc/storage_bucket.go:536 lxc/storage_bucket.go:630 lxc/storage_bucket.go:699 lxc/storage_bucket.go:733 lxc/storage_bucket.go:774 lxc/storage_bucket.go:853 lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158 lxc/storage_volume.go:58 lxc/storage_volume.go:169 lxc/storage_volume.go:283 lxc/storage_volume.go:390 lxc/storage_volume.go:611 lxc/storage_volume.go:720 lxc/storage_volume.go:807 lxc/storage_volume.go:905 lxc/storage_volume.go:1002 lxc/storage_volume.go:1223 lxc/storage_volume.go:1354 lxc/storage_volume.go:1513 lxc/storage_volume.go:1597 lxc/storage_volume.go:1850 lxc/storage_volume.go:1949 lxc/storage_volume.go:2076 lxc/storage_volume.go:2234 lxc/storage_volume.go:2355 lxc/storage_volume.go:2417 lxc/storage_volume.go:2553 lxc/storage_volume.go:2636 lxc/storage_volume.go:2802 lxc/version.go:22 lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid   "Description"
 msgstr  ""
 
@@ -1629,7 +1629,7 @@ msgstr  ""
 msgid   "Device: %s"
 msgstr  ""
 
-#: lxc/init.go:402
+#: lxc/init.go:403
 msgid   "Didn't get any affected image, instance or snapshot from server"
 msgstr  ""
 
@@ -1670,6 +1670,10 @@ msgstr  ""
 msgid   "Disks:"
 msgstr  ""
 
+#: lxc/image.go:1119
+msgid   "Display images from all projects"
+msgstr  ""
+
 #: lxc/list.go:135
 msgid   "Display instances from all projects"
 msgstr  ""
@@ -1678,7 +1682,7 @@ msgstr  ""
 msgid   "Don't require user confirmation for using --force"
 msgstr  ""
 
-#: lxc/main.go:100
+#: lxc/main.go:99
 msgid   "Don't show progress information"
 msgstr  ""
 
@@ -1811,7 +1815,7 @@ msgstr  ""
 msgid   "Edit trust configurations as YAML"
 msgstr  ""
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1772 lxc/warning.go:236
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1772 lxc/warning.go:236
 #, c-format
 msgid   "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr  ""
@@ -1965,7 +1969,7 @@ msgstr  ""
 msgid   "FILENAME"
 msgstr  ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135 lxc/image_alias.go:235
+#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142 lxc/image_alias.go:235
 msgid   "FINGERPRINT"
 msgstr  ""
 
@@ -2167,7 +2171,7 @@ msgstr  ""
 msgid   "Force the removal of running instances"
 msgstr  ""
 
-#: lxc/main.go:96
+#: lxc/main.go:95
 msgid   "Force using the local unix socket"
 msgstr  ""
 
@@ -2190,7 +2194,7 @@ msgid   "Forcefully removing a server from the cluster should only be done as a 
         "Are you really sure you want to force removing %s? (yes/no): "
 msgstr  ""
 
-#: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904 lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442 lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434 lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009 lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59 lxc/network_forward.go:93 lxc/network_load_balancer.go:97 lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770 lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474 lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657 lxc/storage_bucket.go:460 lxc/storage_bucket.go:775 lxc/storage_volume.go:1614 lxc/warning.go:94
+#: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904 lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442 lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434 lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009 lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59 lxc/network_forward.go:93 lxc/network_load_balancer.go:97 lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770 lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474 lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657 lxc/storage_bucket.go:460 lxc/storage_bucket.go:775 lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid   "Format (csv|json|table|yaml|compact)"
 msgstr  ""
 
@@ -2258,7 +2262,7 @@ msgstr  ""
 msgid   "Get a summary of resource allocations"
 msgstr  ""
 
-#: lxc/image.go:1573 lxc/image.go:1574
+#: lxc/image.go:1606 lxc/image.go:1607
 msgid   "Get image properties"
 msgstr  ""
 
@@ -2514,7 +2518,7 @@ msgstr  ""
 msgid   "If the snapshot name already exists, delete and create a new one"
 msgstr  ""
 
-#: lxc/main.go:405
+#: lxc/main.go:404
 msgid   "If this is your first time running LXD on this machine, you should also run: lxd init"
 msgstr  ""
 
@@ -2534,7 +2538,7 @@ msgstr  ""
 msgid   "Ignore the instance state"
 msgstr  ""
 
-#: lxc/image.go:1489
+#: lxc/image.go:1522
 msgid   "Image already up to date."
 msgstr  ""
 
@@ -2550,11 +2554,11 @@ msgstr  ""
 msgid   "Image exported successfully!"
 msgstr  ""
 
-#: lxc/image.go:364 lxc/image.go:1444
+#: lxc/image.go:364 lxc/image.go:1477
 msgid   "Image identifier missing"
 msgstr  ""
 
-#: lxc/image.go:444 lxc/image.go:1670
+#: lxc/image.go:444 lxc/image.go:1703
 #, c-format
 msgid   "Image identifier missing: %s"
 msgstr  ""
@@ -2564,7 +2568,7 @@ msgstr  ""
 msgid   "Image imported with fingerprint: %s"
 msgstr  ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1520
 msgid   "Image refreshed successfully!"
 msgstr  ""
 
@@ -2643,7 +2647,7 @@ msgstr  ""
 msgid   "Instance name is mandatory"
 msgstr  ""
 
-#: lxc/init.go:413
+#: lxc/init.go:414
 #, c-format
 msgid   "Instance name is: %s"
 msgstr  ""
@@ -2741,7 +2745,7 @@ msgstr  ""
 msgid   "Invalid new snapshot name, parent volume must be the same as source"
 msgstr  ""
 
-#: lxc/main.go:507
+#: lxc/main.go:506
 msgid   "Invalid number of arguments"
 msgstr  ""
 
@@ -2829,12 +2833,12 @@ msgstr  ""
 msgid   "Last used: never"
 msgstr  ""
 
-#: lxc/init.go:180
+#: lxc/init.go:176
 #, c-format
 msgid   "Launching %s"
 msgstr  ""
 
-#: lxc/init.go:178
+#: lxc/init.go:174
 msgid   "Launching the instance"
 msgstr  ""
 
@@ -2942,11 +2946,11 @@ msgid   "List image aliases\n"
         "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr  ""
 
-#: lxc/image.go:1089
+#: lxc/image.go:1090
 msgid   "List images"
 msgstr  ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid   "List images\n"
         "\n"
         "Filters may be of the <key>=<value> form for property based filtering,\n"
@@ -2966,6 +2970,7 @@ msgid   "List images\n"
         "    F - Fingerprint (long)\n"
         "    p - Whether image is public\n"
         "    d - Description\n"
+        "    e - Project\n"
         "    a - Architecture\n"
         "    s - Size\n"
         "    u - Upload date\n"
@@ -3966,7 +3971,7 @@ msgstr  ""
 msgid   "Optimized Storage"
 msgstr  ""
 
-#: lxc/main.go:97
+#: lxc/main.go:96
 msgid   "Override the source project"
 msgstr  ""
 
@@ -4008,7 +4013,7 @@ msgstr  ""
 msgid   "PROFILES"
 msgstr  ""
 
-#: lxc/list.go:567 lxc/storage_volume.go:1762 lxc/warning.go:213
+#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1762 lxc/warning.go:213
 msgid   "PROJECT"
 msgstr  ""
 
@@ -4016,7 +4021,7 @@ msgstr  ""
 msgid   "PROTOCOL"
 msgstr  ""
 
-#: lxc/image.go:1136 lxc/remote.go:853
+#: lxc/image.go:1145 lxc/remote.go:853
 msgid   "PUBLIC"
 msgstr  ""
 
@@ -4032,7 +4037,7 @@ msgstr  ""
 msgid   "Partitions:"
 msgstr  ""
 
-#: lxc/main.go:368
+#: lxc/main.go:367
 #, c-format
 msgid   "Password for %s: "
 msgstr  ""
@@ -4082,7 +4087,7 @@ msgstr  ""
 msgid   "Pretty rendering (short for --format=pretty)"
 msgstr  ""
 
-#: lxc/main.go:95
+#: lxc/main.go:94
 msgid   "Print help"
 msgstr  ""
 
@@ -4090,7 +4095,7 @@ msgstr  ""
 msgid   "Print the raw response"
 msgstr  ""
 
-#: lxc/main.go:94
+#: lxc/main.go:93
 msgid   "Print version number"
 msgstr  ""
 
@@ -4187,7 +4192,7 @@ msgstr  ""
 msgid   "Properties:"
 msgstr  ""
 
-#: lxc/image.go:1621
+#: lxc/image.go:1654
 msgid   "Property not found"
 msgstr  ""
 
@@ -4301,7 +4306,7 @@ msgstr  ""
 msgid   "Query path must start with /"
 msgstr  ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
 msgid   "Query virtual machine images"
 msgstr  ""
 
@@ -4338,7 +4343,7 @@ msgstr  ""
 msgid   "Refresh and update the existing storage volume copies"
 msgstr  ""
 
-#: lxc/image.go:1416 lxc/image.go:1417
+#: lxc/image.go:1449 lxc/image.go:1450
 msgid   "Refresh images"
 msgstr  ""
 
@@ -4347,7 +4352,7 @@ msgstr  ""
 msgid   "Refreshing instance: %s"
 msgstr  ""
 
-#: lxc/image.go:1453
+#: lxc/image.go:1486
 #, c-format
 msgid   "Refreshing the image: %s"
 msgstr  ""
@@ -4606,7 +4611,7 @@ msgstr  ""
 msgid   "Retrieve the container's console log"
 msgstr  ""
 
-#: lxc/init.go:356
+#: lxc/init.go:357
 #, c-format
 msgid   "Retrieving image: %s"
 msgstr  ""
@@ -4639,7 +4644,7 @@ msgstr  ""
 msgid   "SEVERITY"
 msgstr  ""
 
-#: lxc/image.go:1139
+#: lxc/image.go:1146
 msgid   "SIZE"
 msgstr  ""
 
@@ -4757,7 +4762,7 @@ msgid   "Set device configuration keys\n"
         "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr  ""
 
-#: lxc/image.go:1637 lxc/image.go:1638
+#: lxc/image.go:1670 lxc/image.go:1671
 msgid   "Set image properties"
 msgstr  ""
 
@@ -4985,11 +4990,11 @@ msgstr  ""
 msgid   "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr  ""
 
-#: lxc/main.go:98
+#: lxc/main.go:97
 msgid   "Show all debug messages"
 msgstr  ""
 
-#: lxc/main.go:99
+#: lxc/main.go:98
 msgid   "Show all information messages"
 msgstr  ""
 
@@ -5034,7 +5039,7 @@ msgid   "Show identity configurations\n"
         "method. Use the identifier instead if this occurs.\n"
 msgstr  ""
 
-#: lxc/image.go:1507 lxc/image.go:1508
+#: lxc/image.go:1540 lxc/image.go:1541
 msgid   "Show image properties"
 msgstr  ""
 
@@ -5054,7 +5059,7 @@ msgstr  ""
 msgid   "Show instance or server information"
 msgstr  ""
 
-#: lxc/main.go:272 lxc/main.go:273
+#: lxc/main.go:271 lxc/main.go:272
 msgid   "Show less common commands"
 msgstr  ""
 
@@ -5376,7 +5381,7 @@ msgstr  ""
 msgid   "TOKEN"
 msgstr  ""
 
-#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1141 lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082 lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172 lxc/storage_volume.go:1736 lxc/warning.go:216
+#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147 lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082 lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172 lxc/storage_volume.go:1736 lxc/warning.go:216
 msgid   "TYPE"
 msgstr  ""
 
@@ -5440,7 +5445,7 @@ msgstr  ""
 msgid   "The instance is currently running. Use --force to have it stopped and restarted"
 msgstr  ""
 
-#: lxc/init.go:434
+#: lxc/init.go:435
 msgid   "The instance you are starting doesn't have any network attached to it."
 msgstr  ""
 
@@ -5583,7 +5588,7 @@ msgstr  ""
 msgid   "This LXD server is not available on the network"
 msgstr  ""
 
-#: lxc/main.go:299
+#: lxc/main.go:298
 msgid   "This client hasn't been configured to use a remote LXD server yet.\n"
         "As your platform can't run native Linux instances, you must connect to a remote LXD server.\n"
         "\n"
@@ -5603,11 +5608,11 @@ msgstr  ""
 msgid   "Timestamps:"
 msgstr  ""
 
-#: lxc/init.go:436
+#: lxc/init.go:437
 msgid   "To attach a network to an instance, use: lxc network attach"
 msgstr  ""
 
-#: lxc/init.go:435
+#: lxc/init.go:436
 msgid   "To create a new network, use: lxc network create"
 msgstr  ""
 
@@ -5615,7 +5620,7 @@ msgstr  ""
 msgid   "To detach from the console, press: <ctrl>+a q"
 msgstr  ""
 
-#: lxc/main.go:411
+#: lxc/main.go:410
 msgid   "To start your first container, try: lxc launch ubuntu:24.04\n"
         "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr  ""
@@ -5717,7 +5722,7 @@ msgstr  ""
 msgid   "UNLIMITED"
 msgstr  ""
 
-#: lxc/image.go:1140
+#: lxc/image.go:1148
 msgid   "UPLOAD DATE"
 msgstr  ""
 
@@ -5761,7 +5766,7 @@ msgstr  ""
 msgid   "Unknown channel type for client %q: %s"
 msgstr  ""
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1778 lxc/warning.go:242
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1778 lxc/warning.go:242
 #, c-format
 msgid   "Unknown column shorthand char '%c' in '%s'"
 msgstr  ""
@@ -5802,7 +5807,7 @@ msgstr  ""
 msgid   "Unset device configuration keys"
 msgstr  ""
 
-#: lxc/image.go:1700 lxc/image.go:1701
+#: lxc/image.go:1733 lxc/image.go:1734
 msgid   "Unset image properties"
 msgstr  ""
 
@@ -5969,7 +5974,7 @@ msgstr  ""
 msgid   "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr  ""
 
-#: lxc/main.go:101
+#: lxc/main.go:100
 msgid   "Use with help or --help to view sub-commands"
 msgstr  ""
 
@@ -6111,7 +6116,7 @@ msgstr  ""
 msgid   "[<remote>:] [<cert>]"
 msgstr  ""
 
-#: lxc/image.go:1087 lxc/list.go:46
+#: lxc/image.go:1088 lxc/list.go:46
 msgid   "[<remote>:] [<filter>...]"
 msgstr  ""
 
@@ -6223,15 +6228,15 @@ msgstr  ""
 msgid   "[<remote>:]<identity_provider_group> <new_name>"
 msgstr  ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
 msgid   "[<remote>:]<image>"
 msgstr  ""
 
-#: lxc/image.go:1572 lxc/image.go:1699
+#: lxc/image.go:1605 lxc/image.go:1732
 msgid   "[<remote>:]<image> <key>"
 msgstr  ""
 
-#: lxc/image.go:1636
+#: lxc/image.go:1669
 msgid   "[<remote>:]<image> <key> <value>"
 msgstr  ""
 
@@ -6251,7 +6256,7 @@ msgstr  ""
 msgid   "[<remote>:]<image> [<target>]"
 msgstr  ""
 
-#: lxc/image.go:334 lxc/image.go:1415
+#: lxc/image.go:334 lxc/image.go:1448
 msgid   "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr  ""
 
@@ -7097,7 +7102,7 @@ msgstr  ""
 msgid   "name"
 msgstr  ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
+#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
 msgid   "no"
 msgstr  ""
 
@@ -7142,7 +7147,7 @@ msgstr  ""
 msgid   "y"
 msgstr  ""
 
-#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001 lxc/image.go:1194
+#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001 lxc/image.go:1206
 msgid   "yes"
 msgstr  ""
 

--- a/po/mr.po
+++ b/po/mr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-11-18 20:34-0300\n"
+"POT-Creation-Date: 2024-11-21 15:57-0700\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Marathi <https://hosted.weblate.org/projects/linux-containers/"
@@ -423,7 +423,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1168
+#: lxc/image.go:1180
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -544,11 +544,11 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1133
+#: lxc/image.go:1144
 msgid "ALIASES"
 msgstr ""
 
@@ -769,7 +769,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:342 lxc/rebuild.go:131
+#: lxc/init.go:343 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1172,7 +1172,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1595
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1595
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1502,7 +1502,7 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:186
+#: lxc/init.go:182
 #, c-format
 msgid "Creating %s"
 msgstr ""
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: lxc/init.go:184
+#: lxc/init.go:180
 msgid "Creating the instance"
 msgstr ""
 
@@ -1526,7 +1526,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -1693,8 +1693,8 @@ msgstr ""
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1090 lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574
-#: lxc/image.go:1638 lxc/image.go:1701 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
+#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:402
+#: lxc/init.go:403
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1880,6 +1880,10 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
+#: lxc/image.go:1119
+msgid "Display images from all projects"
+msgstr ""
+
 #: lxc/list.go:135
 msgid "Display instances from all projects"
 msgstr ""
@@ -1888,7 +1892,7 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:100
+#: lxc/main.go:99
 msgid "Don't show progress information"
 msgstr ""
 
@@ -2023,7 +2027,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1772
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2196,7 +2200,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
+#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2400,7 +2404,7 @@ msgstr ""
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:96
+#: lxc/main.go:95
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -2431,7 +2435,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2506,7 +2510,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1573 lxc/image.go:1574
+#: lxc/image.go:1606 lxc/image.go:1607
 msgid "Get image properties"
 msgstr ""
 
@@ -2762,7 +2766,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:405
+#: lxc/main.go:404
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2784,7 +2788,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1489
+#: lxc/image.go:1522
 msgid "Image already up to date."
 msgstr ""
 
@@ -2800,11 +2804,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1444
+#: lxc/image.go:364 lxc/image.go:1477
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1670
+#: lxc/image.go:444 lxc/image.go:1703
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2814,7 +2818,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1520
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2895,7 +2899,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:413
+#: lxc/init.go:414
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2994,7 +2998,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:507
+#: lxc/main.go:506
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3087,12 +3091,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/init.go:180
+#: lxc/init.go:176
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: lxc/init.go:178
+#: lxc/init.go:174
 msgid "Launching the instance"
 msgstr ""
 
@@ -3201,11 +3205,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1089
+#: lxc/image.go:1090
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid ""
 "List images\n"
 "\n"
@@ -3226,6 +3230,7 @@ msgid ""
 "    F - Fingerprint (long)\n"
 "    p - Whether image is public\n"
 "    d - Description\n"
+"    e - Project\n"
 "    a - Architecture\n"
 "    s - Size\n"
 "    u - Upload date\n"
@@ -4322,7 +4327,7 @@ msgstr ""
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:96
 msgid "Override the source project"
 msgstr ""
 
@@ -4364,7 +4369,8 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:567 lxc/storage_volume.go:1762 lxc/warning.go:213
+#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1762
+#: lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4372,7 +4378,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:853
+#: lxc/image.go:1145 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4388,7 +4394,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:368
+#: lxc/main.go:367
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4447,7 +4453,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:95
+#: lxc/main.go:94
 msgid "Print help"
 msgstr ""
 
@@ -4455,7 +4461,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:94
+#: lxc/main.go:93
 msgid "Print version number"
 msgstr ""
 
@@ -4552,7 +4558,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1621
+#: lxc/image.go:1654
 msgid "Property not found"
 msgstr ""
 
@@ -4682,7 +4688,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4719,7 +4725,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1416 lxc/image.go:1417
+#: lxc/image.go:1449 lxc/image.go:1450
 msgid "Refresh images"
 msgstr ""
 
@@ -4728,7 +4734,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1453
+#: lxc/image.go:1486
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4991,7 +4997,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:356
+#: lxc/init.go:357
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5024,7 +5030,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1139
+#: lxc/image.go:1146
 msgid "SIZE"
 msgstr ""
 
@@ -5147,7 +5153,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1637 lxc/image.go:1638
+#: lxc/image.go:1670 lxc/image.go:1671
 msgid "Set image properties"
 msgstr ""
 
@@ -5399,11 +5405,11 @@ msgstr ""
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: lxc/main.go:98
+#: lxc/main.go:97
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:99
+#: lxc/main.go:98
 msgid "Show all information messages"
 msgstr ""
 
@@ -5452,7 +5458,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1507 lxc/image.go:1508
+#: lxc/image.go:1540 lxc/image.go:1541
 msgid "Show image properties"
 msgstr ""
 
@@ -5472,7 +5478,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:272 lxc/main.go:273
+#: lxc/main.go:271 lxc/main.go:272
 msgid "Show less common commands"
 msgstr ""
 
@@ -5796,7 +5802,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1736 lxc/warning.go:216
@@ -5867,7 +5873,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:434
+#: lxc/init.go:435
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -6013,7 +6019,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:299
+#: lxc/main.go:298
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6037,11 +6043,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:436
+#: lxc/init.go:437
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:435
+#: lxc/init.go:436
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6049,7 +6055,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:411
+#: lxc/main.go:410
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6156,7 +6162,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1140
+#: lxc/image.go:1148
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6202,7 +6208,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1778
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1778
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6244,7 +6250,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1700 lxc/image.go:1701
+#: lxc/image.go:1733 lxc/image.go:1734
 msgid "Unset image properties"
 msgstr ""
 
@@ -6414,7 +6420,7 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/main.go:101
+#: lxc/main.go:100
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -6568,7 +6574,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1087 lxc/list.go:46
+#: lxc/image.go:1088 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6687,15 +6693,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1572 lxc/image.go:1699
+#: lxc/image.go:1605 lxc/image.go:1732
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1636
+#: lxc/image.go:1669
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6715,7 +6721,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1415
+#: lxc/image.go:334 lxc/image.go:1448
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -7670,7 +7676,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
+#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
 msgid "no"
 msgstr ""
 
@@ -7716,6 +7722,6 @@ msgid "y"
 msgstr ""
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1194
+#: lxc/image.go:1206
 msgid "yes"
 msgstr ""

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-11-18 20:34-0300\n"
+"POT-Creation-Date: 2024-11-21 15:57-0700\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Norwegian Bokmål <https://hosted.weblate.org/projects/linux-"
@@ -423,7 +423,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1168
+#: lxc/image.go:1180
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -544,11 +544,11 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1133
+#: lxc/image.go:1144
 msgid "ALIASES"
 msgstr ""
 
@@ -769,7 +769,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:342 lxc/rebuild.go:131
+#: lxc/init.go:343 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1172,7 +1172,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1595
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1595
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1502,7 +1502,7 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:186
+#: lxc/init.go:182
 #, c-format
 msgid "Creating %s"
 msgstr ""
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: lxc/init.go:184
+#: lxc/init.go:180
 msgid "Creating the instance"
 msgstr ""
 
@@ -1526,7 +1526,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -1693,8 +1693,8 @@ msgstr ""
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1090 lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574
-#: lxc/image.go:1638 lxc/image.go:1701 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
+#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:402
+#: lxc/init.go:403
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1880,6 +1880,10 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
+#: lxc/image.go:1119
+msgid "Display images from all projects"
+msgstr ""
+
 #: lxc/list.go:135
 msgid "Display instances from all projects"
 msgstr ""
@@ -1888,7 +1892,7 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:100
+#: lxc/main.go:99
 msgid "Don't show progress information"
 msgstr ""
 
@@ -2023,7 +2027,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1772
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2196,7 +2200,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
+#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2400,7 +2404,7 @@ msgstr ""
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:96
+#: lxc/main.go:95
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -2431,7 +2435,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2506,7 +2510,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1573 lxc/image.go:1574
+#: lxc/image.go:1606 lxc/image.go:1607
 msgid "Get image properties"
 msgstr ""
 
@@ -2762,7 +2766,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:405
+#: lxc/main.go:404
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2784,7 +2788,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1489
+#: lxc/image.go:1522
 msgid "Image already up to date."
 msgstr ""
 
@@ -2800,11 +2804,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1444
+#: lxc/image.go:364 lxc/image.go:1477
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1670
+#: lxc/image.go:444 lxc/image.go:1703
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2814,7 +2818,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1520
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2895,7 +2899,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:413
+#: lxc/init.go:414
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2994,7 +2998,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:507
+#: lxc/main.go:506
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3087,12 +3091,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/init.go:180
+#: lxc/init.go:176
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: lxc/init.go:178
+#: lxc/init.go:174
 msgid "Launching the instance"
 msgstr ""
 
@@ -3201,11 +3205,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1089
+#: lxc/image.go:1090
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid ""
 "List images\n"
 "\n"
@@ -3226,6 +3230,7 @@ msgid ""
 "    F - Fingerprint (long)\n"
 "    p - Whether image is public\n"
 "    d - Description\n"
+"    e - Project\n"
 "    a - Architecture\n"
 "    s - Size\n"
 "    u - Upload date\n"
@@ -4322,7 +4327,7 @@ msgstr ""
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:96
 msgid "Override the source project"
 msgstr ""
 
@@ -4364,7 +4369,8 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:567 lxc/storage_volume.go:1762 lxc/warning.go:213
+#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1762
+#: lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4372,7 +4378,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:853
+#: lxc/image.go:1145 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4388,7 +4394,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:368
+#: lxc/main.go:367
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4447,7 +4453,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:95
+#: lxc/main.go:94
 msgid "Print help"
 msgstr ""
 
@@ -4455,7 +4461,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:94
+#: lxc/main.go:93
 msgid "Print version number"
 msgstr ""
 
@@ -4552,7 +4558,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1621
+#: lxc/image.go:1654
 msgid "Property not found"
 msgstr ""
 
@@ -4682,7 +4688,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4719,7 +4725,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1416 lxc/image.go:1417
+#: lxc/image.go:1449 lxc/image.go:1450
 msgid "Refresh images"
 msgstr ""
 
@@ -4728,7 +4734,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1453
+#: lxc/image.go:1486
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4991,7 +4997,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:356
+#: lxc/init.go:357
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5024,7 +5030,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1139
+#: lxc/image.go:1146
 msgid "SIZE"
 msgstr ""
 
@@ -5147,7 +5153,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1637 lxc/image.go:1638
+#: lxc/image.go:1670 lxc/image.go:1671
 msgid "Set image properties"
 msgstr ""
 
@@ -5399,11 +5405,11 @@ msgstr ""
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: lxc/main.go:98
+#: lxc/main.go:97
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:99
+#: lxc/main.go:98
 msgid "Show all information messages"
 msgstr ""
 
@@ -5452,7 +5458,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1507 lxc/image.go:1508
+#: lxc/image.go:1540 lxc/image.go:1541
 msgid "Show image properties"
 msgstr ""
 
@@ -5472,7 +5478,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:272 lxc/main.go:273
+#: lxc/main.go:271 lxc/main.go:272
 msgid "Show less common commands"
 msgstr ""
 
@@ -5796,7 +5802,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1736 lxc/warning.go:216
@@ -5867,7 +5873,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:434
+#: lxc/init.go:435
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -6013,7 +6019,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:299
+#: lxc/main.go:298
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6037,11 +6043,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:436
+#: lxc/init.go:437
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:435
+#: lxc/init.go:436
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6049,7 +6055,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:411
+#: lxc/main.go:410
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6156,7 +6162,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1140
+#: lxc/image.go:1148
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6202,7 +6208,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1778
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1778
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6244,7 +6250,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1700 lxc/image.go:1701
+#: lxc/image.go:1733 lxc/image.go:1734
 msgid "Unset image properties"
 msgstr ""
 
@@ -6414,7 +6420,7 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/main.go:101
+#: lxc/main.go:100
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -6568,7 +6574,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1087 lxc/list.go:46
+#: lxc/image.go:1088 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6687,15 +6693,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1572 lxc/image.go:1699
+#: lxc/image.go:1605 lxc/image.go:1732
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1636
+#: lxc/image.go:1669
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6715,7 +6721,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1415
+#: lxc/image.go:334 lxc/image.go:1448
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -7670,7 +7676,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
+#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
 msgid "no"
 msgstr ""
 
@@ -7716,6 +7722,6 @@ msgid "y"
 msgstr ""
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1194
+#: lxc/image.go:1206
 msgid "yes"
 msgstr ""

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-11-18 20:34-0300\n"
+"POT-Creation-Date: 2024-11-21 15:57-0700\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Heimen Stoffels <vistausss@fastmail.com>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/linux-containers/"
@@ -647,7 +647,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1168
+#: lxc/image.go:1180
 #, c-format
 msgid "%s (%d more)"
 msgstr "%s (en nog %d)"
@@ -768,11 +768,11 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr "ALIAS"
 
-#: lxc/image.go:1133
+#: lxc/image.go:1144
 msgid "ALIASES"
 msgstr ""
 
@@ -993,7 +993,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:342 lxc/rebuild.go:131
+#: lxc/init.go:343 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -1098,7 +1098,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1396,7 +1396,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1595
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1595
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1726,7 +1726,7 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:186
+#: lxc/init.go:182
 #, c-format
 msgid "Creating %s"
 msgstr ""
@@ -1736,7 +1736,7 @@ msgstr ""
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: lxc/init.go:184
+#: lxc/init.go:180
 msgid "Creating the instance"
 msgstr ""
 
@@ -1750,7 +1750,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -1917,8 +1917,8 @@ msgstr ""
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1090 lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574
-#: lxc/image.go:1638 lxc/image.go:1701 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
+#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -2063,7 +2063,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:402
+#: lxc/init.go:403
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -2104,6 +2104,10 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
+#: lxc/image.go:1119
+msgid "Display images from all projects"
+msgstr ""
+
 #: lxc/list.go:135
 msgid "Display instances from all projects"
 msgstr ""
@@ -2112,7 +2116,7 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:100
+#: lxc/main.go:99
 msgid "Don't show progress information"
 msgstr ""
 
@@ -2247,7 +2251,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1772
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2420,7 +2424,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
+#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2624,7 +2628,7 @@ msgstr ""
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:96
+#: lxc/main.go:95
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -2655,7 +2659,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2730,7 +2734,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1573 lxc/image.go:1574
+#: lxc/image.go:1606 lxc/image.go:1607
 msgid "Get image properties"
 msgstr ""
 
@@ -2986,7 +2990,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:405
+#: lxc/main.go:404
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -3008,7 +3012,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1489
+#: lxc/image.go:1522
 msgid "Image already up to date."
 msgstr ""
 
@@ -3024,11 +3028,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1444
+#: lxc/image.go:364 lxc/image.go:1477
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1670
+#: lxc/image.go:444 lxc/image.go:1703
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -3038,7 +3042,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1520
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3119,7 +3123,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:413
+#: lxc/init.go:414
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -3218,7 +3222,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:507
+#: lxc/main.go:506
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3311,12 +3315,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/init.go:180
+#: lxc/init.go:176
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: lxc/init.go:178
+#: lxc/init.go:174
 msgid "Launching the instance"
 msgstr ""
 
@@ -3425,11 +3429,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1089
+#: lxc/image.go:1090
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid ""
 "List images\n"
 "\n"
@@ -3450,6 +3454,7 @@ msgid ""
 "    F - Fingerprint (long)\n"
 "    p - Whether image is public\n"
 "    d - Description\n"
+"    e - Project\n"
 "    a - Architecture\n"
 "    s - Size\n"
 "    u - Upload date\n"
@@ -4546,7 +4551,7 @@ msgstr ""
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:96
 msgid "Override the source project"
 msgstr ""
 
@@ -4588,7 +4593,8 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:567 lxc/storage_volume.go:1762 lxc/warning.go:213
+#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1762
+#: lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4596,7 +4602,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:853
+#: lxc/image.go:1145 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4612,7 +4618,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:368
+#: lxc/main.go:367
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4671,7 +4677,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:95
+#: lxc/main.go:94
 msgid "Print help"
 msgstr ""
 
@@ -4679,7 +4685,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:94
+#: lxc/main.go:93
 msgid "Print version number"
 msgstr ""
 
@@ -4776,7 +4782,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1621
+#: lxc/image.go:1654
 msgid "Property not found"
 msgstr ""
 
@@ -4906,7 +4912,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4943,7 +4949,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1416 lxc/image.go:1417
+#: lxc/image.go:1449 lxc/image.go:1450
 msgid "Refresh images"
 msgstr ""
 
@@ -4952,7 +4958,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1453
+#: lxc/image.go:1486
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5215,7 +5221,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:356
+#: lxc/init.go:357
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5248,7 +5254,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1139
+#: lxc/image.go:1146
 msgid "SIZE"
 msgstr ""
 
@@ -5371,7 +5377,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1637 lxc/image.go:1638
+#: lxc/image.go:1670 lxc/image.go:1671
 msgid "Set image properties"
 msgstr ""
 
@@ -5623,11 +5629,11 @@ msgstr ""
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: lxc/main.go:98
+#: lxc/main.go:97
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:99
+#: lxc/main.go:98
 msgid "Show all information messages"
 msgstr ""
 
@@ -5676,7 +5682,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1507 lxc/image.go:1508
+#: lxc/image.go:1540 lxc/image.go:1541
 msgid "Show image properties"
 msgstr ""
 
@@ -5696,7 +5702,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:272 lxc/main.go:273
+#: lxc/main.go:271 lxc/main.go:272
 msgid "Show less common commands"
 msgstr ""
 
@@ -6020,7 +6026,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1736 lxc/warning.go:216
@@ -6091,7 +6097,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:434
+#: lxc/init.go:435
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -6237,7 +6243,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:299
+#: lxc/main.go:298
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6261,11 +6267,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:436
+#: lxc/init.go:437
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:435
+#: lxc/init.go:436
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6273,7 +6279,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:411
+#: lxc/main.go:410
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6380,7 +6386,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1140
+#: lxc/image.go:1148
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6426,7 +6432,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1778
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1778
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6468,7 +6474,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1700 lxc/image.go:1701
+#: lxc/image.go:1733 lxc/image.go:1734
 msgid "Unset image properties"
 msgstr ""
 
@@ -6638,7 +6644,7 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/main.go:101
+#: lxc/main.go:100
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -6792,7 +6798,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1087 lxc/list.go:46
+#: lxc/image.go:1088 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6911,15 +6917,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1572 lxc/image.go:1699
+#: lxc/image.go:1605 lxc/image.go:1732
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1636
+#: lxc/image.go:1669
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6939,7 +6945,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1415
+#: lxc/image.go:334 lxc/image.go:1448
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -7894,7 +7900,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
+#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
 msgid "no"
 msgstr ""
 
@@ -7940,7 +7946,7 @@ msgid "y"
 msgstr ""
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1194
+#: lxc/image.go:1206
 msgid "yes"
 msgstr ""
 

--- a/po/pa.po
+++ b/po/pa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-11-18 20:34-0300\n"
+"POT-Creation-Date: 2024-11-21 15:57-0700\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Punjabi <https://hosted.weblate.org/projects/linux-containers/"
@@ -423,7 +423,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1168
+#: lxc/image.go:1180
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -544,11 +544,11 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1133
+#: lxc/image.go:1144
 msgid "ALIASES"
 msgstr ""
 
@@ -769,7 +769,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:342 lxc/rebuild.go:131
+#: lxc/init.go:343 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1172,7 +1172,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1595
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1595
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1502,7 +1502,7 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:186
+#: lxc/init.go:182
 #, c-format
 msgid "Creating %s"
 msgstr ""
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: lxc/init.go:184
+#: lxc/init.go:180
 msgid "Creating the instance"
 msgstr ""
 
@@ -1526,7 +1526,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -1693,8 +1693,8 @@ msgstr ""
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1090 lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574
-#: lxc/image.go:1638 lxc/image.go:1701 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
+#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:402
+#: lxc/init.go:403
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1880,6 +1880,10 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
+#: lxc/image.go:1119
+msgid "Display images from all projects"
+msgstr ""
+
 #: lxc/list.go:135
 msgid "Display instances from all projects"
 msgstr ""
@@ -1888,7 +1892,7 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:100
+#: lxc/main.go:99
 msgid "Don't show progress information"
 msgstr ""
 
@@ -2023,7 +2027,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1772
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2196,7 +2200,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
+#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2400,7 +2404,7 @@ msgstr ""
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:96
+#: lxc/main.go:95
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -2431,7 +2435,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2506,7 +2510,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1573 lxc/image.go:1574
+#: lxc/image.go:1606 lxc/image.go:1607
 msgid "Get image properties"
 msgstr ""
 
@@ -2762,7 +2766,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:405
+#: lxc/main.go:404
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2784,7 +2788,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1489
+#: lxc/image.go:1522
 msgid "Image already up to date."
 msgstr ""
 
@@ -2800,11 +2804,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1444
+#: lxc/image.go:364 lxc/image.go:1477
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1670
+#: lxc/image.go:444 lxc/image.go:1703
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2814,7 +2818,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1520
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2895,7 +2899,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:413
+#: lxc/init.go:414
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2994,7 +2998,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:507
+#: lxc/main.go:506
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3087,12 +3091,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/init.go:180
+#: lxc/init.go:176
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: lxc/init.go:178
+#: lxc/init.go:174
 msgid "Launching the instance"
 msgstr ""
 
@@ -3201,11 +3205,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1089
+#: lxc/image.go:1090
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid ""
 "List images\n"
 "\n"
@@ -3226,6 +3230,7 @@ msgid ""
 "    F - Fingerprint (long)\n"
 "    p - Whether image is public\n"
 "    d - Description\n"
+"    e - Project\n"
 "    a - Architecture\n"
 "    s - Size\n"
 "    u - Upload date\n"
@@ -4322,7 +4327,7 @@ msgstr ""
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:96
 msgid "Override the source project"
 msgstr ""
 
@@ -4364,7 +4369,8 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:567 lxc/storage_volume.go:1762 lxc/warning.go:213
+#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1762
+#: lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4372,7 +4378,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:853
+#: lxc/image.go:1145 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4388,7 +4394,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:368
+#: lxc/main.go:367
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4447,7 +4453,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:95
+#: lxc/main.go:94
 msgid "Print help"
 msgstr ""
 
@@ -4455,7 +4461,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:94
+#: lxc/main.go:93
 msgid "Print version number"
 msgstr ""
 
@@ -4552,7 +4558,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1621
+#: lxc/image.go:1654
 msgid "Property not found"
 msgstr ""
 
@@ -4682,7 +4688,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4719,7 +4725,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1416 lxc/image.go:1417
+#: lxc/image.go:1449 lxc/image.go:1450
 msgid "Refresh images"
 msgstr ""
 
@@ -4728,7 +4734,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1453
+#: lxc/image.go:1486
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4991,7 +4997,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:356
+#: lxc/init.go:357
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5024,7 +5030,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1139
+#: lxc/image.go:1146
 msgid "SIZE"
 msgstr ""
 
@@ -5147,7 +5153,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1637 lxc/image.go:1638
+#: lxc/image.go:1670 lxc/image.go:1671
 msgid "Set image properties"
 msgstr ""
 
@@ -5399,11 +5405,11 @@ msgstr ""
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: lxc/main.go:98
+#: lxc/main.go:97
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:99
+#: lxc/main.go:98
 msgid "Show all information messages"
 msgstr ""
 
@@ -5452,7 +5458,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1507 lxc/image.go:1508
+#: lxc/image.go:1540 lxc/image.go:1541
 msgid "Show image properties"
 msgstr ""
 
@@ -5472,7 +5478,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:272 lxc/main.go:273
+#: lxc/main.go:271 lxc/main.go:272
 msgid "Show less common commands"
 msgstr ""
 
@@ -5796,7 +5802,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1736 lxc/warning.go:216
@@ -5867,7 +5873,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:434
+#: lxc/init.go:435
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -6013,7 +6019,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:299
+#: lxc/main.go:298
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6037,11 +6043,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:436
+#: lxc/init.go:437
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:435
+#: lxc/init.go:436
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6049,7 +6055,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:411
+#: lxc/main.go:410
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6156,7 +6162,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1140
+#: lxc/image.go:1148
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6202,7 +6208,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1778
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1778
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6244,7 +6250,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1700 lxc/image.go:1701
+#: lxc/image.go:1733 lxc/image.go:1734
 msgid "Unset image properties"
 msgstr ""
 
@@ -6414,7 +6420,7 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/main.go:101
+#: lxc/main.go:100
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -6568,7 +6574,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1087 lxc/list.go:46
+#: lxc/image.go:1088 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6687,15 +6693,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1572 lxc/image.go:1699
+#: lxc/image.go:1605 lxc/image.go:1732
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1636
+#: lxc/image.go:1669
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6715,7 +6721,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1415
+#: lxc/image.go:334 lxc/image.go:1448
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -7670,7 +7676,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
+#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
 msgid "no"
 msgstr ""
 
@@ -7716,6 +7722,6 @@ msgid "y"
 msgstr ""
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1194
+#: lxc/image.go:1206
 msgid "yes"
 msgstr ""

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-11-18 20:34-0300\n"
+"POT-Creation-Date: 2024-11-21 15:57-0700\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/linux-containers/"
@@ -685,7 +685,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1168
+#: lxc/image.go:1180
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -806,11 +806,11 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1133
+#: lxc/image.go:1144
 msgid "ALIASES"
 msgstr ""
 
@@ -1031,7 +1031,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:342 lxc/rebuild.go:131
+#: lxc/init.go:343 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -1136,7 +1136,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1434,7 +1434,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1595
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1595
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1764,7 +1764,7 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:186
+#: lxc/init.go:182
 #, c-format
 msgid "Creating %s"
 msgstr ""
@@ -1774,7 +1774,7 @@ msgstr ""
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: lxc/init.go:184
+#: lxc/init.go:180
 msgid "Creating the instance"
 msgstr ""
 
@@ -1788,7 +1788,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -1955,8 +1955,8 @@ msgstr ""
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1090 lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574
-#: lxc/image.go:1638 lxc/image.go:1701 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
+#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -2101,7 +2101,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:402
+#: lxc/init.go:403
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -2142,6 +2142,10 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
+#: lxc/image.go:1119
+msgid "Display images from all projects"
+msgstr ""
+
 #: lxc/list.go:135
 msgid "Display instances from all projects"
 msgstr ""
@@ -2150,7 +2154,7 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:100
+#: lxc/main.go:99
 msgid "Don't show progress information"
 msgstr ""
 
@@ -2285,7 +2289,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1772
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2458,7 +2462,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
+#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2662,7 +2666,7 @@ msgstr ""
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:96
+#: lxc/main.go:95
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -2693,7 +2697,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2768,7 +2772,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1573 lxc/image.go:1574
+#: lxc/image.go:1606 lxc/image.go:1607
 msgid "Get image properties"
 msgstr ""
 
@@ -3024,7 +3028,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:405
+#: lxc/main.go:404
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -3046,7 +3050,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1489
+#: lxc/image.go:1522
 msgid "Image already up to date."
 msgstr ""
 
@@ -3062,11 +3066,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1444
+#: lxc/image.go:364 lxc/image.go:1477
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1670
+#: lxc/image.go:444 lxc/image.go:1703
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -3076,7 +3080,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1520
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3157,7 +3161,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:413
+#: lxc/init.go:414
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -3256,7 +3260,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:507
+#: lxc/main.go:506
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3349,12 +3353,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/init.go:180
+#: lxc/init.go:176
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: lxc/init.go:178
+#: lxc/init.go:174
 msgid "Launching the instance"
 msgstr ""
 
@@ -3463,11 +3467,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1089
+#: lxc/image.go:1090
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid ""
 "List images\n"
 "\n"
@@ -3488,6 +3492,7 @@ msgid ""
 "    F - Fingerprint (long)\n"
 "    p - Whether image is public\n"
 "    d - Description\n"
+"    e - Project\n"
 "    a - Architecture\n"
 "    s - Size\n"
 "    u - Upload date\n"
@@ -4584,7 +4589,7 @@ msgstr ""
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:96
 msgid "Override the source project"
 msgstr ""
 
@@ -4626,7 +4631,8 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:567 lxc/storage_volume.go:1762 lxc/warning.go:213
+#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1762
+#: lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4634,7 +4640,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:853
+#: lxc/image.go:1145 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4650,7 +4656,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:368
+#: lxc/main.go:367
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4709,7 +4715,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:95
+#: lxc/main.go:94
 msgid "Print help"
 msgstr ""
 
@@ -4717,7 +4723,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:94
+#: lxc/main.go:93
 msgid "Print version number"
 msgstr ""
 
@@ -4814,7 +4820,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1621
+#: lxc/image.go:1654
 msgid "Property not found"
 msgstr ""
 
@@ -4944,7 +4950,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4981,7 +4987,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1416 lxc/image.go:1417
+#: lxc/image.go:1449 lxc/image.go:1450
 msgid "Refresh images"
 msgstr ""
 
@@ -4990,7 +4996,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1453
+#: lxc/image.go:1486
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5253,7 +5259,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:356
+#: lxc/init.go:357
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5286,7 +5292,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1139
+#: lxc/image.go:1146
 msgid "SIZE"
 msgstr ""
 
@@ -5409,7 +5415,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1637 lxc/image.go:1638
+#: lxc/image.go:1670 lxc/image.go:1671
 msgid "Set image properties"
 msgstr ""
 
@@ -5661,11 +5667,11 @@ msgstr ""
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: lxc/main.go:98
+#: lxc/main.go:97
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:99
+#: lxc/main.go:98
 msgid "Show all information messages"
 msgstr ""
 
@@ -5714,7 +5720,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1507 lxc/image.go:1508
+#: lxc/image.go:1540 lxc/image.go:1541
 msgid "Show image properties"
 msgstr ""
 
@@ -5734,7 +5740,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:272 lxc/main.go:273
+#: lxc/main.go:271 lxc/main.go:272
 msgid "Show less common commands"
 msgstr ""
 
@@ -6058,7 +6064,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1736 lxc/warning.go:216
@@ -6129,7 +6135,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:434
+#: lxc/init.go:435
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -6275,7 +6281,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:299
+#: lxc/main.go:298
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6299,11 +6305,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:436
+#: lxc/init.go:437
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:435
+#: lxc/init.go:436
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6311,7 +6317,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:411
+#: lxc/main.go:410
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6418,7 +6424,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1140
+#: lxc/image.go:1148
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6464,7 +6470,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1778
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1778
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6506,7 +6512,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1700 lxc/image.go:1701
+#: lxc/image.go:1733 lxc/image.go:1734
 msgid "Unset image properties"
 msgstr ""
 
@@ -6676,7 +6682,7 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/main.go:101
+#: lxc/main.go:100
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -6830,7 +6836,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1087 lxc/list.go:46
+#: lxc/image.go:1088 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6949,15 +6955,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1572 lxc/image.go:1699
+#: lxc/image.go:1605 lxc/image.go:1732
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1636
+#: lxc/image.go:1669
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6977,7 +6983,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1415
+#: lxc/image.go:334 lxc/image.go:1448
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -7932,7 +7938,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
+#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
 msgid "no"
 msgstr ""
 
@@ -7978,7 +7984,7 @@ msgid "y"
 msgstr ""
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1194
+#: lxc/image.go:1206
 msgid "yes"
 msgstr ""
 

--- a/po/pt.po
+++ b/po/pt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-11-18 20:34-0300\n"
+"POT-Creation-Date: 2024-11-21 15:57-0700\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -420,7 +420,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1168
+#: lxc/image.go:1180
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -541,11 +541,11 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1133
+#: lxc/image.go:1144
 msgid "ALIASES"
 msgstr ""
 
@@ -766,7 +766,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:342 lxc/rebuild.go:131
+#: lxc/init.go:343 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -871,7 +871,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1169,7 +1169,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1595
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1595
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1499,7 +1499,7 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:186
+#: lxc/init.go:182
 #, c-format
 msgid "Creating %s"
 msgstr ""
@@ -1509,7 +1509,7 @@ msgstr ""
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: lxc/init.go:184
+#: lxc/init.go:180
 msgid "Creating the instance"
 msgstr ""
 
@@ -1523,7 +1523,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -1690,8 +1690,8 @@ msgstr ""
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1090 lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574
-#: lxc/image.go:1638 lxc/image.go:1701 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
+#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1836,7 +1836,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:402
+#: lxc/init.go:403
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1877,6 +1877,10 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
+#: lxc/image.go:1119
+msgid "Display images from all projects"
+msgstr ""
+
 #: lxc/list.go:135
 msgid "Display instances from all projects"
 msgstr ""
@@ -1885,7 +1889,7 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:100
+#: lxc/main.go:99
 msgid "Don't show progress information"
 msgstr ""
 
@@ -2020,7 +2024,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1772
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2193,7 +2197,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
+#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2397,7 +2401,7 @@ msgstr ""
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:96
+#: lxc/main.go:95
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -2428,7 +2432,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2503,7 +2507,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1573 lxc/image.go:1574
+#: lxc/image.go:1606 lxc/image.go:1607
 msgid "Get image properties"
 msgstr ""
 
@@ -2759,7 +2763,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:405
+#: lxc/main.go:404
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2781,7 +2785,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1489
+#: lxc/image.go:1522
 msgid "Image already up to date."
 msgstr ""
 
@@ -2797,11 +2801,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1444
+#: lxc/image.go:364 lxc/image.go:1477
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1670
+#: lxc/image.go:444 lxc/image.go:1703
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2811,7 +2815,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1520
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2892,7 +2896,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:413
+#: lxc/init.go:414
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2991,7 +2995,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:507
+#: lxc/main.go:506
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3084,12 +3088,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/init.go:180
+#: lxc/init.go:176
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: lxc/init.go:178
+#: lxc/init.go:174
 msgid "Launching the instance"
 msgstr ""
 
@@ -3198,11 +3202,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1089
+#: lxc/image.go:1090
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid ""
 "List images\n"
 "\n"
@@ -3223,6 +3227,7 @@ msgid ""
 "    F - Fingerprint (long)\n"
 "    p - Whether image is public\n"
 "    d - Description\n"
+"    e - Project\n"
 "    a - Architecture\n"
 "    s - Size\n"
 "    u - Upload date\n"
@@ -4319,7 +4324,7 @@ msgstr ""
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:96
 msgid "Override the source project"
 msgstr ""
 
@@ -4361,7 +4366,8 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:567 lxc/storage_volume.go:1762 lxc/warning.go:213
+#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1762
+#: lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4369,7 +4375,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:853
+#: lxc/image.go:1145 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4385,7 +4391,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:368
+#: lxc/main.go:367
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4444,7 +4450,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:95
+#: lxc/main.go:94
 msgid "Print help"
 msgstr ""
 
@@ -4452,7 +4458,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:94
+#: lxc/main.go:93
 msgid "Print version number"
 msgstr ""
 
@@ -4549,7 +4555,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1621
+#: lxc/image.go:1654
 msgid "Property not found"
 msgstr ""
 
@@ -4679,7 +4685,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4716,7 +4722,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1416 lxc/image.go:1417
+#: lxc/image.go:1449 lxc/image.go:1450
 msgid "Refresh images"
 msgstr ""
 
@@ -4725,7 +4731,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1453
+#: lxc/image.go:1486
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4988,7 +4994,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:356
+#: lxc/init.go:357
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5021,7 +5027,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1139
+#: lxc/image.go:1146
 msgid "SIZE"
 msgstr ""
 
@@ -5144,7 +5150,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1637 lxc/image.go:1638
+#: lxc/image.go:1670 lxc/image.go:1671
 msgid "Set image properties"
 msgstr ""
 
@@ -5396,11 +5402,11 @@ msgstr ""
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: lxc/main.go:98
+#: lxc/main.go:97
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:99
+#: lxc/main.go:98
 msgid "Show all information messages"
 msgstr ""
 
@@ -5449,7 +5455,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1507 lxc/image.go:1508
+#: lxc/image.go:1540 lxc/image.go:1541
 msgid "Show image properties"
 msgstr ""
 
@@ -5469,7 +5475,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:272 lxc/main.go:273
+#: lxc/main.go:271 lxc/main.go:272
 msgid "Show less common commands"
 msgstr ""
 
@@ -5793,7 +5799,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1736 lxc/warning.go:216
@@ -5864,7 +5870,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:434
+#: lxc/init.go:435
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -6010,7 +6016,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:299
+#: lxc/main.go:298
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6034,11 +6040,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:436
+#: lxc/init.go:437
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:435
+#: lxc/init.go:436
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6046,7 +6052,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:411
+#: lxc/main.go:410
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6153,7 +6159,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1140
+#: lxc/image.go:1148
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6199,7 +6205,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1778
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1778
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6241,7 +6247,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1700 lxc/image.go:1701
+#: lxc/image.go:1733 lxc/image.go:1734
 msgid "Unset image properties"
 msgstr ""
 
@@ -6411,7 +6417,7 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/main.go:101
+#: lxc/main.go:100
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -6565,7 +6571,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1087 lxc/list.go:46
+#: lxc/image.go:1088 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6684,15 +6690,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1572 lxc/image.go:1699
+#: lxc/image.go:1605 lxc/image.go:1732
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1636
+#: lxc/image.go:1669
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6712,7 +6718,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1415
+#: lxc/image.go:334 lxc/image.go:1448
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -7667,7 +7673,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
+#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
 msgid "no"
 msgstr ""
 
@@ -7713,6 +7719,6 @@ msgid "y"
 msgstr ""
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1194
+#: lxc/image.go:1206
 msgid "yes"
 msgstr ""

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-11-18 20:34-0300\n"
+"POT-Creation-Date: 2024-11-21 15:57-0700\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Renato dos Santos <renato.santos@wplex.com.br>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -671,7 +671,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr "%d (id: %d, online: %v, NUMA nó: %v)"
 
-#: lxc/image.go:1168
+#: lxc/image.go:1180
 #, c-format
 msgid "%s (%d more)"
 msgstr "%s (%d mais)"
@@ -803,11 +803,11 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr "ALIAS"
 
-#: lxc/image.go:1133
+#: lxc/image.go:1144
 msgid "ALIASES"
 msgstr "ALIASES"
 
@@ -1038,7 +1038,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:342 lxc/rebuild.go:131
+#: lxc/init.go:343 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -1150,7 +1150,7 @@ msgstr "Erro de sintaxe, esperado <dispositivo>,<chave>=<valor>: %s"
 msgid "Bad key/value pair: %s"
 msgstr "par de chave/valor inválido %s"
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "par de chave=valor inválido %s"
@@ -1452,7 +1452,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr "Clustering ativado"
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1595
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1595
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr "Colunas"
@@ -1812,7 +1812,7 @@ msgstr ""
 msgid "Created: %s"
 msgstr "Criado: %s"
 
-#: lxc/init.go:186
+#: lxc/init.go:182
 #, c-format
 msgid "Creating %s"
 msgstr "Criando %s"
@@ -1822,7 +1822,7 @@ msgstr "Criando %s"
 msgid "Creating %s: %%s"
 msgstr "Criando %s"
 
-#: lxc/init.go:184
+#: lxc/init.go:180
 #, fuzzy
 msgid "Creating the instance"
 msgstr "Criando %s"
@@ -1837,7 +1837,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -2018,8 +2018,8 @@ msgstr ""
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1090 lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574
-#: lxc/image.go:1638 lxc/image.go:1701 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
+#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -2168,7 +2168,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr "Em cache: %s"
 
-#: lxc/init.go:402
+#: lxc/init.go:403
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -2211,6 +2211,11 @@ msgstr "Uso de disco:"
 msgid "Disks:"
 msgstr "Uso de disco:"
 
+#: lxc/image.go:1119
+#, fuzzy
+msgid "Display images from all projects"
+msgstr "Criar projetos"
+
 #: lxc/list.go:135
 msgid "Display instances from all projects"
 msgstr ""
@@ -2219,7 +2224,7 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:100
+#: lxc/main.go:99
 msgid "Don't show progress information"
 msgstr ""
 
@@ -2373,7 +2378,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1772
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2547,7 +2552,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
+#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2752,7 +2757,7 @@ msgstr "Ignorar o estado do container"
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:96
+#: lxc/main.go:95
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -2783,7 +2788,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2859,7 +2864,7 @@ msgstr "Adicionar perfis aos containers"
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1573 lxc/image.go:1574
+#: lxc/image.go:1606 lxc/image.go:1607
 #, fuzzy
 msgid "Get image properties"
 msgstr "Editar propriedades da imagem"
@@ -3134,7 +3139,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:405
+#: lxc/main.go:404
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -3157,7 +3162,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr "Ignorar o estado do container"
 
-#: lxc/image.go:1489
+#: lxc/image.go:1522
 msgid "Image already up to date."
 msgstr ""
 
@@ -3173,11 +3178,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr "Imagem exportada com sucesso!"
 
-#: lxc/image.go:364 lxc/image.go:1444
+#: lxc/image.go:364 lxc/image.go:1477
 msgid "Image identifier missing"
 msgstr "Falta o identificador da imagem"
 
-#: lxc/image.go:444 lxc/image.go:1670
+#: lxc/image.go:444 lxc/image.go:1703
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr "Falta o identificador da imagem: %s"
@@ -3187,7 +3192,7 @@ msgstr "Falta o identificador da imagem: %s"
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1520
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3269,7 +3274,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:413
+#: lxc/init.go:414
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -3369,7 +3374,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:507
+#: lxc/main.go:506
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3463,12 +3468,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/init.go:180
+#: lxc/init.go:176
 #, fuzzy, c-format
 msgid "Launching %s"
 msgstr "Criando %s"
 
-#: lxc/init.go:178
+#: lxc/init.go:174
 #, fuzzy
 msgid "Launching the instance"
 msgstr "Criando %s"
@@ -3583,11 +3588,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1089
+#: lxc/image.go:1090
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid ""
 "List images\n"
 "\n"
@@ -3608,6 +3613,7 @@ msgid ""
 "    F - Fingerprint (long)\n"
 "    p - Whether image is public\n"
 "    d - Description\n"
+"    e - Project\n"
 "    a - Architecture\n"
 "    s - Size\n"
 "    u - Upload date\n"
@@ -4752,7 +4758,7 @@ msgstr ""
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:96
 msgid "Override the source project"
 msgstr ""
 
@@ -4794,7 +4800,8 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:567 lxc/storage_volume.go:1762 lxc/warning.go:213
+#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1762
+#: lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4802,7 +4809,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:853
+#: lxc/image.go:1145 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4818,7 +4825,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:368
+#: lxc/main.go:367
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4878,7 +4885,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:95
+#: lxc/main.go:94
 msgid "Print help"
 msgstr ""
 
@@ -4886,7 +4893,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:94
+#: lxc/main.go:93
 msgid "Print version number"
 msgstr ""
 
@@ -4988,7 +4995,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1621
+#: lxc/image.go:1654
 msgid "Property not found"
 msgstr ""
 
@@ -5119,7 +5126,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -5158,7 +5165,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1416 lxc/image.go:1417
+#: lxc/image.go:1449 lxc/image.go:1450
 msgid "Refresh images"
 msgstr ""
 
@@ -5167,7 +5174,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr "Editar arquivos no container"
 
-#: lxc/image.go:1453
+#: lxc/image.go:1486
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5454,7 +5461,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:356
+#: lxc/init.go:357
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5490,7 +5497,7 @@ msgstr "Criar projetos"
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1139
+#: lxc/image.go:1146
 msgid "SIZE"
 msgstr ""
 
@@ -5616,7 +5623,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1637 lxc/image.go:1638
+#: lxc/image.go:1670 lxc/image.go:1671
 #, fuzzy
 msgid "Set image properties"
 msgstr "Editar propriedades da imagem"
@@ -5885,11 +5892,11 @@ msgstr ""
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: lxc/main.go:98
+#: lxc/main.go:97
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:99
+#: lxc/main.go:98
 msgid "Show all information messages"
 msgstr ""
 
@@ -5942,7 +5949,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1507 lxc/image.go:1508
+#: lxc/image.go:1540 lxc/image.go:1541
 msgid "Show image properties"
 msgstr ""
 
@@ -5966,7 +5973,7 @@ msgstr "Editar configurações do container ou do servidor como YAML"
 msgid "Show instance or server information"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: lxc/main.go:272 lxc/main.go:273
+#: lxc/main.go:271 lxc/main.go:272
 msgid "Show less common commands"
 msgstr ""
 
@@ -6304,7 +6311,7 @@ msgstr "Certificado fingerprint: %s"
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1736 lxc/warning.go:216
@@ -6379,7 +6386,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:434
+#: lxc/init.go:435
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -6527,7 +6534,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr "A importação de diretório não está disponível nessa plataforma"
 
-#: lxc/main.go:299
+#: lxc/main.go:298
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6551,11 +6558,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:436
+#: lxc/init.go:437
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:435
+#: lxc/init.go:436
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6563,7 +6570,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:411
+#: lxc/main.go:410
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6672,7 +6679,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1140
+#: lxc/image.go:1148
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6719,7 +6726,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1778
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1778
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6765,7 +6772,7 @@ msgstr "Não pode fornecer um nome para a imagem de destino"
 msgid "Unset device configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/image.go:1700 lxc/image.go:1701
+#: lxc/image.go:1733 lxc/image.go:1734
 #, fuzzy
 msgid "Unset image properties"
 msgstr "Editar propriedades da imagem"
@@ -6957,7 +6964,7 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/main.go:101
+#: lxc/main.go:100
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -7115,7 +7122,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr "Criar perfis"
 
-#: lxc/image.go:1087 lxc/list.go:46
+#: lxc/image.go:1088 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -7252,16 +7259,16 @@ msgstr "Editar templates de arquivo do container"
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr "Criar perfis"
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1572 lxc/image.go:1699
+#: lxc/image.go:1605 lxc/image.go:1732
 #, fuzzy
 msgid "[<remote>:]<image> <key>"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/image.go:1636
+#: lxc/image.go:1669
 #, fuzzy
 msgid "[<remote>:]<image> <key> <value>"
 msgstr "Editar templates de arquivo do container"
@@ -7283,7 +7290,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1415
+#: lxc/image.go:334 lxc/image.go:1448
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -8289,7 +8296,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
+#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
 msgid "no"
 msgstr ""
 
@@ -8335,7 +8342,7 @@ msgid "y"
 msgstr ""
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1194
+#: lxc/image.go:1206
 msgid "yes"
 msgstr "sim"
 

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-11-18 20:34-0300\n"
+"POT-Creation-Date: 2024-11-21 15:57-0700\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Александр Киль <shorrey@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -680,7 +680,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1168
+#: lxc/image.go:1180
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -806,11 +806,11 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr "ПСЕВДОНИМ"
 
-#: lxc/image.go:1133
+#: lxc/image.go:1144
 #, fuzzy
 msgid "ALIASES"
 msgstr "ПСЕВДОНИМ"
@@ -1039,7 +1039,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:342 lxc/rebuild.go:131
+#: lxc/init.go:343 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -1147,7 +1147,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "Имя контейнера: %s"
@@ -1452,7 +1452,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1595
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1595
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr "Столбцы"
@@ -1803,7 +1803,7 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:186
+#: lxc/init.go:182
 #, c-format
 msgid "Creating %s"
 msgstr ""
@@ -1813,7 +1813,7 @@ msgstr ""
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: lxc/init.go:184
+#: lxc/init.go:180
 #, fuzzy
 msgid "Creating the instance"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -1828,7 +1828,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -2005,8 +2005,8 @@ msgstr ""
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1090 lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574
-#: lxc/image.go:1638 lxc/image.go:1701 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
+#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -2153,7 +2153,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:402
+#: lxc/init.go:403
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -2197,6 +2197,11 @@ msgstr " Использование диска:"
 msgid "Disks:"
 msgstr " Использование диска:"
 
+#: lxc/image.go:1119
+#, fuzzy
+msgid "Display images from all projects"
+msgstr "Копирование образа: %s"
+
 #: lxc/list.go:135
 #, fuzzy
 msgid "Display instances from all projects"
@@ -2206,7 +2211,7 @@ msgstr "Копирование образа: %s"
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:100
+#: lxc/main.go:99
 msgid "Don't show progress information"
 msgstr ""
 
@@ -2350,7 +2355,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1772
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2532,7 +2537,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
+#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2737,7 +2742,7 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:96
+#: lxc/main.go:95
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -2768,7 +2773,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2844,7 +2849,7 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1573 lxc/image.go:1574
+#: lxc/image.go:1606 lxc/image.go:1607
 msgid "Get image properties"
 msgstr ""
 
@@ -3116,7 +3121,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:405
+#: lxc/main.go:404
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -3139,7 +3144,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/image.go:1489
+#: lxc/image.go:1522
 msgid "Image already up to date."
 msgstr ""
 
@@ -3155,11 +3160,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1444
+#: lxc/image.go:364 lxc/image.go:1477
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1670
+#: lxc/image.go:444 lxc/image.go:1703
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -3169,7 +3174,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1520
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3255,7 +3260,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr "Имя контейнера является обязательным"
 
-#: lxc/init.go:413
+#: lxc/init.go:414
 #, fuzzy, c-format
 msgid "Instance name is: %s"
 msgstr "Имя контейнера: %s"
@@ -3356,7 +3361,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:507
+#: lxc/main.go:506
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3450,12 +3455,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/init.go:180
+#: lxc/init.go:176
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: lxc/init.go:178
+#: lxc/init.go:174
 #, fuzzy
 msgid "Launching the instance"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -3573,11 +3578,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1089
+#: lxc/image.go:1090
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid ""
 "List images\n"
 "\n"
@@ -3598,6 +3603,7 @@ msgid ""
 "    F - Fingerprint (long)\n"
 "    p - Whether image is public\n"
 "    d - Description\n"
+"    e - Project\n"
 "    a - Architecture\n"
 "    s - Size\n"
 "    u - Upload date\n"
@@ -4758,7 +4764,7 @@ msgstr ""
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:96
 msgid "Override the source project"
 msgstr ""
 
@@ -4800,7 +4806,8 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:567 lxc/storage_volume.go:1762 lxc/warning.go:213
+#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1762
+#: lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4808,7 +4815,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:853
+#: lxc/image.go:1145 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4824,7 +4831,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:368
+#: lxc/main.go:367
 #, fuzzy, c-format
 msgid "Password for %s: "
 msgstr "Пароль администратора для %s: "
@@ -4884,7 +4891,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:95
+#: lxc/main.go:94
 msgid "Print help"
 msgstr ""
 
@@ -4892,7 +4899,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:94
+#: lxc/main.go:93
 msgid "Print version number"
 msgstr ""
 
@@ -4989,7 +4996,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1621
+#: lxc/image.go:1654
 msgid "Property not found"
 msgstr ""
 
@@ -5119,7 +5126,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -5159,7 +5166,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr "Копирование образа: %s"
 
-#: lxc/image.go:1416 lxc/image.go:1417
+#: lxc/image.go:1449 lxc/image.go:1450
 #, fuzzy
 msgid "Refresh images"
 msgstr "Копирование образа: %s"
@@ -5169,7 +5176,7 @@ msgstr "Копирование образа: %s"
 msgid "Refreshing instance: %s"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/image.go:1453
+#: lxc/image.go:1486
 #, fuzzy, c-format
 msgid "Refreshing the image: %s"
 msgstr "Копирование образа: %s"
@@ -5449,7 +5456,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:356
+#: lxc/init.go:357
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5485,7 +5492,7 @@ msgstr "Доступные команды:"
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1139
+#: lxc/image.go:1146
 msgid "SIZE"
 msgstr ""
 
@@ -5610,7 +5617,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1637 lxc/image.go:1638
+#: lxc/image.go:1670 lxc/image.go:1671
 msgid "Set image properties"
 msgstr ""
 
@@ -5876,11 +5883,11 @@ msgstr ""
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: lxc/main.go:98
+#: lxc/main.go:97
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:99
+#: lxc/main.go:98
 msgid "Show all information messages"
 msgstr ""
 
@@ -5932,7 +5939,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1507 lxc/image.go:1508
+#: lxc/image.go:1540 lxc/image.go:1541
 msgid "Show image properties"
 msgstr ""
 
@@ -5954,7 +5961,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:272 lxc/main.go:273
+#: lxc/main.go:271 lxc/main.go:272
 msgid "Show less common commands"
 msgstr ""
 
@@ -6295,7 +6302,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1736 lxc/warning.go:216
@@ -6366,7 +6373,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:434
+#: lxc/init.go:435
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -6513,7 +6520,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:299
+#: lxc/main.go:298
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6537,11 +6544,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:436
+#: lxc/init.go:437
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:435
+#: lxc/init.go:436
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6549,7 +6556,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:411
+#: lxc/main.go:410
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6657,7 +6664,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1140
+#: lxc/image.go:1148
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6703,7 +6710,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1778
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1778
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6747,7 +6754,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1700 lxc/image.go:1701
+#: lxc/image.go:1733 lxc/image.go:1734
 msgid "Unset image properties"
 msgstr ""
 
@@ -6937,7 +6944,7 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/main.go:101
+#: lxc/main.go:100
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -7119,7 +7126,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/image.go:1087 lxc/list.go:46
+#: lxc/image.go:1088 lxc/list.go:46
 #, fuzzy
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
@@ -7334,7 +7341,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
 #, fuzzy
 msgid "[<remote>:]<image>"
 msgstr ""
@@ -7342,7 +7349,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/image.go:1572 lxc/image.go:1699
+#: lxc/image.go:1605 lxc/image.go:1732
 #, fuzzy
 msgid "[<remote>:]<image> <key>"
 msgstr ""
@@ -7350,7 +7357,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/image.go:1636
+#: lxc/image.go:1669
 #, fuzzy
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
@@ -7390,7 +7397,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/image.go:334 lxc/image.go:1415
+#: lxc/image.go:334 lxc/image.go:1448
 #, fuzzy
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
@@ -8777,7 +8784,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
+#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
 msgid "no"
 msgstr ""
 
@@ -8823,7 +8830,7 @@ msgid "y"
 msgstr ""
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1194
+#: lxc/image.go:1206
 msgid "yes"
 msgstr "да"
 

--- a/po/si.po
+++ b/po/si.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-11-18 20:34-0300\n"
+"POT-Creation-Date: 2024-11-21 15:57-0700\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Sinhala <https://hosted.weblate.org/projects/linux-containers/"
@@ -423,7 +423,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1168
+#: lxc/image.go:1180
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -544,11 +544,11 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1133
+#: lxc/image.go:1144
 msgid "ALIASES"
 msgstr ""
 
@@ -769,7 +769,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:342 lxc/rebuild.go:131
+#: lxc/init.go:343 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1172,7 +1172,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1595
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1595
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1502,7 +1502,7 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:186
+#: lxc/init.go:182
 #, c-format
 msgid "Creating %s"
 msgstr ""
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: lxc/init.go:184
+#: lxc/init.go:180
 msgid "Creating the instance"
 msgstr ""
 
@@ -1526,7 +1526,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -1693,8 +1693,8 @@ msgstr ""
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1090 lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574
-#: lxc/image.go:1638 lxc/image.go:1701 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
+#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:402
+#: lxc/init.go:403
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1880,6 +1880,10 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
+#: lxc/image.go:1119
+msgid "Display images from all projects"
+msgstr ""
+
 #: lxc/list.go:135
 msgid "Display instances from all projects"
 msgstr ""
@@ -1888,7 +1892,7 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:100
+#: lxc/main.go:99
 msgid "Don't show progress information"
 msgstr ""
 
@@ -2023,7 +2027,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1772
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2196,7 +2200,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
+#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2400,7 +2404,7 @@ msgstr ""
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:96
+#: lxc/main.go:95
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -2431,7 +2435,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2506,7 +2510,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1573 lxc/image.go:1574
+#: lxc/image.go:1606 lxc/image.go:1607
 msgid "Get image properties"
 msgstr ""
 
@@ -2762,7 +2766,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:405
+#: lxc/main.go:404
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2784,7 +2788,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1489
+#: lxc/image.go:1522
 msgid "Image already up to date."
 msgstr ""
 
@@ -2800,11 +2804,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1444
+#: lxc/image.go:364 lxc/image.go:1477
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1670
+#: lxc/image.go:444 lxc/image.go:1703
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2814,7 +2818,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1520
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2895,7 +2899,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:413
+#: lxc/init.go:414
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2994,7 +2998,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:507
+#: lxc/main.go:506
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3087,12 +3091,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/init.go:180
+#: lxc/init.go:176
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: lxc/init.go:178
+#: lxc/init.go:174
 msgid "Launching the instance"
 msgstr ""
 
@@ -3201,11 +3205,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1089
+#: lxc/image.go:1090
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid ""
 "List images\n"
 "\n"
@@ -3226,6 +3230,7 @@ msgid ""
 "    F - Fingerprint (long)\n"
 "    p - Whether image is public\n"
 "    d - Description\n"
+"    e - Project\n"
 "    a - Architecture\n"
 "    s - Size\n"
 "    u - Upload date\n"
@@ -4322,7 +4327,7 @@ msgstr ""
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:96
 msgid "Override the source project"
 msgstr ""
 
@@ -4364,7 +4369,8 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:567 lxc/storage_volume.go:1762 lxc/warning.go:213
+#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1762
+#: lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4372,7 +4378,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:853
+#: lxc/image.go:1145 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4388,7 +4394,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:368
+#: lxc/main.go:367
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4447,7 +4453,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:95
+#: lxc/main.go:94
 msgid "Print help"
 msgstr ""
 
@@ -4455,7 +4461,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:94
+#: lxc/main.go:93
 msgid "Print version number"
 msgstr ""
 
@@ -4552,7 +4558,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1621
+#: lxc/image.go:1654
 msgid "Property not found"
 msgstr ""
 
@@ -4682,7 +4688,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4719,7 +4725,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1416 lxc/image.go:1417
+#: lxc/image.go:1449 lxc/image.go:1450
 msgid "Refresh images"
 msgstr ""
 
@@ -4728,7 +4734,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1453
+#: lxc/image.go:1486
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4991,7 +4997,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:356
+#: lxc/init.go:357
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5024,7 +5030,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1139
+#: lxc/image.go:1146
 msgid "SIZE"
 msgstr ""
 
@@ -5147,7 +5153,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1637 lxc/image.go:1638
+#: lxc/image.go:1670 lxc/image.go:1671
 msgid "Set image properties"
 msgstr ""
 
@@ -5399,11 +5405,11 @@ msgstr ""
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: lxc/main.go:98
+#: lxc/main.go:97
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:99
+#: lxc/main.go:98
 msgid "Show all information messages"
 msgstr ""
 
@@ -5452,7 +5458,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1507 lxc/image.go:1508
+#: lxc/image.go:1540 lxc/image.go:1541
 msgid "Show image properties"
 msgstr ""
 
@@ -5472,7 +5478,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:272 lxc/main.go:273
+#: lxc/main.go:271 lxc/main.go:272
 msgid "Show less common commands"
 msgstr ""
 
@@ -5796,7 +5802,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1736 lxc/warning.go:216
@@ -5867,7 +5873,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:434
+#: lxc/init.go:435
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -6013,7 +6019,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:299
+#: lxc/main.go:298
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6037,11 +6043,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:436
+#: lxc/init.go:437
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:435
+#: lxc/init.go:436
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6049,7 +6055,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:411
+#: lxc/main.go:410
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6156,7 +6162,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1140
+#: lxc/image.go:1148
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6202,7 +6208,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1778
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1778
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6244,7 +6250,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1700 lxc/image.go:1701
+#: lxc/image.go:1733 lxc/image.go:1734
 msgid "Unset image properties"
 msgstr ""
 
@@ -6414,7 +6420,7 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/main.go:101
+#: lxc/main.go:100
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -6568,7 +6574,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1087 lxc/list.go:46
+#: lxc/image.go:1088 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6687,15 +6693,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1572 lxc/image.go:1699
+#: lxc/image.go:1605 lxc/image.go:1732
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1636
+#: lxc/image.go:1669
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6715,7 +6721,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1415
+#: lxc/image.go:334 lxc/image.go:1448
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -7670,7 +7676,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
+#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
 msgid "no"
 msgstr ""
 
@@ -7716,6 +7722,6 @@ msgid "y"
 msgstr ""
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1194
+#: lxc/image.go:1206
 msgid "yes"
 msgstr ""

--- a/po/sl.po
+++ b/po/sl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-11-18 20:34-0300\n"
+"POT-Creation-Date: 2024-11-21 15:57-0700\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Slovenian <https://hosted.weblate.org/projects/linux-"
@@ -424,7 +424,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1168
+#: lxc/image.go:1180
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -545,11 +545,11 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1133
+#: lxc/image.go:1144
 msgid "ALIASES"
 msgstr ""
 
@@ -770,7 +770,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:342 lxc/rebuild.go:131
+#: lxc/init.go:343 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -875,7 +875,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1173,7 +1173,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1595
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1595
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1503,7 +1503,7 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:186
+#: lxc/init.go:182
 #, c-format
 msgid "Creating %s"
 msgstr ""
@@ -1513,7 +1513,7 @@ msgstr ""
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: lxc/init.go:184
+#: lxc/init.go:180
 msgid "Creating the instance"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -1694,8 +1694,8 @@ msgstr ""
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1090 lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574
-#: lxc/image.go:1638 lxc/image.go:1701 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
+#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1840,7 +1840,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:402
+#: lxc/init.go:403
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1881,6 +1881,10 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
+#: lxc/image.go:1119
+msgid "Display images from all projects"
+msgstr ""
+
 #: lxc/list.go:135
 msgid "Display instances from all projects"
 msgstr ""
@@ -1889,7 +1893,7 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:100
+#: lxc/main.go:99
 msgid "Don't show progress information"
 msgstr ""
 
@@ -2024,7 +2028,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1772
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2197,7 +2201,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
+#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2401,7 +2405,7 @@ msgstr ""
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:96
+#: lxc/main.go:95
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -2432,7 +2436,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2507,7 +2511,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1573 lxc/image.go:1574
+#: lxc/image.go:1606 lxc/image.go:1607
 msgid "Get image properties"
 msgstr ""
 
@@ -2763,7 +2767,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:405
+#: lxc/main.go:404
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2785,7 +2789,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1489
+#: lxc/image.go:1522
 msgid "Image already up to date."
 msgstr ""
 
@@ -2801,11 +2805,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1444
+#: lxc/image.go:364 lxc/image.go:1477
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1670
+#: lxc/image.go:444 lxc/image.go:1703
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2815,7 +2819,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1520
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2896,7 +2900,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:413
+#: lxc/init.go:414
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2995,7 +2999,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:507
+#: lxc/main.go:506
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3088,12 +3092,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/init.go:180
+#: lxc/init.go:176
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: lxc/init.go:178
+#: lxc/init.go:174
 msgid "Launching the instance"
 msgstr ""
 
@@ -3202,11 +3206,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1089
+#: lxc/image.go:1090
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid ""
 "List images\n"
 "\n"
@@ -3227,6 +3231,7 @@ msgid ""
 "    F - Fingerprint (long)\n"
 "    p - Whether image is public\n"
 "    d - Description\n"
+"    e - Project\n"
 "    a - Architecture\n"
 "    s - Size\n"
 "    u - Upload date\n"
@@ -4323,7 +4328,7 @@ msgstr ""
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:96
 msgid "Override the source project"
 msgstr ""
 
@@ -4365,7 +4370,8 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:567 lxc/storage_volume.go:1762 lxc/warning.go:213
+#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1762
+#: lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4373,7 +4379,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:853
+#: lxc/image.go:1145 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4389,7 +4395,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:368
+#: lxc/main.go:367
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4448,7 +4454,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:95
+#: lxc/main.go:94
 msgid "Print help"
 msgstr ""
 
@@ -4456,7 +4462,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:94
+#: lxc/main.go:93
 msgid "Print version number"
 msgstr ""
 
@@ -4553,7 +4559,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1621
+#: lxc/image.go:1654
 msgid "Property not found"
 msgstr ""
 
@@ -4683,7 +4689,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4720,7 +4726,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1416 lxc/image.go:1417
+#: lxc/image.go:1449 lxc/image.go:1450
 msgid "Refresh images"
 msgstr ""
 
@@ -4729,7 +4735,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1453
+#: lxc/image.go:1486
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4992,7 +4998,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:356
+#: lxc/init.go:357
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5025,7 +5031,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1139
+#: lxc/image.go:1146
 msgid "SIZE"
 msgstr ""
 
@@ -5148,7 +5154,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1637 lxc/image.go:1638
+#: lxc/image.go:1670 lxc/image.go:1671
 msgid "Set image properties"
 msgstr ""
 
@@ -5400,11 +5406,11 @@ msgstr ""
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: lxc/main.go:98
+#: lxc/main.go:97
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:99
+#: lxc/main.go:98
 msgid "Show all information messages"
 msgstr ""
 
@@ -5453,7 +5459,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1507 lxc/image.go:1508
+#: lxc/image.go:1540 lxc/image.go:1541
 msgid "Show image properties"
 msgstr ""
 
@@ -5473,7 +5479,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:272 lxc/main.go:273
+#: lxc/main.go:271 lxc/main.go:272
 msgid "Show less common commands"
 msgstr ""
 
@@ -5797,7 +5803,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1736 lxc/warning.go:216
@@ -5868,7 +5874,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:434
+#: lxc/init.go:435
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -6014,7 +6020,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:299
+#: lxc/main.go:298
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6038,11 +6044,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:436
+#: lxc/init.go:437
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:435
+#: lxc/init.go:436
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6050,7 +6056,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:411
+#: lxc/main.go:410
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6157,7 +6163,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1140
+#: lxc/image.go:1148
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6203,7 +6209,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1778
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1778
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6245,7 +6251,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1700 lxc/image.go:1701
+#: lxc/image.go:1733 lxc/image.go:1734
 msgid "Unset image properties"
 msgstr ""
 
@@ -6415,7 +6421,7 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/main.go:101
+#: lxc/main.go:100
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -6569,7 +6575,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1087 lxc/list.go:46
+#: lxc/image.go:1088 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6688,15 +6694,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1572 lxc/image.go:1699
+#: lxc/image.go:1605 lxc/image.go:1732
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1636
+#: lxc/image.go:1669
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6716,7 +6722,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1415
+#: lxc/image.go:334 lxc/image.go:1448
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -7671,7 +7677,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
+#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
 msgid "no"
 msgstr ""
 
@@ -7717,6 +7723,6 @@ msgid "y"
 msgstr ""
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1194
+#: lxc/image.go:1206
 msgid "yes"
 msgstr ""

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-11-18 20:34-0300\n"
+"POT-Creation-Date: 2024-11-21 15:57-0700\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Serbian <https://hosted.weblate.org/projects/linux-containers/"
@@ -424,7 +424,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1168
+#: lxc/image.go:1180
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -545,11 +545,11 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1133
+#: lxc/image.go:1144
 msgid "ALIASES"
 msgstr ""
 
@@ -770,7 +770,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:342 lxc/rebuild.go:131
+#: lxc/init.go:343 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -875,7 +875,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1173,7 +1173,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1595
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1595
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1503,7 +1503,7 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:186
+#: lxc/init.go:182
 #, c-format
 msgid "Creating %s"
 msgstr ""
@@ -1513,7 +1513,7 @@ msgstr ""
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: lxc/init.go:184
+#: lxc/init.go:180
 msgid "Creating the instance"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -1694,8 +1694,8 @@ msgstr ""
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1090 lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574
-#: lxc/image.go:1638 lxc/image.go:1701 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
+#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1840,7 +1840,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:402
+#: lxc/init.go:403
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1881,6 +1881,10 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
+#: lxc/image.go:1119
+msgid "Display images from all projects"
+msgstr ""
+
 #: lxc/list.go:135
 msgid "Display instances from all projects"
 msgstr ""
@@ -1889,7 +1893,7 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:100
+#: lxc/main.go:99
 msgid "Don't show progress information"
 msgstr ""
 
@@ -2024,7 +2028,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1772
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2197,7 +2201,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
+#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2401,7 +2405,7 @@ msgstr ""
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:96
+#: lxc/main.go:95
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -2432,7 +2436,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2507,7 +2511,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1573 lxc/image.go:1574
+#: lxc/image.go:1606 lxc/image.go:1607
 msgid "Get image properties"
 msgstr ""
 
@@ -2763,7 +2767,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:405
+#: lxc/main.go:404
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2785,7 +2789,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1489
+#: lxc/image.go:1522
 msgid "Image already up to date."
 msgstr ""
 
@@ -2801,11 +2805,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1444
+#: lxc/image.go:364 lxc/image.go:1477
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1670
+#: lxc/image.go:444 lxc/image.go:1703
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2815,7 +2819,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1520
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2896,7 +2900,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:413
+#: lxc/init.go:414
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2995,7 +2999,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:507
+#: lxc/main.go:506
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3088,12 +3092,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/init.go:180
+#: lxc/init.go:176
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: lxc/init.go:178
+#: lxc/init.go:174
 msgid "Launching the instance"
 msgstr ""
 
@@ -3202,11 +3206,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1089
+#: lxc/image.go:1090
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid ""
 "List images\n"
 "\n"
@@ -3227,6 +3231,7 @@ msgid ""
 "    F - Fingerprint (long)\n"
 "    p - Whether image is public\n"
 "    d - Description\n"
+"    e - Project\n"
 "    a - Architecture\n"
 "    s - Size\n"
 "    u - Upload date\n"
@@ -4323,7 +4328,7 @@ msgstr ""
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:96
 msgid "Override the source project"
 msgstr ""
 
@@ -4365,7 +4370,8 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:567 lxc/storage_volume.go:1762 lxc/warning.go:213
+#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1762
+#: lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4373,7 +4379,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:853
+#: lxc/image.go:1145 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4389,7 +4395,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:368
+#: lxc/main.go:367
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4448,7 +4454,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:95
+#: lxc/main.go:94
 msgid "Print help"
 msgstr ""
 
@@ -4456,7 +4462,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:94
+#: lxc/main.go:93
 msgid "Print version number"
 msgstr ""
 
@@ -4553,7 +4559,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1621
+#: lxc/image.go:1654
 msgid "Property not found"
 msgstr ""
 
@@ -4683,7 +4689,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4720,7 +4726,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1416 lxc/image.go:1417
+#: lxc/image.go:1449 lxc/image.go:1450
 msgid "Refresh images"
 msgstr ""
 
@@ -4729,7 +4735,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1453
+#: lxc/image.go:1486
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4992,7 +4998,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:356
+#: lxc/init.go:357
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5025,7 +5031,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1139
+#: lxc/image.go:1146
 msgid "SIZE"
 msgstr ""
 
@@ -5148,7 +5154,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1637 lxc/image.go:1638
+#: lxc/image.go:1670 lxc/image.go:1671
 msgid "Set image properties"
 msgstr ""
 
@@ -5400,11 +5406,11 @@ msgstr ""
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: lxc/main.go:98
+#: lxc/main.go:97
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:99
+#: lxc/main.go:98
 msgid "Show all information messages"
 msgstr ""
 
@@ -5453,7 +5459,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1507 lxc/image.go:1508
+#: lxc/image.go:1540 lxc/image.go:1541
 msgid "Show image properties"
 msgstr ""
 
@@ -5473,7 +5479,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:272 lxc/main.go:273
+#: lxc/main.go:271 lxc/main.go:272
 msgid "Show less common commands"
 msgstr ""
 
@@ -5797,7 +5803,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1736 lxc/warning.go:216
@@ -5868,7 +5874,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:434
+#: lxc/init.go:435
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -6014,7 +6020,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:299
+#: lxc/main.go:298
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6038,11 +6044,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:436
+#: lxc/init.go:437
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:435
+#: lxc/init.go:436
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6050,7 +6056,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:411
+#: lxc/main.go:410
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6157,7 +6163,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1140
+#: lxc/image.go:1148
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6203,7 +6209,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1778
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1778
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6245,7 +6251,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1700 lxc/image.go:1701
+#: lxc/image.go:1733 lxc/image.go:1734
 msgid "Unset image properties"
 msgstr ""
 
@@ -6415,7 +6421,7 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/main.go:101
+#: lxc/main.go:100
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -6569,7 +6575,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1087 lxc/list.go:46
+#: lxc/image.go:1088 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6688,15 +6694,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1572 lxc/image.go:1699
+#: lxc/image.go:1605 lxc/image.go:1732
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1636
+#: lxc/image.go:1669
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6716,7 +6722,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1415
+#: lxc/image.go:334 lxc/image.go:1448
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -7671,7 +7677,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
+#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
 msgid "no"
 msgstr ""
 
@@ -7717,6 +7723,6 @@ msgid "y"
 msgstr ""
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1194
+#: lxc/image.go:1206
 msgid "yes"
 msgstr ""

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-11-18 20:34-0300\n"
+"POT-Creation-Date: 2024-11-21 15:57-0700\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Swedish <https://hosted.weblate.org/projects/linux-containers/"
@@ -423,7 +423,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1168
+#: lxc/image.go:1180
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -544,11 +544,11 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1133
+#: lxc/image.go:1144
 msgid "ALIASES"
 msgstr ""
 
@@ -769,7 +769,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:342 lxc/rebuild.go:131
+#: lxc/init.go:343 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1172,7 +1172,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1595
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1595
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1502,7 +1502,7 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:186
+#: lxc/init.go:182
 #, c-format
 msgid "Creating %s"
 msgstr ""
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: lxc/init.go:184
+#: lxc/init.go:180
 msgid "Creating the instance"
 msgstr ""
 
@@ -1526,7 +1526,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -1693,8 +1693,8 @@ msgstr ""
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1090 lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574
-#: lxc/image.go:1638 lxc/image.go:1701 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
+#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:402
+#: lxc/init.go:403
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1880,6 +1880,10 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
+#: lxc/image.go:1119
+msgid "Display images from all projects"
+msgstr ""
+
 #: lxc/list.go:135
 msgid "Display instances from all projects"
 msgstr ""
@@ -1888,7 +1892,7 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:100
+#: lxc/main.go:99
 msgid "Don't show progress information"
 msgstr ""
 
@@ -2023,7 +2027,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1772
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2196,7 +2200,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
+#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2400,7 +2404,7 @@ msgstr ""
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:96
+#: lxc/main.go:95
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -2431,7 +2435,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2506,7 +2510,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1573 lxc/image.go:1574
+#: lxc/image.go:1606 lxc/image.go:1607
 msgid "Get image properties"
 msgstr ""
 
@@ -2762,7 +2766,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:405
+#: lxc/main.go:404
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2784,7 +2788,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1489
+#: lxc/image.go:1522
 msgid "Image already up to date."
 msgstr ""
 
@@ -2800,11 +2804,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1444
+#: lxc/image.go:364 lxc/image.go:1477
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1670
+#: lxc/image.go:444 lxc/image.go:1703
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2814,7 +2818,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1520
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2895,7 +2899,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:413
+#: lxc/init.go:414
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2994,7 +2998,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:507
+#: lxc/main.go:506
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3087,12 +3091,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/init.go:180
+#: lxc/init.go:176
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: lxc/init.go:178
+#: lxc/init.go:174
 msgid "Launching the instance"
 msgstr ""
 
@@ -3201,11 +3205,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1089
+#: lxc/image.go:1090
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid ""
 "List images\n"
 "\n"
@@ -3226,6 +3230,7 @@ msgid ""
 "    F - Fingerprint (long)\n"
 "    p - Whether image is public\n"
 "    d - Description\n"
+"    e - Project\n"
 "    a - Architecture\n"
 "    s - Size\n"
 "    u - Upload date\n"
@@ -4322,7 +4327,7 @@ msgstr ""
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:96
 msgid "Override the source project"
 msgstr ""
 
@@ -4364,7 +4369,8 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:567 lxc/storage_volume.go:1762 lxc/warning.go:213
+#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1762
+#: lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4372,7 +4378,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:853
+#: lxc/image.go:1145 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4388,7 +4394,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:368
+#: lxc/main.go:367
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4447,7 +4453,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:95
+#: lxc/main.go:94
 msgid "Print help"
 msgstr ""
 
@@ -4455,7 +4461,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:94
+#: lxc/main.go:93
 msgid "Print version number"
 msgstr ""
 
@@ -4552,7 +4558,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1621
+#: lxc/image.go:1654
 msgid "Property not found"
 msgstr ""
 
@@ -4682,7 +4688,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4719,7 +4725,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1416 lxc/image.go:1417
+#: lxc/image.go:1449 lxc/image.go:1450
 msgid "Refresh images"
 msgstr ""
 
@@ -4728,7 +4734,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1453
+#: lxc/image.go:1486
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4991,7 +4997,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:356
+#: lxc/init.go:357
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5024,7 +5030,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1139
+#: lxc/image.go:1146
 msgid "SIZE"
 msgstr ""
 
@@ -5147,7 +5153,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1637 lxc/image.go:1638
+#: lxc/image.go:1670 lxc/image.go:1671
 msgid "Set image properties"
 msgstr ""
 
@@ -5399,11 +5405,11 @@ msgstr ""
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: lxc/main.go:98
+#: lxc/main.go:97
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:99
+#: lxc/main.go:98
 msgid "Show all information messages"
 msgstr ""
 
@@ -5452,7 +5458,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1507 lxc/image.go:1508
+#: lxc/image.go:1540 lxc/image.go:1541
 msgid "Show image properties"
 msgstr ""
 
@@ -5472,7 +5478,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:272 lxc/main.go:273
+#: lxc/main.go:271 lxc/main.go:272
 msgid "Show less common commands"
 msgstr ""
 
@@ -5796,7 +5802,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1736 lxc/warning.go:216
@@ -5867,7 +5873,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:434
+#: lxc/init.go:435
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -6013,7 +6019,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:299
+#: lxc/main.go:298
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6037,11 +6043,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:436
+#: lxc/init.go:437
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:435
+#: lxc/init.go:436
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6049,7 +6055,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:411
+#: lxc/main.go:410
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6156,7 +6162,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1140
+#: lxc/image.go:1148
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6202,7 +6208,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1778
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1778
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6244,7 +6250,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1700 lxc/image.go:1701
+#: lxc/image.go:1733 lxc/image.go:1734
 msgid "Unset image properties"
 msgstr ""
 
@@ -6414,7 +6420,7 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/main.go:101
+#: lxc/main.go:100
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -6568,7 +6574,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1087 lxc/list.go:46
+#: lxc/image.go:1088 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6687,15 +6693,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1572 lxc/image.go:1699
+#: lxc/image.go:1605 lxc/image.go:1732
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1636
+#: lxc/image.go:1669
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6715,7 +6721,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1415
+#: lxc/image.go:334 lxc/image.go:1448
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -7670,7 +7676,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
+#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
 msgid "no"
 msgstr ""
 
@@ -7716,6 +7722,6 @@ msgid "y"
 msgstr ""
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1194
+#: lxc/image.go:1206
 msgid "yes"
 msgstr ""

--- a/po/te.po
+++ b/po/te.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-11-18 20:34-0300\n"
+"POT-Creation-Date: 2024-11-21 15:57-0700\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Telugu <https://hosted.weblate.org/projects/linux-containers/"
@@ -423,7 +423,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1168
+#: lxc/image.go:1180
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -544,11 +544,11 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1133
+#: lxc/image.go:1144
 msgid "ALIASES"
 msgstr ""
 
@@ -769,7 +769,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:342 lxc/rebuild.go:131
+#: lxc/init.go:343 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1172,7 +1172,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1595
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1595
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1502,7 +1502,7 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:186
+#: lxc/init.go:182
 #, c-format
 msgid "Creating %s"
 msgstr ""
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: lxc/init.go:184
+#: lxc/init.go:180
 msgid "Creating the instance"
 msgstr ""
 
@@ -1526,7 +1526,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -1693,8 +1693,8 @@ msgstr ""
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1090 lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574
-#: lxc/image.go:1638 lxc/image.go:1701 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
+#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:402
+#: lxc/init.go:403
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1880,6 +1880,10 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
+#: lxc/image.go:1119
+msgid "Display images from all projects"
+msgstr ""
+
 #: lxc/list.go:135
 msgid "Display instances from all projects"
 msgstr ""
@@ -1888,7 +1892,7 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:100
+#: lxc/main.go:99
 msgid "Don't show progress information"
 msgstr ""
 
@@ -2023,7 +2027,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1772
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2196,7 +2200,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
+#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2400,7 +2404,7 @@ msgstr ""
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:96
+#: lxc/main.go:95
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -2431,7 +2435,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2506,7 +2510,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1573 lxc/image.go:1574
+#: lxc/image.go:1606 lxc/image.go:1607
 msgid "Get image properties"
 msgstr ""
 
@@ -2762,7 +2766,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:405
+#: lxc/main.go:404
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2784,7 +2788,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1489
+#: lxc/image.go:1522
 msgid "Image already up to date."
 msgstr ""
 
@@ -2800,11 +2804,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1444
+#: lxc/image.go:364 lxc/image.go:1477
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1670
+#: lxc/image.go:444 lxc/image.go:1703
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2814,7 +2818,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1520
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2895,7 +2899,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:413
+#: lxc/init.go:414
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2994,7 +2998,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:507
+#: lxc/main.go:506
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3087,12 +3091,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/init.go:180
+#: lxc/init.go:176
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: lxc/init.go:178
+#: lxc/init.go:174
 msgid "Launching the instance"
 msgstr ""
 
@@ -3201,11 +3205,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1089
+#: lxc/image.go:1090
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid ""
 "List images\n"
 "\n"
@@ -3226,6 +3230,7 @@ msgid ""
 "    F - Fingerprint (long)\n"
 "    p - Whether image is public\n"
 "    d - Description\n"
+"    e - Project\n"
 "    a - Architecture\n"
 "    s - Size\n"
 "    u - Upload date\n"
@@ -4322,7 +4327,7 @@ msgstr ""
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:96
 msgid "Override the source project"
 msgstr ""
 
@@ -4364,7 +4369,8 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:567 lxc/storage_volume.go:1762 lxc/warning.go:213
+#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1762
+#: lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4372,7 +4378,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:853
+#: lxc/image.go:1145 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4388,7 +4394,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:368
+#: lxc/main.go:367
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4447,7 +4453,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:95
+#: lxc/main.go:94
 msgid "Print help"
 msgstr ""
 
@@ -4455,7 +4461,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:94
+#: lxc/main.go:93
 msgid "Print version number"
 msgstr ""
 
@@ -4552,7 +4558,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1621
+#: lxc/image.go:1654
 msgid "Property not found"
 msgstr ""
 
@@ -4682,7 +4688,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4719,7 +4725,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1416 lxc/image.go:1417
+#: lxc/image.go:1449 lxc/image.go:1450
 msgid "Refresh images"
 msgstr ""
 
@@ -4728,7 +4734,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1453
+#: lxc/image.go:1486
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4991,7 +4997,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:356
+#: lxc/init.go:357
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5024,7 +5030,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1139
+#: lxc/image.go:1146
 msgid "SIZE"
 msgstr ""
 
@@ -5147,7 +5153,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1637 lxc/image.go:1638
+#: lxc/image.go:1670 lxc/image.go:1671
 msgid "Set image properties"
 msgstr ""
 
@@ -5399,11 +5405,11 @@ msgstr ""
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: lxc/main.go:98
+#: lxc/main.go:97
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:99
+#: lxc/main.go:98
 msgid "Show all information messages"
 msgstr ""
 
@@ -5452,7 +5458,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1507 lxc/image.go:1508
+#: lxc/image.go:1540 lxc/image.go:1541
 msgid "Show image properties"
 msgstr ""
 
@@ -5472,7 +5478,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:272 lxc/main.go:273
+#: lxc/main.go:271 lxc/main.go:272
 msgid "Show less common commands"
 msgstr ""
 
@@ -5796,7 +5802,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1736 lxc/warning.go:216
@@ -5867,7 +5873,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:434
+#: lxc/init.go:435
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -6013,7 +6019,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:299
+#: lxc/main.go:298
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6037,11 +6043,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:436
+#: lxc/init.go:437
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:435
+#: lxc/init.go:436
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6049,7 +6055,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:411
+#: lxc/main.go:410
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6156,7 +6162,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1140
+#: lxc/image.go:1148
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6202,7 +6208,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1778
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1778
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6244,7 +6250,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1700 lxc/image.go:1701
+#: lxc/image.go:1733 lxc/image.go:1734
 msgid "Unset image properties"
 msgstr ""
 
@@ -6414,7 +6420,7 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/main.go:101
+#: lxc/main.go:100
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -6568,7 +6574,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1087 lxc/list.go:46
+#: lxc/image.go:1088 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6687,15 +6693,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1572 lxc/image.go:1699
+#: lxc/image.go:1605 lxc/image.go:1732
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1636
+#: lxc/image.go:1669
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6715,7 +6721,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1415
+#: lxc/image.go:334 lxc/image.go:1448
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -7670,7 +7676,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
+#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
 msgid "no"
 msgstr ""
 
@@ -7716,6 +7722,6 @@ msgid "y"
 msgstr ""
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1194
+#: lxc/image.go:1206
 msgid "yes"
 msgstr ""

--- a/po/th.po
+++ b/po/th.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-11-18 20:34-0300\n"
+"POT-Creation-Date: 2024-11-21 15:57-0700\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -420,7 +420,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1168
+#: lxc/image.go:1180
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -541,11 +541,11 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1133
+#: lxc/image.go:1144
 msgid "ALIASES"
 msgstr ""
 
@@ -766,7 +766,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:342 lxc/rebuild.go:131
+#: lxc/init.go:343 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -871,7 +871,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1169,7 +1169,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1595
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1595
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1499,7 +1499,7 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:186
+#: lxc/init.go:182
 #, c-format
 msgid "Creating %s"
 msgstr ""
@@ -1509,7 +1509,7 @@ msgstr ""
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: lxc/init.go:184
+#: lxc/init.go:180
 msgid "Creating the instance"
 msgstr ""
 
@@ -1523,7 +1523,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -1690,8 +1690,8 @@ msgstr ""
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1090 lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574
-#: lxc/image.go:1638 lxc/image.go:1701 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
+#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1836,7 +1836,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:402
+#: lxc/init.go:403
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1877,6 +1877,10 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
+#: lxc/image.go:1119
+msgid "Display images from all projects"
+msgstr ""
+
 #: lxc/list.go:135
 msgid "Display instances from all projects"
 msgstr ""
@@ -1885,7 +1889,7 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:100
+#: lxc/main.go:99
 msgid "Don't show progress information"
 msgstr ""
 
@@ -2020,7 +2024,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1772
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2193,7 +2197,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
+#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2397,7 +2401,7 @@ msgstr ""
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:96
+#: lxc/main.go:95
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -2428,7 +2432,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2503,7 +2507,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1573 lxc/image.go:1574
+#: lxc/image.go:1606 lxc/image.go:1607
 msgid "Get image properties"
 msgstr ""
 
@@ -2759,7 +2763,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:405
+#: lxc/main.go:404
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2781,7 +2785,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1489
+#: lxc/image.go:1522
 msgid "Image already up to date."
 msgstr ""
 
@@ -2797,11 +2801,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1444
+#: lxc/image.go:364 lxc/image.go:1477
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1670
+#: lxc/image.go:444 lxc/image.go:1703
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2811,7 +2815,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1520
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2892,7 +2896,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:413
+#: lxc/init.go:414
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2991,7 +2995,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:507
+#: lxc/main.go:506
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3084,12 +3088,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/init.go:180
+#: lxc/init.go:176
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: lxc/init.go:178
+#: lxc/init.go:174
 msgid "Launching the instance"
 msgstr ""
 
@@ -3198,11 +3202,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1089
+#: lxc/image.go:1090
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid ""
 "List images\n"
 "\n"
@@ -3223,6 +3227,7 @@ msgid ""
 "    F - Fingerprint (long)\n"
 "    p - Whether image is public\n"
 "    d - Description\n"
+"    e - Project\n"
 "    a - Architecture\n"
 "    s - Size\n"
 "    u - Upload date\n"
@@ -4319,7 +4324,7 @@ msgstr ""
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:96
 msgid "Override the source project"
 msgstr ""
 
@@ -4361,7 +4366,8 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:567 lxc/storage_volume.go:1762 lxc/warning.go:213
+#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1762
+#: lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4369,7 +4375,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:853
+#: lxc/image.go:1145 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4385,7 +4391,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:368
+#: lxc/main.go:367
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4444,7 +4450,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:95
+#: lxc/main.go:94
 msgid "Print help"
 msgstr ""
 
@@ -4452,7 +4458,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:94
+#: lxc/main.go:93
 msgid "Print version number"
 msgstr ""
 
@@ -4549,7 +4555,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1621
+#: lxc/image.go:1654
 msgid "Property not found"
 msgstr ""
 
@@ -4679,7 +4685,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4716,7 +4722,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1416 lxc/image.go:1417
+#: lxc/image.go:1449 lxc/image.go:1450
 msgid "Refresh images"
 msgstr ""
 
@@ -4725,7 +4731,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1453
+#: lxc/image.go:1486
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4988,7 +4994,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:356
+#: lxc/init.go:357
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5021,7 +5027,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1139
+#: lxc/image.go:1146
 msgid "SIZE"
 msgstr ""
 
@@ -5144,7 +5150,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1637 lxc/image.go:1638
+#: lxc/image.go:1670 lxc/image.go:1671
 msgid "Set image properties"
 msgstr ""
 
@@ -5396,11 +5402,11 @@ msgstr ""
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: lxc/main.go:98
+#: lxc/main.go:97
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:99
+#: lxc/main.go:98
 msgid "Show all information messages"
 msgstr ""
 
@@ -5449,7 +5455,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1507 lxc/image.go:1508
+#: lxc/image.go:1540 lxc/image.go:1541
 msgid "Show image properties"
 msgstr ""
 
@@ -5469,7 +5475,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:272 lxc/main.go:273
+#: lxc/main.go:271 lxc/main.go:272
 msgid "Show less common commands"
 msgstr ""
 
@@ -5793,7 +5799,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1736 lxc/warning.go:216
@@ -5864,7 +5870,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:434
+#: lxc/init.go:435
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -6010,7 +6016,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:299
+#: lxc/main.go:298
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6034,11 +6040,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:436
+#: lxc/init.go:437
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:435
+#: lxc/init.go:436
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6046,7 +6052,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:411
+#: lxc/main.go:410
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6153,7 +6159,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1140
+#: lxc/image.go:1148
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6199,7 +6205,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1778
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1778
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6241,7 +6247,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1700 lxc/image.go:1701
+#: lxc/image.go:1733 lxc/image.go:1734
 msgid "Unset image properties"
 msgstr ""
 
@@ -6411,7 +6417,7 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/main.go:101
+#: lxc/main.go:100
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -6565,7 +6571,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1087 lxc/list.go:46
+#: lxc/image.go:1088 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6684,15 +6690,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1572 lxc/image.go:1699
+#: lxc/image.go:1605 lxc/image.go:1732
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1636
+#: lxc/image.go:1669
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6712,7 +6718,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1415
+#: lxc/image.go:334 lxc/image.go:1448
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -7667,7 +7673,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
+#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
 msgid "no"
 msgstr ""
 
@@ -7713,6 +7719,6 @@ msgid "y"
 msgstr ""
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1194
+#: lxc/image.go:1206
 msgid "yes"
 msgstr ""

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-11-18 20:34-0300\n"
+"POT-Creation-Date: 2024-11-21 15:57-0700\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Turkish <https://hosted.weblate.org/projects/linux-containers/"
@@ -423,7 +423,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1168
+#: lxc/image.go:1180
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -544,11 +544,11 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1133
+#: lxc/image.go:1144
 msgid "ALIASES"
 msgstr ""
 
@@ -769,7 +769,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:342 lxc/rebuild.go:131
+#: lxc/init.go:343 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1172,7 +1172,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1595
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1595
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1502,7 +1502,7 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:186
+#: lxc/init.go:182
 #, c-format
 msgid "Creating %s"
 msgstr ""
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: lxc/init.go:184
+#: lxc/init.go:180
 msgid "Creating the instance"
 msgstr ""
 
@@ -1526,7 +1526,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -1693,8 +1693,8 @@ msgstr ""
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1090 lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574
-#: lxc/image.go:1638 lxc/image.go:1701 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
+#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:402
+#: lxc/init.go:403
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1880,6 +1880,10 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
+#: lxc/image.go:1119
+msgid "Display images from all projects"
+msgstr ""
+
 #: lxc/list.go:135
 msgid "Display instances from all projects"
 msgstr ""
@@ -1888,7 +1892,7 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:100
+#: lxc/main.go:99
 msgid "Don't show progress information"
 msgstr ""
 
@@ -2023,7 +2027,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1772
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2196,7 +2200,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
+#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2400,7 +2404,7 @@ msgstr ""
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:96
+#: lxc/main.go:95
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -2431,7 +2435,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2506,7 +2510,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1573 lxc/image.go:1574
+#: lxc/image.go:1606 lxc/image.go:1607
 msgid "Get image properties"
 msgstr ""
 
@@ -2762,7 +2766,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:405
+#: lxc/main.go:404
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2784,7 +2788,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1489
+#: lxc/image.go:1522
 msgid "Image already up to date."
 msgstr ""
 
@@ -2800,11 +2804,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1444
+#: lxc/image.go:364 lxc/image.go:1477
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1670
+#: lxc/image.go:444 lxc/image.go:1703
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2814,7 +2818,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1520
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2895,7 +2899,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:413
+#: lxc/init.go:414
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2994,7 +2998,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:507
+#: lxc/main.go:506
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3087,12 +3091,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/init.go:180
+#: lxc/init.go:176
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: lxc/init.go:178
+#: lxc/init.go:174
 msgid "Launching the instance"
 msgstr ""
 
@@ -3201,11 +3205,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1089
+#: lxc/image.go:1090
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid ""
 "List images\n"
 "\n"
@@ -3226,6 +3230,7 @@ msgid ""
 "    F - Fingerprint (long)\n"
 "    p - Whether image is public\n"
 "    d - Description\n"
+"    e - Project\n"
 "    a - Architecture\n"
 "    s - Size\n"
 "    u - Upload date\n"
@@ -4322,7 +4327,7 @@ msgstr ""
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:96
 msgid "Override the source project"
 msgstr ""
 
@@ -4364,7 +4369,8 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:567 lxc/storage_volume.go:1762 lxc/warning.go:213
+#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1762
+#: lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4372,7 +4378,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:853
+#: lxc/image.go:1145 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4388,7 +4394,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:368
+#: lxc/main.go:367
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4447,7 +4453,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:95
+#: lxc/main.go:94
 msgid "Print help"
 msgstr ""
 
@@ -4455,7 +4461,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:94
+#: lxc/main.go:93
 msgid "Print version number"
 msgstr ""
 
@@ -4552,7 +4558,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1621
+#: lxc/image.go:1654
 msgid "Property not found"
 msgstr ""
 
@@ -4682,7 +4688,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4719,7 +4725,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1416 lxc/image.go:1417
+#: lxc/image.go:1449 lxc/image.go:1450
 msgid "Refresh images"
 msgstr ""
 
@@ -4728,7 +4734,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1453
+#: lxc/image.go:1486
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4991,7 +4997,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:356
+#: lxc/init.go:357
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5024,7 +5030,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1139
+#: lxc/image.go:1146
 msgid "SIZE"
 msgstr ""
 
@@ -5147,7 +5153,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1637 lxc/image.go:1638
+#: lxc/image.go:1670 lxc/image.go:1671
 msgid "Set image properties"
 msgstr ""
 
@@ -5399,11 +5405,11 @@ msgstr ""
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: lxc/main.go:98
+#: lxc/main.go:97
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:99
+#: lxc/main.go:98
 msgid "Show all information messages"
 msgstr ""
 
@@ -5452,7 +5458,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1507 lxc/image.go:1508
+#: lxc/image.go:1540 lxc/image.go:1541
 msgid "Show image properties"
 msgstr ""
 
@@ -5472,7 +5478,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:272 lxc/main.go:273
+#: lxc/main.go:271 lxc/main.go:272
 msgid "Show less common commands"
 msgstr ""
 
@@ -5796,7 +5802,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1736 lxc/warning.go:216
@@ -5867,7 +5873,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:434
+#: lxc/init.go:435
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -6013,7 +6019,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:299
+#: lxc/main.go:298
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6037,11 +6043,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:436
+#: lxc/init.go:437
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:435
+#: lxc/init.go:436
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6049,7 +6055,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:411
+#: lxc/main.go:410
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6156,7 +6162,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1140
+#: lxc/image.go:1148
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6202,7 +6208,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1778
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1778
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6244,7 +6250,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1700 lxc/image.go:1701
+#: lxc/image.go:1733 lxc/image.go:1734
 msgid "Unset image properties"
 msgstr ""
 
@@ -6414,7 +6420,7 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/main.go:101
+#: lxc/main.go:100
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -6568,7 +6574,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1087 lxc/list.go:46
+#: lxc/image.go:1088 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6687,15 +6693,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1572 lxc/image.go:1699
+#: lxc/image.go:1605 lxc/image.go:1732
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1636
+#: lxc/image.go:1669
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6715,7 +6721,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1415
+#: lxc/image.go:334 lxc/image.go:1448
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -7670,7 +7676,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
+#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
 msgid "no"
 msgstr ""
 
@@ -7716,6 +7722,6 @@ msgid "y"
 msgstr ""
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1194
+#: lxc/image.go:1206
 msgid "yes"
 msgstr ""

--- a/po/tzm.po
+++ b/po/tzm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-11-18 20:34-0300\n"
+"POT-Creation-Date: 2024-11-21 15:57-0700\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Tamazight (Central Atlas) <https://hosted.weblate.org/"
@@ -423,7 +423,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1168
+#: lxc/image.go:1180
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -544,11 +544,11 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1133
+#: lxc/image.go:1144
 msgid "ALIASES"
 msgstr ""
 
@@ -769,7 +769,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:342 lxc/rebuild.go:131
+#: lxc/init.go:343 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1172,7 +1172,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1595
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1595
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1502,7 +1502,7 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:186
+#: lxc/init.go:182
 #, c-format
 msgid "Creating %s"
 msgstr ""
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: lxc/init.go:184
+#: lxc/init.go:180
 msgid "Creating the instance"
 msgstr ""
 
@@ -1526,7 +1526,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -1693,8 +1693,8 @@ msgstr ""
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1090 lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574
-#: lxc/image.go:1638 lxc/image.go:1701 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
+#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:402
+#: lxc/init.go:403
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1880,6 +1880,10 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
+#: lxc/image.go:1119
+msgid "Display images from all projects"
+msgstr ""
+
 #: lxc/list.go:135
 msgid "Display instances from all projects"
 msgstr ""
@@ -1888,7 +1892,7 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:100
+#: lxc/main.go:99
 msgid "Don't show progress information"
 msgstr ""
 
@@ -2023,7 +2027,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1772
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2196,7 +2200,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
+#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2400,7 +2404,7 @@ msgstr ""
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:96
+#: lxc/main.go:95
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -2431,7 +2435,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2506,7 +2510,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1573 lxc/image.go:1574
+#: lxc/image.go:1606 lxc/image.go:1607
 msgid "Get image properties"
 msgstr ""
 
@@ -2762,7 +2766,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:405
+#: lxc/main.go:404
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2784,7 +2788,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1489
+#: lxc/image.go:1522
 msgid "Image already up to date."
 msgstr ""
 
@@ -2800,11 +2804,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1444
+#: lxc/image.go:364 lxc/image.go:1477
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1670
+#: lxc/image.go:444 lxc/image.go:1703
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2814,7 +2818,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1520
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2895,7 +2899,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:413
+#: lxc/init.go:414
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2994,7 +2998,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:507
+#: lxc/main.go:506
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3087,12 +3091,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/init.go:180
+#: lxc/init.go:176
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: lxc/init.go:178
+#: lxc/init.go:174
 msgid "Launching the instance"
 msgstr ""
 
@@ -3201,11 +3205,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1089
+#: lxc/image.go:1090
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid ""
 "List images\n"
 "\n"
@@ -3226,6 +3230,7 @@ msgid ""
 "    F - Fingerprint (long)\n"
 "    p - Whether image is public\n"
 "    d - Description\n"
+"    e - Project\n"
 "    a - Architecture\n"
 "    s - Size\n"
 "    u - Upload date\n"
@@ -4322,7 +4327,7 @@ msgstr ""
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:96
 msgid "Override the source project"
 msgstr ""
 
@@ -4364,7 +4369,8 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:567 lxc/storage_volume.go:1762 lxc/warning.go:213
+#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1762
+#: lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4372,7 +4378,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:853
+#: lxc/image.go:1145 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4388,7 +4394,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:368
+#: lxc/main.go:367
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4447,7 +4453,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:95
+#: lxc/main.go:94
 msgid "Print help"
 msgstr ""
 
@@ -4455,7 +4461,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:94
+#: lxc/main.go:93
 msgid "Print version number"
 msgstr ""
 
@@ -4552,7 +4558,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1621
+#: lxc/image.go:1654
 msgid "Property not found"
 msgstr ""
 
@@ -4682,7 +4688,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4719,7 +4725,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1416 lxc/image.go:1417
+#: lxc/image.go:1449 lxc/image.go:1450
 msgid "Refresh images"
 msgstr ""
 
@@ -4728,7 +4734,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1453
+#: lxc/image.go:1486
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4991,7 +4997,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:356
+#: lxc/init.go:357
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5024,7 +5030,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1139
+#: lxc/image.go:1146
 msgid "SIZE"
 msgstr ""
 
@@ -5147,7 +5153,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1637 lxc/image.go:1638
+#: lxc/image.go:1670 lxc/image.go:1671
 msgid "Set image properties"
 msgstr ""
 
@@ -5399,11 +5405,11 @@ msgstr ""
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: lxc/main.go:98
+#: lxc/main.go:97
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:99
+#: lxc/main.go:98
 msgid "Show all information messages"
 msgstr ""
 
@@ -5452,7 +5458,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1507 lxc/image.go:1508
+#: lxc/image.go:1540 lxc/image.go:1541
 msgid "Show image properties"
 msgstr ""
 
@@ -5472,7 +5478,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:272 lxc/main.go:273
+#: lxc/main.go:271 lxc/main.go:272
 msgid "Show less common commands"
 msgstr ""
 
@@ -5796,7 +5802,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1736 lxc/warning.go:216
@@ -5867,7 +5873,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:434
+#: lxc/init.go:435
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -6013,7 +6019,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:299
+#: lxc/main.go:298
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6037,11 +6043,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:436
+#: lxc/init.go:437
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:435
+#: lxc/init.go:436
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6049,7 +6055,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:411
+#: lxc/main.go:410
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6156,7 +6162,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1140
+#: lxc/image.go:1148
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6202,7 +6208,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1778
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1778
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6244,7 +6250,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1700 lxc/image.go:1701
+#: lxc/image.go:1733 lxc/image.go:1734
 msgid "Unset image properties"
 msgstr ""
 
@@ -6414,7 +6420,7 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/main.go:101
+#: lxc/main.go:100
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -6568,7 +6574,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1087 lxc/list.go:46
+#: lxc/image.go:1088 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6687,15 +6693,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1572 lxc/image.go:1699
+#: lxc/image.go:1605 lxc/image.go:1732
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1636
+#: lxc/image.go:1669
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6715,7 +6721,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1415
+#: lxc/image.go:334 lxc/image.go:1448
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -7670,7 +7676,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
+#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
 msgid "no"
 msgstr ""
 
@@ -7716,6 +7722,6 @@ msgid "y"
 msgstr ""
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1194
+#: lxc/image.go:1206
 msgid "yes"
 msgstr ""

--- a/po/ug.po
+++ b/po/ug.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-11-18 20:34-0300\n"
+"POT-Creation-Date: 2024-11-21 15:57-0700\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Uyghur <https://hosted.weblate.org/projects/linux-containers/"
@@ -423,7 +423,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1168
+#: lxc/image.go:1180
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -544,11 +544,11 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1133
+#: lxc/image.go:1144
 msgid "ALIASES"
 msgstr ""
 
@@ -769,7 +769,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:342 lxc/rebuild.go:131
+#: lxc/init.go:343 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1172,7 +1172,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1595
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1595
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1502,7 +1502,7 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:186
+#: lxc/init.go:182
 #, c-format
 msgid "Creating %s"
 msgstr ""
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: lxc/init.go:184
+#: lxc/init.go:180
 msgid "Creating the instance"
 msgstr ""
 
@@ -1526,7 +1526,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -1693,8 +1693,8 @@ msgstr ""
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1090 lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574
-#: lxc/image.go:1638 lxc/image.go:1701 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
+#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:402
+#: lxc/init.go:403
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1880,6 +1880,10 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
+#: lxc/image.go:1119
+msgid "Display images from all projects"
+msgstr ""
+
 #: lxc/list.go:135
 msgid "Display instances from all projects"
 msgstr ""
@@ -1888,7 +1892,7 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:100
+#: lxc/main.go:99
 msgid "Don't show progress information"
 msgstr ""
 
@@ -2023,7 +2027,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1772
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2196,7 +2200,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
+#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2400,7 +2404,7 @@ msgstr ""
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:96
+#: lxc/main.go:95
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -2431,7 +2435,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2506,7 +2510,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1573 lxc/image.go:1574
+#: lxc/image.go:1606 lxc/image.go:1607
 msgid "Get image properties"
 msgstr ""
 
@@ -2762,7 +2766,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:405
+#: lxc/main.go:404
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2784,7 +2788,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1489
+#: lxc/image.go:1522
 msgid "Image already up to date."
 msgstr ""
 
@@ -2800,11 +2804,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1444
+#: lxc/image.go:364 lxc/image.go:1477
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1670
+#: lxc/image.go:444 lxc/image.go:1703
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2814,7 +2818,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1520
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2895,7 +2899,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:413
+#: lxc/init.go:414
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2994,7 +2998,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:507
+#: lxc/main.go:506
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3087,12 +3091,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/init.go:180
+#: lxc/init.go:176
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: lxc/init.go:178
+#: lxc/init.go:174
 msgid "Launching the instance"
 msgstr ""
 
@@ -3201,11 +3205,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1089
+#: lxc/image.go:1090
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid ""
 "List images\n"
 "\n"
@@ -3226,6 +3230,7 @@ msgid ""
 "    F - Fingerprint (long)\n"
 "    p - Whether image is public\n"
 "    d - Description\n"
+"    e - Project\n"
 "    a - Architecture\n"
 "    s - Size\n"
 "    u - Upload date\n"
@@ -4322,7 +4327,7 @@ msgstr ""
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:96
 msgid "Override the source project"
 msgstr ""
 
@@ -4364,7 +4369,8 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:567 lxc/storage_volume.go:1762 lxc/warning.go:213
+#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1762
+#: lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4372,7 +4378,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:853
+#: lxc/image.go:1145 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4388,7 +4394,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:368
+#: lxc/main.go:367
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4447,7 +4453,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:95
+#: lxc/main.go:94
 msgid "Print help"
 msgstr ""
 
@@ -4455,7 +4461,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:94
+#: lxc/main.go:93
 msgid "Print version number"
 msgstr ""
 
@@ -4552,7 +4558,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1621
+#: lxc/image.go:1654
 msgid "Property not found"
 msgstr ""
 
@@ -4682,7 +4688,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4719,7 +4725,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1416 lxc/image.go:1417
+#: lxc/image.go:1449 lxc/image.go:1450
 msgid "Refresh images"
 msgstr ""
 
@@ -4728,7 +4734,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1453
+#: lxc/image.go:1486
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4991,7 +4997,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:356
+#: lxc/init.go:357
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5024,7 +5030,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1139
+#: lxc/image.go:1146
 msgid "SIZE"
 msgstr ""
 
@@ -5147,7 +5153,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1637 lxc/image.go:1638
+#: lxc/image.go:1670 lxc/image.go:1671
 msgid "Set image properties"
 msgstr ""
 
@@ -5399,11 +5405,11 @@ msgstr ""
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: lxc/main.go:98
+#: lxc/main.go:97
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:99
+#: lxc/main.go:98
 msgid "Show all information messages"
 msgstr ""
 
@@ -5452,7 +5458,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1507 lxc/image.go:1508
+#: lxc/image.go:1540 lxc/image.go:1541
 msgid "Show image properties"
 msgstr ""
 
@@ -5472,7 +5478,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:272 lxc/main.go:273
+#: lxc/main.go:271 lxc/main.go:272
 msgid "Show less common commands"
 msgstr ""
 
@@ -5796,7 +5802,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1736 lxc/warning.go:216
@@ -5867,7 +5873,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:434
+#: lxc/init.go:435
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -6013,7 +6019,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:299
+#: lxc/main.go:298
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6037,11 +6043,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:436
+#: lxc/init.go:437
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:435
+#: lxc/init.go:436
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6049,7 +6055,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:411
+#: lxc/main.go:410
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6156,7 +6162,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1140
+#: lxc/image.go:1148
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6202,7 +6208,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1778
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1778
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6244,7 +6250,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1700 lxc/image.go:1701
+#: lxc/image.go:1733 lxc/image.go:1734
 msgid "Unset image properties"
 msgstr ""
 
@@ -6414,7 +6420,7 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/main.go:101
+#: lxc/main.go:100
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -6568,7 +6574,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1087 lxc/list.go:46
+#: lxc/image.go:1088 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6687,15 +6693,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1572 lxc/image.go:1699
+#: lxc/image.go:1605 lxc/image.go:1732
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1636
+#: lxc/image.go:1669
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6715,7 +6721,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1415
+#: lxc/image.go:334 lxc/image.go:1448
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -7670,7 +7676,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
+#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
 msgid "no"
 msgstr ""
 
@@ -7716,6 +7722,6 @@ msgid "y"
 msgstr ""
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1194
+#: lxc/image.go:1206
 msgid "yes"
 msgstr ""

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-11-18 20:34-0300\n"
+"POT-Creation-Date: 2024-11-21 15:57-0700\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Ukrainian <https://hosted.weblate.org/projects/linux-"
@@ -424,7 +424,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1168
+#: lxc/image.go:1180
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -545,11 +545,11 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1133
+#: lxc/image.go:1144
 msgid "ALIASES"
 msgstr ""
 
@@ -770,7 +770,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:342 lxc/rebuild.go:131
+#: lxc/init.go:343 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -875,7 +875,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1173,7 +1173,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1595
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1595
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1503,7 +1503,7 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:186
+#: lxc/init.go:182
 #, c-format
 msgid "Creating %s"
 msgstr ""
@@ -1513,7 +1513,7 @@ msgstr ""
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: lxc/init.go:184
+#: lxc/init.go:180
 msgid "Creating the instance"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -1694,8 +1694,8 @@ msgstr ""
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1090 lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574
-#: lxc/image.go:1638 lxc/image.go:1701 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
+#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1840,7 +1840,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:402
+#: lxc/init.go:403
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1881,6 +1881,10 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
+#: lxc/image.go:1119
+msgid "Display images from all projects"
+msgstr ""
+
 #: lxc/list.go:135
 msgid "Display instances from all projects"
 msgstr ""
@@ -1889,7 +1893,7 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:100
+#: lxc/main.go:99
 msgid "Don't show progress information"
 msgstr ""
 
@@ -2024,7 +2028,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1772
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2197,7 +2201,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
+#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2401,7 +2405,7 @@ msgstr ""
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:96
+#: lxc/main.go:95
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -2432,7 +2436,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2507,7 +2511,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1573 lxc/image.go:1574
+#: lxc/image.go:1606 lxc/image.go:1607
 msgid "Get image properties"
 msgstr ""
 
@@ -2763,7 +2767,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:405
+#: lxc/main.go:404
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2785,7 +2789,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1489
+#: lxc/image.go:1522
 msgid "Image already up to date."
 msgstr ""
 
@@ -2801,11 +2805,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1444
+#: lxc/image.go:364 lxc/image.go:1477
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1670
+#: lxc/image.go:444 lxc/image.go:1703
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2815,7 +2819,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1520
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2896,7 +2900,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:413
+#: lxc/init.go:414
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2995,7 +2999,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:507
+#: lxc/main.go:506
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3088,12 +3092,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/init.go:180
+#: lxc/init.go:176
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: lxc/init.go:178
+#: lxc/init.go:174
 msgid "Launching the instance"
 msgstr ""
 
@@ -3202,11 +3206,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1089
+#: lxc/image.go:1090
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid ""
 "List images\n"
 "\n"
@@ -3227,6 +3231,7 @@ msgid ""
 "    F - Fingerprint (long)\n"
 "    p - Whether image is public\n"
 "    d - Description\n"
+"    e - Project\n"
 "    a - Architecture\n"
 "    s - Size\n"
 "    u - Upload date\n"
@@ -4323,7 +4328,7 @@ msgstr ""
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:96
 msgid "Override the source project"
 msgstr ""
 
@@ -4365,7 +4370,8 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:567 lxc/storage_volume.go:1762 lxc/warning.go:213
+#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1762
+#: lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4373,7 +4379,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:853
+#: lxc/image.go:1145 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4389,7 +4395,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:368
+#: lxc/main.go:367
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4448,7 +4454,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:95
+#: lxc/main.go:94
 msgid "Print help"
 msgstr ""
 
@@ -4456,7 +4462,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:94
+#: lxc/main.go:93
 msgid "Print version number"
 msgstr ""
 
@@ -4553,7 +4559,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1621
+#: lxc/image.go:1654
 msgid "Property not found"
 msgstr ""
 
@@ -4683,7 +4689,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4720,7 +4726,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1416 lxc/image.go:1417
+#: lxc/image.go:1449 lxc/image.go:1450
 msgid "Refresh images"
 msgstr ""
 
@@ -4729,7 +4735,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1453
+#: lxc/image.go:1486
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4992,7 +4998,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:356
+#: lxc/init.go:357
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5025,7 +5031,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1139
+#: lxc/image.go:1146
 msgid "SIZE"
 msgstr ""
 
@@ -5148,7 +5154,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1637 lxc/image.go:1638
+#: lxc/image.go:1670 lxc/image.go:1671
 msgid "Set image properties"
 msgstr ""
 
@@ -5400,11 +5406,11 @@ msgstr ""
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: lxc/main.go:98
+#: lxc/main.go:97
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:99
+#: lxc/main.go:98
 msgid "Show all information messages"
 msgstr ""
 
@@ -5453,7 +5459,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1507 lxc/image.go:1508
+#: lxc/image.go:1540 lxc/image.go:1541
 msgid "Show image properties"
 msgstr ""
 
@@ -5473,7 +5479,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:272 lxc/main.go:273
+#: lxc/main.go:271 lxc/main.go:272
 msgid "Show less common commands"
 msgstr ""
 
@@ -5797,7 +5803,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1736 lxc/warning.go:216
@@ -5868,7 +5874,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:434
+#: lxc/init.go:435
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -6014,7 +6020,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:299
+#: lxc/main.go:298
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6038,11 +6044,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:436
+#: lxc/init.go:437
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:435
+#: lxc/init.go:436
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6050,7 +6056,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:411
+#: lxc/main.go:410
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6157,7 +6163,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1140
+#: lxc/image.go:1148
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6203,7 +6209,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1778
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1778
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6245,7 +6251,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1700 lxc/image.go:1701
+#: lxc/image.go:1733 lxc/image.go:1734
 msgid "Unset image properties"
 msgstr ""
 
@@ -6415,7 +6421,7 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/main.go:101
+#: lxc/main.go:100
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -6569,7 +6575,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1087 lxc/list.go:46
+#: lxc/image.go:1088 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6688,15 +6694,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1572 lxc/image.go:1699
+#: lxc/image.go:1605 lxc/image.go:1732
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1636
+#: lxc/image.go:1669
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6716,7 +6722,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1415
+#: lxc/image.go:334 lxc/image.go:1448
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -7671,7 +7677,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
+#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
 msgid "no"
 msgstr ""
 
@@ -7717,6 +7723,6 @@ msgid "y"
 msgstr ""
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1194
+#: lxc/image.go:1206
 msgid "yes"
 msgstr ""

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-11-18 20:34-0300\n"
+"POT-Creation-Date: 2024-11-21 15:57-0700\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: 0x0916 <w@laoqinren.net>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -584,7 +584,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1168
+#: lxc/image.go:1180
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -705,11 +705,11 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1133
+#: lxc/image.go:1144
 msgid "ALIASES"
 msgstr ""
 
@@ -930,7 +930,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:342 lxc/rebuild.go:131
+#: lxc/init.go:343 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -1035,7 +1035,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1333,7 +1333,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1595
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1595
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1663,7 +1663,7 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:186
+#: lxc/init.go:182
 #, c-format
 msgid "Creating %s"
 msgstr ""
@@ -1673,7 +1673,7 @@ msgstr ""
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: lxc/init.go:184
+#: lxc/init.go:180
 msgid "Creating the instance"
 msgstr ""
 
@@ -1687,7 +1687,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -1854,8 +1854,8 @@ msgstr ""
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1090 lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574
-#: lxc/image.go:1638 lxc/image.go:1701 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
+#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -2000,7 +2000,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:402
+#: lxc/init.go:403
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -2041,6 +2041,10 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
+#: lxc/image.go:1119
+msgid "Display images from all projects"
+msgstr ""
+
 #: lxc/list.go:135
 msgid "Display instances from all projects"
 msgstr ""
@@ -2049,7 +2053,7 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:100
+#: lxc/main.go:99
 msgid "Don't show progress information"
 msgstr ""
 
@@ -2184,7 +2188,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1772
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2357,7 +2361,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
+#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2561,7 +2565,7 @@ msgstr ""
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:96
+#: lxc/main.go:95
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -2592,7 +2596,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2667,7 +2671,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1573 lxc/image.go:1574
+#: lxc/image.go:1606 lxc/image.go:1607
 msgid "Get image properties"
 msgstr ""
 
@@ -2923,7 +2927,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:405
+#: lxc/main.go:404
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2945,7 +2949,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1489
+#: lxc/image.go:1522
 msgid "Image already up to date."
 msgstr ""
 
@@ -2961,11 +2965,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1444
+#: lxc/image.go:364 lxc/image.go:1477
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1670
+#: lxc/image.go:444 lxc/image.go:1703
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2975,7 +2979,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1520
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3056,7 +3060,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:413
+#: lxc/init.go:414
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -3155,7 +3159,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:507
+#: lxc/main.go:506
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3248,12 +3252,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/init.go:180
+#: lxc/init.go:176
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: lxc/init.go:178
+#: lxc/init.go:174
 msgid "Launching the instance"
 msgstr ""
 
@@ -3362,11 +3366,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1089
+#: lxc/image.go:1090
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid ""
 "List images\n"
 "\n"
@@ -3387,6 +3391,7 @@ msgid ""
 "    F - Fingerprint (long)\n"
 "    p - Whether image is public\n"
 "    d - Description\n"
+"    e - Project\n"
 "    a - Architecture\n"
 "    s - Size\n"
 "    u - Upload date\n"
@@ -4483,7 +4488,7 @@ msgstr ""
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:96
 msgid "Override the source project"
 msgstr ""
 
@@ -4525,7 +4530,8 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:567 lxc/storage_volume.go:1762 lxc/warning.go:213
+#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1762
+#: lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4533,7 +4539,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:853
+#: lxc/image.go:1145 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4549,7 +4555,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:368
+#: lxc/main.go:367
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4608,7 +4614,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:95
+#: lxc/main.go:94
 msgid "Print help"
 msgstr ""
 
@@ -4616,7 +4622,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:94
+#: lxc/main.go:93
 msgid "Print version number"
 msgstr ""
 
@@ -4713,7 +4719,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1621
+#: lxc/image.go:1654
 msgid "Property not found"
 msgstr ""
 
@@ -4843,7 +4849,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4880,7 +4886,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1416 lxc/image.go:1417
+#: lxc/image.go:1449 lxc/image.go:1450
 msgid "Refresh images"
 msgstr ""
 
@@ -4889,7 +4895,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1453
+#: lxc/image.go:1486
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5152,7 +5158,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:356
+#: lxc/init.go:357
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5185,7 +5191,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1139
+#: lxc/image.go:1146
 msgid "SIZE"
 msgstr ""
 
@@ -5308,7 +5314,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1637 lxc/image.go:1638
+#: lxc/image.go:1670 lxc/image.go:1671
 msgid "Set image properties"
 msgstr ""
 
@@ -5560,11 +5566,11 @@ msgstr ""
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: lxc/main.go:98
+#: lxc/main.go:97
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:99
+#: lxc/main.go:98
 msgid "Show all information messages"
 msgstr ""
 
@@ -5613,7 +5619,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1507 lxc/image.go:1508
+#: lxc/image.go:1540 lxc/image.go:1541
 msgid "Show image properties"
 msgstr ""
 
@@ -5633,7 +5639,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:272 lxc/main.go:273
+#: lxc/main.go:271 lxc/main.go:272
 msgid "Show less common commands"
 msgstr ""
 
@@ -5957,7 +5963,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1736 lxc/warning.go:216
@@ -6028,7 +6034,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:434
+#: lxc/init.go:435
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -6174,7 +6180,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:299
+#: lxc/main.go:298
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6198,11 +6204,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:436
+#: lxc/init.go:437
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:435
+#: lxc/init.go:436
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6210,7 +6216,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:411
+#: lxc/main.go:410
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6317,7 +6323,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1140
+#: lxc/image.go:1148
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6363,7 +6369,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1778
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1778
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6405,7 +6411,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1700 lxc/image.go:1701
+#: lxc/image.go:1733 lxc/image.go:1734
 msgid "Unset image properties"
 msgstr ""
 
@@ -6575,7 +6581,7 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/main.go:101
+#: lxc/main.go:100
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -6729,7 +6735,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1087 lxc/list.go:46
+#: lxc/image.go:1088 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6848,15 +6854,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1572 lxc/image.go:1699
+#: lxc/image.go:1605 lxc/image.go:1732
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1636
+#: lxc/image.go:1669
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6876,7 +6882,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1415
+#: lxc/image.go:334 lxc/image.go:1448
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -7831,7 +7837,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
+#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
 msgid "no"
 msgstr ""
 
@@ -7877,7 +7883,7 @@ msgid "y"
 msgstr ""
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1194
+#: lxc/image.go:1206
 msgid "yes"
 msgstr ""
 

--- a/po/zh_Hant.po
+++ b/po/zh_Hant.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-11-18 20:34-0300\n"
+"POT-Creation-Date: 2024-11-21 15:57-0700\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Chinese (Traditional) <https://hosted.weblate.org/projects/"
@@ -423,7 +423,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1168
+#: lxc/image.go:1180
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -544,11 +544,11 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1133
+#: lxc/image.go:1144
 msgid "ALIASES"
 msgstr ""
 
@@ -769,7 +769,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:342 lxc/rebuild.go:131
+#: lxc/init.go:343 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1172,7 +1172,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1595
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1595
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1502,7 +1502,7 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:186
+#: lxc/init.go:182
 #, c-format
 msgid "Creating %s"
 msgstr ""
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: lxc/init.go:184
+#: lxc/init.go:180
 msgid "Creating the instance"
 msgstr ""
 
@@ -1526,7 +1526,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -1693,8 +1693,8 @@ msgstr ""
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1090 lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574
-#: lxc/image.go:1638 lxc/image.go:1701 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
+#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:402
+#: lxc/init.go:403
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1880,6 +1880,10 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
+#: lxc/image.go:1119
+msgid "Display images from all projects"
+msgstr ""
+
 #: lxc/list.go:135
 msgid "Display instances from all projects"
 msgstr ""
@@ -1888,7 +1892,7 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:100
+#: lxc/main.go:99
 msgid "Don't show progress information"
 msgstr ""
 
@@ -2023,7 +2027,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1772
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2196,7 +2200,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
+#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2400,7 +2404,7 @@ msgstr ""
 msgid "Force the removal of running instances"
 msgstr ""
 
-#: lxc/main.go:96
+#: lxc/main.go:95
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -2431,7 +2435,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2506,7 +2510,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1573 lxc/image.go:1574
+#: lxc/image.go:1606 lxc/image.go:1607
 msgid "Get image properties"
 msgstr ""
 
@@ -2762,7 +2766,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:405
+#: lxc/main.go:404
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2784,7 +2788,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1489
+#: lxc/image.go:1522
 msgid "Image already up to date."
 msgstr ""
 
@@ -2800,11 +2804,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1444
+#: lxc/image.go:364 lxc/image.go:1477
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1670
+#: lxc/image.go:444 lxc/image.go:1703
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2814,7 +2818,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1520
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2895,7 +2899,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:413
+#: lxc/init.go:414
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2994,7 +2998,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:507
+#: lxc/main.go:506
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3087,12 +3091,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/init.go:180
+#: lxc/init.go:176
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: lxc/init.go:178
+#: lxc/init.go:174
 msgid "Launching the instance"
 msgstr ""
 
@@ -3201,11 +3205,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1089
+#: lxc/image.go:1090
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid ""
 "List images\n"
 "\n"
@@ -3226,6 +3230,7 @@ msgid ""
 "    F - Fingerprint (long)\n"
 "    p - Whether image is public\n"
 "    d - Description\n"
+"    e - Project\n"
 "    a - Architecture\n"
 "    s - Size\n"
 "    u - Upload date\n"
@@ -4322,7 +4327,7 @@ msgstr ""
 msgid "Optimized Storage"
 msgstr ""
 
-#: lxc/main.go:97
+#: lxc/main.go:96
 msgid "Override the source project"
 msgstr ""
 
@@ -4364,7 +4369,8 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:567 lxc/storage_volume.go:1762 lxc/warning.go:213
+#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1762
+#: lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4372,7 +4378,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1136 lxc/remote.go:853
+#: lxc/image.go:1145 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4388,7 +4394,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:368
+#: lxc/main.go:367
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4447,7 +4453,7 @@ msgstr ""
 msgid "Pretty rendering (short for --format=pretty)"
 msgstr ""
 
-#: lxc/main.go:95
+#: lxc/main.go:94
 msgid "Print help"
 msgstr ""
 
@@ -4455,7 +4461,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:94
+#: lxc/main.go:93
 msgid "Print version number"
 msgstr ""
 
@@ -4552,7 +4558,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1621
+#: lxc/image.go:1654
 msgid "Property not found"
 msgstr ""
 
@@ -4682,7 +4688,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4719,7 +4725,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1416 lxc/image.go:1417
+#: lxc/image.go:1449 lxc/image.go:1450
 msgid "Refresh images"
 msgstr ""
 
@@ -4728,7 +4734,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1453
+#: lxc/image.go:1486
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4991,7 +4997,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:356
+#: lxc/init.go:357
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5024,7 +5030,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1139
+#: lxc/image.go:1146
 msgid "SIZE"
 msgstr ""
 
@@ -5147,7 +5153,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1637 lxc/image.go:1638
+#: lxc/image.go:1670 lxc/image.go:1671
 msgid "Set image properties"
 msgstr ""
 
@@ -5399,11 +5405,11 @@ msgstr ""
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
-#: lxc/main.go:98
+#: lxc/main.go:97
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:99
+#: lxc/main.go:98
 msgid "Show all information messages"
 msgstr ""
 
@@ -5452,7 +5458,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1507 lxc/image.go:1508
+#: lxc/image.go:1540 lxc/image.go:1541
 msgid "Show image properties"
 msgstr ""
 
@@ -5472,7 +5478,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:272 lxc/main.go:273
+#: lxc/main.go:271 lxc/main.go:272
 msgid "Show less common commands"
 msgstr ""
 
@@ -5796,7 +5802,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1141
+#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1736 lxc/warning.go:216
@@ -5867,7 +5873,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:434
+#: lxc/init.go:435
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -6013,7 +6019,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:299
+#: lxc/main.go:298
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6037,11 +6043,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:436
+#: lxc/init.go:437
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:435
+#: lxc/init.go:436
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6049,7 +6055,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:411
+#: lxc/main.go:410
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6156,7 +6162,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1140
+#: lxc/image.go:1148
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6202,7 +6208,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1778
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1778
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6244,7 +6250,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1700 lxc/image.go:1701
+#: lxc/image.go:1733 lxc/image.go:1734
 msgid "Unset image properties"
 msgstr ""
 
@@ -6414,7 +6420,7 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/main.go:101
+#: lxc/main.go:100
 msgid "Use with help or --help to view sub-commands"
 msgstr ""
 
@@ -6568,7 +6574,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1087 lxc/list.go:46
+#: lxc/image.go:1088 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6687,15 +6693,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1572 lxc/image.go:1699
+#: lxc/image.go:1605 lxc/image.go:1732
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1636
+#: lxc/image.go:1669
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6715,7 +6721,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1415
+#: lxc/image.go:334 lxc/image.go:1448
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -7670,7 +7676,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
+#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
 msgid "no"
 msgstr ""
 
@@ -7716,6 +7722,6 @@ msgid "y"
 msgstr ""
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1194
+#: lxc/image.go:1206
 msgid "yes"
 msgstr ""

--- a/shared/api/image.go
+++ b/shared/api/image.go
@@ -201,6 +201,12 @@ type Image struct {
 	//
 	// API extension: image_profiles
 	Profiles []string `json:"profiles" yaml:"profiles"`
+
+	// Project name
+	// Example: project1
+	//
+	// API extension: images_all_projects
+	Project string `json:"project" yaml:"project"`
 }
 
 // Writable converts a full Image struct into a ImagePut struct (filters read-only fields).

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -423,6 +423,7 @@ var APIExtensions = []string{
 	"state_logical_cpus",
 	"vm_limits_cpu_pin_strategy",
 	"gpu_cdi",
+	"images_all_projects",
 }
 
 // APIExtensionsCount returns the number of available API extensions.

--- a/test/suites/auth.sh
+++ b/test/suites/auth.sh
@@ -656,6 +656,7 @@ user_is_not_project_operator() {
 
   # Image list will still work but none will be shown because none are public.
   [ "$(lxc_remote image list "${remote}:" -f csv | wc -l)" = 0 ]
+  [ "$(lxc_remote image list "${remote}:" -f csv --all-projects | wc -l)" = 0 ]
 
   # Image edit will fail. Note that this fails with "not found" because we fail to resolve the alias (image is not public
   # so it is not returned from the DB).
@@ -732,11 +733,14 @@ auth_project_features() {
 
   # We can always list images, but there are no public images in the default project now, so the list should be empty.
   [ "$(lxc_remote image list "${remote}:" --project default --format csv)" = "" ]
+  # The list should also be empty when the --all-projects flag is set to true.
+  [ "$(lxc_remote image list "${remote}:" --all-projects --format csv)" = "" ]
   ! lxc_remote image show "${remote}:testimage" --project default || false
 
   # Set the image to public and ensure we can view it.
   lxc image show testimage --project default | sed -e "s/public: false/public: true/" | lxc image edit testimage --project default
-  [ "$(lxc_remote image list "${remote}:" --project default --format csv | wc -l)" = 1 ]
+  [ "$(lxc_remote image list "${remote}:" --project default --format csv | wc -l)" = 1 ] # --project flag set to default.
+  [ "$(lxc_remote image list "${remote}:" --all-projects --format csv | wc -l)" = 1 ] # --all-projects flag set to true.
   lxc_remote image show "${remote}:testimage" --project default
 
   # Check we can export the public image:


### PR DESCRIPTION
Resolves https://github.com/canonical/lxd/issues/14126.

This PR adds support for fetching images across all projects by adding a query parameter `all-projects`.