### PR TITLE
Auth: Prune pending TLS identities

### DIFF
--- a/lxd/api_internal.go
+++ b/lxd/api_internal.go
@@ -61,6 +61,7 @@ var apiInternal = []APIEndpoint{
 	internalSQLCmd,
 	internalWarningCreateCmd,
 	internalIdentityCacheRefreshCmd,
+	internalPruneTokenCmd,
 }
 
 var internalShutdownCmd = APIEndpoint{
@@ -134,6 +135,11 @@ var internalBGPStateCmd = APIEndpoint{
 	Path: "testing/bgp",
 
 	Get: APIEndpointAction{Handler: internalBGPState, AccessHandler: allowPermission(entity.TypeServer, auth.EntitlementCanEdit)},
+}
+
+var internalPruneTokenCmd = APIEndpoint{
+	Path: "testing/prune-tokens",
+	Post: APIEndpointAction{Handler: removeTokenHandler, AccessHandler: allowPermission(entity.TypeServer, auth.EntitlementCanEdit)},
 }
 
 var internalIdentityCacheRefreshCmd = APIEndpoint{

--- a/lxd/db/cluster/identities.go
+++ b/lxd/db/cluster/identities.go
@@ -328,13 +328,13 @@ type PendingTLSMetadata struct {
 // PendingTLSMetadata returns the pending TLS identity metadata.
 func (i Identity) PendingTLSMetadata() (*PendingTLSMetadata, error) {
 	if i.Type != api.IdentityTypeCertificateClientPending {
-		return nil, fmt.Errorf("Cannot extract pending TLS identity secret: Identity is not pending")
+		return nil, api.NewStatusError(http.StatusBadRequest, "Cannot extract pending TLS identity secret: Identity is not pending")
 	}
 
 	var metadata PendingTLSMetadata
 	err := json.Unmarshal([]byte(i.Metadata), &metadata)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to unmarshal pending TLS identity metadata: %w", err)
+		return nil, api.StatusErrorf(http.StatusInternalServerError, "Failed to unmarshal pending TLS identity metadata: %w", err)
 	}
 
 	return &metadata, nil

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -4606,21 +4605,19 @@ func autoSyncImagesTask(d *Daemon) (task.Func, task.Schedule) {
 	f := func(ctx context.Context) {
 		s := d.State()
 
-		// In order to only have one task operation executed per image when syncing the images
-		// across the cluster, only leader node can launch the task, no others.
-		localClusterAddress := s.LocalConfig.ClusterAddress()
-
-		leader, err := d.gateway.LeaderAddress()
+		leaderInfo, err := s.LeaderInfo()
 		if err != nil {
-			if errors.Is(err, cluster.ErrNodeIsNotClustered) {
-				return // No error if not clustered.
-			}
-
 			logger.Error("Failed to get leader cluster member address", logger.Ctx{"err": err})
 			return
 		}
 
-		if localClusterAddress != leader {
+		if !leaderInfo.Clustered {
+			return
+		}
+
+		// In order to only have one task operation executed per image when syncing the images
+		// across the cluster, only leader node can launch the task, no others.
+		if !leaderInfo.Leader {
 			logger.Debug("Skipping image synchronization task since we're not leader")
 			return
 		}

--- a/lxd/instance_post.go
+++ b/lxd/instance_post.go
@@ -232,7 +232,7 @@ func instancePost(d *Daemon, r *http.Request) response.Response {
 		}
 
 		if targetMemberInfo == nil && s.GlobalConfig.InstancesPlacementScriptlet() != "" {
-			leaderAddress, err := d.gateway.LeaderAddress()
+			leaderInfo, err := s.LeaderInfo()
 			if err != nil {
 				return response.InternalError(err)
 			}
@@ -250,7 +250,7 @@ func instancePost(d *Daemon, r *http.Request) response.Response {
 				Reason:  apiScriptlet.InstancePlacementReasonRelocation,
 			}
 
-			targetMemberInfo, err = scriptlet.InstancePlacementRun(r.Context(), logger.Log, s, &req, candidateMembers, leaderAddress)
+			targetMemberInfo, err = scriptlet.InstancePlacementRun(r.Context(), logger.Log, s, &req, candidateMembers, leaderInfo.Address)
 			if err != nil {
 				return response.BadRequest(fmt.Errorf("Failed instance placement scriptlet: %w", err))
 			}

--- a/lxd/instances_post.go
+++ b/lxd/instances_post.go
@@ -1281,7 +1281,7 @@ func instancesPost(d *Daemon, r *http.Request) response.Response {
 	if s.ServerClustered && !clusterNotification && targetMemberInfo == nil {
 		// Run instance placement scriptlet if enabled and no cluster member selected yet.
 		if s.GlobalConfig.InstancesPlacementScriptlet() != "" {
-			leaderAddress, err := d.gateway.LeaderAddress()
+			leaderInfo, err := s.LeaderInfo()
 			if err != nil {
 				return response.InternalError(err)
 			}
@@ -1301,7 +1301,7 @@ func instancesPost(d *Daemon, r *http.Request) response.Response {
 			reqExpanded.Config = instancetype.ExpandInstanceConfig(globalConfigDump, reqExpanded.Config, profiles)
 			reqExpanded.Devices = instancetype.ExpandInstanceDevices(deviceConfig.NewDevices(reqExpanded.Devices), profiles).CloneNative()
 
-			targetMemberInfo, err = scriptlet.InstancePlacementRun(r.Context(), logger.Log, s, &reqExpanded, candidateMembers, leaderAddress)
+			targetMemberInfo, err = scriptlet.InstancePlacementRun(r.Context(), logger.Log, s, &reqExpanded, candidateMembers, leaderInfo.Address)
 			if err != nil {
 				return response.SmartError(fmt.Errorf("Failed instance placement scriptlet: %w", err))
 			}

--- a/lxd/state/state.go
+++ b/lxd/state/state.go
@@ -84,6 +84,9 @@ type State struct {
 	// Whether the server is clustered.
 	ServerClustered bool
 
+	// Whether we are the leader and the leader address if not.
+	LeaderInfo func() (*LeaderInfo, error)
+
 	// Local server UUID.
 	ServerUUID string
 
@@ -95,4 +98,16 @@ type State struct {
 
 	// Ubuntu pro settings.
 	UbuntuPro *ubuntupro.Client
+}
+
+// LeaderInfo represents information regarding cluster member leadership.
+type LeaderInfo struct {
+	// Clustered is true if the server is clustered and false otherwise.
+	Clustered bool
+
+	// Leader is true if the server is the raft leader or if the server is not clustered, and false otherwise.
+	Leader bool
+
+	// Address is the address of the leader. It is not set if the server is not clustered.
+	Address string
 }

--- a/lxd/tokens.go
+++ b/lxd/tokens.go
@@ -2,17 +2,24 @@ package main
 
 import (
 	"context"
+	"net/http"
 	"time"
 
 	"github.com/canonical/lxd/lxd/db"
 	"github.com/canonical/lxd/lxd/db/cluster"
 	"github.com/canonical/lxd/lxd/db/operationtype"
 	"github.com/canonical/lxd/lxd/operations"
+	"github.com/canonical/lxd/lxd/response"
 	"github.com/canonical/lxd/lxd/state"
 	"github.com/canonical/lxd/lxd/task"
 	"github.com/canonical/lxd/shared/api"
 	"github.com/canonical/lxd/shared/logger"
 )
+
+func removeTokenHandler(d *Daemon, r *http.Request) response.Response {
+	autoRemoveExpiredTokens(r.Context(), d.State())
+	return response.EmptySyncResponse
+}
 
 func autoRemoveExpiredTokens(ctx context.Context, s *state.State) {
 	expiredTokenOps := make([]*operations.Operation, 0)

--- a/lxd/tokens.go
+++ b/lxd/tokens.go
@@ -55,7 +55,7 @@ func autoRemoveExpiredTokens(ctx context.Context, s *state.State) {
 		for _, op := range expiredTokenOps {
 			_, err := op.Cancel()
 			if err != nil {
-				logger.Debug("Failed removing expired token", logger.Ctx{"err": err, "id": op.ID()})
+				logger.Warn("Failed removing expired token", logger.Ctx{"err": err, "operation": op.ID()})
 			}
 		}
 
@@ -70,7 +70,7 @@ func autoRemoveExpiredTokens(ctx context.Context, s *state.State) {
 			return nil
 		})
 		if err != nil {
-			logger.Warn("Failed removing pending TLS identities", logger.Ctx{"err": err, "id": op.ID()})
+			logger.Warn("Failed removing pending TLS identities", logger.Ctx{"err": err, "operation": op.ID()})
 		}
 
 		return nil
@@ -78,7 +78,7 @@ func autoRemoveExpiredTokens(ctx context.Context, s *state.State) {
 
 	op, err := operations.OperationCreate(s, "", operations.OperationClassTask, operationtype.RemoveExpiredTokens, nil, nil, opRun, nil, nil, nil)
 	if err != nil {
-		logger.Error("Failed creating remove expired tokens operation", logger.Ctx{"err": err})
+		logger.Warn("Failed creating remove expired tokens operation", logger.Ctx{"err": err})
 		return
 	}
 
@@ -86,13 +86,13 @@ func autoRemoveExpiredTokens(ctx context.Context, s *state.State) {
 
 	err = op.Start()
 	if err != nil {
-		logger.Error("Failed starting remove expired tokens operation", logger.Ctx{"err": err})
+		logger.Warn("Failed starting remove expired tokens operation", logger.Ctx{"err": err})
 		return
 	}
 
 	err = op.Wait(ctx)
 	if err != nil {
-		logger.Error("Failed removing expired tokens", logger.Ctx{"err": err})
+		logger.Warn("Failed removing expired tokens", logger.Ctx{"err": err})
 		return
 	}
 

--- a/test/suites/auth.sh
+++ b/test/suites/auth.sh
@@ -99,6 +99,9 @@ test_authorization() {
   LXD_CONF="${LXD_CONF3}" gen_cert_and_key "client"
   ! LXD_CONF="${LXD_CONF3}" lxc remote add tls "${tls_identity_token2}" || false
 
+  # The token was used, so the pending identity should be deleted.
+  [ "$(lxc auth identity list --format csv | grep -cF 'pending')" = 0 ]
+
   # Check users have been added to the group.
   tls_identity_fingerprint="$(cert_fingerprint "${LXD_CONF2}/client.crt")"
   lxc auth identity list --format csv | grep -Fq 'oidc,OIDC client," ",test-user@example.com,test-group'

--- a/test/suites/auth.sh
+++ b/test/suites/auth.sh
@@ -102,6 +102,13 @@ test_authorization() {
   # The token was used, so the pending identity should be deleted.
   [ "$(lxc auth identity list --format csv | grep -cF 'pending')" = 0 ]
 
+  # Check token prune task works
+  lxc auth identity create tls/test-user2 --quiet
+  [ "$(lxc auth identity list --format csv | grep -cF 'pending')" = 1 ]
+  sleep 2 # Wait for token to expire (expiry is still set to 1 second)
+  lxc query --request POST /internal/testing/prune-tokens
+  [ "$(lxc auth identity list --format csv | grep -cF 'pending')" = 0 ]
+
   # Check users have been added to the group.
   tls_identity_fingerprint="$(cert_fingerprint "${LXD_CONF2}/client.crt")"
   lxc auth identity list --format csv | grep -Fq 'oidc,OIDC client," ",test-user@example.com,test-group'


### PR DESCRIPTION
As part of the [TLS fine-grained authorization specification](https://discourse.ubuntu.com/t/tls-fine-grained-authorization/48497), pending TLS identities must be pruned when their associated token expires. This pull request adds logic to the `autoRemoveExpiredTokens` task such that the leader will retrieve all the pending TLS identities and delete those that have expired. Non-leaders will continue to cancel "certificate add" and "cluster join" operations in-memory in each member.

There was a lot of duplication of logic to identify the database leader. This PR adds a method to `Daemon` and `State` to determine if the member is a leader and refactors existing code to use that method. If the Daemon is standalone it is considered to be the leader. It is the responsibility of the caller to check `(*State).ServerClustered` before calling `(*State).LeaderInfo` when necessary.

Marked as draft until #14207 is merged.