### PR TITLE
lxc/completion: `lxc storage volume copy` shell completion fixes and improvements to `completions.go`

### DIFF
--- a/lxc/completion.go
+++ b/lxc/completion.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"regexp"
 	"strings"
 
@@ -65,7 +64,7 @@ func (g *cmdGlobal) cmpClusterGroups(toComplete string) ([]string, cobra.ShellCo
 		if resource.remote == g.conf.DefaultRemote && !strings.Contains(toComplete, g.conf.DefaultRemote) {
 			name = group
 		} else {
-			name = fmt.Sprintf("%s:%s", resource.remote, group)
+			name = resource.remote + ":" + group
 		}
 
 		results = append(results, name)
@@ -157,7 +156,7 @@ func (g *cmdGlobal) cmpClusterMembers(toComplete string) ([]string, cobra.ShellC
 			if resource.remote == g.conf.DefaultRemote && !strings.Contains(toComplete, g.conf.DefaultRemote) {
 				name = member.ServerName
 			} else {
-				name = fmt.Sprintf("%s:%s", resource.remote, member.ServerName)
+				name = resource.remote + ":" + member.ServerName
 			}
 
 			results = append(results, name)
@@ -195,7 +194,7 @@ func (g *cmdGlobal) cmpImages(toComplete string) ([]string, cobra.ShellCompDirec
 			if remote == g.conf.DefaultRemote && !strings.Contains(toComplete, g.conf.DefaultRemote) {
 				name = alias.Name
 			} else {
-				name = fmt.Sprintf("%s:%s", remote, alias.Name)
+				name = remote + ":" + alias.Name
 			}
 
 			results = append(results, name)
@@ -310,7 +309,7 @@ func (g *cmdGlobal) cmpInstanceConfigTemplates(instanceName string) ([]string, c
 
 	results, err := client.GetInstanceTemplateFiles(instanceNameOnly)
 	if err != nil {
-		cobra.CompDebug(fmt.Sprintf("%v", err), true)
+		cobra.CompDebug(err.Error(), true)
 		return nil, cobra.ShellCompDirectiveError
 	}
 
@@ -415,7 +414,7 @@ func (g *cmdGlobal) cmpInstances(toComplete string) ([]string, cobra.ShellCompDi
 			if resource.remote == g.conf.DefaultRemote && !strings.Contains(toComplete, g.conf.DefaultRemote) {
 				name = instance
 			} else {
-				name = fmt.Sprintf("%s:%s", resource.remote, instance)
+				name = resource.remote + ":" + instance
 			}
 
 			results = append(results, name)
@@ -474,7 +473,7 @@ func (g *cmdGlobal) cmpInstancesAction(toComplete string, action string, flagFor
 				if resource.remote == g.conf.DefaultRemote && !strings.Contains(toComplete, g.conf.DefaultRemote) {
 					name = instance.Name
 				} else {
-					name = fmt.Sprintf("%s:%s", resource.remote, instance.Name)
+					name = resource.remote + ":" + instance.Name
 				}
 
 				results = append(results, name)
@@ -504,7 +503,7 @@ func (g *cmdGlobal) cmpInstancesAndSnapshots(toComplete string) ([]string, cobra
 			instName, _, _ := strings.Cut(resource.name, shared.SnapshotDelimiter)
 			snapshots, _ := resource.server.GetInstanceSnapshotNames(instName)
 			for _, snapshot := range snapshots {
-				results = append(results, fmt.Sprintf("%s/%s", instName, snapshot))
+				results = append(results, instName+"/"+snapshot)
 			}
 		} else {
 			instances, _ := resource.server.GetInstanceNames("")
@@ -514,7 +513,7 @@ func (g *cmdGlobal) cmpInstancesAndSnapshots(toComplete string) ([]string, cobra
 				if resource.remote == g.conf.DefaultRemote && !strings.Contains(toComplete, g.conf.DefaultRemote) {
 					name = instance
 				} else {
-					name = fmt.Sprintf("%s:%s", resource.remote, instance)
+					name = resource.remote + ":" + instance
 				}
 
 				results = append(results, name)
@@ -594,7 +593,7 @@ func (g *cmdGlobal) cmpNetworkACLs(toComplete string) ([]string, cobra.ShellComp
 		if resource.remote == g.conf.DefaultRemote && !strings.Contains(toComplete, g.conf.DefaultRemote) {
 			name = acl
 		} else {
-			name = fmt.Sprintf("%s:%s", resource.remote, acl)
+			name = resource.remote + ":" + acl
 		}
 
 		results = append(results, name)
@@ -614,7 +613,7 @@ func (g *cmdGlobal) cmpNetworkACLRuleProperties() ([]string, cobra.ShellCompDire
 
 	allowedKeys := networkACLRuleJSONStructFieldMap()
 	for key := range allowedKeys {
-		results = append(results, fmt.Sprintf("%s=", key))
+		results = append(results, key+"=")
 	}
 
 	return results, cobra.ShellCompDirectiveNoSpace
@@ -747,7 +746,7 @@ func (g *cmdGlobal) cmpNetworks(toComplete string) ([]string, cobra.ShellCompDir
 			if resource.remote == g.conf.DefaultRemote && !strings.Contains(toComplete, g.conf.DefaultRemote) {
 				name = network
 			} else {
-				name = fmt.Sprintf("%s:%s", resource.remote, network)
+				name = resource.remote + ":" + network
 			}
 
 			results = append(results, name)
@@ -929,7 +928,7 @@ func (g *cmdGlobal) cmpNetworkZones(toComplete string) ([]string, cobra.ShellCom
 			if resource.remote == g.conf.DefaultRemote && !strings.Contains(toComplete, g.conf.DefaultRemote) {
 				name = project
 			} else {
-				name = fmt.Sprintf("%s:%s", resource.remote, project)
+				name = resource.remote + ":" + project
 			}
 
 			results = append(results, name)
@@ -1022,7 +1021,7 @@ func (g *cmdGlobal) cmpProfiles(toComplete string, includeRemotes bool) ([]strin
 			if resource.remote == g.conf.DefaultRemote && !strings.Contains(toComplete, g.conf.DefaultRemote) {
 				name = profile
 			} else {
-				name = fmt.Sprintf("%s:%s", resource.remote, profile)
+				name = resource.remote + ":" + profile
 			}
 
 			results = append(results, name)
@@ -1080,7 +1079,7 @@ func (g *cmdGlobal) cmpProjects(toComplete string) ([]string, cobra.ShellCompDir
 			if resource.remote == g.conf.DefaultRemote && !strings.Contains(toComplete, g.conf.DefaultRemote) {
 				name = project
 			} else {
-				name = fmt.Sprintf("%s:%s", resource.remote, project)
+				name = resource.remote + ":" + project
 			}
 
 			results = append(results, name)
@@ -1104,7 +1103,7 @@ func (g *cmdGlobal) cmpRemotes(includeAll bool) ([]string, cobra.ShellCompDirect
 			continue
 		}
 
-		results = append(results, fmt.Sprintf("%s:", remoteName))
+		results = append(results, remoteName+":")
 	}
 
 	return results, cobra.ShellCompDirectiveNoSpace
@@ -1159,7 +1158,7 @@ func (g *cmdGlobal) cmpStoragePoolWithVolume(toComplete string) ([]string, cobra
 			if strings.HasSuffix(pool, ":") {
 				results = append(results, pool)
 			} else {
-				results = append(results, fmt.Sprintf("%s/", pool))
+				results = append(results, pool+"/")
 			}
 		}
 
@@ -1199,7 +1198,7 @@ func (g *cmdGlobal) cmpStoragePools(toComplete string, noSpace bool) ([]string, 
 			if resource.remote == g.conf.DefaultRemote && !strings.Contains(toComplete, g.conf.DefaultRemote) {
 				name = storage
 			} else {
-				name = fmt.Sprintf("%s:%s", resource.remote, storage)
+				name = resource.remote + ":" + storage
 			}
 
 			results = append(results, name)

--- a/lxc/completion.go
+++ b/lxc/completion.go
@@ -1149,7 +1149,7 @@ func (g *cmdGlobal) cmpStoragePoolConfigs(poolName string) ([]string, cobra.Shel
 
 func (g *cmdGlobal) cmpStoragePoolWithVolume(toComplete string) ([]string, cobra.ShellCompDirective) {
 	if !strings.Contains(toComplete, "/") {
-		pools, compdir := g.cmpStoragePools(toComplete)
+		pools, compdir := g.cmpStoragePools(toComplete, false)
 		if compdir == cobra.ShellCompDirectiveError {
 			return nil, compdir
 		}
@@ -1174,13 +1174,16 @@ func (g *cmdGlobal) cmpStoragePoolWithVolume(toComplete string) ([]string, cobra
 
 	var results []string
 	for _, volume := range volumes {
-		results = append(results, fmt.Sprintf("%s/%s", pool, volume))
+		volName, _ := parseVolume("volume", volume)
+		results = append(results, pool+"/"+volName)
 	}
 
 	return results, cobra.ShellCompDirectiveNoFileComp
 }
 
-func (g *cmdGlobal) cmpStoragePools(toComplete string) ([]string, cobra.ShellCompDirective) {
+// cmpStoragePools provides shell completion for storage pool names.
+// It takes a partial input string and a boolean indicating whether to avoid appending a space after the completion. The function returns a list of matching storage pool names and a shell completion directive.
+func (g *cmdGlobal) cmpStoragePools(toComplete string, noSpace bool) ([]string, cobra.ShellCompDirective) {
 	var results []string
 
 	resources, _ := g.ParseServers(toComplete)
@@ -1206,6 +1209,10 @@ func (g *cmdGlobal) cmpStoragePools(toComplete string) ([]string, cobra.ShellCom
 	if !strings.Contains(toComplete, ":") {
 		remotes, _ := g.cmpRemotes(false)
 		results = append(results, remotes...)
+	}
+
+	if noSpace {
+		return results, cobra.ShellCompDirectiveNoSpace
 	}
 
 	return results, cobra.ShellCompDirectiveNoFileComp

--- a/lxc/completion.go
+++ b/lxc/completion.go
@@ -11,6 +11,8 @@ import (
 	"github.com/canonical/lxd/shared/api"
 )
 
+// cmpClusterGroupNames provides shell completion for cluster group names.
+// It takes a partial input string and returns a list of matching names along with a shell completion directive.
 func (g *cmdGlobal) cmpClusterGroupNames(toComplete string) ([]string, cobra.ShellCompDirective) {
 	var results []string
 	cmpDirectives := cobra.ShellCompDirectiveNoFileComp
@@ -36,6 +38,8 @@ func (g *cmdGlobal) cmpClusterGroupNames(toComplete string) ([]string, cobra.She
 	return results, cmpDirectives
 }
 
+// cmpClusterGroups provides shell completion for cluster groups and their remotes.
+// It takes a partial input string and returns a list of matching cluster groups along with a shell completion directive.
 func (g *cmdGlobal) cmpClusterGroups(toComplete string) ([]string, cobra.ShellCompDirective) {
 	var results []string
 	cmpDirectives := cobra.ShellCompDirectiveNoFileComp
@@ -79,6 +83,8 @@ func (g *cmdGlobal) cmpClusterGroups(toComplete string) ([]string, cobra.ShellCo
 	return results, cmpDirectives
 }
 
+// cmpClusterMemberConfigs provides shell completion for cluster member configs.
+// It takes a partial input string (member name) and returns a list of matching cluster member configs along with a shell completion directive.
 func (g *cmdGlobal) cmpClusterMemberConfigs(memberName string) ([]string, cobra.ShellCompDirective) {
 	// Parse remote
 	resources, err := g.ParseServers(memberName)
@@ -107,6 +113,8 @@ func (g *cmdGlobal) cmpClusterMemberConfigs(memberName string) ([]string, cobra.
 	return results, cobra.ShellCompDirectiveNoFileComp
 }
 
+// cmpClusterMemberRoles provides shell completion for cluster member roles.
+// It takes a member name and returns a list of matching cluster member roles along with a shell completion directive.
 func (g *cmdGlobal) cmpClusterMemberRoles(memberName string) ([]string, cobra.ShellCompDirective) {
 	// Parse remote
 	resources, err := g.ParseServers(memberName)
@@ -130,6 +138,8 @@ func (g *cmdGlobal) cmpClusterMemberRoles(memberName string) ([]string, cobra.Sh
 	return member.Roles, cobra.ShellCompDirectiveNoFileComp
 }
 
+// cmpClusterMembers provides shell completion for cluster members.
+// It takes a partial input string and returns a list of matching cluster members along with a shell completion directive.
 func (g *cmdGlobal) cmpClusterMembers(toComplete string) ([]string, cobra.ShellCompDirective) {
 	var results []string
 	cmpDirectives := cobra.ShellCompDirectiveNoFileComp
@@ -172,6 +182,8 @@ func (g *cmdGlobal) cmpClusterMembers(toComplete string) ([]string, cobra.ShellC
 	return results, cmpDirectives
 }
 
+// cmpImages provides shell completion for image aliases.
+// It takes a partial input string and returns a list of matching image aliases along with a shell completion directive.
 func (g *cmdGlobal) cmpImages(toComplete string) ([]string, cobra.ShellCompDirective) {
 	var results []string
 	var remote string
@@ -210,6 +222,8 @@ func (g *cmdGlobal) cmpImages(toComplete string) ([]string, cobra.ShellCompDirec
 	return results, cmpDirectives
 }
 
+// cmpInstanceAllKeys provides shell completion for all instance configuration keys.
+// It takes an instance name and returns a list of all instance configuration keys along with a shell completion directive.
 func (g *cmdGlobal) cmpInstanceAllKeys(instanceName string) ([]string, cobra.ShellCompDirective) {
 	var keys []string
 	cmpDirectives := cobra.ShellCompDirectiveNoFileComp
@@ -255,6 +269,8 @@ func (g *cmdGlobal) cmpInstanceAllKeys(instanceName string) ([]string, cobra.She
 	return keys, cmpDirectives
 }
 
+// cmpServerAllKeys provides shell completion for all server configuration keys.
+// It takes an instance name and returns a list of all server configuration keys along with a shell completion directive.
 func (g *cmdGlobal) cmpServerAllKeys(instanceName string) ([]string, cobra.ShellCompDirective) {
 	resources, err := g.ParseServers(instanceName)
 	if err != nil || len(resources) == 0 {
@@ -292,6 +308,8 @@ func (g *cmdGlobal) cmpServerAllKeys(instanceName string) ([]string, cobra.Shell
 	return keys, cobra.ShellCompDirectiveNoFileComp
 }
 
+// cmpInstanceConfigTemplates provides shell completion for instance config templates.
+// It takes an instance name and returns a list of instance config templates along with a shell completion directive.
 func (g *cmdGlobal) cmpInstanceConfigTemplates(instanceName string) ([]string, cobra.ShellCompDirective) {
 	// Parse remote
 	resources, err := g.ParseServers(instanceName)
@@ -316,6 +334,8 @@ func (g *cmdGlobal) cmpInstanceConfigTemplates(instanceName string) ([]string, c
 	return results, cobra.ShellCompDirectiveNoFileComp
 }
 
+// cmpInstanceDeviceNames provides shell completion for instance devices.
+// It takes an instance name and returns a list of instance device names along with a shell completion directive.
 func (g *cmdGlobal) cmpInstanceDeviceNames(instanceName string) ([]string, cobra.ShellCompDirective) {
 	// Parse remote
 	resources, err := g.ParseServers(instanceName)
@@ -339,6 +359,8 @@ func (g *cmdGlobal) cmpInstanceDeviceNames(instanceName string) ([]string, cobra
 	return results, cobra.ShellCompDirectiveNoFileComp
 }
 
+// cmpInstanceAllDevices provides shell completion for all instance devices.
+// It takes an instance name and returns a list of all possible instance devices along with a shell completion directive.
 func (g *cmdGlobal) cmpInstanceAllDevices(instanceName string) ([]string, cobra.ShellCompDirective) {
 	resources, err := g.ParseServers(instanceName)
 	if err != nil || len(resources) == 0 {
@@ -366,6 +388,8 @@ func (g *cmdGlobal) cmpInstanceAllDevices(instanceName string) ([]string, cobra.
 	return devices, cobra.ShellCompDirectiveNoFileComp
 }
 
+// cmpInstanceAllDeviceOptions provides shell completion for all instance device options.
+// It takes an instance name and device name and returns a list of all possible instance device options along with a shell completion directive.
 func (g *cmdGlobal) cmpInstanceAllDeviceOptions(instanceName string, deviceName string) ([]string, cobra.ShellCompDirective) {
 	resources, err := g.ParseServers(instanceName)
 	if err != nil || len(resources) == 0 {
@@ -397,6 +421,8 @@ func (g *cmdGlobal) cmpInstanceAllDeviceOptions(instanceName string, deviceName 
 	return deviceOptions, cobra.ShellCompDirectiveNoFileComp
 }
 
+// cmpInstances provides shell completion for all instances.
+// It takes a partial input string and returns a list of matching instances along with a shell completion directive.
 func (g *cmdGlobal) cmpInstances(toComplete string) ([]string, cobra.ShellCompDirective) {
 	var results []string
 	cmpDirectives := cobra.ShellCompDirectiveNoFileComp
@@ -430,6 +456,8 @@ func (g *cmdGlobal) cmpInstances(toComplete string) ([]string, cobra.ShellCompDi
 	return results, cmpDirectives
 }
 
+// cmpInstancesAction provides shell completion for all instance actions (start, pause, exec, stop and delete).
+// It takes a partial input string, an action, and a boolean indicating if the force flag has been passed in. It returns a list of applicable instances based on their state and the requested action, along with a shell completion directive.
 func (g *cmdGlobal) cmpInstancesAction(toComplete string, action string, flagForce bool) ([]string, cobra.ShellCompDirective) {
 	var results []string
 	cmpDirectives := cobra.ShellCompDirectiveNoFileComp
@@ -490,6 +518,8 @@ func (g *cmdGlobal) cmpInstancesAction(toComplete string, action string, flagFor
 	return results, cmpDirectives
 }
 
+// cmpInstancesAndSnapshots provides shell completion for instances and their snapshots.
+// It takes a partial input string and returns a list of matching instances and their snapshots, along with a shell completion directive.
 func (g *cmdGlobal) cmpInstancesAndSnapshots(toComplete string) ([]string, cobra.ShellCompDirective) {
 	results := []string{}
 	cmpDirectives := cobra.ShellCompDirectiveNoFileComp
@@ -530,6 +560,8 @@ func (g *cmdGlobal) cmpInstancesAndSnapshots(toComplete string) ([]string, cobra
 	return results, cmpDirectives
 }
 
+// cmpInstanceNamesFromRemote provides shell completion for instances for a specific remote.
+// It takes a partial input string and returns a list of matching instances along with a shell completion directive.
 func (g *cmdGlobal) cmpInstanceNamesFromRemote(toComplete string) ([]string, cobra.ShellCompDirective) {
 	var results []string
 
@@ -547,6 +579,8 @@ func (g *cmdGlobal) cmpInstanceNamesFromRemote(toComplete string) ([]string, cob
 	return results, cobra.ShellCompDirectiveNoFileComp
 }
 
+// cmpNetworkACLConfigs provides shell completion for network ACL configs.
+// It takes an ACL name and returns a list of network ACL configs along with a shell completion directive.
 func (g *cmdGlobal) cmpNetworkACLConfigs(aclName string) ([]string, cobra.ShellCompDirective) {
 	// Parse remote
 	resources, err := g.ParseServers(aclName)
@@ -570,6 +604,8 @@ func (g *cmdGlobal) cmpNetworkACLConfigs(aclName string) ([]string, cobra.ShellC
 	return results, cobra.ShellCompDirectiveNoFileComp
 }
 
+// cmpNetworkACLs provides shell completion for network ACL's.
+// It takes a partial input string and returns a list of matching network ACL's along with a shell completion directive.
 func (g *cmdGlobal) cmpNetworkACLs(toComplete string) ([]string, cobra.ShellCompDirective) {
 	var results []string
 	cmpDirectives := cobra.ShellCompDirectiveNoFileComp
@@ -608,6 +644,8 @@ func (g *cmdGlobal) cmpNetworkACLs(toComplete string) ([]string, cobra.ShellComp
 	return results, cmpDirectives
 }
 
+// cmpNetworkACLRuleProperties provides shell completion for network ACL rule properties.
+// It returns a list of network ACL rules provided by `networkACLRuleJSONStructFieldMap()“ along with a shell completion directive.
 func (g *cmdGlobal) cmpNetworkACLRuleProperties() ([]string, cobra.ShellCompDirective) {
 	var results []string
 
@@ -619,6 +657,8 @@ func (g *cmdGlobal) cmpNetworkACLRuleProperties() ([]string, cobra.ShellCompDire
 	return results, cobra.ShellCompDirectiveNoSpace
 }
 
+// cmpNetworkForwardConfigs provides shell completion for network forward configs.
+// It takes a network name and listen address, and returns a list of network forward configs along with a shell completion directive.
 func (g *cmdGlobal) cmpNetworkForwardConfigs(networkName string, listenAddress string) ([]string, cobra.ShellCompDirective) {
 	// Parse remote
 	resources, err := g.ParseServers(networkName)
@@ -642,6 +682,8 @@ func (g *cmdGlobal) cmpNetworkForwardConfigs(networkName string, listenAddress s
 	return results, cobra.ShellCompDirectiveNoFileComp
 }
 
+// cmpNetworkForwards provides shell completion for network forwards.
+// It takes a network name and returns a list of network forwards along with a shell completion directive.
 func (g *cmdGlobal) cmpNetworkForwards(networkName string) ([]string, cobra.ShellCompDirective) {
 	var results []string
 	cmpDirectives := cobra.ShellCompDirectiveNoFileComp
@@ -662,6 +704,8 @@ func (g *cmdGlobal) cmpNetworkForwards(networkName string) ([]string, cobra.Shel
 	return results, cmpDirectives
 }
 
+// cmpNetworkLoadBalancers provides shell completion for network load balancers.
+// It takes a network name and returns a list of network load balancers along with a shell completion directive.
 func (g *cmdGlobal) cmpNetworkLoadBalancers(networkName string) ([]string, cobra.ShellCompDirective) {
 	var results []string
 	cmpDirectives := cobra.ShellCompDirectiveNoFileComp
@@ -682,6 +726,8 @@ func (g *cmdGlobal) cmpNetworkLoadBalancers(networkName string) ([]string, cobra
 	return results, cmpDirectives
 }
 
+// cmpNetworkPeerConfigs provides shell completion for network peer configs.
+// It takes a network name and peer name, and returns a list of network peer configs along with a shell completion directive.
 func (g *cmdGlobal) cmpNetworkPeerConfigs(networkName string, peerName string) ([]string, cobra.ShellCompDirective) {
 	var results []string
 	cmpDirectives := cobra.ShellCompDirectiveNoFileComp
@@ -706,6 +752,8 @@ func (g *cmdGlobal) cmpNetworkPeerConfigs(networkName string, peerName string) (
 	return results, cmpDirectives
 }
 
+// cmpNetworkPeers provides shell completion for network peers.
+// It takes a network name and returns a list of network peers along with a shell completion directive.
 func (g *cmdGlobal) cmpNetworkPeers(networkName string) ([]string, cobra.ShellCompDirective) {
 	var results []string
 	cmpDirectives := cobra.ShellCompDirectiveNoFileComp
@@ -726,6 +774,8 @@ func (g *cmdGlobal) cmpNetworkPeers(networkName string) ([]string, cobra.ShellCo
 	return results, cmpDirectives
 }
 
+// cmpNetworks provides shell completion for networks.
+// It takes a partial input string and returns a list of matching networks along with a shell completion directive.
 func (g *cmdGlobal) cmpNetworks(toComplete string) ([]string, cobra.ShellCompDirective) {
 	var results []string
 	cmpDirectives := cobra.ShellCompDirectiveNoFileComp
@@ -762,6 +812,8 @@ func (g *cmdGlobal) cmpNetworks(toComplete string) ([]string, cobra.ShellCompDir
 	return results, cmpDirectives
 }
 
+// cmpNetworkConfigs provides shell completion for network configs.
+// It takes a network name and returns a list of network configs along with a shell completion directive.
 func (g *cmdGlobal) cmpNetworkConfigs(networkName string) ([]string, cobra.ShellCompDirective) {
 	// Parse remote
 	resources, err := g.ParseServers(networkName)
@@ -785,6 +837,8 @@ func (g *cmdGlobal) cmpNetworkConfigs(networkName string) ([]string, cobra.Shell
 	return results, cobra.ShellCompDirectiveNoFileComp
 }
 
+// cmpNetworkInstances provides shell completion for network instances.
+// It takes a network name and returns a list of instances along with a shell completion directive.
 func (g *cmdGlobal) cmpNetworkInstances(networkName string) ([]string, cobra.ShellCompDirective) {
 	// Parse remote
 	resources, err := g.ParseServers(networkName)
@@ -813,6 +867,8 @@ func (g *cmdGlobal) cmpNetworkInstances(networkName string) ([]string, cobra.She
 	return results, cobra.ShellCompDirectiveNoFileComp
 }
 
+// cmpNetworkProfiles provides shell completion for network profiles.
+// It takes a network name and returns a list of network profiles along with a shell completion directive.
 func (g *cmdGlobal) cmpNetworkProfiles(networkName string) ([]string, cobra.ShellCompDirective) {
 	// Parse remote
 	resources, err := g.ParseServers(networkName)
@@ -841,6 +897,8 @@ func (g *cmdGlobal) cmpNetworkProfiles(networkName string) ([]string, cobra.Shel
 	return results, cobra.ShellCompDirectiveNoFileComp
 }
 
+// cmpNetworkZoneConfigs provides shell completion for network zone configs.
+// It takes a zone name and returns a list of network zone configs, along with a shell completion directive.
 func (g *cmdGlobal) cmpNetworkZoneConfigs(zoneName string) ([]string, cobra.ShellCompDirective) {
 	// Parse remote
 	resources, err := g.ParseServers(zoneName)
@@ -864,6 +922,8 @@ func (g *cmdGlobal) cmpNetworkZoneConfigs(zoneName string) ([]string, cobra.Shel
 	return results, cobra.ShellCompDirectiveNoFileComp
 }
 
+// cmpNetworkZoneRecordConfigs provides shell completion for network zone record configs.
+// It takes a zone name and record name, and returns a list of network zone record configs along with a shell completion directive.
 func (g *cmdGlobal) cmpNetworkZoneRecordConfigs(zoneName string, recordName string) ([]string, cobra.ShellCompDirective) {
 	var results []string
 	cmpDirectives := cobra.ShellCompDirectiveNoFileComp
@@ -888,6 +948,8 @@ func (g *cmdGlobal) cmpNetworkZoneRecordConfigs(zoneName string, recordName stri
 	return results, cmpDirectives
 }
 
+// cmpNetworkZoneRecords provides shell completion for network zone records.
+// It takes a zone name and returns a list of network zone records along with a shell completion directive.
 func (g *cmdGlobal) cmpNetworkZoneRecords(zoneName string) ([]string, cobra.ShellCompDirective) {
 	var results []string
 	cmpDirectives := cobra.ShellCompDirectiveNoFileComp
@@ -908,6 +970,8 @@ func (g *cmdGlobal) cmpNetworkZoneRecords(zoneName string) ([]string, cobra.Shel
 	return results, cmpDirectives
 }
 
+// cmpNetworkZones provides shell completion for network zones.
+// It takes a partial input string and returns a list of network zones along with a shell completion directive.
 func (g *cmdGlobal) cmpNetworkZones(toComplete string) ([]string, cobra.ShellCompDirective) {
 	var results []string
 	cmpDirectives := cobra.ShellCompDirectiveNoFileComp
@@ -944,6 +1008,8 @@ func (g *cmdGlobal) cmpNetworkZones(toComplete string) ([]string, cobra.ShellCom
 	return results, cmpDirectives
 }
 
+// cmpProfileConfigs provides shell completion for profile configs.
+// It takes a profile name and returns a list of profile configs along with a shell completion directive.
 func (g *cmdGlobal) cmpProfileConfigs(profileName string) ([]string, cobra.ShellCompDirective) {
 	resources, err := g.ParseServers(profileName)
 	if err != nil || len(resources) == 0 {
@@ -966,6 +1032,8 @@ func (g *cmdGlobal) cmpProfileConfigs(profileName string) ([]string, cobra.Shell
 	return configs, cobra.ShellCompDirectiveNoFileComp
 }
 
+// cmpProfileDeviceNames provides shell completion for profile device names.
+// It takes an instance name and returns a list of profile device names along with a shell completion directive.
 func (g *cmdGlobal) cmpProfileDeviceNames(instanceName string) ([]string, cobra.ShellCompDirective) {
 	// Parse remote
 	resources, err := g.ParseServers(instanceName)
@@ -989,6 +1057,8 @@ func (g *cmdGlobal) cmpProfileDeviceNames(instanceName string) ([]string, cobra.
 	return results, cobra.ShellCompDirectiveNoFileComp
 }
 
+// cmpProfileNamesFromRemote provides shell completion for profile names from a remote.
+// It takes a partial input string and returns a list of profile names along with a shell completion directive.
 func (g *cmdGlobal) cmpProfileNamesFromRemote(toComplete string) ([]string, cobra.ShellCompDirective) {
 	var results []string
 
@@ -1004,6 +1074,8 @@ func (g *cmdGlobal) cmpProfileNamesFromRemote(toComplete string) ([]string, cobr
 	return results, cobra.ShellCompDirectiveNoFileComp
 }
 
+// cmpProfiles provides shell completion for profiles.
+// It takes a partial input string and a boolean specifying whether to include remotes or not, and returns a list of profiles along with a shell completion directive.
 func (g *cmdGlobal) cmpProfiles(toComplete string, includeRemotes bool) ([]string, cobra.ShellCompDirective) {
 	var results []string
 	cmpDirectives := cobra.ShellCompDirectiveNoFileComp
@@ -1037,6 +1109,8 @@ func (g *cmdGlobal) cmpProfiles(toComplete string, includeRemotes bool) ([]strin
 	return results, cmpDirectives
 }
 
+// cmpProjectConfigs provides shell completion for project configs.
+// It takes a project name and returns a list of project configs along with a shell completion directive.
 func (g *cmdGlobal) cmpProjectConfigs(projectName string) ([]string, cobra.ShellCompDirective) {
 	resources, err := g.ParseServers(projectName)
 	if err != nil || len(resources) == 0 {
@@ -1059,6 +1133,8 @@ func (g *cmdGlobal) cmpProjectConfigs(projectName string) ([]string, cobra.Shell
 	return configs, cobra.ShellCompDirectiveNoFileComp
 }
 
+// cmpProjects provides shell completion for projects.
+// It takes a partial input string and returns a list of projects along with a shell completion directive.
 func (g *cmdGlobal) cmpProjects(toComplete string) ([]string, cobra.ShellCompDirective) {
 	var results []string
 	cmpDirectives := cobra.ShellCompDirectiveNoFileComp
@@ -1095,6 +1171,8 @@ func (g *cmdGlobal) cmpProjects(toComplete string) ([]string, cobra.ShellCompDir
 	return results, cmpDirectives
 }
 
+// cmpRemotes provides shell completion for remotes.
+// It takes a boolean specifying whether to include all remotes or not and returns a list of remotes along with a shell completion directive.
 func (g *cmdGlobal) cmpRemotes(includeAll bool) ([]string, cobra.ShellCompDirective) {
 	results := make([]string, 0, len(g.conf.Remotes))
 
@@ -1109,6 +1187,8 @@ func (g *cmdGlobal) cmpRemotes(includeAll bool) ([]string, cobra.ShellCompDirect
 	return results, cobra.ShellCompDirectiveNoSpace
 }
 
+// cmpRemoteNames provides shell completion for remote names.
+// It returns a list of remote names provided by `g.conf.Remotes` along with a shell completion directive.
 func (g *cmdGlobal) cmpRemoteNames() ([]string, cobra.ShellCompDirective) {
 	var results []string
 
@@ -1119,6 +1199,8 @@ func (g *cmdGlobal) cmpRemoteNames() ([]string, cobra.ShellCompDirective) {
 	return results, cobra.ShellCompDirectiveNoFileComp
 }
 
+// cmpStoragePoolConfigs provides shell completion for storage pool configs.
+// It takes a storage pool name and returns a list of storage pool configs, along with a shell completion directive.
 func (g *cmdGlobal) cmpStoragePoolConfigs(poolName string) ([]string, cobra.ShellCompDirective) {
 	// Parse remote
 	resources, err := g.ParseServers(poolName)
@@ -1146,6 +1228,8 @@ func (g *cmdGlobal) cmpStoragePoolConfigs(poolName string) ([]string, cobra.Shel
 	return results, cobra.ShellCompDirectiveNoFileComp
 }
 
+// cmpStoragePoolWithVolume provides shell completion for storage pools and their volumes.
+// It takes a partial input string and returns a list of storage pools and their volumes, along with a shell completion directive.
 func (g *cmdGlobal) cmpStoragePoolWithVolume(toComplete string) ([]string, cobra.ShellCompDirective) {
 	if !strings.Contains(toComplete, "/") {
 		pools, compdir := g.cmpStoragePools(toComplete, false)
@@ -1217,6 +1301,8 @@ func (g *cmdGlobal) cmpStoragePools(toComplete string, noSpace bool) ([]string, 
 	return results, cobra.ShellCompDirectiveNoFileComp
 }
 
+// cmpStoragePoolVolumeConfigs provides shell completion for storage pool volume configs.
+// It takes a storage pool name and volume name, returns a list of storage pool volume configs, along with a shell completion directive.
 func (g *cmdGlobal) cmpStoragePoolVolumeConfigs(poolName string, volumeName string) ([]string, cobra.ShellCompDirective) {
 	// Parse remote
 	resources, err := g.ParseServers(poolName)
@@ -1247,6 +1333,8 @@ func (g *cmdGlobal) cmpStoragePoolVolumeConfigs(poolName string, volumeName stri
 	return results, cobra.ShellCompDirectiveNoFileComp
 }
 
+// cmpStoragePoolVolumeInstances provides shell completion for storage pool volume instances.
+// It takes a storage pool name and volume name, returns a list of storage pool volume instances, along with a shell completion directive.
 func (g *cmdGlobal) cmpStoragePoolVolumeInstances(poolName string, volumeName string) ([]string, cobra.ShellCompDirective) {
 	// Parse remote
 	resources, err := g.ParseServers(poolName)
@@ -1282,6 +1370,8 @@ func (g *cmdGlobal) cmpStoragePoolVolumeInstances(poolName string, volumeName st
 	return results, cobra.ShellCompDirectiveNoFileComp
 }
 
+// cmpStoragePoolVolumeProfiles provides shell completion for storage pool volume instances.
+// It takes a storage pool name and volume name, returns a list of storage pool volume profiles, along with a shell completion directive.
 func (g *cmdGlobal) cmpStoragePoolVolumeProfiles(poolName string, volumeName string) ([]string, cobra.ShellCompDirective) {
 	// Parse remote
 	resources, err := g.ParseServers(poolName)
@@ -1317,6 +1407,8 @@ func (g *cmdGlobal) cmpStoragePoolVolumeProfiles(poolName string, volumeName str
 	return results, cobra.ShellCompDirectiveNoFileComp
 }
 
+// cmpStoragePoolVolumeSnapshots provides shell completion for storage pool volume snapshots.
+// It takes a storage pool name and volume name, returns a list of storage pool volume snapshots, along with a shell completion directive.
 func (g *cmdGlobal) cmpStoragePoolVolumeSnapshots(poolName string, volumeName string) ([]string, cobra.ShellCompDirective) {
 	// Parse remote
 	resources, err := g.ParseServers(poolName)
@@ -1342,6 +1434,8 @@ func (g *cmdGlobal) cmpStoragePoolVolumeSnapshots(poolName string, volumeName st
 	return snapshots, cobra.ShellCompDirectiveNoFileComp
 }
 
+// cmpStoragePoolVolumes provides shell completion for storage pool volumes.
+// It takes a storage pool name and returns a list of storage pool volumes along with a shell completion directive.
 func (g *cmdGlobal) cmpStoragePoolVolumes(poolName string) ([]string, cobra.ShellCompDirective) {
 	// Parse remote
 	resources, err := g.ParseServers(poolName)

--- a/lxc/storage.go
+++ b/lxc/storage.go
@@ -207,7 +207,7 @@ func (c *cmdStorageDelete) command() *cobra.Command {
 
 	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
-			return c.global.cmpStoragePools(toComplete)
+			return c.global.cmpStoragePools(toComplete, false)
 		}
 
 		return nil, cobra.ShellCompDirectiveNoFileComp
@@ -268,7 +268,7 @@ func (c *cmdStorageEdit) command() *cobra.Command {
 
 	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
-			return c.global.cmpStoragePools(toComplete)
+			return c.global.cmpStoragePools(toComplete, false)
 		}
 
 		return nil, cobra.ShellCompDirectiveNoFileComp
@@ -399,7 +399,7 @@ func (c *cmdStorageGet) command() *cobra.Command {
 
 	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
-			return c.global.cmpStoragePools(toComplete)
+			return c.global.cmpStoragePools(toComplete, false)
 		}
 
 		if len(args) == 1 {
@@ -481,7 +481,7 @@ func (c *cmdStorageInfo) command() *cobra.Command {
 
 	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
-			return c.global.cmpStoragePools(toComplete)
+			return c.global.cmpStoragePools(toComplete, false)
 		}
 
 		return nil, cobra.ShellCompDirectiveNoFileComp
@@ -751,7 +751,7 @@ For backward compatibility, a single configuration key may still be set with:
 
 	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
-			return c.global.cmpStoragePools(toComplete)
+			return c.global.cmpStoragePools(toComplete, false)
 		}
 
 		return nil, cobra.ShellCompDirectiveNoFileComp
@@ -852,7 +852,7 @@ func (c *cmdStorageShow) command() *cobra.Command {
 
 	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
-			return c.global.cmpStoragePools(toComplete)
+			return c.global.cmpStoragePools(toComplete, false)
 		}
 
 		return nil, cobra.ShellCompDirectiveNoFileComp
@@ -946,7 +946,7 @@ func (c *cmdStorageUnset) command() *cobra.Command {
 
 	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
-			return c.global.cmpStoragePools(toComplete)
+			return c.global.cmpStoragePools(toComplete, false)
 		}
 
 		if len(args) == 1 {

--- a/lxc/storage_volume.go
+++ b/lxc/storage_volume.go
@@ -173,7 +173,7 @@ func (c *cmdStorageVolumeAttach) command() *cobra.Command {
 
 	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
-			return c.global.cmpStoragePools(toComplete)
+			return c.global.cmpStoragePools(toComplete, false)
 		}
 
 		if len(args) == 1 {
@@ -287,7 +287,7 @@ func (c *cmdStorageVolumeAttachProfile) command() *cobra.Command {
 
 	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
-			return c.global.cmpStoragePools(toComplete)
+			return c.global.cmpStoragePools(toComplete, false)
 		}
 
 		if len(args) == 1 {
@@ -404,7 +404,13 @@ func (c *cmdStorageVolumeCopy) command() *cobra.Command {
 		}
 
 		if len(args) == 1 {
-			return c.global.cmpStoragePools(toComplete)
+			completions, directive := c.global.cmpStoragePools(toComplete, true)
+			for i, completion := range completions {
+				if !strings.Contains(completion, ":") {
+					completions[i] = completion + "/"
+				}
+			}
+			return completions, directive
 		}
 
 		return nil, cobra.ShellCompDirectiveNoFileComp
@@ -615,7 +621,7 @@ lxc storage volume create p1 v1 < config.yaml
 
 	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
-			return c.global.cmpStoragePools(toComplete)
+			return c.global.cmpStoragePools(toComplete, false)
 		}
 
 		return nil, cobra.ShellCompDirectiveNoFileComp
@@ -719,7 +725,7 @@ func (c *cmdStorageVolumeDelete) command() *cobra.Command {
 
 	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
-			return c.global.cmpStoragePools(toComplete)
+			return c.global.cmpStoragePools(toComplete, false)
 		}
 
 		if len(args) == 1 {
@@ -805,7 +811,7 @@ func (c *cmdStorageVolumeDetach) command() *cobra.Command {
 
 	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
-			return c.global.cmpStoragePools(toComplete)
+			return c.global.cmpStoragePools(toComplete, false)
 		}
 
 		if len(args) == 1 {
@@ -903,7 +909,7 @@ func (c *cmdStorageVolumeDetachProfile) command() *cobra.Command {
 
 	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
-			return c.global.cmpStoragePools(toComplete)
+			return c.global.cmpStoragePools(toComplete, false)
 		}
 
 		if len(args) == 1 {
@@ -1007,7 +1013,7 @@ lxc storage volume edit [<remote>:]<pool> [<type>/]<volume> < volume.yaml
 
 	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
-			return c.global.cmpStoragePools(toComplete)
+			return c.global.cmpStoragePools(toComplete, false)
 		}
 
 		if len(args) == 1 {
@@ -1234,7 +1240,7 @@ lxc storage volume get default virtual-machine/data snapshots.expiry
 
 	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
-			return c.global.cmpStoragePools(toComplete)
+			return c.global.cmpStoragePools(toComplete, false)
 		}
 
 		if len(args) == 1 {
@@ -1362,7 +1368,7 @@ lxc storage volume info default virtual-machine/data
 
 	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
-			return c.global.cmpStoragePools(toComplete)
+			return c.global.cmpStoragePools(toComplete, false)
 		}
 
 		if len(args) == 1 {
@@ -1611,7 +1617,7 @@ Column shorthand chars:
 
 	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
-			return c.global.cmpStoragePools(toComplete)
+			return c.global.cmpStoragePools(toComplete, false)
 		}
 
 		return nil, cobra.ShellCompDirectiveNoFileComp
@@ -1856,7 +1862,7 @@ func (c *cmdStorageVolumeMove) command() *cobra.Command {
 		}
 
 		if len(args) == 1 {
-			return c.global.cmpStoragePools(toComplete)
+			return c.global.cmpStoragePools(toComplete, false)
 		}
 
 		return nil, cobra.ShellCompDirectiveNoFileComp
@@ -1942,7 +1948,7 @@ func (c *cmdStorageVolumeRename) command() *cobra.Command {
 
 	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
-			return c.global.cmpStoragePools(toComplete)
+			return c.global.cmpStoragePools(toComplete, false)
 		}
 
 		if len(args) == 1 {
@@ -2082,7 +2088,7 @@ lxc storage volume set default virtual-machine/data snapshots.expiry=7d
 
 	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
-			return c.global.cmpStoragePools(toComplete)
+			return c.global.cmpStoragePools(toComplete, false)
 		}
 
 		if len(args) == 1 {
@@ -2241,7 +2247,7 @@ lxc storage volume show default virtual-machine/data/snap0
 
 	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
-			return c.global.cmpStoragePools(toComplete)
+			return c.global.cmpStoragePools(toComplete, false)
 		}
 
 		if len(args) == 1 {
@@ -2358,7 +2364,7 @@ lxc storage volume unset default virtual-machine/data snapshots.expiry
 
 	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
-			return c.global.cmpStoragePools(toComplete)
+			return c.global.cmpStoragePools(toComplete, false)
 		}
 
 		if len(args) == 1 {
@@ -2418,7 +2424,7 @@ lxc storage volume snapshot create default v1 snap0 < config.yaml
 
 	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
-			return c.global.cmpStoragePools(toComplete)
+			return c.global.cmpStoragePools(toComplete, false)
 		}
 
 		if len(args) == 1 {
@@ -2546,7 +2552,7 @@ func (c *cmdStorageVolumeRestore) command() *cobra.Command {
 
 	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
-			return c.global.cmpStoragePools(toComplete)
+			return c.global.cmpStoragePools(toComplete, false)
 		}
 
 		if len(args) == 1 {
@@ -2633,7 +2639,7 @@ func (c *cmdStorageVolumeExport) command() *cobra.Command {
 
 	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
-			return c.global.cmpStoragePools(toComplete)
+			return c.global.cmpStoragePools(toComplete, false)
 		}
 
 		if len(args) == 1 {
@@ -2798,7 +2804,7 @@ func (c *cmdStorageVolumeImport) command() *cobra.Command {
 
 	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
-			return c.global.cmpStoragePools(toComplete)
+			return c.global.cmpStoragePools(toComplete, false)
 		}
 
 		return nil, cobra.ShellCompDirectiveDefault


### PR DESCRIPTION
Fixes https://github.com/canonical/lxd/issues/14264.

This PR also replaces the use of `Sprintf()` with string concatenation where possible, and adds go doc comments to all completion functions.