### PR TITLE
Improve API metrics logging

### DIFF
--- a/lxd/metrics/api_rates.go
+++ b/lxd/metrics/api_rates.go
@@ -2,14 +2,11 @@ package metrics
 
 import (
 	"net/http"
-	"strings"
 	"sync"
 	"sync/atomic"
 
-	"github.com/canonical/lxd/lxd/auth"
 	"github.com/canonical/lxd/lxd/request"
 	"github.com/canonical/lxd/shared/entity"
-	"github.com/canonical/lxd/shared/logger"
 )
 
 // RequestResult represents a completed request status category.
@@ -99,12 +96,7 @@ func TrackStartedRequest(r *http.Request, endpointType entity.Type) {
 func UseMetricsCallback(req *http.Request, result RequestResult) {
 	callback, err := request.GetCtxValue[func(RequestResult)](req.Context(), request.CtxMetricsCallbackFunc)
 
-	// Verify the auth method in the request context to determine if the request comes from the /dev/lxd socket.
-	authMethod, _ := auth.GetAuthenticationMethodFromCtx(req.Context())
-	if err != nil && strings.HasPrefix(req.URL.Path, "/1.0") && authMethod != auth.AuthenticationMethodDevLXD {
-		// Log a warning if endpoint is part of the main API, and therefore should be counted fot the API metrics.
-		logger.Warn("Request will not be counted for the API metrics", logger.Ctx{"url": req.URL.Path, "method": req.Method, "remote": req.RemoteAddr})
-	} else if err == nil && callback != nil {
+	if err == nil && callback != nil {
 		callback(result)
 	}
 }

--- a/lxd/operations/response.go
+++ b/lxd/operations/response.go
@@ -118,14 +118,9 @@ func (r *forwardedOperationResponse) Render(w http.ResponseWriter, req *http.Req
 		debugLogger = logger.AddContext(logger.Ctx{"http_code": code})
 	}
 
-	err := util.WriteJSON(w, body, debugLogger)
+	metrics.UseMetricsCallback(req, metrics.Success)
 
-	if err == nil {
-		// If there was an error on Render, the callback function will be called during the error handling.
-		metrics.UseMetricsCallback(req, metrics.Success)
-	}
-
-	return err
+	return util.WriteJSON(w, body, debugLogger)
 }
 
 func (r *forwardedOperationResponse) String() string {

--- a/lxd/response/response.go
+++ b/lxd/response/response.go
@@ -148,7 +148,7 @@ func SyncResponsePlain(success bool, compress bool, metadata string) Response {
 }
 
 // Render renders a synchronous response.
-func (r *syncResponse) Render(w http.ResponseWriter, req *http.Request) (err error) {
+func (r *syncResponse) Render(w http.ResponseWriter, req *http.Request) error {
 	// Set an appropriate ETag header
 	if r.etag != nil {
 		etag, err := util.EtagHash(r.etag)
@@ -206,13 +206,10 @@ func (r *syncResponse) Render(w http.ResponseWriter, req *http.Request) (err err
 
 	// defer calling the callback function after possibly considering the response a SmartError.
 	defer func() {
-		// If there was an error on Render, the callback function will be called during the error handling.
-		if err == nil {
-			if r.success {
-				metrics.UseMetricsCallback(req, metrics.Success)
-			} else {
-				metrics.UseMetricsCallback(req, metrics.ErrorServer)
-			}
+		if r.success {
+			metrics.UseMetricsCallback(req, metrics.Success)
+		} else {
+			metrics.UseMetricsCallback(req, metrics.ErrorServer)
 		}
 	}()
 
@@ -223,12 +220,12 @@ func (r *syncResponse) Render(w http.ResponseWriter, req *http.Request) (err err
 				comp := gzip.NewWriter(w)
 				defer comp.Close()
 
-				_, err = comp.Write([]byte(r.metadata.(string)))
+				_, err := comp.Write([]byte(r.metadata.(string)))
 				if err != nil {
 					return err
 				}
 			} else {
-				_, err = w.Write([]byte(r.metadata.(string)))
+				_, err := w.Write([]byte(r.metadata.(string)))
 				if err != nil {
 					return err
 				}
@@ -251,9 +248,7 @@ func (r *syncResponse) Render(w http.ResponseWriter, req *http.Request) (err err
 		debugLogger = logger.AddContext(logger.Ctx{"http_code": code})
 	}
 
-	err = util.WriteJSON(w, resp, debugLogger)
-
-	return err
+	return util.WriteJSON(w, resp, debugLogger)
 }
 
 func (r *syncResponse) String() string {
@@ -426,13 +421,14 @@ func FileResponse(files []FileResponseEntry, headers map[string]string) Response
 }
 
 // Render renders a file response.
-func (r *fileResponse) Render(w http.ResponseWriter, req *http.Request) (err error) {
+func (r *fileResponse) Render(w http.ResponseWriter, req *http.Request) error {
 	if r.headers != nil {
 		for k, v := range r.headers {
 			w.Header().Set(k, v)
 		}
 	}
 
+	var err error
 	defer func() {
 		if err == nil {
 			// If there was an error on Render, the callback function will be called during the error handling.
@@ -527,7 +523,7 @@ func (r *fileResponse) Render(w http.ResponseWriter, req *http.Request) (err err
 			return err
 		}
 
-		_, err = io.Copy(fw, rd)
+		_, err := io.Copy(fw, rd)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Recently we are getting unwanted API metrics logging on the LXD agent, MicroCloud and MicroCluster.

As a fix, this PR removes the logging logic, as it is not needed since https://github.com/canonical/lxd/pull/14228. We are now typing the endpoints manually and checking if all the appropriate endpoints are typed.

This also fixes handling communication errors for the metrics, to not let those errors affect the request result.