### PR TITLE
Firewall: Don't masquerade multicast traffic

### DIFF
--- a/lxd/firewall/drivers/drivers_xtables.go
+++ b/lxd/firewall/drivers/drivers_xtables.go
@@ -352,6 +352,11 @@ func (d Xtables) networkSetupOutboundNAT(networkName string, subnet *net.IPNet, 
 	args := []string{
 		"-s", subnet.String(),
 		"!", "-d", subnet.String(),
+		// If the output interface name is the network itself the traffic stays within the network.
+		// It's important to check for both the destination address and the output interface
+		// to not falsely snat/masquerade multicast traffic whose destination address it outside of the subnet.
+		// In case br_netfilter is loaded on the host multicast traffic also traverses the postrouting chain.
+		"!", "-o", networkName,
 	}
 
 	// If SNAT IP not supplied then use the IP of the outbound interface (MASQUERADE).


### PR DESCRIPTION
In case `br_netfilter` is loaded on the host all traffic is also passing the respective postrouting chain. This leads to false masquerading of multicast traffic if the traffic stays within the network.

An investigation on the traffic passing the `pstrt.{network name}` chain of a LXD managed bridge surfaced the following behavior:

> INFO: In the examples `wlp0s20f3` is my uplink nic and the traffic is generated between two VMs attached to `lxdbr0`.

1) `br_netfilter` enabled:
  * multicast traffic shows the following attributes: `IN= OUT=lxdbr0 PHYSIN=tapc938f176 PHYSOUT=tap48ceb22c`
  * unicast traffic shows this attributes: `IN=lxdbr0 OUT=wlp0s20f3 PHYSIN=tapc938f176`

2) `br_netfilter` disabled:
  * multicast traffic doesn't show up
  * unicast traffic shows this attributes: `IN=lxdbr0 OUT=wlp0s20f3`

This allows us to always exclude multicast traffic by checking if the outgoing `OUT=` is not the same as the actual network. 

The PR adds this condition to both the `nftables` and `xtables` drivers.
Some additions to the `lxd-ci` test suite can be found in https://github.com/canonical/lxd-ci/pull/322.