### PR TITLE
Network: Allow OVN subnets smaller than /64 when stateful DHCPv6 is enabled

### DIFF
--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -596,13 +596,16 @@ func (n *ovn) Validate(config map[string]string) error {
 		return err
 	}
 
-	// Check that if IPv6 enabled then the network size must be at least a /64 as both RA and DHCPv6
-	// in OVN (as it generates addresses using EUI64) require at least a /64 subnet to operate.
-	_, ipv6Net, _ := net.ParseCIDR(config["ipv6.address"])
-	if ipv6Net != nil {
-		ones, _ := ipv6Net.Mask.Size()
-		if ones > 64 {
-			return fmt.Errorf("IPv6 subnet must be at least a /64")
+	// Check that if stateless DHCPv6 is enabled and IPv6 subnet is set then the network size
+	// must be at least a /64 as both RA and DHCPv6 in OVN (as it generates addresses using EUI64)
+	// require at least a /64 subnet to operate.
+	if shared.IsTrueOrEmpty(config["ipv6.dhcp"]) && shared.IsFalseOrEmpty(config["ipv6.dhcp.stateful"]) {
+		_, ipv6Net, _ := net.ParseCIDR(config["ipv6.address"])
+		if ipv6Net != nil {
+			ones, _ := ipv6Net.Mask.Size()
+			if ones > 64 {
+				return fmt.Errorf("IPv6 subnet must be at least a /64 when stateless DHCPv6 is enabled")
+			}
 		}
 	}
 


### PR DESCRIPTION
We can allow IPv6 subnets smaller than /64 for the case when stateful DHCPv6 is used or DHCP is completely disabled.

Suggested-by: Thomas Parrott <thomas.parrott@canonical.com>

See also:
https://github.com/canonical/lxd-ci/pull/321
https://github.com/canonical/lxd/pull/14276