### PR TITLE
`lxc storage volume copy/move` shell completion fixes

### DIFF
--- a/lxc/completion.go
+++ b/lxc/completion.go
@@ -1257,8 +1257,10 @@ func (g *cmdGlobal) cmpStoragePoolWithVolume(toComplete string) ([]string, cobra
 
 	var results []string
 	for _, volume := range volumes {
-		volName, _ := parseVolume("volume", volume)
-		results = append(results, pool+"/"+volName)
+		volName, volType := parseVolume("custom", volume)
+		if volType == "custom" {
+			results = append(results, pool+"/"+volName)
+		}
 	}
 
 	return results, cobra.ShellCompDirectiveNoFileComp

--- a/lxc/storage_volume.go
+++ b/lxc/storage_volume.go
@@ -1862,7 +1862,13 @@ func (c *cmdStorageVolumeMove) command() *cobra.Command {
 		}
 
 		if len(args) == 1 {
-			return c.global.cmpStoragePools(toComplete, false)
+			completions, directive := c.global.cmpStoragePools(toComplete, true)
+			for i, completion := range completions {
+				if !strings.Contains(completion, ":") {
+					completions[i] = completion + "/"
+				}
+			}
+			return completions, directive
 		}
 
 		return nil, cobra.ShellCompDirectiveNoFileComp


### PR DESCRIPTION
This PR partially fixes https://github.com/canonical/lxd/issues/14264. I'll spend some more time trying to figure out why the completions generated during the snap build include an erroneous space, but a fix for that will likely land in the lxd snap repo.