### PR TITLE
github: use shorter job names for Trivy scanning

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -18,7 +18,7 @@ defaults:
 
 jobs:
   trivy-repo:
-    name: Trivy vulnerability scanner - Repository
+    name: Trivy - Repository
     runs-on: ubuntu-22.04
     if: ${{ ( github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' ) && github.ref_name == 'main' && github.repository == 'canonical/lxd' }}
     steps:
@@ -49,7 +49,7 @@ jobs:
           ref: refs/heads/main
 
   trivy-snap:
-    name: Trivy vulnerability scanner - Snap
+    name: Trivy - Snap
     runs-on: ubuntu-22.04
     needs: trivy-repo
     if: ${{ ( github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' ) && github.ref_name == 'main' && github.repository == 'canonical/lxd' }}


### PR DESCRIPTION
The GitHub UI trims long names like this:

> Trivy vulnerability scanner - Rep...
> Trivy vulnerability scanner - Sna...
> Trivy vulnerability scanner - Sna...
> Trivy vulnerability scanner - Sna...
> Trivy vulnerability scanner - Sna...

Since the workflow title already makes it clear that Trivy is a vulnerability scanner, there is no need to repeat it.