### PR TITLE
Notifier update; MemberState update

### DIFF
--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -602,6 +602,10 @@ definitions:
                     type: number
                 type: array
                 x-go-name: LoadAverages
+            logical_cpus:
+                format: uint64
+                type: integer
+                x-go-name: LogicalCPUs
             processes:
                 format: uint16
                 type: integer

--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -767,7 +767,7 @@ func doAPI10Update(d *Daemon, r *http.Request, req api.ServerPut, patch bool) re
 		return response.SmartError(err)
 	}
 
-	err = notifier(func(client lxd.InstanceServer) error {
+	err = notifier(func(member db.NodeInfo, client lxd.InstanceServer) error {
 		server, etag, err := client.GetServer()
 		if err != nil {
 			return err

--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -701,7 +701,7 @@ func doAPI10Update(d *Daemon, r *http.Request, req api.ServerPut, patch bool) re
 	// Then deal with cluster wide configuration
 	var clusterChanged map[string]string
 	var newClusterConfig *clusterConfig.Config
-	oldClusterConfig := make(map[string]any)
+	var oldClusterConfig map[string]any
 
 	err = s.DB.Cluster.Transaction(context.Background(), func(ctx context.Context, tx *db.ClusterTx) error {
 		var err error
@@ -711,9 +711,7 @@ func doAPI10Update(d *Daemon, r *http.Request, req api.ServerPut, patch bool) re
 		}
 
 		// Keep old config around in case something goes wrong. In that case the config will be reverted.
-		for k, v := range newClusterConfig.Dump() {
-			oldClusterConfig[k] = v
-		}
+		oldClusterConfig = newClusterConfig.Dump()
 
 		if patch {
 			clusterChanged, err = newClusterConfig.Patch(req.Config)

--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -2974,7 +2974,7 @@ func clusterNodeStateGet(d *Daemon, r *http.Request) response.Response {
 		return resp
 	}
 
-	memberState, err := cluster.MemberState(r.Context(), s, memberName)
+	memberState, err := cluster.MemberState(r.Context(), s)
 	if err != nil {
 		return response.SmartError(err)
 	}

--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -1634,6 +1634,11 @@ func updateClusterNode(s *state.State, gateway *cluster.Gateway, r *http.Request
 		return response.SmartError(err)
 	}
 
+	resp := forwardedResponseToNode(s, r, name)
+	if resp != nil {
+		return resp
+	}
+
 	leaderAddress, err := gateway.LeaderAddress()
 	if err != nil {
 		return response.InternalError(err)

--- a/lxd/auth_groups.go
+++ b/lxd/auth_groups.go
@@ -713,7 +713,7 @@ func renameAuthGroup(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	err = notifier(func(client lxd.InstanceServer) error {
+	err = notifier(func(member db.NodeInfo, client lxd.InstanceServer) error {
 		_, _, err := client.RawQuery(http.MethodPost, "/internal/identity-cache-refresh", nil, "")
 		return err
 	})
@@ -774,7 +774,7 @@ func deleteAuthGroup(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	err = notifier(func(client lxd.InstanceServer) error {
+	err = notifier(func(member db.NodeInfo, client lxd.InstanceServer) error {
 		_, _, err := client.RawQuery(http.MethodPost, "/internal/identity-cache-refresh", nil, "")
 		return err
 	})

--- a/lxd/certificates.go
+++ b/lxd/certificates.go
@@ -710,7 +710,7 @@ func certificatesPost(d *Daemon, r *http.Request) response.Response {
 		Type:        api.CertificateTypeClient,
 	}
 
-	err = notifier(func(client lxd.InstanceServer) error {
+	err = notifier(func(member db.NodeInfo, client lxd.InstanceServer) error {
 		_, _, err := client.RawQuery(http.MethodPost, "/internal/identity-cache-refresh", nil, "")
 		return err
 	})
@@ -1051,7 +1051,7 @@ func doCertificateUpdate(ctx context.Context, d *Daemon, dbInfo api.Certificate,
 		return response.SmartError(err)
 	}
 
-	err = notifier(func(client lxd.InstanceServer) error {
+	err = notifier(func(member db.NodeInfo, client lxd.InstanceServer) error {
 		_, _, err := client.RawQuery(http.MethodPost, "/internal/identity-cache-refresh", nil, "")
 		return err
 	})
@@ -1162,7 +1162,7 @@ func certificateDelete(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	err = notifier(func(client lxd.InstanceServer) error {
+	err = notifier(func(member db.NodeInfo, client lxd.InstanceServer) error {
 		_, _, err := client.RawQuery(http.MethodPost, "/internal/identity-cache-refresh", nil, "")
 		return err
 	})

--- a/lxd/cluster/member_state.go
+++ b/lxd/cluster/member_state.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"runtime"
 	"strconv"
 	"strings"
 
@@ -72,6 +73,10 @@ func LocalSysInfo() (*api.ClusterMemberSysInfo, error) {
 	if err != nil {
 		return nil, fmt.Errorf("Failed getting load averages: %w", err)
 	}
+
+	// NumCPU gives the number of threads available to the LXD server at startup,
+	// not the currently available number of threads.
+	sysInfo.LogicalCPUs = uint64(runtime.NumCPU())
 
 	return sysInfo, nil
 }

--- a/lxd/cluster/member_state.go
+++ b/lxd/cluster/member_state.go
@@ -77,7 +77,7 @@ func LocalSysInfo() (*api.ClusterMemberSysInfo, error) {
 }
 
 // MemberState retrieves state information about the cluster member.
-func MemberState(ctx context.Context, s *state.State, memberName string) (*api.ClusterMemberState, error) {
+func MemberState(ctx context.Context, s *state.State) (*api.ClusterMemberState, error) {
 	var memberState api.ClusterMemberState
 
 	sysInfo, err := LocalSysInfo()

--- a/lxd/cluster/member_state_test.go
+++ b/lxd/cluster/member_state_test.go
@@ -1,0 +1,77 @@
+package cluster_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/canonical/lxd/lxd/cluster"
+	"github.com/canonical/lxd/lxd/db"
+	"github.com/canonical/lxd/lxd/node"
+	"github.com/canonical/lxd/lxd/state"
+	"github.com/canonical/lxd/shared"
+)
+
+func TestClusterState(t *testing.T) {
+	state, cleanup := state.NewTestState(t)
+	defer cleanup()
+
+	cert := shared.TestingKeyPair()
+
+	state.ServerCert = func() *shared.CertInfo { return cert }
+
+	f := notifyFixtures{t: t, state: state}
+	cleanupF := f.Nodes(cert, 3)
+	defer cleanupF()
+
+	// Populate state.LocalConfig after nodes created above.
+	var err error
+	var nodeConfig *node.Config
+	err = state.DB.Node.Transaction(context.TODO(), func(ctx context.Context, tx *db.NodeTx) error {
+		nodeConfig, err = node.ConfigLoad(ctx, tx)
+		return err
+	})
+	require.NoError(t, err)
+
+	state.LocalConfig = nodeConfig
+
+	states, err := cluster.ClusterState(state, cert)
+	require.NoError(t, err)
+
+	assert.Equal(t, 3, len(states))
+
+	for clusterMemberName, state := range states {
+		// Local cluster member
+		if clusterMemberName == "0" {
+			assert.Greater(t, state.SysInfo.LogicalCPUs, uint64(0))
+			continue
+		}
+
+		assert.Equal(t, uint64(24), state.SysInfo.LogicalCPUs)
+	}
+
+	var members []db.NodeInfo
+	err = state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		members, err = tx.GetNodes(ctx)
+		return err
+	})
+	require.NoError(t, err)
+
+	for i, memberInfo := range members {
+		if memberInfo.Name == "0" {
+			members[i] = members[len(members)-1]
+			members = members[:len(members)-1]
+			break
+		}
+	}
+
+	states, err = cluster.ClusterState(state, cert, members...)
+	require.NoError(t, err)
+
+	assert.Equal(t, 2, len(states))
+	for _, state := range states {
+		assert.Equal(t, uint64(24), state.SysInfo.LogicalCPUs)
+	}
+}

--- a/lxd/cluster/notify.go
+++ b/lxd/cluster/notify.go
@@ -15,9 +15,10 @@ import (
 	"github.com/canonical/lxd/shared/logger"
 )
 
-// Notifier is a function that invokes the given function against each node in
-// the cluster excluding the invoking one.
-type Notifier func(hook func(lxd.InstanceServer) error) error
+// Notifier is a function that invokes `hook` against each node in the cluster,
+// excluding the invoking one. The NodeInfo passed to `hook` describes the
+// cluster member of InstanceServer.
+type Notifier func(hook func(db.NodeInfo, lxd.InstanceServer) error) error
 
 // NotifierPolicy can be used to tweak the behavior of NewNotifier in case of
 // some nodes are down.
@@ -45,7 +46,7 @@ func NewNotifier(state *state.State, networkCert *shared.CertInfo, serverCert *s
 
 	// Fast-track the case where we're not clustered at all.
 	if !state.ServerClustered {
-		nullNotifier := func(func(lxd.InstanceServer) error) error { return nil }
+		nullNotifier := func(func(db.NodeInfo, lxd.InstanceServer) error) error { return nil }
 		return nullNotifier, nil
 	}
 
@@ -73,7 +74,7 @@ func NewNotifier(state *state.State, networkCert *shared.CertInfo, serverCert *s
 		}
 	}
 
-	peers := []string{}
+	var peers []db.NodeInfo
 	for _, member := range members {
 		if member.Address == localClusterAddress || member.Address == "0.0.0.0" {
 			continue // Exclude ourselves
@@ -87,7 +88,7 @@ func NewNotifier(state *state.State, networkCert *shared.CertInfo, serverCert *s
 			if !HasConnectivity(networkCert, serverCert, member.Address) {
 				switch policy {
 				case NotifyAll:
-					return nil, fmt.Errorf("peer node %s is down", member.Address)
+					return nil, fmt.Errorf("Peer cluster member %s at %s is down", member.Name, member.Address)
 				case NotifyAlive:
 					continue // Just skip this node
 				case NotifyTryAll:
@@ -95,28 +96,28 @@ func NewNotifier(state *state.State, networkCert *shared.CertInfo, serverCert *s
 			}
 		}
 
-		peers = append(peers, member.Address)
+		peers = append(peers, member)
 	}
 
-	notifier := func(hook func(lxd.InstanceServer) error) error {
+	notifier := func(hook func(db.NodeInfo, lxd.InstanceServer) error) error {
 		errs := make([]error, len(peers))
 		wg := sync.WaitGroup{}
 		wg.Add(len(peers))
-		for i, address := range peers {
-			logger.Debugf("Notify node %s of state changes", address)
-			go func(i int, address string) {
+		for i, member := range peers {
+			logger.Debug("Notify cluster member of state changes", logger.Ctx{"name": member.Name, "address": member.Address})
+			go func(i int, member db.NodeInfo) {
 				defer wg.Done()
-				client, err := Connect(address, networkCert, serverCert, nil, true)
+				client, err := Connect(member.Address, networkCert, serverCert, nil, true)
 				if err != nil {
-					errs[i] = fmt.Errorf("failed to connect to peer %s: %w", address, err)
+					errs[i] = fmt.Errorf("Failed to connect to peer %s at %s: %w", member.Name, member.Address, err)
 					return
 				}
 
-				err = hook(client)
+				err = hook(member, client)
 				if err != nil {
-					errs[i] = fmt.Errorf("failed to notify peer %s: %w", address, err)
+					errs[i] = fmt.Errorf("Failed to notify peer %s at %s: %w", member.Name, member.Address, err)
 				}
-			}(i, address)
+			}(i, member)
 		}
 
 		wg.Wait()
@@ -126,7 +127,7 @@ func NewNotifier(state *state.State, networkCert *shared.CertInfo, serverCert *s
 				isDown := shared.IsConnectionError(err) || api.StatusErrorCheck(err, http.StatusServiceUnavailable)
 
 				if isDown && policy == NotifyAlive {
-					logger.Warnf("Could not notify node %s", peers[i])
+					logger.Warn("Could not notify cluster member", logger.Ctx{"name": peers[i].Name, "address": peers[i].Address})
 					continue
 				}
 

--- a/lxd/cluster/notify.go
+++ b/lxd/cluster/notify.go
@@ -44,7 +44,7 @@ func NewNotifier(state *state.State, networkCert *shared.CertInfo, serverCert *s
 	}
 
 	// Fast-track the case where we're not clustered at all.
-	if localClusterAddress == "" {
+	if !state.ServerClustered {
 		nullNotifier := func(func(lxd.InstanceServer) error) error { return nil }
 		return nullNotifier, nil
 	}

--- a/lxd/cluster/upgrade.go
+++ b/lxd/cluster/upgrade.go
@@ -27,7 +27,7 @@ func NotifyUpgradeCompleted(state *state.State, networkCert *shared.CertInfo, se
 		return err
 	}
 
-	return notifier(func(client lxd.InstanceServer) error {
+	return notifier(func(member db.NodeInfo, client lxd.InstanceServer) error {
 		info, err := client.GetConnectionInfo()
 		if err != nil {
 			return fmt.Errorf("failed to get connection info: %w", err)

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -549,7 +549,7 @@ func (d *Daemon) handleOIDCAuthenticationResult(r *http.Request, result *oidc.Au
 			return fmt.Errorf("Failed to notify cluster members of new or updated OIDC identity: %w", err)
 		}
 
-		err = notifier(func(client lxd.InstanceServer) error {
+		err = notifier(func(member db.NodeInfo, client lxd.InstanceServer) error {
 			_, _, err := client.RawQuery(http.MethodPost, "/internal/identity-cache-refresh", nil, "")
 			return err
 		})

--- a/lxd/db/node.go
+++ b/lxd/db/node.go
@@ -99,9 +99,9 @@ func (n NodeInfo) ToAPI(ctx context.Context, tx *ClusterTx, args NodeInfoArgs) (
 
 	// From local database.
 	var raftNode *RaftNode
-	for _, node := range args.RaftNodes {
+	for i, node := range args.RaftNodes {
 		if node.Address == n.Address {
-			raftNode = &node
+			raftNode = &args.RaftNodes[i]
 			break
 		}
 	}
@@ -156,12 +156,12 @@ func (n NodeInfo) ToAPI(ctx context.Context, tx *ClusterTx, args NodeInfoArgs) (
 		result.Message = fmt.Sprintf("No heartbeat for %s (%s)", time.Since(n.Heartbeat), n.Heartbeat)
 	} else {
 		// Check if up to date.
-		n, err := util.CompareVersions(maxVersion, n.Version())
+		cmp, err := util.CompareVersions(maxVersion, n.Version())
 		if err != nil {
 			return nil, err
 		}
 
-		if n == 1 {
+		if cmp == 1 {
 			result.Status = "Blocked"
 			result.Message = "Needs updating to newer version"
 		}
@@ -241,7 +241,7 @@ func (c *ClusterTx) GetNodeWithID(ctx context.Context, nodeID int) (NodeInfo, er
 // GetPendingNodeByAddress returns the pending node with the given network address.
 func (c *ClusterTx) GetPendingNodeByAddress(ctx context.Context, address string) (NodeInfo, error) {
 	null := NodeInfo{}
-	nodes, err := c.nodes(ctx, true /*pending */, "address=?", address)
+	nodes, err := c.nodes(ctx, true /* pending */, "address=?", address)
 	if err != nil {
 		return null, err
 	}

--- a/lxd/identities.go
+++ b/lxd/identities.go
@@ -1422,7 +1422,7 @@ func newIdentityNotificationFunc(s *state.State, r *http.Request, networkCert *s
 				return nil, err
 			}
 
-			err = notifier(func(client lxd.InstanceServer) error {
+			err = notifier(func(member db.NodeInfo, client lxd.InstanceServer) error {
 				_, _, err := client.RawQuery(http.MethodPost, "/internal/identity-cache-refresh", nil, "")
 				return err
 			})

--- a/lxd/identity_provider_groups.go
+++ b/lxd/identity_provider_groups.go
@@ -326,7 +326,7 @@ func createIdentityProviderGroup(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	err = notifier(func(client lxd.InstanceServer) error {
+	err = notifier(func(member db.NodeInfo, client lxd.InstanceServer) error {
 		_, _, err := client.RawQuery(http.MethodPost, "/internal/identity-cache-refresh", nil, "")
 		return err
 	})
@@ -395,7 +395,7 @@ func renameIdentityProviderGroup(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	err = notifier(func(client lxd.InstanceServer) error {
+	err = notifier(func(member db.NodeInfo, client lxd.InstanceServer) error {
 		_, _, err := client.RawQuery(http.MethodPost, "/internal/identity-cache-refresh", nil, "")
 		return err
 	})
@@ -484,7 +484,7 @@ func updateIdentityProviderGroup(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	err = notifier(func(client lxd.InstanceServer) error {
+	err = notifier(func(member db.NodeInfo, client lxd.InstanceServer) error {
 		_, _, err := client.RawQuery(http.MethodPost, "/internal/identity-cache-refresh", nil, "")
 		return err
 	})
@@ -580,7 +580,7 @@ func patchIdentityProviderGroup(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	err = notifier(func(client lxd.InstanceServer) error {
+	err = notifier(func(member db.NodeInfo, client lxd.InstanceServer) error {
 		_, _, err := client.RawQuery(http.MethodPost, "/internal/identity-cache-refresh", nil, "")
 		return err
 	})
@@ -635,7 +635,7 @@ func deleteIdentityProviderGroup(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	err = notifier(func(client lxd.InstanceServer) error {
+	err = notifier(func(member db.NodeInfo, client lxd.InstanceServer) error {
 		_, _, err := client.RawQuery(http.MethodPost, "/internal/identity-cache-refresh", nil, "")
 		return err
 	})

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -2821,7 +2821,7 @@ func imageDelete(d *Daemon, r *http.Request) response.Response {
 				return err
 			}
 
-			err = notifier(func(client lxd.InstanceServer) error {
+			err = notifier(func(member db.NodeInfo, client lxd.InstanceServer) error {
 				op, err := client.UseProject(projectName).DeleteImage(details.image.Fingerprint)
 				if err != nil {
 					return fmt.Errorf("Failed to request to delete image from peer node: %w", err)

--- a/lxd/network/acl/driver_common.go
+++ b/lxd/network/acl/driver_common.go
@@ -686,7 +686,7 @@ func (d *common) Update(config *api.NetworkACLPut, clientType request.ClientType
 			return err
 		}
 
-		err = notifier(func(client lxd.InstanceServer) error {
+		err = notifier(func(member db.NodeInfo, client lxd.InstanceServer) error {
 			return client.UseProject(d.projectName).UpdateNetworkACL(d.info.Name, d.info.Writable(), "")
 		})
 		if err != nil {
@@ -789,7 +789,7 @@ func (d *common) GetLog(clientType request.ClientType) (string, error) {
 		}
 
 		mu := sync.Mutex{}
-		err = notifier(func(client lxd.InstanceServer) error {
+		err = notifier(func(member db.NodeInfo, client lxd.InstanceServer) error {
 			// Get the entries.
 			entries, err := client.UseProject(d.projectName).GetNetworkACLLogfile(d.info.Name)
 			if err != nil {

--- a/lxd/network/driver_bridge.go
+++ b/lxd/network/driver_bridge.go
@@ -3644,7 +3644,7 @@ func (n *bridge) Leases(projectName string, clientType request.ClientType) ([]ap
 			wg.Done()
 		}()
 
-		err = notifier(func(client lxd.InstanceServer) error {
+		err = notifier(func(member db.NodeInfo, client lxd.InstanceServer) error {
 			memberLeases, err := client.GetNetworkLeases(n.name)
 			if err != nil {
 				return err

--- a/lxd/network/driver_common.go
+++ b/lxd/network/driver_common.go
@@ -382,7 +382,7 @@ func (n *common) update(applyNetwork api.NetworkPut, targetNode string, clientTy
 				sendNetwork.Config[k] = v
 			}
 
-			err = notifier(func(client lxd.InstanceServer) error {
+			err = notifier(func(member db.NodeInfo, client lxd.InstanceServer) error {
 				return client.UseProject(n.project).UpdateNetwork(n.name, sendNetwork, "")
 			})
 			if err != nil {

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -4878,7 +4878,7 @@ func (n *ovn) ForwardCreate(forward api.NetworkForwardsPost, clientType request.
 			return nil, err
 		}
 
-		err = notifier(func(client lxd.InstanceServer) error {
+		err = notifier(func(member db.NodeInfo, client lxd.InstanceServer) error {
 			return client.UseProject(n.project).CreateNetworkForward(n.name, forward)
 		})
 		if err != nil {
@@ -4983,7 +4983,7 @@ func (n *ovn) ForwardUpdate(listenAddress string, req api.NetworkForwardPut, cli
 			return err
 		}
 
-		err = notifier(func(client lxd.InstanceServer) error {
+		err = notifier(func(member db.NodeInfo, client lxd.InstanceServer) error {
 			return client.UseProject(n.project).UpdateNetworkForward(n.name, curForward.ListenAddress, req, "")
 		})
 		if err != nil {
@@ -5043,7 +5043,7 @@ func (n *ovn) ForwardDelete(listenAddress string, clientType request.ClientType)
 			return err
 		}
 
-		err = notifier(func(client lxd.InstanceServer) error {
+		err = notifier(func(member db.NodeInfo, client lxd.InstanceServer) error {
 			return client.UseProject(n.project).DeleteNetworkForward(n.name, forward.ListenAddress)
 		})
 		if err != nil {
@@ -5253,7 +5253,7 @@ func (n *ovn) LoadBalancerCreate(loadBalancer api.NetworkLoadBalancersPost, clie
 			return nil, err
 		}
 
-		err = notifier(func(client lxd.InstanceServer) error {
+		err = notifier(func(member db.NodeInfo, client lxd.InstanceServer) error {
 			return client.UseProject(n.project).CreateNetworkLoadBalancer(n.name, loadBalancer)
 		})
 		if err != nil {
@@ -5359,7 +5359,7 @@ func (n *ovn) LoadBalancerUpdate(listenAddress string, req api.NetworkLoadBalanc
 			return err
 		}
 
-		err = notifier(func(client lxd.InstanceServer) error {
+		err = notifier(func(member db.NodeInfo, client lxd.InstanceServer) error {
 			return client.UseProject(n.project).UpdateNetworkLoadBalancer(n.name, curLoadBalancer.ListenAddress, req, "")
 		})
 		if err != nil {
@@ -5419,7 +5419,7 @@ func (n *ovn) LoadBalancerDelete(listenAddress string, clientType request.Client
 			return err
 		}
 
-		err = notifier(func(client lxd.InstanceServer) error {
+		err = notifier(func(member db.NodeInfo, client lxd.InstanceServer) error {
 			return client.UseProject(n.project).DeleteNetworkLoadBalancer(n.name, forward.ListenAddress)
 		})
 		if err != nil {

--- a/lxd/network/zone/zone.go
+++ b/lxd/network/zone/zone.go
@@ -297,7 +297,7 @@ func (d *zone) Update(config *api.NetworkZonePut, clientType request.ClientType)
 			return err
 		}
 
-		err = notifier(func(client lxd.InstanceServer) error {
+		err = notifier(func(member db.NodeInfo, client lxd.InstanceServer) error {
 			return client.UseProject(d.projectName).UpdateNetworkZone(d.info.Name, d.info.Writable(), "")
 		})
 		if err != nil {

--- a/lxd/profiles.go
+++ b/lxd/profiles.go
@@ -586,7 +586,7 @@ func profilePut(d *Daemon, r *http.Request) response.Response {
 			return response.SmartError(err)
 		}
 
-		err = notifier(func(client lxd.InstanceServer) error {
+		err = notifier(func(member db.NodeInfo, client lxd.InstanceServer) error {
 			return client.UseProject(details.effectiveProject.Name).UpdateProfile(details.profileName, profile.Writable(), "")
 		})
 		if err != nil {

--- a/lxd/scriptlet/instance_placement.go
+++ b/lxd/scriptlet/instance_placement.go
@@ -138,7 +138,7 @@ func InstancePlacementRun(ctx context.Context, l logger.Logger, s *state.State, 
 
 		// Get the local resource usage.
 		if memberName == s.ServerName {
-			memberState, err = cluster.MemberState(ctx, s, memberName)
+			memberState, err = cluster.MemberState(ctx, s)
 			if err != nil {
 				return nil, err
 			}

--- a/shared/api/cluster_state.go
+++ b/shared/api/cluster_state.go
@@ -15,6 +15,7 @@ type ClusterMemberSysInfo struct {
 	TotalSwap    uint64    `json:"total_swap" yaml:"total_swap"`
 	FreeSwap     uint64    `json:"free_swap" yaml:"free_swap"`
 	Processes    uint16    `json:"processes" yaml:"processes"`
+	LogicalCPUs  uint64    `json:"logical_cpus" yaml:"logical_cpus"`
 }
 
 // ClusterMemberState represents the state of a cluster member.


### PR DESCRIPTION
This includes preparatory changes as described in #14247:

- Notifier improvements
  - Use `state.ServerClustered`
  - Don't query for `OfflineThreshold` unless needed (see commit msg)
  - Allow passing `db.NodeInfo` to `NewNotifier`
  - Pass `db.NodeInfo` to the notifier hook to reduce the need for extra http calls for basic info (like the target server's name)
- Member state updates
  - Add `CPUThreads` to `ClusterMemberSysInfo` (name tbd)
  - Refactor `MemberState` to expose local `ClusterMemberSysinfo`
  - Implement helper to collect member state from all cluster members, using the notifier improvements above
- Other odds and ends

Performance improvements for project limits will be in a separate PR.