### PR TITLE
doc: embed discourse post title as link text

### DIFF
--- a/doc/explanation/authorization.md
+++ b/doc/explanation/authorization.md
@@ -1,5 +1,5 @@
 ---
-discourse: ubuntu:41516
+discourse: ubuntu:[Identity&#32;and&#32;Access&#32;Management&#32;for&#32;LXD](41516)
 ---
 
 (authorization)=

--- a/doc/howto/snap.md
+++ b/doc/howto/snap.md
@@ -1,5 +1,5 @@
 ---
-discourse: ubuntu:37214
+discourse: ubuntu:[Managing&#32;the&#32;LXD&#32;snap&#32;package](37214)
 ---
 
 (howto-snap)=

--- a/doc/installing.md
+++ b/doc/installing.md
@@ -1,5 +1,5 @@
 ---
-discourse: ubuntu:37327
+discourse: ubuntu:[Building&#32;custom&#32;LXD&#32;binaries&#32;for&#32;side&#32;loading&#32;into&#32;an&#32;existing&#32;snap&#32;installation](37327)
 ---
 
 (installing)=

--- a/doc/reference/remote_image_servers.md
+++ b/doc/reference/remote_image_servers.md
@@ -1,5 +1,5 @@
 ---
-discourse: ubuntu:43824,16647
+discourse: ubuntu:[New&#32;LXD&#32;image&#32;server&#32;available&#32;(images.lxd.canonical.com)](43824),[Image&#32;server&#32;infrastructure](16647)
 relatedlinks: https://www.youtube.com/watch?v=pM0EgUqj2a0
 ---
 

--- a/doc/reference/uefi_variables.md
+++ b/doc/reference/uefi_variables.md
@@ -1,5 +1,5 @@
 ---
-discourse: ubuntu:42313
+discourse: ubuntu:[LXD&#32;VM&#32;instance&#32;EFI&#32;Variables&#32;edit&#32;CLI](42313)
 ---
 
 # UEFI variables for VMs


### PR DESCRIPTION
This PR explicitly specifies the link text for Discourse posts (from the posts' titles) instead of extracting it at build time. Recent Discourse outages have caused build failures when the link text couldn't be fetched dynamically. Hard-setting the link text should prevent this.

**Note:** Docs on specifying link text [here](https://github.com/canonical/canonical-sphinx-extensions/?tab=readme-ov-file#specify-links-for-a-page). The docs also describes a backup link text option, but I did not use it due to buggy behavior. _My expectation:_ The backup link text will be used if the link text cannot be extracted dynamically, and the build will not fail. _Reality:_ The backup link text is recognized, yet the build still fails. 