### PR TITLE
api: Add network_ovn_uplink_vlan API extension

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -2507,3 +2507,7 @@ Expands APIs under `/1.0/auth` to include:
 Includes OVN virtual routers external IPs to `/1.0/network-allocations` responses with the type `uplink`.
 Introduces the `network` field on each allocation, indicating to which network each allocated address belongs.
 And lastly, adds a `project` field on leases, leases can be retrieved via `/1.0/networks/<network>/leases`.
+
+## `network_ovn_uplink_vlan`
+
+Adds support for using a bridge network with a specified VLAN ID as an OVN uplink.

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -420,6 +420,7 @@ var APIExtensions = []string{
 	"metadata_configuration_entity_types",
 	"access_management_tls",
 	"network_allocations_ovn_uplink",
+	"network_ovn_uplink_vlan",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
This PR adds API extension `network_ovn_uplink_vlan`, which adds support for using a bridge network with a specified VLAN ID as the uplink for an OVN network.

Related: https://github.com/canonical/lxd-ci/pull/302, https://github.com/canonical/lxd/pull/14196.