### PR TITLE
Networt: Fix incorrect handling of instances in UsedByInstanceDevices

### DIFF
--- a/lxd/network/driver_bridge.go
+++ b/lxd/network/driver_bridge.go
@@ -3632,6 +3632,18 @@ func (n *bridge) Leases(projectName string, clientType request.ClientType) ([]ap
 			return nil, err
 		}
 
+		leasesCh := make(chan api.NetworkLease)
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			for lease := range leasesCh {
+				leases = append(leases, lease)
+			}
+
+			wg.Done()
+		}()
+
 		err = notifier(func(client lxd.InstanceServer) error {
 			memberLeases, err := client.GetNetworkLeases(n.name)
 			if err != nil {
@@ -3641,12 +3653,17 @@ func (n *bridge) Leases(projectName string, clientType request.ClientType) ([]ap
 			// Add local leases from other members, filtering them for MACs that belong to the project.
 			for _, lease := range memberLeases {
 				if lease.Hwaddr != "" && shared.ValueInSlice(lease.Hwaddr, projectMacs) {
-					leases = append(leases, lease)
+					leasesCh <- lease
 				}
 			}
 
 			return nil
 		})
+
+		// Finish up and wait for go routine.
+		close(leasesCh)
+		wg.Wait()
+
 		if err != nil {
 			return nil, err
 		}

--- a/lxd/network/network_utils.go
+++ b/lxd/network/network_utils.go
@@ -82,7 +82,7 @@ func MACDevName(mac net.HardwareAddr) string {
 func UsedByInstanceDevices(s *state.State, networkProjectName string, networkName string, networkType string, usageFunc func(inst db.InstanceArgs, nicName string, nicConfig map[string]string) error, filters ...cluster.InstanceFilter) error {
 	// Get the instances.
 	projects := map[string]api.Project{}
-	instances := []db.InstanceArgs{}
+	var instances []db.InstanceArgs
 
 	err := s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
 		return tx.InstanceList(ctx, func(inst db.InstanceArgs, p api.Project) error {
@@ -105,7 +105,7 @@ func UsedByInstanceDevices(s *state.State, networkProjectName string, networkNam
 
 		// Skip instances who's effective network project doesn't match this Network's project.
 		if instNetworkProject != networkProjectName {
-			return nil
+			continue
 		}
 
 		// Look for NIC devices using this network.


### PR DESCRIPTION
During cherry-pick from Incus of refactor of this function in e5f5b887ae11d50f9b6bb99df2a008d2edd6e4e9 the project filtering logic was incorrectly returning rather than continuing to next instance.

This meant some instances were being excluded incorrectly.

Also fixes a potential issue with concurrent modification of the leases slice in `bridge.Leases()` when collecting leases from each cluster member concurrently.

Fixes https://github.com/canonical/lxd/issues/13412