### PR TITLE
Backports (stable-5.0)

### DIFF
--- a/po/ber.po
+++ b/po/ber.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-01 10:44+0100\n"
+"POT-Creation-Date: 2024-10-18 13:21+0000\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Berber <https://hosted.weblate.org/projects/linux-containers/"
@@ -380,15 +380,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:830 lxc/remote.go:887
+#: lxc/remote.go:848 lxc/remote.go:905
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:927
+#: lxc/remote.go:945
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:757
+#: lxc/remote.go:775
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -421,7 +421,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:739
+#: lxc/remote.go:757
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -528,7 +528,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:564
+#: lxc/remote.go:582
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -560,7 +560,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:188
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -631,7 +631,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:550
+#: lxc/remote.go:568
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -804,7 +804,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:866
+#: lxc/remote.go:884
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -870,13 +870,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:218
+#: lxc/remote.go:225
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:451
+#: lxc/remote.go:469
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -890,7 +890,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:604
+#: lxc/remote.go:622
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1129,12 +1129,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:486
+#: lxc/remote.go:504
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:470
+#: lxc/remote.go:231 lxc/remote.go:488
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1163,7 +1163,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:481
+#: lxc/remote.go:499
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1455,8 +1455,8 @@ msgstr ""
 #: lxc/project.go:221 lxc/project.go:348 lxc/project.go:409 lxc/project.go:510
 #: lxc/project.go:567 lxc/project.go:646 lxc/project.go:677 lxc/project.go:730
 #: lxc/project.go:789 lxc/publish.go:33 lxc/query.go:34 lxc/remote.go:34
-#: lxc/remote.go:90 lxc/remote.go:632 lxc/remote.go:670 lxc/remote.go:760
-#: lxc/remote.go:833 lxc/remote.go:889 lxc/remote.go:929 lxc/rename.go:21
+#: lxc/remote.go:90 lxc/remote.go:650 lxc/remote.go:688 lxc/remote.go:778
+#: lxc/remote.go:851 lxc/remote.go:907 lxc/remote.go:947 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:92
 #: lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:340 lxc/storage.go:410
 #: lxc/storage.go:582 lxc/storage.go:661 lxc/storage.go:757 lxc/storage.go:843
@@ -1971,11 +1971,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:190
+#: lxc/remote.go:197
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:241
+#: lxc/remote.go:248
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -1985,7 +1985,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:231
+#: lxc/remote.go:238
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -1995,12 +1995,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:256
+#: lxc/remote.go:263
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:263
+#: lxc/remote.go:270
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2025,7 +2025,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:236
+#: lxc/remote.go:243
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2103,7 +2103,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:411
-#: lxc/project.go:791 lxc/remote.go:674 lxc/storage.go:584
+#: lxc/project.go:791 lxc/remote.go:692 lxc/storage.go:584
 #: lxc/storage_volume.go:1418 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -2140,7 +2140,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:742
+#: lxc/remote.go:760
 msgid "GLOBAL"
 msgstr ""
 
@@ -2156,7 +2156,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:397
+#: lxc/remote.go:159 lxc/remote.go:406
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2507,7 +2507,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:349
+#: lxc/remote.go:358
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2588,7 +2588,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:338
+#: lxc/remote.go:347
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -2924,7 +2924,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:669 lxc/remote.go:670
+#: lxc/remote.go:687 lxc/remote.go:688
 msgid "List the available remotes"
 msgstr ""
 
@@ -3458,7 +3458,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:566
 #: lxc/network.go:976 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:487 lxc/remote.go:736 lxc/storage.go:634
+#: lxc/project.go:487 lxc/remote.go:754 lxc/storage.go:634
 #: lxc/storage_volume.go:1506
 msgid "NAME"
 msgstr ""
@@ -3480,8 +3480,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:953 lxc/operation.go:154 lxc/project.go:455
-#: lxc/project.go:460 lxc/project.go:465 lxc/project.go:470 lxc/remote.go:692
-#: lxc/remote.go:697 lxc/remote.go:702
+#: lxc/project.go:460 lxc/project.go:465 lxc/project.go:470 lxc/remote.go:710
+#: lxc/remote.go:715 lxc/remote.go:720
 msgid "NO"
 msgstr ""
 
@@ -3696,7 +3696,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:332
+#: lxc/remote.go:341
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -3763,11 +3763,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:738
+#: lxc/remote.go:756
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1070 lxc/remote.go:740
+#: lxc/image.go:1070 lxc/remote.go:758
 msgid "PUBLIC"
 msgstr ""
 
@@ -3796,7 +3796,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:182
+#: lxc/remote.go:189
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -3808,7 +3808,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:462
+#: lxc/remote.go:480
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4109,33 +4109,33 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:790
+#: lxc/remote.go:808
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:756 lxc/remote.go:781 lxc/remote.go:854 lxc/remote.go:910
-#: lxc/remote.go:950
+#: lxc/project.go:756 lxc/remote.go:799 lxc/remote.go:872 lxc/remote.go:928
+#: lxc/remote.go:968
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:301
+#: lxc/remote.go:308
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:862
+#: lxc/remote.go:880
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:785 lxc/remote.go:858 lxc/remote.go:954
+#: lxc/remote.go:803 lxc/remote.go:876 lxc/remote.go:972
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:290
+#: lxc/remote.go:297
 msgid "Remote address must not be empty"
 msgstr ""
 
@@ -4143,7 +4143,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:295
+#: lxc/remote.go:302
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4201,7 +4201,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:832 lxc/remote.go:833
+#: lxc/remote.go:850 lxc/remote.go:851
 msgid "Remove remotes"
 msgstr ""
 
@@ -4250,7 +4250,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:759 lxc/remote.go:760
+#: lxc/remote.go:777 lxc/remote.go:778
 msgid "Rename remotes"
 msgstr ""
 
@@ -4387,7 +4387,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:741
+#: lxc/remote.go:759
 msgid "STATIC"
 msgstr ""
 
@@ -4415,11 +4415,11 @@ msgstr ""
 msgid "Server authentication type (tls or candid)"
 msgstr ""
 
-#: lxc/remote.go:460
+#: lxc/remote.go:478
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:600
+#: lxc/remote.go:618
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -4600,7 +4600,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:928 lxc/remote.go:929
+#: lxc/remote.go:946 lxc/remote.go:947
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -4776,7 +4776,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:631 lxc/remote.go:632
+#: lxc/remote.go:649 lxc/remote.go:650
 msgid "Show the default remote"
 msgstr ""
 
@@ -4964,7 +4964,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:888 lxc/remote.go:889
+#: lxc/remote.go:906 lxc/remote.go:907
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5302,7 +5302,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:180 lxc/remote.go:737
+#: lxc/cluster.go:180 lxc/remote.go:755
 msgid "URL"
 msgstr ""
 
@@ -5330,7 +5330,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:213 lxc/remote.go:247
+#: lxc/remote.go:220 lxc/remote.go:254
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -5610,8 +5610,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:955 lxc/operation.go:156 lxc/project.go:457
-#: lxc/project.go:462 lxc/project.go:467 lxc/project.go:472 lxc/remote.go:694
-#: lxc/remote.go:699 lxc/remote.go:704
+#: lxc/project.go:462 lxc/project.go:467 lxc/project.go:472 lxc/remote.go:712
+#: lxc/remote.go:717 lxc/remote.go:722
 msgid "YES"
 msgstr ""
 
@@ -6176,7 +6176,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:477 lxc/remote.go:727
+#: lxc/project.go:477 lxc/remote.go:745
 msgid "current"
 msgstr ""
 
@@ -6467,7 +6467,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:459
+#: lxc/remote.go:477
 msgid "n"
 msgstr ""
 
@@ -6479,7 +6479,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:452
+#: lxc/remote.go:470
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6516,7 +6516,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:461
+#: lxc/remote.go:479
 msgid "y"
 msgstr ""
 

--- a/po/bg.po
+++ b/po/bg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-01 10:44+0100\n"
+"POT-Creation-Date: 2024-10-18 13:21+0000\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Bulgarian <https://hosted.weblate.org/projects/linux-"
@@ -380,15 +380,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:830 lxc/remote.go:887
+#: lxc/remote.go:848 lxc/remote.go:905
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:927
+#: lxc/remote.go:945
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:757
+#: lxc/remote.go:775
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -421,7 +421,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:739
+#: lxc/remote.go:757
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -528,7 +528,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:564
+#: lxc/remote.go:582
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -560,7 +560,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:188
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -631,7 +631,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:550
+#: lxc/remote.go:568
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -804,7 +804,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:866
+#: lxc/remote.go:884
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -870,13 +870,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:218
+#: lxc/remote.go:225
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:451
+#: lxc/remote.go:469
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -890,7 +890,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:604
+#: lxc/remote.go:622
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1129,12 +1129,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:486
+#: lxc/remote.go:504
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:470
+#: lxc/remote.go:231 lxc/remote.go:488
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1163,7 +1163,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:481
+#: lxc/remote.go:499
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1455,8 +1455,8 @@ msgstr ""
 #: lxc/project.go:221 lxc/project.go:348 lxc/project.go:409 lxc/project.go:510
 #: lxc/project.go:567 lxc/project.go:646 lxc/project.go:677 lxc/project.go:730
 #: lxc/project.go:789 lxc/publish.go:33 lxc/query.go:34 lxc/remote.go:34
-#: lxc/remote.go:90 lxc/remote.go:632 lxc/remote.go:670 lxc/remote.go:760
-#: lxc/remote.go:833 lxc/remote.go:889 lxc/remote.go:929 lxc/rename.go:21
+#: lxc/remote.go:90 lxc/remote.go:650 lxc/remote.go:688 lxc/remote.go:778
+#: lxc/remote.go:851 lxc/remote.go:907 lxc/remote.go:947 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:92
 #: lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:340 lxc/storage.go:410
 #: lxc/storage.go:582 lxc/storage.go:661 lxc/storage.go:757 lxc/storage.go:843
@@ -1971,11 +1971,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:190
+#: lxc/remote.go:197
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:241
+#: lxc/remote.go:248
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -1985,7 +1985,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:231
+#: lxc/remote.go:238
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -1995,12 +1995,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:256
+#: lxc/remote.go:263
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:263
+#: lxc/remote.go:270
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2025,7 +2025,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:236
+#: lxc/remote.go:243
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2103,7 +2103,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:411
-#: lxc/project.go:791 lxc/remote.go:674 lxc/storage.go:584
+#: lxc/project.go:791 lxc/remote.go:692 lxc/storage.go:584
 #: lxc/storage_volume.go:1418 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -2140,7 +2140,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:742
+#: lxc/remote.go:760
 msgid "GLOBAL"
 msgstr ""
 
@@ -2156,7 +2156,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:397
+#: lxc/remote.go:159 lxc/remote.go:406
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2507,7 +2507,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:349
+#: lxc/remote.go:358
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2588,7 +2588,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:338
+#: lxc/remote.go:347
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -2924,7 +2924,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:669 lxc/remote.go:670
+#: lxc/remote.go:687 lxc/remote.go:688
 msgid "List the available remotes"
 msgstr ""
 
@@ -3458,7 +3458,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:566
 #: lxc/network.go:976 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:487 lxc/remote.go:736 lxc/storage.go:634
+#: lxc/project.go:487 lxc/remote.go:754 lxc/storage.go:634
 #: lxc/storage_volume.go:1506
 msgid "NAME"
 msgstr ""
@@ -3480,8 +3480,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:953 lxc/operation.go:154 lxc/project.go:455
-#: lxc/project.go:460 lxc/project.go:465 lxc/project.go:470 lxc/remote.go:692
-#: lxc/remote.go:697 lxc/remote.go:702
+#: lxc/project.go:460 lxc/project.go:465 lxc/project.go:470 lxc/remote.go:710
+#: lxc/remote.go:715 lxc/remote.go:720
 msgid "NO"
 msgstr ""
 
@@ -3696,7 +3696,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:332
+#: lxc/remote.go:341
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -3763,11 +3763,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:738
+#: lxc/remote.go:756
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1070 lxc/remote.go:740
+#: lxc/image.go:1070 lxc/remote.go:758
 msgid "PUBLIC"
 msgstr ""
 
@@ -3796,7 +3796,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:182
+#: lxc/remote.go:189
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -3808,7 +3808,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:462
+#: lxc/remote.go:480
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4109,33 +4109,33 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:790
+#: lxc/remote.go:808
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:756 lxc/remote.go:781 lxc/remote.go:854 lxc/remote.go:910
-#: lxc/remote.go:950
+#: lxc/project.go:756 lxc/remote.go:799 lxc/remote.go:872 lxc/remote.go:928
+#: lxc/remote.go:968
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:301
+#: lxc/remote.go:308
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:862
+#: lxc/remote.go:880
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:785 lxc/remote.go:858 lxc/remote.go:954
+#: lxc/remote.go:803 lxc/remote.go:876 lxc/remote.go:972
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:290
+#: lxc/remote.go:297
 msgid "Remote address must not be empty"
 msgstr ""
 
@@ -4143,7 +4143,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:295
+#: lxc/remote.go:302
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4201,7 +4201,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:832 lxc/remote.go:833
+#: lxc/remote.go:850 lxc/remote.go:851
 msgid "Remove remotes"
 msgstr ""
 
@@ -4250,7 +4250,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:759 lxc/remote.go:760
+#: lxc/remote.go:777 lxc/remote.go:778
 msgid "Rename remotes"
 msgstr ""
 
@@ -4387,7 +4387,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:741
+#: lxc/remote.go:759
 msgid "STATIC"
 msgstr ""
 
@@ -4415,11 +4415,11 @@ msgstr ""
 msgid "Server authentication type (tls or candid)"
 msgstr ""
 
-#: lxc/remote.go:460
+#: lxc/remote.go:478
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:600
+#: lxc/remote.go:618
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -4600,7 +4600,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:928 lxc/remote.go:929
+#: lxc/remote.go:946 lxc/remote.go:947
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -4776,7 +4776,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:631 lxc/remote.go:632
+#: lxc/remote.go:649 lxc/remote.go:650
 msgid "Show the default remote"
 msgstr ""
 
@@ -4964,7 +4964,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:888 lxc/remote.go:889
+#: lxc/remote.go:906 lxc/remote.go:907
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5302,7 +5302,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:180 lxc/remote.go:737
+#: lxc/cluster.go:180 lxc/remote.go:755
 msgid "URL"
 msgstr ""
 
@@ -5330,7 +5330,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:213 lxc/remote.go:247
+#: lxc/remote.go:220 lxc/remote.go:254
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -5610,8 +5610,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:955 lxc/operation.go:156 lxc/project.go:457
-#: lxc/project.go:462 lxc/project.go:467 lxc/project.go:472 lxc/remote.go:694
-#: lxc/remote.go:699 lxc/remote.go:704
+#: lxc/project.go:462 lxc/project.go:467 lxc/project.go:472 lxc/remote.go:712
+#: lxc/remote.go:717 lxc/remote.go:722
 msgid "YES"
 msgstr ""
 
@@ -6176,7 +6176,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:477 lxc/remote.go:727
+#: lxc/project.go:477 lxc/remote.go:745
 msgid "current"
 msgstr ""
 
@@ -6467,7 +6467,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:459
+#: lxc/remote.go:477
 msgid "n"
 msgstr ""
 
@@ -6479,7 +6479,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:452
+#: lxc/remote.go:470
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6516,7 +6516,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:461
+#: lxc/remote.go:479
 msgid "y"
 msgstr ""
 

--- a/po/ca.po
+++ b/po/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-01 10:44+0100\n"
+"POT-Creation-Date: 2024-10-18 13:21+0000\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Catalan <https://hosted.weblate.org/projects/linux-containers/"
@@ -380,15 +380,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:830 lxc/remote.go:887
+#: lxc/remote.go:848 lxc/remote.go:905
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:927
+#: lxc/remote.go:945
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:757
+#: lxc/remote.go:775
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -421,7 +421,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:739
+#: lxc/remote.go:757
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -528,7 +528,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:564
+#: lxc/remote.go:582
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -560,7 +560,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:188
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -631,7 +631,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:550
+#: lxc/remote.go:568
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -804,7 +804,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:866
+#: lxc/remote.go:884
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -870,13 +870,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:218
+#: lxc/remote.go:225
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:451
+#: lxc/remote.go:469
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -890,7 +890,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:604
+#: lxc/remote.go:622
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1129,12 +1129,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:486
+#: lxc/remote.go:504
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:470
+#: lxc/remote.go:231 lxc/remote.go:488
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1163,7 +1163,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:481
+#: lxc/remote.go:499
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1455,8 +1455,8 @@ msgstr ""
 #: lxc/project.go:221 lxc/project.go:348 lxc/project.go:409 lxc/project.go:510
 #: lxc/project.go:567 lxc/project.go:646 lxc/project.go:677 lxc/project.go:730
 #: lxc/project.go:789 lxc/publish.go:33 lxc/query.go:34 lxc/remote.go:34
-#: lxc/remote.go:90 lxc/remote.go:632 lxc/remote.go:670 lxc/remote.go:760
-#: lxc/remote.go:833 lxc/remote.go:889 lxc/remote.go:929 lxc/rename.go:21
+#: lxc/remote.go:90 lxc/remote.go:650 lxc/remote.go:688 lxc/remote.go:778
+#: lxc/remote.go:851 lxc/remote.go:907 lxc/remote.go:947 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:92
 #: lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:340 lxc/storage.go:410
 #: lxc/storage.go:582 lxc/storage.go:661 lxc/storage.go:757 lxc/storage.go:843
@@ -1971,11 +1971,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:190
+#: lxc/remote.go:197
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:241
+#: lxc/remote.go:248
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -1985,7 +1985,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:231
+#: lxc/remote.go:238
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -1995,12 +1995,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:256
+#: lxc/remote.go:263
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:263
+#: lxc/remote.go:270
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2025,7 +2025,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:236
+#: lxc/remote.go:243
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2103,7 +2103,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:411
-#: lxc/project.go:791 lxc/remote.go:674 lxc/storage.go:584
+#: lxc/project.go:791 lxc/remote.go:692 lxc/storage.go:584
 #: lxc/storage_volume.go:1418 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -2140,7 +2140,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:742
+#: lxc/remote.go:760
 msgid "GLOBAL"
 msgstr ""
 
@@ -2156,7 +2156,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:397
+#: lxc/remote.go:159 lxc/remote.go:406
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2507,7 +2507,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:349
+#: lxc/remote.go:358
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2588,7 +2588,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:338
+#: lxc/remote.go:347
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -2924,7 +2924,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:669 lxc/remote.go:670
+#: lxc/remote.go:687 lxc/remote.go:688
 msgid "List the available remotes"
 msgstr ""
 
@@ -3458,7 +3458,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:566
 #: lxc/network.go:976 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:487 lxc/remote.go:736 lxc/storage.go:634
+#: lxc/project.go:487 lxc/remote.go:754 lxc/storage.go:634
 #: lxc/storage_volume.go:1506
 msgid "NAME"
 msgstr ""
@@ -3480,8 +3480,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:953 lxc/operation.go:154 lxc/project.go:455
-#: lxc/project.go:460 lxc/project.go:465 lxc/project.go:470 lxc/remote.go:692
-#: lxc/remote.go:697 lxc/remote.go:702
+#: lxc/project.go:460 lxc/project.go:465 lxc/project.go:470 lxc/remote.go:710
+#: lxc/remote.go:715 lxc/remote.go:720
 msgid "NO"
 msgstr ""
 
@@ -3696,7 +3696,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:332
+#: lxc/remote.go:341
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -3763,11 +3763,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:738
+#: lxc/remote.go:756
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1070 lxc/remote.go:740
+#: lxc/image.go:1070 lxc/remote.go:758
 msgid "PUBLIC"
 msgstr ""
 
@@ -3796,7 +3796,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:182
+#: lxc/remote.go:189
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -3808,7 +3808,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:462
+#: lxc/remote.go:480
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4109,33 +4109,33 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:790
+#: lxc/remote.go:808
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:756 lxc/remote.go:781 lxc/remote.go:854 lxc/remote.go:910
-#: lxc/remote.go:950
+#: lxc/project.go:756 lxc/remote.go:799 lxc/remote.go:872 lxc/remote.go:928
+#: lxc/remote.go:968
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:301
+#: lxc/remote.go:308
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:862
+#: lxc/remote.go:880
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:785 lxc/remote.go:858 lxc/remote.go:954
+#: lxc/remote.go:803 lxc/remote.go:876 lxc/remote.go:972
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:290
+#: lxc/remote.go:297
 msgid "Remote address must not be empty"
 msgstr ""
 
@@ -4143,7 +4143,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:295
+#: lxc/remote.go:302
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4201,7 +4201,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:832 lxc/remote.go:833
+#: lxc/remote.go:850 lxc/remote.go:851
 msgid "Remove remotes"
 msgstr ""
 
@@ -4250,7 +4250,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:759 lxc/remote.go:760
+#: lxc/remote.go:777 lxc/remote.go:778
 msgid "Rename remotes"
 msgstr ""
 
@@ -4387,7 +4387,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:741
+#: lxc/remote.go:759
 msgid "STATIC"
 msgstr ""
 
@@ -4415,11 +4415,11 @@ msgstr ""
 msgid "Server authentication type (tls or candid)"
 msgstr ""
 
-#: lxc/remote.go:460
+#: lxc/remote.go:478
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:600
+#: lxc/remote.go:618
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -4600,7 +4600,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:928 lxc/remote.go:929
+#: lxc/remote.go:946 lxc/remote.go:947
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -4776,7 +4776,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:631 lxc/remote.go:632
+#: lxc/remote.go:649 lxc/remote.go:650
 msgid "Show the default remote"
 msgstr ""
 
@@ -4964,7 +4964,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:888 lxc/remote.go:889
+#: lxc/remote.go:906 lxc/remote.go:907
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5302,7 +5302,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:180 lxc/remote.go:737
+#: lxc/cluster.go:180 lxc/remote.go:755
 msgid "URL"
 msgstr ""
 
@@ -5330,7 +5330,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:213 lxc/remote.go:247
+#: lxc/remote.go:220 lxc/remote.go:254
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -5610,8 +5610,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:955 lxc/operation.go:156 lxc/project.go:457
-#: lxc/project.go:462 lxc/project.go:467 lxc/project.go:472 lxc/remote.go:694
-#: lxc/remote.go:699 lxc/remote.go:704
+#: lxc/project.go:462 lxc/project.go:467 lxc/project.go:472 lxc/remote.go:712
+#: lxc/remote.go:717 lxc/remote.go:722
 msgid "YES"
 msgstr ""
 
@@ -6176,7 +6176,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:477 lxc/remote.go:727
+#: lxc/project.go:477 lxc/remote.go:745
 msgid "current"
 msgstr ""
 
@@ -6467,7 +6467,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:459
+#: lxc/remote.go:477
 msgid "n"
 msgstr ""
 
@@ -6479,7 +6479,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:452
+#: lxc/remote.go:470
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6516,7 +6516,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:461
+#: lxc/remote.go:479
 msgid "y"
 msgstr ""
 

--- a/po/cs.po
+++ b/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-01 10:44+0100\n"
+"POT-Creation-Date: 2024-10-18 13:21+0000\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Czech <https://hosted.weblate.org/projects/linux-containers/"
@@ -380,15 +380,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:830 lxc/remote.go:887
+#: lxc/remote.go:848 lxc/remote.go:905
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:927
+#: lxc/remote.go:945
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:757
+#: lxc/remote.go:775
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -421,7 +421,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:739
+#: lxc/remote.go:757
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -528,7 +528,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:564
+#: lxc/remote.go:582
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -560,7 +560,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:188
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -631,7 +631,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:550
+#: lxc/remote.go:568
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -804,7 +804,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:866
+#: lxc/remote.go:884
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -870,13 +870,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:218
+#: lxc/remote.go:225
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:451
+#: lxc/remote.go:469
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -890,7 +890,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:604
+#: lxc/remote.go:622
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1129,12 +1129,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:486
+#: lxc/remote.go:504
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:470
+#: lxc/remote.go:231 lxc/remote.go:488
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1163,7 +1163,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:481
+#: lxc/remote.go:499
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1455,8 +1455,8 @@ msgstr ""
 #: lxc/project.go:221 lxc/project.go:348 lxc/project.go:409 lxc/project.go:510
 #: lxc/project.go:567 lxc/project.go:646 lxc/project.go:677 lxc/project.go:730
 #: lxc/project.go:789 lxc/publish.go:33 lxc/query.go:34 lxc/remote.go:34
-#: lxc/remote.go:90 lxc/remote.go:632 lxc/remote.go:670 lxc/remote.go:760
-#: lxc/remote.go:833 lxc/remote.go:889 lxc/remote.go:929 lxc/rename.go:21
+#: lxc/remote.go:90 lxc/remote.go:650 lxc/remote.go:688 lxc/remote.go:778
+#: lxc/remote.go:851 lxc/remote.go:907 lxc/remote.go:947 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:92
 #: lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:340 lxc/storage.go:410
 #: lxc/storage.go:582 lxc/storage.go:661 lxc/storage.go:757 lxc/storage.go:843
@@ -1971,11 +1971,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:190
+#: lxc/remote.go:197
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:241
+#: lxc/remote.go:248
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -1985,7 +1985,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:231
+#: lxc/remote.go:238
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -1995,12 +1995,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:256
+#: lxc/remote.go:263
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:263
+#: lxc/remote.go:270
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2025,7 +2025,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:236
+#: lxc/remote.go:243
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2103,7 +2103,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:411
-#: lxc/project.go:791 lxc/remote.go:674 lxc/storage.go:584
+#: lxc/project.go:791 lxc/remote.go:692 lxc/storage.go:584
 #: lxc/storage_volume.go:1418 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -2140,7 +2140,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:742
+#: lxc/remote.go:760
 msgid "GLOBAL"
 msgstr ""
 
@@ -2156,7 +2156,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:397
+#: lxc/remote.go:159 lxc/remote.go:406
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2507,7 +2507,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:349
+#: lxc/remote.go:358
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2588,7 +2588,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:338
+#: lxc/remote.go:347
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -2924,7 +2924,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:669 lxc/remote.go:670
+#: lxc/remote.go:687 lxc/remote.go:688
 msgid "List the available remotes"
 msgstr ""
 
@@ -3458,7 +3458,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:566
 #: lxc/network.go:976 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:487 lxc/remote.go:736 lxc/storage.go:634
+#: lxc/project.go:487 lxc/remote.go:754 lxc/storage.go:634
 #: lxc/storage_volume.go:1506
 msgid "NAME"
 msgstr ""
@@ -3480,8 +3480,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:953 lxc/operation.go:154 lxc/project.go:455
-#: lxc/project.go:460 lxc/project.go:465 lxc/project.go:470 lxc/remote.go:692
-#: lxc/remote.go:697 lxc/remote.go:702
+#: lxc/project.go:460 lxc/project.go:465 lxc/project.go:470 lxc/remote.go:710
+#: lxc/remote.go:715 lxc/remote.go:720
 msgid "NO"
 msgstr ""
 
@@ -3696,7 +3696,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:332
+#: lxc/remote.go:341
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -3763,11 +3763,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:738
+#: lxc/remote.go:756
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1070 lxc/remote.go:740
+#: lxc/image.go:1070 lxc/remote.go:758
 msgid "PUBLIC"
 msgstr ""
 
@@ -3796,7 +3796,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:182
+#: lxc/remote.go:189
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -3808,7 +3808,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:462
+#: lxc/remote.go:480
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4109,33 +4109,33 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:790
+#: lxc/remote.go:808
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:756 lxc/remote.go:781 lxc/remote.go:854 lxc/remote.go:910
-#: lxc/remote.go:950
+#: lxc/project.go:756 lxc/remote.go:799 lxc/remote.go:872 lxc/remote.go:928
+#: lxc/remote.go:968
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:301
+#: lxc/remote.go:308
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:862
+#: lxc/remote.go:880
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:785 lxc/remote.go:858 lxc/remote.go:954
+#: lxc/remote.go:803 lxc/remote.go:876 lxc/remote.go:972
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:290
+#: lxc/remote.go:297
 msgid "Remote address must not be empty"
 msgstr ""
 
@@ -4143,7 +4143,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:295
+#: lxc/remote.go:302
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4201,7 +4201,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:832 lxc/remote.go:833
+#: lxc/remote.go:850 lxc/remote.go:851
 msgid "Remove remotes"
 msgstr ""
 
@@ -4250,7 +4250,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:759 lxc/remote.go:760
+#: lxc/remote.go:777 lxc/remote.go:778
 msgid "Rename remotes"
 msgstr ""
 
@@ -4387,7 +4387,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:741
+#: lxc/remote.go:759
 msgid "STATIC"
 msgstr ""
 
@@ -4415,11 +4415,11 @@ msgstr ""
 msgid "Server authentication type (tls or candid)"
 msgstr ""
 
-#: lxc/remote.go:460
+#: lxc/remote.go:478
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:600
+#: lxc/remote.go:618
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -4600,7 +4600,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:928 lxc/remote.go:929
+#: lxc/remote.go:946 lxc/remote.go:947
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -4776,7 +4776,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:631 lxc/remote.go:632
+#: lxc/remote.go:649 lxc/remote.go:650
 msgid "Show the default remote"
 msgstr ""
 
@@ -4964,7 +4964,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:888 lxc/remote.go:889
+#: lxc/remote.go:906 lxc/remote.go:907
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5302,7 +5302,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:180 lxc/remote.go:737
+#: lxc/cluster.go:180 lxc/remote.go:755
 msgid "URL"
 msgstr ""
 
@@ -5330,7 +5330,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:213 lxc/remote.go:247
+#: lxc/remote.go:220 lxc/remote.go:254
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -5610,8 +5610,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:955 lxc/operation.go:156 lxc/project.go:457
-#: lxc/project.go:462 lxc/project.go:467 lxc/project.go:472 lxc/remote.go:694
-#: lxc/remote.go:699 lxc/remote.go:704
+#: lxc/project.go:462 lxc/project.go:467 lxc/project.go:472 lxc/remote.go:712
+#: lxc/remote.go:717 lxc/remote.go:722
 msgid "YES"
 msgstr ""
 
@@ -6176,7 +6176,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:477 lxc/remote.go:727
+#: lxc/project.go:477 lxc/remote.go:745
 msgid "current"
 msgstr ""
 
@@ -6467,7 +6467,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:459
+#: lxc/remote.go:477
 msgid "n"
 msgstr ""
 
@@ -6479,7 +6479,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:452
+#: lxc/remote.go:470
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6516,7 +6516,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:461
+#: lxc/remote.go:479
 msgid "y"
 msgstr ""
 

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-01 10:44+0100\n"
+"POT-Creation-Date: 2024-10-18 13:21+0000\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Krombel <krombel@krombel.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/linux-containers/"
@@ -602,15 +602,15 @@ msgstr "Ungültiges Ziel %s"
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:830 lxc/remote.go:887
+#: lxc/remote.go:848 lxc/remote.go:905
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:927
+#: lxc/remote.go:945
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:757
+#: lxc/remote.go:775
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -648,7 +648,7 @@ msgstr "ALIASES"
 msgid "ARCHITECTURE"
 msgstr "ARCHITEKTUR"
 
-#: lxc/remote.go:739
+#: lxc/remote.go:757
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -765,7 +765,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Address: %s"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/remote.go:564
+#: lxc/remote.go:582
 #, fuzzy, c-format
 msgid "Admin password (or token) for %s:"
 msgstr "Administrator Passwort für %s: "
@@ -799,7 +799,7 @@ msgstr "Aliasse:\n"
 msgid "All projects"
 msgstr "Fehlerhafte Profil URL %s"
 
-#: lxc/remote.go:181
+#: lxc/remote.go:188
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -877,7 +877,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:550
+#: lxc/remote.go:568
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -1063,7 +1063,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:866
+#: lxc/remote.go:884
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1133,13 +1133,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: lxc/remote.go:218
+#: lxc/remote.go:225
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:451
+#: lxc/remote.go:469
 #, fuzzy, c-format
 msgid "Certificate fingerprint: %s"
 msgstr "Fingerabdruck des Zertifikats: % x\n"
@@ -1153,7 +1153,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/remote.go:604
+#: lxc/remote.go:622
 #, fuzzy
 msgid "Client certificate now trusted by server:"
 msgstr "Gespeichertes Nutzerzertifikat auf dem Server: "
@@ -1401,12 +1401,12 @@ msgstr "Fehler: %v\n"
 msgid "Cores:"
 msgstr "Fehler: %v\n"
 
-#: lxc/remote.go:486
+#: lxc/remote.go:504
 #, fuzzy, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "Kann Verzeichnis für Zertifikate auf dem Server nicht erstellen"
 
-#: lxc/remote.go:224 lxc/remote.go:470
+#: lxc/remote.go:231 lxc/remote.go:488
 msgid "Could not create server cert dir"
 msgstr "Kann Verzeichnis für Zertifikate auf dem Server nicht erstellen"
 
@@ -1435,7 +1435,7 @@ msgstr "Fingerabdruck des Zertifikats: % x\n"
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:481
+#: lxc/remote.go:499
 #, fuzzy, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "Kann Verzeichnis für Zertifikate auf dem Server nicht erstellen"
@@ -1750,8 +1750,8 @@ msgstr ""
 #: lxc/project.go:221 lxc/project.go:348 lxc/project.go:409 lxc/project.go:510
 #: lxc/project.go:567 lxc/project.go:646 lxc/project.go:677 lxc/project.go:730
 #: lxc/project.go:789 lxc/publish.go:33 lxc/query.go:34 lxc/remote.go:34
-#: lxc/remote.go:90 lxc/remote.go:632 lxc/remote.go:670 lxc/remote.go:760
-#: lxc/remote.go:833 lxc/remote.go:889 lxc/remote.go:929 lxc/rename.go:21
+#: lxc/remote.go:90 lxc/remote.go:650 lxc/remote.go:688 lxc/remote.go:778
+#: lxc/remote.go:851 lxc/remote.go:907 lxc/remote.go:947 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:92
 #: lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:340 lxc/storage.go:410
 #: lxc/storage.go:582 lxc/storage.go:661 lxc/storage.go:757 lxc/storage.go:843
@@ -2306,11 +2306,11 @@ msgstr "Akzeptiere Zertifikat"
 msgid "Failed to accept incoming connection: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/remote.go:190
+#: lxc/remote.go:197
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:241
+#: lxc/remote.go:248
 #, fuzzy, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr "Akzeptiere Zertifikat"
@@ -2320,7 +2320,7 @@ msgstr "Akzeptiere Zertifikat"
 msgid "Failed to connect to cluster member: %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/remote.go:231
+#: lxc/remote.go:238
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2330,12 +2330,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/remote.go:256
+#: lxc/remote.go:263
 #, fuzzy, c-format
 msgid "Failed to create certificate: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/remote.go:263
+#: lxc/remote.go:270
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2360,7 +2360,7 @@ msgstr "Akzeptiere Zertifikat"
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:236
+#: lxc/remote.go:243
 #, fuzzy, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr "Akzeptiere Zertifikat"
@@ -2442,7 +2442,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:411
-#: lxc/project.go:791 lxc/remote.go:674 lxc/storage.go:584
+#: lxc/project.go:791 lxc/remote.go:692 lxc/storage.go:584
 #: lxc/storage_volume.go:1418 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -2479,7 +2479,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:742
+#: lxc/remote.go:760
 msgid "GLOBAL"
 msgstr ""
 
@@ -2495,7 +2495,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:397
+#: lxc/remote.go:159 lxc/remote.go:406
 #, fuzzy
 msgid "Generating a client certificate. This may take a minute..."
 msgstr "Generiere Nutzerzertifikat. Dies kann wenige Minuten dauern...\n"
@@ -2869,7 +2869,7 @@ msgstr "Abbild mit Fingerabdruck %s importiert\n"
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:349
+#: lxc/remote.go:358
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2953,7 +2953,7 @@ msgstr "ungültiges Argument %s"
 msgid "Invalid path %s"
 msgstr "Ungültiges Ziel %s"
 
-#: lxc/remote.go:338
+#: lxc/remote.go:347
 #, fuzzy, c-format
 msgid "Invalid protocol: %s"
 msgstr "Ungültiges Ziel %s"
@@ -3319,7 +3319,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:669 lxc/remote.go:670
+#: lxc/remote.go:687 lxc/remote.go:688
 msgid "List the available remotes"
 msgstr ""
 
@@ -3906,7 +3906,7 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:566
 #: lxc/network.go:976 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:487 lxc/remote.go:736 lxc/storage.go:634
+#: lxc/project.go:487 lxc/remote.go:754 lxc/storage.go:634
 #: lxc/storage_volume.go:1506
 msgid "NAME"
 msgstr ""
@@ -3928,8 +3928,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:953 lxc/operation.go:154 lxc/project.go:455
-#: lxc/project.go:460 lxc/project.go:465 lxc/project.go:470 lxc/remote.go:692
-#: lxc/remote.go:697 lxc/remote.go:702
+#: lxc/project.go:460 lxc/project.go:465 lxc/project.go:470 lxc/remote.go:710
+#: lxc/remote.go:715 lxc/remote.go:720
 msgid "NO"
 msgstr ""
 
@@ -4150,7 +4150,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:332
+#: lxc/remote.go:341
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4217,11 +4217,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:738
+#: lxc/remote.go:756
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1070 lxc/remote.go:740
+#: lxc/image.go:1070 lxc/remote.go:758
 msgid "PUBLIC"
 msgstr ""
 
@@ -4251,7 +4251,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:182
+#: lxc/remote.go:189
 #, fuzzy
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr "Alternatives config Verzeichnis."
@@ -4265,7 +4265,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/remote.go:462
+#: lxc/remote.go:480
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4575,33 +4575,33 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:790
+#: lxc/remote.go:808
 #, fuzzy, c-format
 msgid "Remote %s already exists"
 msgstr "entfernte Instanz %s existiert bereits"
 
-#: lxc/project.go:756 lxc/remote.go:781 lxc/remote.go:854 lxc/remote.go:910
-#: lxc/remote.go:950
+#: lxc/project.go:756 lxc/remote.go:799 lxc/remote.go:872 lxc/remote.go:928
+#: lxc/remote.go:968
 #, fuzzy, c-format
 msgid "Remote %s doesn't exist"
 msgstr "entfernte Instanz %s existiert nicht"
 
-#: lxc/remote.go:301
+#: lxc/remote.go:308
 #, fuzzy, c-format
 msgid "Remote %s exists as <%s>"
 msgstr "entfernte Instanz %s existiert als <%s>"
 
-#: lxc/remote.go:862
+#: lxc/remote.go:880
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:785 lxc/remote.go:858 lxc/remote.go:954
+#: lxc/remote.go:803 lxc/remote.go:876 lxc/remote.go:972
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:290
+#: lxc/remote.go:297
 msgid "Remote address must not be empty"
 msgstr ""
 
@@ -4609,7 +4609,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr "Entferntes Administrator Passwort"
 
-#: lxc/remote.go:295
+#: lxc/remote.go:302
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4674,7 +4674,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Remove profiles from instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/remote.go:832 lxc/remote.go:833
+#: lxc/remote.go:850 lxc/remote.go:851
 msgid "Remove remotes"
 msgstr ""
 
@@ -4728,7 +4728,7 @@ msgstr "Fehlerhafte Profil URL %s"
 msgid "Rename projects"
 msgstr "Fehlerhafte Profil URL %s"
 
-#: lxc/remote.go:759 lxc/remote.go:760
+#: lxc/remote.go:777 lxc/remote.go:778
 msgid "Rename remotes"
 msgstr ""
 
@@ -4875,7 +4875,7 @@ msgstr "Entferntes Administrator Passwort"
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:741
+#: lxc/remote.go:759
 msgid "STATIC"
 msgstr ""
 
@@ -4903,11 +4903,11 @@ msgstr ""
 msgid "Server authentication type (tls or candid)"
 msgstr ""
 
-#: lxc/remote.go:460
+#: lxc/remote.go:478
 msgid "Server certificate NACKed by user"
 msgstr "Server Zertifikat vom Benutzer nicht akzeptiert"
 
-#: lxc/remote.go:600
+#: lxc/remote.go:618
 #, fuzzy
 msgid "Server doesn't trust us after authentication"
 msgstr ""
@@ -5101,7 +5101,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:928 lxc/remote.go:929
+#: lxc/remote.go:946 lxc/remote.go:947
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5297,7 +5297,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Show storage volume state information"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/remote.go:631 lxc/remote.go:632
+#: lxc/remote.go:649 lxc/remote.go:650
 msgid "Show the default remote"
 msgstr ""
 
@@ -5496,7 +5496,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:888 lxc/remote.go:889
+#: lxc/remote.go:906 lxc/remote.go:907
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5846,7 +5846,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:180 lxc/remote.go:737
+#: lxc/cluster.go:180 lxc/remote.go:755
 msgid "URL"
 msgstr ""
 
@@ -5874,7 +5874,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:213 lxc/remote.go:247
+#: lxc/remote.go:220 lxc/remote.go:254
 #, fuzzy
 msgid "Unavailable remote server"
 msgstr "Neue entfernte Server hinzufügen"
@@ -6185,8 +6185,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr "Zustand des laufenden Containers sichern oder nicht"
 
 #: lxc/network.go:955 lxc/operation.go:156 lxc/project.go:457
-#: lxc/project.go:462 lxc/project.go:467 lxc/project.go:472 lxc/remote.go:694
-#: lxc/remote.go:699 lxc/remote.go:704
+#: lxc/project.go:462 lxc/project.go:467 lxc/project.go:472 lxc/remote.go:712
+#: lxc/remote.go:717 lxc/remote.go:722
 msgid "YES"
 msgstr ""
 
@@ -7314,7 +7314,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/project.go:477 lxc/remote.go:727
+#: lxc/project.go:477 lxc/remote.go:745
 msgid "current"
 msgstr ""
 
@@ -7609,7 +7609,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:459
+#: lxc/remote.go:477
 msgid "n"
 msgstr ""
 
@@ -7621,7 +7621,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:452
+#: lxc/remote.go:470
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7658,7 +7658,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:461
+#: lxc/remote.go:479
 msgid "y"
 msgstr ""
 

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-01 10:44+0100\n"
+"POT-Creation-Date: 2024-10-18 13:21+0000\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/linux-containers/"
@@ -380,15 +380,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:830 lxc/remote.go:887
+#: lxc/remote.go:848 lxc/remote.go:905
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:927
+#: lxc/remote.go:945
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:757
+#: lxc/remote.go:775
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -421,7 +421,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:739
+#: lxc/remote.go:757
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -531,7 +531,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:564
+#: lxc/remote.go:582
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -563,7 +563,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:188
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -634,7 +634,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:550
+#: lxc/remote.go:568
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -808,7 +808,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:866
+#: lxc/remote.go:884
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -874,13 +874,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/remote.go:218
+#: lxc/remote.go:225
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:451
+#: lxc/remote.go:469
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -894,7 +894,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/remote.go:604
+#: lxc/remote.go:622
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1133,12 +1133,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:486
+#: lxc/remote.go:504
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:470
+#: lxc/remote.go:231 lxc/remote.go:488
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1167,7 +1167,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:481
+#: lxc/remote.go:499
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1462,8 +1462,8 @@ msgstr ""
 #: lxc/project.go:221 lxc/project.go:348 lxc/project.go:409 lxc/project.go:510
 #: lxc/project.go:567 lxc/project.go:646 lxc/project.go:677 lxc/project.go:730
 #: lxc/project.go:789 lxc/publish.go:33 lxc/query.go:34 lxc/remote.go:34
-#: lxc/remote.go:90 lxc/remote.go:632 lxc/remote.go:670 lxc/remote.go:760
-#: lxc/remote.go:833 lxc/remote.go:889 lxc/remote.go:929 lxc/rename.go:21
+#: lxc/remote.go:90 lxc/remote.go:650 lxc/remote.go:688 lxc/remote.go:778
+#: lxc/remote.go:851 lxc/remote.go:907 lxc/remote.go:947 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:92
 #: lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:340 lxc/storage.go:410
 #: lxc/storage.go:582 lxc/storage.go:661 lxc/storage.go:757 lxc/storage.go:843
@@ -1985,11 +1985,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:190
+#: lxc/remote.go:197
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:241
+#: lxc/remote.go:248
 #, fuzzy, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr "  Χρήση δικτύου:"
@@ -1999,7 +1999,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Failed to connect to cluster member: %w"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/remote.go:231
+#: lxc/remote.go:238
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2009,12 +2009,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:256
+#: lxc/remote.go:263
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:263
+#: lxc/remote.go:270
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2039,7 +2039,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:236
+#: lxc/remote.go:243
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2117,7 +2117,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:411
-#: lxc/project.go:791 lxc/remote.go:674 lxc/storage.go:584
+#: lxc/project.go:791 lxc/remote.go:692 lxc/storage.go:584
 #: lxc/storage_volume.go:1418 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -2154,7 +2154,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:742
+#: lxc/remote.go:760
 msgid "GLOBAL"
 msgstr ""
 
@@ -2170,7 +2170,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:397
+#: lxc/remote.go:159 lxc/remote.go:406
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2530,7 +2530,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:349
+#: lxc/remote.go:358
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2611,7 +2611,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:338
+#: lxc/remote.go:347
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -2948,7 +2948,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:669 lxc/remote.go:670
+#: lxc/remote.go:687 lxc/remote.go:688
 msgid "List the available remotes"
 msgstr ""
 
@@ -3491,7 +3491,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:566
 #: lxc/network.go:976 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:487 lxc/remote.go:736 lxc/storage.go:634
+#: lxc/project.go:487 lxc/remote.go:754 lxc/storage.go:634
 #: lxc/storage_volume.go:1506
 msgid "NAME"
 msgstr ""
@@ -3513,8 +3513,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:953 lxc/operation.go:154 lxc/project.go:455
-#: lxc/project.go:460 lxc/project.go:465 lxc/project.go:470 lxc/remote.go:692
-#: lxc/remote.go:697 lxc/remote.go:702
+#: lxc/project.go:460 lxc/project.go:465 lxc/project.go:470 lxc/remote.go:710
+#: lxc/remote.go:715 lxc/remote.go:720
 msgid "NO"
 msgstr ""
 
@@ -3731,7 +3731,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:332
+#: lxc/remote.go:341
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -3798,11 +3798,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:738
+#: lxc/remote.go:756
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1070 lxc/remote.go:740
+#: lxc/image.go:1070 lxc/remote.go:758
 msgid "PUBLIC"
 msgstr ""
 
@@ -3831,7 +3831,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:182
+#: lxc/remote.go:189
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -3844,7 +3844,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/remote.go:462
+#: lxc/remote.go:480
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4145,33 +4145,33 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:790
+#: lxc/remote.go:808
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:756 lxc/remote.go:781 lxc/remote.go:854 lxc/remote.go:910
-#: lxc/remote.go:950
+#: lxc/project.go:756 lxc/remote.go:799 lxc/remote.go:872 lxc/remote.go:928
+#: lxc/remote.go:968
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:301
+#: lxc/remote.go:308
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:862
+#: lxc/remote.go:880
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:785 lxc/remote.go:858 lxc/remote.go:954
+#: lxc/remote.go:803 lxc/remote.go:876 lxc/remote.go:972
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:290
+#: lxc/remote.go:297
 msgid "Remote address must not be empty"
 msgstr ""
 
@@ -4179,7 +4179,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:295
+#: lxc/remote.go:302
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4238,7 +4238,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:832 lxc/remote.go:833
+#: lxc/remote.go:850 lxc/remote.go:851
 msgid "Remove remotes"
 msgstr ""
 
@@ -4288,7 +4288,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:759 lxc/remote.go:760
+#: lxc/remote.go:777 lxc/remote.go:778
 msgid "Rename remotes"
 msgstr ""
 
@@ -4426,7 +4426,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:741
+#: lxc/remote.go:759
 msgid "STATIC"
 msgstr ""
 
@@ -4454,11 +4454,11 @@ msgstr ""
 msgid "Server authentication type (tls or candid)"
 msgstr ""
 
-#: lxc/remote.go:460
+#: lxc/remote.go:478
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:600
+#: lxc/remote.go:618
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -4644,7 +4644,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:928 lxc/remote.go:929
+#: lxc/remote.go:946 lxc/remote.go:947
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -4830,7 +4830,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:631 lxc/remote.go:632
+#: lxc/remote.go:649 lxc/remote.go:650
 msgid "Show the default remote"
 msgstr ""
 
@@ -5018,7 +5018,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:888 lxc/remote.go:889
+#: lxc/remote.go:906 lxc/remote.go:907
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5357,7 +5357,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:180 lxc/remote.go:737
+#: lxc/cluster.go:180 lxc/remote.go:755
 msgid "URL"
 msgstr ""
 
@@ -5385,7 +5385,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:213 lxc/remote.go:247
+#: lxc/remote.go:220 lxc/remote.go:254
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -5677,8 +5677,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:955 lxc/operation.go:156 lxc/project.go:457
-#: lxc/project.go:462 lxc/project.go:467 lxc/project.go:472 lxc/remote.go:694
-#: lxc/remote.go:699 lxc/remote.go:704
+#: lxc/project.go:462 lxc/project.go:467 lxc/project.go:472 lxc/remote.go:712
+#: lxc/remote.go:717 lxc/remote.go:722
 msgid "YES"
 msgstr ""
 
@@ -6243,7 +6243,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:477 lxc/remote.go:727
+#: lxc/project.go:477 lxc/remote.go:745
 msgid "current"
 msgstr ""
 
@@ -6534,7 +6534,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:459
+#: lxc/remote.go:477
 msgid "n"
 msgstr ""
 
@@ -6546,7 +6546,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:452
+#: lxc/remote.go:470
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6583,7 +6583,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:461
+#: lxc/remote.go:479
 msgid "y"
 msgstr ""
 

--- a/po/eo.po
+++ b/po/eo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-01 10:44+0100\n"
+"POT-Creation-Date: 2024-10-18 13:21+0000\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Esperanto <https://hosted.weblate.org/projects/linux-"
@@ -380,15 +380,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:830 lxc/remote.go:887
+#: lxc/remote.go:848 lxc/remote.go:905
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:927
+#: lxc/remote.go:945
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:757
+#: lxc/remote.go:775
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -421,7 +421,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:739
+#: lxc/remote.go:757
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -528,7 +528,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:564
+#: lxc/remote.go:582
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -560,7 +560,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:188
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -631,7 +631,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:550
+#: lxc/remote.go:568
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -804,7 +804,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:866
+#: lxc/remote.go:884
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -870,13 +870,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:218
+#: lxc/remote.go:225
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:451
+#: lxc/remote.go:469
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -890,7 +890,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:604
+#: lxc/remote.go:622
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1129,12 +1129,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:486
+#: lxc/remote.go:504
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:470
+#: lxc/remote.go:231 lxc/remote.go:488
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1163,7 +1163,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:481
+#: lxc/remote.go:499
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1455,8 +1455,8 @@ msgstr ""
 #: lxc/project.go:221 lxc/project.go:348 lxc/project.go:409 lxc/project.go:510
 #: lxc/project.go:567 lxc/project.go:646 lxc/project.go:677 lxc/project.go:730
 #: lxc/project.go:789 lxc/publish.go:33 lxc/query.go:34 lxc/remote.go:34
-#: lxc/remote.go:90 lxc/remote.go:632 lxc/remote.go:670 lxc/remote.go:760
-#: lxc/remote.go:833 lxc/remote.go:889 lxc/remote.go:929 lxc/rename.go:21
+#: lxc/remote.go:90 lxc/remote.go:650 lxc/remote.go:688 lxc/remote.go:778
+#: lxc/remote.go:851 lxc/remote.go:907 lxc/remote.go:947 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:92
 #: lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:340 lxc/storage.go:410
 #: lxc/storage.go:582 lxc/storage.go:661 lxc/storage.go:757 lxc/storage.go:843
@@ -1971,11 +1971,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:190
+#: lxc/remote.go:197
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:241
+#: lxc/remote.go:248
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -1985,7 +1985,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:231
+#: lxc/remote.go:238
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -1995,12 +1995,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:256
+#: lxc/remote.go:263
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:263
+#: lxc/remote.go:270
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2025,7 +2025,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:236
+#: lxc/remote.go:243
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2103,7 +2103,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:411
-#: lxc/project.go:791 lxc/remote.go:674 lxc/storage.go:584
+#: lxc/project.go:791 lxc/remote.go:692 lxc/storage.go:584
 #: lxc/storage_volume.go:1418 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -2140,7 +2140,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:742
+#: lxc/remote.go:760
 msgid "GLOBAL"
 msgstr ""
 
@@ -2156,7 +2156,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:397
+#: lxc/remote.go:159 lxc/remote.go:406
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2507,7 +2507,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:349
+#: lxc/remote.go:358
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2588,7 +2588,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:338
+#: lxc/remote.go:347
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -2924,7 +2924,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:669 lxc/remote.go:670
+#: lxc/remote.go:687 lxc/remote.go:688
 msgid "List the available remotes"
 msgstr ""
 
@@ -3458,7 +3458,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:566
 #: lxc/network.go:976 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:487 lxc/remote.go:736 lxc/storage.go:634
+#: lxc/project.go:487 lxc/remote.go:754 lxc/storage.go:634
 #: lxc/storage_volume.go:1506
 msgid "NAME"
 msgstr ""
@@ -3480,8 +3480,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:953 lxc/operation.go:154 lxc/project.go:455
-#: lxc/project.go:460 lxc/project.go:465 lxc/project.go:470 lxc/remote.go:692
-#: lxc/remote.go:697 lxc/remote.go:702
+#: lxc/project.go:460 lxc/project.go:465 lxc/project.go:470 lxc/remote.go:710
+#: lxc/remote.go:715 lxc/remote.go:720
 msgid "NO"
 msgstr ""
 
@@ -3696,7 +3696,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:332
+#: lxc/remote.go:341
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -3763,11 +3763,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:738
+#: lxc/remote.go:756
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1070 lxc/remote.go:740
+#: lxc/image.go:1070 lxc/remote.go:758
 msgid "PUBLIC"
 msgstr ""
 
@@ -3796,7 +3796,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:182
+#: lxc/remote.go:189
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -3808,7 +3808,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:462
+#: lxc/remote.go:480
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4109,33 +4109,33 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:790
+#: lxc/remote.go:808
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:756 lxc/remote.go:781 lxc/remote.go:854 lxc/remote.go:910
-#: lxc/remote.go:950
+#: lxc/project.go:756 lxc/remote.go:799 lxc/remote.go:872 lxc/remote.go:928
+#: lxc/remote.go:968
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:301
+#: lxc/remote.go:308
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:862
+#: lxc/remote.go:880
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:785 lxc/remote.go:858 lxc/remote.go:954
+#: lxc/remote.go:803 lxc/remote.go:876 lxc/remote.go:972
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:290
+#: lxc/remote.go:297
 msgid "Remote address must not be empty"
 msgstr ""
 
@@ -4143,7 +4143,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:295
+#: lxc/remote.go:302
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4201,7 +4201,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:832 lxc/remote.go:833
+#: lxc/remote.go:850 lxc/remote.go:851
 msgid "Remove remotes"
 msgstr ""
 
@@ -4250,7 +4250,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:759 lxc/remote.go:760
+#: lxc/remote.go:777 lxc/remote.go:778
 msgid "Rename remotes"
 msgstr ""
 
@@ -4387,7 +4387,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:741
+#: lxc/remote.go:759
 msgid "STATIC"
 msgstr ""
 
@@ -4415,11 +4415,11 @@ msgstr ""
 msgid "Server authentication type (tls or candid)"
 msgstr ""
 
-#: lxc/remote.go:460
+#: lxc/remote.go:478
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:600
+#: lxc/remote.go:618
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -4600,7 +4600,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:928 lxc/remote.go:929
+#: lxc/remote.go:946 lxc/remote.go:947
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -4776,7 +4776,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:631 lxc/remote.go:632
+#: lxc/remote.go:649 lxc/remote.go:650
 msgid "Show the default remote"
 msgstr ""
 
@@ -4964,7 +4964,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:888 lxc/remote.go:889
+#: lxc/remote.go:906 lxc/remote.go:907
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5302,7 +5302,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:180 lxc/remote.go:737
+#: lxc/cluster.go:180 lxc/remote.go:755
 msgid "URL"
 msgstr ""
 
@@ -5330,7 +5330,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:213 lxc/remote.go:247
+#: lxc/remote.go:220 lxc/remote.go:254
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -5610,8 +5610,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:955 lxc/operation.go:156 lxc/project.go:457
-#: lxc/project.go:462 lxc/project.go:467 lxc/project.go:472 lxc/remote.go:694
-#: lxc/remote.go:699 lxc/remote.go:704
+#: lxc/project.go:462 lxc/project.go:467 lxc/project.go:472 lxc/remote.go:712
+#: lxc/remote.go:717 lxc/remote.go:722
 msgid "YES"
 msgstr ""
 
@@ -6176,7 +6176,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:477 lxc/remote.go:727
+#: lxc/project.go:477 lxc/remote.go:745
 msgid "current"
 msgstr ""
 
@@ -6467,7 +6467,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:459
+#: lxc/remote.go:477
 msgid "n"
 msgstr ""
 
@@ -6479,7 +6479,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:452
+#: lxc/remote.go:470
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6516,7 +6516,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:461
+#: lxc/remote.go:479
 msgid "y"
 msgstr ""
 

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-01 10:44+0100\n"
+"POT-Creation-Date: 2024-10-18 13:21+0000\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Alonso José Lara Plana <alonso.lara.plana@gmail.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -592,15 +592,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:830 lxc/remote.go:887
+#: lxc/remote.go:848 lxc/remote.go:905
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:927
+#: lxc/remote.go:945
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:757
+#: lxc/remote.go:775
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -634,7 +634,7 @@ msgstr "ALIASES"
 msgid "ARCHITECTURE"
 msgstr "ARQUITECTURA"
 
-#: lxc/remote.go:739
+#: lxc/remote.go:757
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -745,7 +745,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr "Expira: %s"
 
-#: lxc/remote.go:564
+#: lxc/remote.go:582
 #, fuzzy, c-format
 msgid "Admin password (or token) for %s:"
 msgstr "Contraseña admin para %s: "
@@ -777,7 +777,7 @@ msgstr "Aliases:"
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:188
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -850,7 +850,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:550
+#: lxc/remote.go:568
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr "Tipo de autenticación %s no está soportada por el servidor"
@@ -1025,7 +1025,7 @@ msgstr "No se puede jalar un directorio sin - recursivo"
 msgid "Can't read from stdin: %w"
 msgstr "No se peude leer desde stdin: %s"
 
-#: lxc/remote.go:866
+#: lxc/remote.go:884
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1092,13 +1092,13 @@ msgstr "Cacheado: %s"
 msgid "Certificate add token for %s deleted"
 msgstr "Perfil %s eliminado"
 
-#: lxc/remote.go:218
+#: lxc/remote.go:225
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:451
+#: lxc/remote.go:469
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr "Certificado de la huella digital: %s"
@@ -1112,7 +1112,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/remote.go:604
+#: lxc/remote.go:622
 #, fuzzy
 msgid "Client certificate now trusted by server:"
 msgstr "Certificado del cliente almacenado en el servidor: "
@@ -1356,12 +1356,12 @@ msgstr "Expira: %s"
 msgid "Cores:"
 msgstr "Expira: %s"
 
-#: lxc/remote.go:486
+#: lxc/remote.go:504
 #, fuzzy, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "Certificado de la huella digital: %s"
 
-#: lxc/remote.go:224 lxc/remote.go:470
+#: lxc/remote.go:231 lxc/remote.go:488
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1390,7 +1390,7 @@ msgstr "Certificado de la huella digital: %s"
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:481
+#: lxc/remote.go:499
 #, fuzzy, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "Certificado de la huella digital: %s"
@@ -1690,8 +1690,8 @@ msgstr ""
 #: lxc/project.go:221 lxc/project.go:348 lxc/project.go:409 lxc/project.go:510
 #: lxc/project.go:567 lxc/project.go:646 lxc/project.go:677 lxc/project.go:730
 #: lxc/project.go:789 lxc/publish.go:33 lxc/query.go:34 lxc/remote.go:34
-#: lxc/remote.go:90 lxc/remote.go:632 lxc/remote.go:670 lxc/remote.go:760
-#: lxc/remote.go:833 lxc/remote.go:889 lxc/remote.go:929 lxc/rename.go:21
+#: lxc/remote.go:90 lxc/remote.go:650 lxc/remote.go:688 lxc/remote.go:778
+#: lxc/remote.go:851 lxc/remote.go:907 lxc/remote.go:947 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:92
 #: lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:340 lxc/storage.go:410
 #: lxc/storage.go:582 lxc/storage.go:661 lxc/storage.go:757 lxc/storage.go:843
@@ -2219,11 +2219,11 @@ msgstr "Acepta certificado"
 msgid "Failed to accept incoming connection: %w"
 msgstr "Acepta certificado"
 
-#: lxc/remote.go:190
+#: lxc/remote.go:197
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:241
+#: lxc/remote.go:248
 #, fuzzy, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr "Acepta certificado"
@@ -2233,7 +2233,7 @@ msgstr "Acepta certificado"
 msgid "Failed to connect to cluster member: %w"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/remote.go:231
+#: lxc/remote.go:238
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2243,12 +2243,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr "Acepta certificado"
 
-#: lxc/remote.go:256
+#: lxc/remote.go:263
 #, fuzzy, c-format
 msgid "Failed to create certificate: %w"
 msgstr "Acepta certificado"
 
-#: lxc/remote.go:263
+#: lxc/remote.go:270
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2273,7 +2273,7 @@ msgstr "Acepta certificado"
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:236
+#: lxc/remote.go:243
 #, fuzzy, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr "Acepta certificado"
@@ -2352,7 +2352,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:411
-#: lxc/project.go:791 lxc/remote.go:674 lxc/storage.go:584
+#: lxc/project.go:791 lxc/remote.go:692 lxc/storage.go:584
 #: lxc/storage_volume.go:1418 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -2389,7 +2389,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:742
+#: lxc/remote.go:760
 msgid "GLOBAL"
 msgstr ""
 
@@ -2405,7 +2405,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:397
+#: lxc/remote.go:159 lxc/remote.go:406
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2771,7 +2771,7 @@ msgstr "Contenedor publicado con huella digital: %s"
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:349
+#: lxc/remote.go:358
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2853,7 +2853,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:338
+#: lxc/remote.go:347
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3198,7 +3198,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:669 lxc/remote.go:670
+#: lxc/remote.go:687 lxc/remote.go:688
 msgid "List the available remotes"
 msgstr ""
 
@@ -3753,7 +3753,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:566
 #: lxc/network.go:976 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:487 lxc/remote.go:736 lxc/storage.go:634
+#: lxc/project.go:487 lxc/remote.go:754 lxc/storage.go:634
 #: lxc/storage_volume.go:1506
 msgid "NAME"
 msgstr ""
@@ -3775,8 +3775,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:953 lxc/operation.go:154 lxc/project.go:455
-#: lxc/project.go:460 lxc/project.go:465 lxc/project.go:470 lxc/remote.go:692
-#: lxc/remote.go:697 lxc/remote.go:702
+#: lxc/project.go:460 lxc/project.go:465 lxc/project.go:470 lxc/remote.go:710
+#: lxc/remote.go:715 lxc/remote.go:720
 msgid "NO"
 msgstr ""
 
@@ -3991,7 +3991,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:332
+#: lxc/remote.go:341
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4058,11 +4058,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:738
+#: lxc/remote.go:756
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1070 lxc/remote.go:740
+#: lxc/image.go:1070 lxc/remote.go:758
 msgid "PUBLIC"
 msgstr ""
 
@@ -4091,7 +4091,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:182
+#: lxc/remote.go:189
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4104,7 +4104,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/remote.go:462
+#: lxc/remote.go:480
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4408,33 +4408,33 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "Refreshing the image: %s"
 msgstr "Refrescando la imagen: %s"
 
-#: lxc/remote.go:790
+#: lxc/remote.go:808
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:756 lxc/remote.go:781 lxc/remote.go:854 lxc/remote.go:910
-#: lxc/remote.go:950
+#: lxc/project.go:756 lxc/remote.go:799 lxc/remote.go:872 lxc/remote.go:928
+#: lxc/remote.go:968
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:301
+#: lxc/remote.go:308
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:862
+#: lxc/remote.go:880
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:785 lxc/remote.go:858 lxc/remote.go:954
+#: lxc/remote.go:803 lxc/remote.go:876 lxc/remote.go:972
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:290
+#: lxc/remote.go:297
 msgid "Remote address must not be empty"
 msgstr ""
 
@@ -4442,7 +4442,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:295
+#: lxc/remote.go:302
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4502,7 +4502,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:832 lxc/remote.go:833
+#: lxc/remote.go:850 lxc/remote.go:851
 msgid "Remove remotes"
 msgstr ""
 
@@ -4553,7 +4553,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:759 lxc/remote.go:760
+#: lxc/remote.go:777 lxc/remote.go:778
 msgid "Rename remotes"
 msgstr ""
 
@@ -4696,7 +4696,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:741
+#: lxc/remote.go:759
 msgid "STATIC"
 msgstr ""
 
@@ -4724,11 +4724,11 @@ msgstr ""
 msgid "Server authentication type (tls or candid)"
 msgstr ""
 
-#: lxc/remote.go:460
+#: lxc/remote.go:478
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:600
+#: lxc/remote.go:618
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -4914,7 +4914,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:928 lxc/remote.go:929
+#: lxc/remote.go:946 lxc/remote.go:947
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5100,7 +5100,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:631 lxc/remote.go:632
+#: lxc/remote.go:649 lxc/remote.go:650
 msgid "Show the default remote"
 msgstr ""
 
@@ -5289,7 +5289,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:888 lxc/remote.go:889
+#: lxc/remote.go:906 lxc/remote.go:907
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5633,7 +5633,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:180 lxc/remote.go:737
+#: lxc/cluster.go:180 lxc/remote.go:755
 msgid "URL"
 msgstr ""
 
@@ -5661,7 +5661,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:213 lxc/remote.go:247
+#: lxc/remote.go:220 lxc/remote.go:254
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -5954,8 +5954,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:955 lxc/operation.go:156 lxc/project.go:457
-#: lxc/project.go:462 lxc/project.go:467 lxc/project.go:472 lxc/remote.go:694
-#: lxc/remote.go:699 lxc/remote.go:704
+#: lxc/project.go:462 lxc/project.go:467 lxc/project.go:472 lxc/remote.go:712
+#: lxc/remote.go:717 lxc/remote.go:722
 msgid "YES"
 msgstr ""
 
@@ -6649,7 +6649,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[[<remote>:]<name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/project.go:477 lxc/remote.go:727
+#: lxc/project.go:477 lxc/remote.go:745
 msgid "current"
 msgstr ""
 
@@ -6940,7 +6940,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:459
+#: lxc/remote.go:477
 msgid "n"
 msgstr ""
 
@@ -6952,7 +6952,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:452
+#: lxc/remote.go:470
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6989,7 +6989,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:461
+#: lxc/remote.go:479
 msgid "y"
 msgstr ""
 

--- a/po/fa.po
+++ b/po/fa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-01 10:44+0100\n"
+"POT-Creation-Date: 2024-10-18 13:21+0000\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Persian <https://hosted.weblate.org/projects/linux-containers/"
@@ -380,15 +380,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:830 lxc/remote.go:887
+#: lxc/remote.go:848 lxc/remote.go:905
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:927
+#: lxc/remote.go:945
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:757
+#: lxc/remote.go:775
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -421,7 +421,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:739
+#: lxc/remote.go:757
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -528,7 +528,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:564
+#: lxc/remote.go:582
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -560,7 +560,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:188
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -631,7 +631,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:550
+#: lxc/remote.go:568
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -804,7 +804,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:866
+#: lxc/remote.go:884
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -870,13 +870,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:218
+#: lxc/remote.go:225
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:451
+#: lxc/remote.go:469
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -890,7 +890,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:604
+#: lxc/remote.go:622
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1129,12 +1129,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:486
+#: lxc/remote.go:504
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:470
+#: lxc/remote.go:231 lxc/remote.go:488
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1163,7 +1163,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:481
+#: lxc/remote.go:499
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1455,8 +1455,8 @@ msgstr ""
 #: lxc/project.go:221 lxc/project.go:348 lxc/project.go:409 lxc/project.go:510
 #: lxc/project.go:567 lxc/project.go:646 lxc/project.go:677 lxc/project.go:730
 #: lxc/project.go:789 lxc/publish.go:33 lxc/query.go:34 lxc/remote.go:34
-#: lxc/remote.go:90 lxc/remote.go:632 lxc/remote.go:670 lxc/remote.go:760
-#: lxc/remote.go:833 lxc/remote.go:889 lxc/remote.go:929 lxc/rename.go:21
+#: lxc/remote.go:90 lxc/remote.go:650 lxc/remote.go:688 lxc/remote.go:778
+#: lxc/remote.go:851 lxc/remote.go:907 lxc/remote.go:947 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:92
 #: lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:340 lxc/storage.go:410
 #: lxc/storage.go:582 lxc/storage.go:661 lxc/storage.go:757 lxc/storage.go:843
@@ -1971,11 +1971,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:190
+#: lxc/remote.go:197
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:241
+#: lxc/remote.go:248
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -1985,7 +1985,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:231
+#: lxc/remote.go:238
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -1995,12 +1995,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:256
+#: lxc/remote.go:263
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:263
+#: lxc/remote.go:270
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2025,7 +2025,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:236
+#: lxc/remote.go:243
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2103,7 +2103,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:411
-#: lxc/project.go:791 lxc/remote.go:674 lxc/storage.go:584
+#: lxc/project.go:791 lxc/remote.go:692 lxc/storage.go:584
 #: lxc/storage_volume.go:1418 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -2140,7 +2140,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:742
+#: lxc/remote.go:760
 msgid "GLOBAL"
 msgstr ""
 
@@ -2156,7 +2156,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:397
+#: lxc/remote.go:159 lxc/remote.go:406
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2507,7 +2507,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:349
+#: lxc/remote.go:358
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2588,7 +2588,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:338
+#: lxc/remote.go:347
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -2924,7 +2924,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:669 lxc/remote.go:670
+#: lxc/remote.go:687 lxc/remote.go:688
 msgid "List the available remotes"
 msgstr ""
 
@@ -3458,7 +3458,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:566
 #: lxc/network.go:976 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:487 lxc/remote.go:736 lxc/storage.go:634
+#: lxc/project.go:487 lxc/remote.go:754 lxc/storage.go:634
 #: lxc/storage_volume.go:1506
 msgid "NAME"
 msgstr ""
@@ -3480,8 +3480,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:953 lxc/operation.go:154 lxc/project.go:455
-#: lxc/project.go:460 lxc/project.go:465 lxc/project.go:470 lxc/remote.go:692
-#: lxc/remote.go:697 lxc/remote.go:702
+#: lxc/project.go:460 lxc/project.go:465 lxc/project.go:470 lxc/remote.go:710
+#: lxc/remote.go:715 lxc/remote.go:720
 msgid "NO"
 msgstr ""
 
@@ -3696,7 +3696,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:332
+#: lxc/remote.go:341
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -3763,11 +3763,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:738
+#: lxc/remote.go:756
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1070 lxc/remote.go:740
+#: lxc/image.go:1070 lxc/remote.go:758
 msgid "PUBLIC"
 msgstr ""
 
@@ -3796,7 +3796,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:182
+#: lxc/remote.go:189
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -3808,7 +3808,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:462
+#: lxc/remote.go:480
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4109,33 +4109,33 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:790
+#: lxc/remote.go:808
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:756 lxc/remote.go:781 lxc/remote.go:854 lxc/remote.go:910
-#: lxc/remote.go:950
+#: lxc/project.go:756 lxc/remote.go:799 lxc/remote.go:872 lxc/remote.go:928
+#: lxc/remote.go:968
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:301
+#: lxc/remote.go:308
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:862
+#: lxc/remote.go:880
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:785 lxc/remote.go:858 lxc/remote.go:954
+#: lxc/remote.go:803 lxc/remote.go:876 lxc/remote.go:972
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:290
+#: lxc/remote.go:297
 msgid "Remote address must not be empty"
 msgstr ""
 
@@ -4143,7 +4143,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:295
+#: lxc/remote.go:302
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4201,7 +4201,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:832 lxc/remote.go:833
+#: lxc/remote.go:850 lxc/remote.go:851
 msgid "Remove remotes"
 msgstr ""
 
@@ -4250,7 +4250,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:759 lxc/remote.go:760
+#: lxc/remote.go:777 lxc/remote.go:778
 msgid "Rename remotes"
 msgstr ""
 
@@ -4387,7 +4387,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:741
+#: lxc/remote.go:759
 msgid "STATIC"
 msgstr ""
 
@@ -4415,11 +4415,11 @@ msgstr ""
 msgid "Server authentication type (tls or candid)"
 msgstr ""
 
-#: lxc/remote.go:460
+#: lxc/remote.go:478
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:600
+#: lxc/remote.go:618
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -4600,7 +4600,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:928 lxc/remote.go:929
+#: lxc/remote.go:946 lxc/remote.go:947
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -4776,7 +4776,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:631 lxc/remote.go:632
+#: lxc/remote.go:649 lxc/remote.go:650
 msgid "Show the default remote"
 msgstr ""
 
@@ -4964,7 +4964,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:888 lxc/remote.go:889
+#: lxc/remote.go:906 lxc/remote.go:907
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5302,7 +5302,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:180 lxc/remote.go:737
+#: lxc/cluster.go:180 lxc/remote.go:755
 msgid "URL"
 msgstr ""
 
@@ -5330,7 +5330,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:213 lxc/remote.go:247
+#: lxc/remote.go:220 lxc/remote.go:254
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -5610,8 +5610,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:955 lxc/operation.go:156 lxc/project.go:457
-#: lxc/project.go:462 lxc/project.go:467 lxc/project.go:472 lxc/remote.go:694
-#: lxc/remote.go:699 lxc/remote.go:704
+#: lxc/project.go:462 lxc/project.go:467 lxc/project.go:472 lxc/remote.go:712
+#: lxc/remote.go:717 lxc/remote.go:722
 msgid "YES"
 msgstr ""
 
@@ -6176,7 +6176,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:477 lxc/remote.go:727
+#: lxc/project.go:477 lxc/remote.go:745
 msgid "current"
 msgstr ""
 
@@ -6467,7 +6467,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:459
+#: lxc/remote.go:477
 msgid "n"
 msgstr ""
 
@@ -6479,7 +6479,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:452
+#: lxc/remote.go:470
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6516,7 +6516,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:461
+#: lxc/remote.go:479
 msgid "y"
 msgstr ""
 

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-01 10:44+0100\n"
+"POT-Creation-Date: 2024-10-18 13:21+0000\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/linux-containers/"
@@ -380,15 +380,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:830 lxc/remote.go:887
+#: lxc/remote.go:848 lxc/remote.go:905
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:927
+#: lxc/remote.go:945
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:757
+#: lxc/remote.go:775
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -421,7 +421,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:739
+#: lxc/remote.go:757
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -528,7 +528,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:564
+#: lxc/remote.go:582
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -560,7 +560,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:188
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -631,7 +631,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:550
+#: lxc/remote.go:568
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -804,7 +804,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:866
+#: lxc/remote.go:884
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -870,13 +870,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:218
+#: lxc/remote.go:225
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:451
+#: lxc/remote.go:469
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -890,7 +890,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:604
+#: lxc/remote.go:622
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1129,12 +1129,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:486
+#: lxc/remote.go:504
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:470
+#: lxc/remote.go:231 lxc/remote.go:488
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1163,7 +1163,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:481
+#: lxc/remote.go:499
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1455,8 +1455,8 @@ msgstr ""
 #: lxc/project.go:221 lxc/project.go:348 lxc/project.go:409 lxc/project.go:510
 #: lxc/project.go:567 lxc/project.go:646 lxc/project.go:677 lxc/project.go:730
 #: lxc/project.go:789 lxc/publish.go:33 lxc/query.go:34 lxc/remote.go:34
-#: lxc/remote.go:90 lxc/remote.go:632 lxc/remote.go:670 lxc/remote.go:760
-#: lxc/remote.go:833 lxc/remote.go:889 lxc/remote.go:929 lxc/rename.go:21
+#: lxc/remote.go:90 lxc/remote.go:650 lxc/remote.go:688 lxc/remote.go:778
+#: lxc/remote.go:851 lxc/remote.go:907 lxc/remote.go:947 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:92
 #: lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:340 lxc/storage.go:410
 #: lxc/storage.go:582 lxc/storage.go:661 lxc/storage.go:757 lxc/storage.go:843
@@ -1971,11 +1971,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:190
+#: lxc/remote.go:197
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:241
+#: lxc/remote.go:248
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -1985,7 +1985,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:231
+#: lxc/remote.go:238
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -1995,12 +1995,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:256
+#: lxc/remote.go:263
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:263
+#: lxc/remote.go:270
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2025,7 +2025,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:236
+#: lxc/remote.go:243
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2103,7 +2103,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:411
-#: lxc/project.go:791 lxc/remote.go:674 lxc/storage.go:584
+#: lxc/project.go:791 lxc/remote.go:692 lxc/storage.go:584
 #: lxc/storage_volume.go:1418 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -2140,7 +2140,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:742
+#: lxc/remote.go:760
 msgid "GLOBAL"
 msgstr ""
 
@@ -2156,7 +2156,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:397
+#: lxc/remote.go:159 lxc/remote.go:406
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2507,7 +2507,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:349
+#: lxc/remote.go:358
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2588,7 +2588,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:338
+#: lxc/remote.go:347
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -2924,7 +2924,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:669 lxc/remote.go:670
+#: lxc/remote.go:687 lxc/remote.go:688
 msgid "List the available remotes"
 msgstr ""
 
@@ -3458,7 +3458,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:566
 #: lxc/network.go:976 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:487 lxc/remote.go:736 lxc/storage.go:634
+#: lxc/project.go:487 lxc/remote.go:754 lxc/storage.go:634
 #: lxc/storage_volume.go:1506
 msgid "NAME"
 msgstr ""
@@ -3480,8 +3480,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:953 lxc/operation.go:154 lxc/project.go:455
-#: lxc/project.go:460 lxc/project.go:465 lxc/project.go:470 lxc/remote.go:692
-#: lxc/remote.go:697 lxc/remote.go:702
+#: lxc/project.go:460 lxc/project.go:465 lxc/project.go:470 lxc/remote.go:710
+#: lxc/remote.go:715 lxc/remote.go:720
 msgid "NO"
 msgstr ""
 
@@ -3696,7 +3696,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:332
+#: lxc/remote.go:341
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -3763,11 +3763,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:738
+#: lxc/remote.go:756
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1070 lxc/remote.go:740
+#: lxc/image.go:1070 lxc/remote.go:758
 msgid "PUBLIC"
 msgstr ""
 
@@ -3796,7 +3796,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:182
+#: lxc/remote.go:189
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -3808,7 +3808,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:462
+#: lxc/remote.go:480
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4109,33 +4109,33 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:790
+#: lxc/remote.go:808
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:756 lxc/remote.go:781 lxc/remote.go:854 lxc/remote.go:910
-#: lxc/remote.go:950
+#: lxc/project.go:756 lxc/remote.go:799 lxc/remote.go:872 lxc/remote.go:928
+#: lxc/remote.go:968
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:301
+#: lxc/remote.go:308
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:862
+#: lxc/remote.go:880
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:785 lxc/remote.go:858 lxc/remote.go:954
+#: lxc/remote.go:803 lxc/remote.go:876 lxc/remote.go:972
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:290
+#: lxc/remote.go:297
 msgid "Remote address must not be empty"
 msgstr ""
 
@@ -4143,7 +4143,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:295
+#: lxc/remote.go:302
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4201,7 +4201,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:832 lxc/remote.go:833
+#: lxc/remote.go:850 lxc/remote.go:851
 msgid "Remove remotes"
 msgstr ""
 
@@ -4250,7 +4250,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:759 lxc/remote.go:760
+#: lxc/remote.go:777 lxc/remote.go:778
 msgid "Rename remotes"
 msgstr ""
 
@@ -4387,7 +4387,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:741
+#: lxc/remote.go:759
 msgid "STATIC"
 msgstr ""
 
@@ -4415,11 +4415,11 @@ msgstr ""
 msgid "Server authentication type (tls or candid)"
 msgstr ""
 
-#: lxc/remote.go:460
+#: lxc/remote.go:478
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:600
+#: lxc/remote.go:618
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -4600,7 +4600,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:928 lxc/remote.go:929
+#: lxc/remote.go:946 lxc/remote.go:947
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -4776,7 +4776,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:631 lxc/remote.go:632
+#: lxc/remote.go:649 lxc/remote.go:650
 msgid "Show the default remote"
 msgstr ""
 
@@ -4964,7 +4964,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:888 lxc/remote.go:889
+#: lxc/remote.go:906 lxc/remote.go:907
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5302,7 +5302,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:180 lxc/remote.go:737
+#: lxc/cluster.go:180 lxc/remote.go:755
 msgid "URL"
 msgstr ""
 
@@ -5330,7 +5330,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:213 lxc/remote.go:247
+#: lxc/remote.go:220 lxc/remote.go:254
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -5610,8 +5610,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:955 lxc/operation.go:156 lxc/project.go:457
-#: lxc/project.go:462 lxc/project.go:467 lxc/project.go:472 lxc/remote.go:694
-#: lxc/remote.go:699 lxc/remote.go:704
+#: lxc/project.go:462 lxc/project.go:467 lxc/project.go:472 lxc/remote.go:712
+#: lxc/remote.go:717 lxc/remote.go:722
 msgid "YES"
 msgstr ""
 
@@ -6176,7 +6176,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:477 lxc/remote.go:727
+#: lxc/project.go:477 lxc/remote.go:745
 msgid "current"
 msgstr ""
 
@@ -6467,7 +6467,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:459
+#: lxc/remote.go:477
 msgid "n"
 msgstr ""
 
@@ -6479,7 +6479,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:452
+#: lxc/remote.go:470
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6516,7 +6516,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:461
+#: lxc/remote.go:479
 msgid "y"
 msgstr ""
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-01 10:44+0100\n"
+"POT-Creation-Date: 2024-10-18 13:21+0000\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Wivik <seb+weblate@zedas.fr>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/linux-containers/"
@@ -594,17 +594,17 @@ msgstr "Cible invalide %s"
 msgid "<old alias> <new alias>"
 msgstr "<ancien alias> <nouvel alias>"
 
-#: lxc/remote.go:830 lxc/remote.go:887
+#: lxc/remote.go:848 lxc/remote.go:905
 #, fuzzy
 msgid "<remote>"
 msgstr "Serveur distant : %s"
 
-#: lxc/remote.go:927
+#: lxc/remote.go:945
 #, fuzzy
 msgid "<remote> <URL>"
 msgstr "Serveur distant : %s"
 
-#: lxc/remote.go:757
+#: lxc/remote.go:775
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -647,7 +647,7 @@ msgstr "ALIAS"
 msgid "ARCHITECTURE"
 msgstr "ARCHITECTURE"
 
-#: lxc/remote.go:739
+#: lxc/remote.go:757
 #, fuzzy
 msgid "AUTH TYPE"
 msgstr "TYPE"
@@ -772,7 +772,7 @@ msgstr "Création du conteneur"
 msgid "Address: %s"
 msgstr "Expire : %s"
 
-#: lxc/remote.go:564
+#: lxc/remote.go:582
 #, fuzzy, c-format
 msgid "Admin password (or token) for %s:"
 msgstr "Mot de passe administrateur pour %s : "
@@ -805,7 +805,7 @@ msgstr "Alias :"
 msgid "All projects"
 msgstr "Rendre l'image publique"
 
-#: lxc/remote.go:181
+#: lxc/remote.go:188
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -882,7 +882,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:550
+#: lxc/remote.go:568
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr "Le type d'authentification '%s' n'est pas supporté par le serveur"
@@ -1060,7 +1060,7 @@ msgstr "impossible de récupérer un répertoire sans --recursive"
 msgid "Can't read from stdin: %w"
 msgstr "Impossible de lire depuis stdin : %s"
 
-#: lxc/remote.go:866
+#: lxc/remote.go:884
 #, fuzzy
 msgid "Can't remove the default remote"
 msgstr "impossible de supprimer le serveur distant par défaut"
@@ -1129,13 +1129,13 @@ msgstr "Créé : %s"
 msgid "Certificate add token for %s deleted"
 msgstr "Le réseau %s a été supprimé"
 
-#: lxc/remote.go:218
+#: lxc/remote.go:225
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:451
+#: lxc/remote.go:469
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr "Empreinte du certificat : %s"
@@ -1149,7 +1149,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/remote.go:604
+#: lxc/remote.go:622
 #, fuzzy
 msgid "Client certificate now trusted by server:"
 msgstr "Certificat client enregistré sur le serveur : "
@@ -1406,12 +1406,12 @@ msgstr "erreur : %v"
 msgid "Cores:"
 msgstr "erreur : %v"
 
-#: lxc/remote.go:486
+#: lxc/remote.go:504
 #, fuzzy, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "Impossible de créer le dossier de stockage des certificats serveurs"
 
-#: lxc/remote.go:224 lxc/remote.go:470
+#: lxc/remote.go:231 lxc/remote.go:488
 msgid "Could not create server cert dir"
 msgstr "Impossible de créer le dossier de stockage des certificats serveurs"
 
@@ -1440,7 +1440,7 @@ msgstr "Impossible d'assainir le chemin %s"
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:481
+#: lxc/remote.go:499
 #, fuzzy, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "Impossible de créer le dossier de stockage des certificats serveurs"
@@ -1776,8 +1776,8 @@ msgstr "Récupération de l'image : %s"
 #: lxc/project.go:221 lxc/project.go:348 lxc/project.go:409 lxc/project.go:510
 #: lxc/project.go:567 lxc/project.go:646 lxc/project.go:677 lxc/project.go:730
 #: lxc/project.go:789 lxc/publish.go:33 lxc/query.go:34 lxc/remote.go:34
-#: lxc/remote.go:90 lxc/remote.go:632 lxc/remote.go:670 lxc/remote.go:760
-#: lxc/remote.go:833 lxc/remote.go:889 lxc/remote.go:929 lxc/rename.go:21
+#: lxc/remote.go:90 lxc/remote.go:650 lxc/remote.go:688 lxc/remote.go:778
+#: lxc/remote.go:851 lxc/remote.go:907 lxc/remote.go:947 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:92
 #: lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:340 lxc/storage.go:410
 #: lxc/storage.go:582 lxc/storage.go:661 lxc/storage.go:757 lxc/storage.go:843
@@ -2339,12 +2339,12 @@ msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 msgid "Failed to accept incoming connection: %w"
 msgstr "Échec lors de la génération de 'lxc.1': %v"
 
-#: lxc/remote.go:190
+#: lxc/remote.go:197
 #, fuzzy
 msgid "Failed to add remote"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
-#: lxc/remote.go:241
+#: lxc/remote.go:248
 #, fuzzy, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
@@ -2354,7 +2354,7 @@ msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 msgid "Failed to connect to cluster member: %w"
 msgstr "Profil à appliquer au nouveau conteneur"
 
-#: lxc/remote.go:231
+#: lxc/remote.go:238
 #, fuzzy, c-format
 msgid "Failed to create %q: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
@@ -2364,12 +2364,12 @@ msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 msgid "Failed to create alias %s: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
-#: lxc/remote.go:256
+#: lxc/remote.go:263
 #, fuzzy, c-format
 msgid "Failed to create certificate: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
-#: lxc/remote.go:263
+#: lxc/remote.go:270
 #, fuzzy, c-format
 msgid "Failed to find project: %w"
 msgstr "Échec lors de la génération de 'lxc.1': %v"
@@ -2394,7 +2394,7 @@ msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:236
+#: lxc/remote.go:243
 #, fuzzy, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
@@ -2477,7 +2477,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:411
-#: lxc/project.go:791 lxc/remote.go:674 lxc/storage.go:584
+#: lxc/project.go:791 lxc/remote.go:692 lxc/storage.go:584
 #: lxc/storage_volume.go:1418 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -2514,7 +2514,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:742
+#: lxc/remote.go:760
 msgid "GLOBAL"
 msgstr ""
 
@@ -2530,7 +2530,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:397
+#: lxc/remote.go:159 lxc/remote.go:406
 msgid "Generating a client certificate. This may take a minute..."
 msgstr "Génération d'un certificat client. Ceci peut prendre une minute…"
 
@@ -2915,7 +2915,7 @@ msgstr "Conteneur publié avec l'empreinte : %s"
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:349
+#: lxc/remote.go:358
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr "Schème d'URL invalide \"%s\" in \"%s\""
@@ -2998,7 +2998,7 @@ msgstr "nombre d'arguments incorrect pour la sous-comande"
 msgid "Invalid path %s"
 msgstr "Cible invalide %s"
 
-#: lxc/remote.go:338
+#: lxc/remote.go:347
 #, fuzzy, c-format
 msgid "Invalid protocol: %s"
 msgstr "Cible invalide %s"
@@ -3407,7 +3407,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:669 lxc/remote.go:670
+#: lxc/remote.go:687 lxc/remote.go:688
 msgid "List the available remotes"
 msgstr ""
 
@@ -3994,7 +3994,7 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:566
 #: lxc/network.go:976 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:487 lxc/remote.go:736 lxc/storage.go:634
+#: lxc/project.go:487 lxc/remote.go:754 lxc/storage.go:634
 #: lxc/storage_volume.go:1506
 msgid "NAME"
 msgstr "NOM"
@@ -4016,8 +4016,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:953 lxc/operation.go:154 lxc/project.go:455
-#: lxc/project.go:460 lxc/project.go:465 lxc/project.go:470 lxc/remote.go:692
-#: lxc/remote.go:697 lxc/remote.go:702
+#: lxc/project.go:460 lxc/project.go:465 lxc/project.go:470 lxc/remote.go:710
+#: lxc/remote.go:715 lxc/remote.go:720
 msgid "NO"
 msgstr "NON"
 
@@ -4245,7 +4245,7 @@ msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 "Seuls les volumes \"personnalisés\" peuvent être attachés aux conteneurs."
 
-#: lxc/remote.go:332
+#: lxc/remote.go:341
 msgid "Only https URLs are supported for simplestreams"
 msgstr "Seules les URLs https sont supportées par simplestreams"
 
@@ -4317,11 +4317,11 @@ msgstr "PROFILS"
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:738
+#: lxc/remote.go:756
 msgid "PROTOCOL"
 msgstr "PROTOCOLE"
 
-#: lxc/image.go:1070 lxc/remote.go:740
+#: lxc/image.go:1070 lxc/remote.go:758
 msgid "PUBLIC"
 msgstr "PUBLIC"
 
@@ -4352,7 +4352,7 @@ msgstr "Création du conteneur"
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:182
+#: lxc/remote.go:189
 #, fuzzy
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr "Chemin vers un dossier de configuration serveur alternatif"
@@ -4366,7 +4366,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/remote.go:462
+#: lxc/remote.go:480
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4679,33 +4679,33 @@ msgstr "Ignorer l'état du conteneur (seulement pour start)"
 msgid "Refreshing the image: %s"
 msgstr "Récupération de l'image : %s"
 
-#: lxc/remote.go:790
+#: lxc/remote.go:808
 #, fuzzy, c-format
 msgid "Remote %s already exists"
 msgstr "le serveur distant %s existe déjà"
 
-#: lxc/project.go:756 lxc/remote.go:781 lxc/remote.go:854 lxc/remote.go:910
-#: lxc/remote.go:950
+#: lxc/project.go:756 lxc/remote.go:799 lxc/remote.go:872 lxc/remote.go:928
+#: lxc/remote.go:968
 #, fuzzy, c-format
 msgid "Remote %s doesn't exist"
 msgstr "le serveur distant %s n'existe pas"
 
-#: lxc/remote.go:301
+#: lxc/remote.go:308
 #, fuzzy, c-format
 msgid "Remote %s exists as <%s>"
 msgstr "le serveur distant %s existe en tant que <%s>"
 
-#: lxc/remote.go:862
+#: lxc/remote.go:880
 #, fuzzy, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr "le serveur distant %s est statique et ne peut être modifié"
 
-#: lxc/remote.go:785 lxc/remote.go:858 lxc/remote.go:954
+#: lxc/remote.go:803 lxc/remote.go:876 lxc/remote.go:972
 #, fuzzy, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr "le serveur distant %s est statique et ne peut être modifié"
 
-#: lxc/remote.go:290
+#: lxc/remote.go:297
 msgid "Remote address must not be empty"
 msgstr ""
 
@@ -4713,7 +4713,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr "Mot de passe de l'administrateur distant"
 
-#: lxc/remote.go:295
+#: lxc/remote.go:302
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4778,7 +4778,7 @@ msgstr "Création du conteneur"
 msgid "Remove profiles from instances"
 msgstr "Création du conteneur"
 
-#: lxc/remote.go:832 lxc/remote.go:833
+#: lxc/remote.go:850 lxc/remote.go:851
 msgid "Remove remotes"
 msgstr ""
 
@@ -4832,7 +4832,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr "Créé : %s"
 
-#: lxc/remote.go:759 lxc/remote.go:760
+#: lxc/remote.go:777 lxc/remote.go:778
 msgid "Rename remotes"
 msgstr ""
 
@@ -4996,7 +4996,7 @@ msgstr "Mot de passe de l'administrateur distant"
 msgid "STATE"
 msgstr "ÉTAT"
 
-#: lxc/remote.go:741
+#: lxc/remote.go:759
 msgid "STATIC"
 msgstr "STATIQUE"
 
@@ -5026,11 +5026,11 @@ msgstr ""
 msgid "Server authentication type (tls or candid)"
 msgstr ""
 
-#: lxc/remote.go:460
+#: lxc/remote.go:478
 msgid "Server certificate NACKed by user"
 msgstr "Certificat serveur rejeté par l'utilisateur"
 
-#: lxc/remote.go:600
+#: lxc/remote.go:618
 #, fuzzy
 msgid "Server doesn't trust us after authentication"
 msgstr ""
@@ -5226,7 +5226,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:928 lxc/remote.go:929
+#: lxc/remote.go:946 lxc/remote.go:947
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5427,7 +5427,7 @@ msgstr "Afficher la configuration étendue"
 msgid "Show storage volume state information"
 msgstr "Afficher la configuration étendue"
 
-#: lxc/remote.go:631 lxc/remote.go:632
+#: lxc/remote.go:649 lxc/remote.go:650
 #, fuzzy
 msgid "Show the default remote"
 msgstr "impossible de supprimer le serveur distant par défaut"
@@ -5629,7 +5629,7 @@ msgstr "Swap (pointe)"
 msgid "Switch the current project"
 msgstr "impossible de supprimer le serveur distant par défaut"
 
-#: lxc/remote.go:888 lxc/remote.go:889
+#: lxc/remote.go:906 lxc/remote.go:907
 #, fuzzy
 msgid "Switch the default remote"
 msgstr "impossible de supprimer le serveur distant par défaut"
@@ -5986,7 +5986,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr "DATE DE PUBLICATION"
 
-#: lxc/cluster.go:180 lxc/remote.go:737
+#: lxc/cluster.go:180 lxc/remote.go:755
 msgid "URL"
 msgstr "URL"
 
@@ -6014,7 +6014,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:213 lxc/remote.go:247
+#: lxc/remote.go:220 lxc/remote.go:254
 #, fuzzy
 msgid "Unavailable remote server"
 msgstr "Ajouter de nouveaux serveurs distants"
@@ -6325,8 +6325,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr "Réaliser ou pas l'instantané de l'état de fonctionnement du conteneur"
 
 #: lxc/network.go:955 lxc/operation.go:156 lxc/project.go:457
-#: lxc/project.go:462 lxc/project.go:467 lxc/project.go:472 lxc/remote.go:694
-#: lxc/remote.go:699 lxc/remote.go:704
+#: lxc/project.go:462 lxc/project.go:467 lxc/project.go:472 lxc/remote.go:712
+#: lxc/remote.go:717 lxc/remote.go:722
 msgid "YES"
 msgstr "OUI"
 
@@ -7565,7 +7565,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/project.go:477 lxc/remote.go:727
+#: lxc/project.go:477 lxc/remote.go:745
 #, fuzzy
 msgid "current"
 msgstr "Swap (courant)"
@@ -7879,7 +7879,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:459
+#: lxc/remote.go:477
 #, fuzzy
 msgid "n"
 msgstr "non"
@@ -7892,7 +7892,7 @@ msgstr ""
 msgid "no"
 msgstr "non"
 
-#: lxc/remote.go:452
+#: lxc/remote.go:470
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7929,7 +7929,7 @@ msgstr "inaccessible"
 msgid "used by"
 msgstr "utilisé par"
 
-#: lxc/remote.go:461
+#: lxc/remote.go:479
 msgid "y"
 msgstr "o"
 

--- a/po/he.po
+++ b/po/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-01 10:44+0100\n"
+"POT-Creation-Date: 2024-10-18 13:21+0000\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hebrew <https://hosted.weblate.org/projects/linux-containers/"
@@ -381,15 +381,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:830 lxc/remote.go:887
+#: lxc/remote.go:848 lxc/remote.go:905
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:927
+#: lxc/remote.go:945
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:757
+#: lxc/remote.go:775
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -422,7 +422,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:739
+#: lxc/remote.go:757
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -529,7 +529,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:564
+#: lxc/remote.go:582
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -561,7 +561,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:188
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -632,7 +632,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:550
+#: lxc/remote.go:568
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -805,7 +805,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:866
+#: lxc/remote.go:884
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -871,13 +871,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:218
+#: lxc/remote.go:225
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:451
+#: lxc/remote.go:469
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -891,7 +891,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:604
+#: lxc/remote.go:622
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1130,12 +1130,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:486
+#: lxc/remote.go:504
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:470
+#: lxc/remote.go:231 lxc/remote.go:488
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1164,7 +1164,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:481
+#: lxc/remote.go:499
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1456,8 +1456,8 @@ msgstr ""
 #: lxc/project.go:221 lxc/project.go:348 lxc/project.go:409 lxc/project.go:510
 #: lxc/project.go:567 lxc/project.go:646 lxc/project.go:677 lxc/project.go:730
 #: lxc/project.go:789 lxc/publish.go:33 lxc/query.go:34 lxc/remote.go:34
-#: lxc/remote.go:90 lxc/remote.go:632 lxc/remote.go:670 lxc/remote.go:760
-#: lxc/remote.go:833 lxc/remote.go:889 lxc/remote.go:929 lxc/rename.go:21
+#: lxc/remote.go:90 lxc/remote.go:650 lxc/remote.go:688 lxc/remote.go:778
+#: lxc/remote.go:851 lxc/remote.go:907 lxc/remote.go:947 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:92
 #: lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:340 lxc/storage.go:410
 #: lxc/storage.go:582 lxc/storage.go:661 lxc/storage.go:757 lxc/storage.go:843
@@ -1972,11 +1972,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:190
+#: lxc/remote.go:197
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:241
+#: lxc/remote.go:248
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -1986,7 +1986,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:231
+#: lxc/remote.go:238
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -1996,12 +1996,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:256
+#: lxc/remote.go:263
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:263
+#: lxc/remote.go:270
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2026,7 +2026,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:236
+#: lxc/remote.go:243
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2104,7 +2104,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:411
-#: lxc/project.go:791 lxc/remote.go:674 lxc/storage.go:584
+#: lxc/project.go:791 lxc/remote.go:692 lxc/storage.go:584
 #: lxc/storage_volume.go:1418 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -2141,7 +2141,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:742
+#: lxc/remote.go:760
 msgid "GLOBAL"
 msgstr ""
 
@@ -2157,7 +2157,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:397
+#: lxc/remote.go:159 lxc/remote.go:406
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2508,7 +2508,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:349
+#: lxc/remote.go:358
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2589,7 +2589,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:338
+#: lxc/remote.go:347
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -2925,7 +2925,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:669 lxc/remote.go:670
+#: lxc/remote.go:687 lxc/remote.go:688
 msgid "List the available remotes"
 msgstr ""
 
@@ -3459,7 +3459,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:566
 #: lxc/network.go:976 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:487 lxc/remote.go:736 lxc/storage.go:634
+#: lxc/project.go:487 lxc/remote.go:754 lxc/storage.go:634
 #: lxc/storage_volume.go:1506
 msgid "NAME"
 msgstr ""
@@ -3481,8 +3481,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:953 lxc/operation.go:154 lxc/project.go:455
-#: lxc/project.go:460 lxc/project.go:465 lxc/project.go:470 lxc/remote.go:692
-#: lxc/remote.go:697 lxc/remote.go:702
+#: lxc/project.go:460 lxc/project.go:465 lxc/project.go:470 lxc/remote.go:710
+#: lxc/remote.go:715 lxc/remote.go:720
 msgid "NO"
 msgstr ""
 
@@ -3697,7 +3697,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:332
+#: lxc/remote.go:341
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -3764,11 +3764,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:738
+#: lxc/remote.go:756
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1070 lxc/remote.go:740
+#: lxc/image.go:1070 lxc/remote.go:758
 msgid "PUBLIC"
 msgstr ""
 
@@ -3797,7 +3797,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:182
+#: lxc/remote.go:189
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -3809,7 +3809,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:462
+#: lxc/remote.go:480
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4110,33 +4110,33 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:790
+#: lxc/remote.go:808
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:756 lxc/remote.go:781 lxc/remote.go:854 lxc/remote.go:910
-#: lxc/remote.go:950
+#: lxc/project.go:756 lxc/remote.go:799 lxc/remote.go:872 lxc/remote.go:928
+#: lxc/remote.go:968
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:301
+#: lxc/remote.go:308
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:862
+#: lxc/remote.go:880
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:785 lxc/remote.go:858 lxc/remote.go:954
+#: lxc/remote.go:803 lxc/remote.go:876 lxc/remote.go:972
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:290
+#: lxc/remote.go:297
 msgid "Remote address must not be empty"
 msgstr ""
 
@@ -4144,7 +4144,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:295
+#: lxc/remote.go:302
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4202,7 +4202,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:832 lxc/remote.go:833
+#: lxc/remote.go:850 lxc/remote.go:851
 msgid "Remove remotes"
 msgstr ""
 
@@ -4251,7 +4251,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:759 lxc/remote.go:760
+#: lxc/remote.go:777 lxc/remote.go:778
 msgid "Rename remotes"
 msgstr ""
 
@@ -4388,7 +4388,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:741
+#: lxc/remote.go:759
 msgid "STATIC"
 msgstr ""
 
@@ -4416,11 +4416,11 @@ msgstr ""
 msgid "Server authentication type (tls or candid)"
 msgstr ""
 
-#: lxc/remote.go:460
+#: lxc/remote.go:478
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:600
+#: lxc/remote.go:618
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -4601,7 +4601,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:928 lxc/remote.go:929
+#: lxc/remote.go:946 lxc/remote.go:947
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -4777,7 +4777,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:631 lxc/remote.go:632
+#: lxc/remote.go:649 lxc/remote.go:650
 msgid "Show the default remote"
 msgstr ""
 
@@ -4965,7 +4965,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:888 lxc/remote.go:889
+#: lxc/remote.go:906 lxc/remote.go:907
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5303,7 +5303,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:180 lxc/remote.go:737
+#: lxc/cluster.go:180 lxc/remote.go:755
 msgid "URL"
 msgstr ""
 
@@ -5331,7 +5331,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:213 lxc/remote.go:247
+#: lxc/remote.go:220 lxc/remote.go:254
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -5611,8 +5611,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:955 lxc/operation.go:156 lxc/project.go:457
-#: lxc/project.go:462 lxc/project.go:467 lxc/project.go:472 lxc/remote.go:694
-#: lxc/remote.go:699 lxc/remote.go:704
+#: lxc/project.go:462 lxc/project.go:467 lxc/project.go:472 lxc/remote.go:712
+#: lxc/remote.go:717 lxc/remote.go:722
 msgid "YES"
 msgstr ""
 
@@ -6177,7 +6177,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:477 lxc/remote.go:727
+#: lxc/project.go:477 lxc/remote.go:745
 msgid "current"
 msgstr ""
 
@@ -6468,7 +6468,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:459
+#: lxc/remote.go:477
 msgid "n"
 msgstr ""
 
@@ -6480,7 +6480,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:452
+#: lxc/remote.go:470
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6517,7 +6517,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:461
+#: lxc/remote.go:479
 msgid "y"
 msgstr ""
 

--- a/po/hi.po
+++ b/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-01 10:44+0100\n"
+"POT-Creation-Date: 2024-10-18 13:21+0000\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hindi <https://hosted.weblate.org/projects/linux-containers/"
@@ -380,15 +380,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:830 lxc/remote.go:887
+#: lxc/remote.go:848 lxc/remote.go:905
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:927
+#: lxc/remote.go:945
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:757
+#: lxc/remote.go:775
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -421,7 +421,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:739
+#: lxc/remote.go:757
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -528,7 +528,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:564
+#: lxc/remote.go:582
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -560,7 +560,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:188
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -631,7 +631,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:550
+#: lxc/remote.go:568
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -804,7 +804,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:866
+#: lxc/remote.go:884
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -870,13 +870,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:218
+#: lxc/remote.go:225
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:451
+#: lxc/remote.go:469
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -890,7 +890,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:604
+#: lxc/remote.go:622
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1129,12 +1129,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:486
+#: lxc/remote.go:504
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:470
+#: lxc/remote.go:231 lxc/remote.go:488
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1163,7 +1163,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:481
+#: lxc/remote.go:499
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1455,8 +1455,8 @@ msgstr ""
 #: lxc/project.go:221 lxc/project.go:348 lxc/project.go:409 lxc/project.go:510
 #: lxc/project.go:567 lxc/project.go:646 lxc/project.go:677 lxc/project.go:730
 #: lxc/project.go:789 lxc/publish.go:33 lxc/query.go:34 lxc/remote.go:34
-#: lxc/remote.go:90 lxc/remote.go:632 lxc/remote.go:670 lxc/remote.go:760
-#: lxc/remote.go:833 lxc/remote.go:889 lxc/remote.go:929 lxc/rename.go:21
+#: lxc/remote.go:90 lxc/remote.go:650 lxc/remote.go:688 lxc/remote.go:778
+#: lxc/remote.go:851 lxc/remote.go:907 lxc/remote.go:947 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:92
 #: lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:340 lxc/storage.go:410
 #: lxc/storage.go:582 lxc/storage.go:661 lxc/storage.go:757 lxc/storage.go:843
@@ -1971,11 +1971,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:190
+#: lxc/remote.go:197
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:241
+#: lxc/remote.go:248
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -1985,7 +1985,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:231
+#: lxc/remote.go:238
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -1995,12 +1995,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:256
+#: lxc/remote.go:263
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:263
+#: lxc/remote.go:270
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2025,7 +2025,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:236
+#: lxc/remote.go:243
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2103,7 +2103,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:411
-#: lxc/project.go:791 lxc/remote.go:674 lxc/storage.go:584
+#: lxc/project.go:791 lxc/remote.go:692 lxc/storage.go:584
 #: lxc/storage_volume.go:1418 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -2140,7 +2140,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:742
+#: lxc/remote.go:760
 msgid "GLOBAL"
 msgstr ""
 
@@ -2156,7 +2156,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:397
+#: lxc/remote.go:159 lxc/remote.go:406
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2507,7 +2507,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:349
+#: lxc/remote.go:358
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2588,7 +2588,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:338
+#: lxc/remote.go:347
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -2924,7 +2924,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:669 lxc/remote.go:670
+#: lxc/remote.go:687 lxc/remote.go:688
 msgid "List the available remotes"
 msgstr ""
 
@@ -3458,7 +3458,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:566
 #: lxc/network.go:976 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:487 lxc/remote.go:736 lxc/storage.go:634
+#: lxc/project.go:487 lxc/remote.go:754 lxc/storage.go:634
 #: lxc/storage_volume.go:1506
 msgid "NAME"
 msgstr ""
@@ -3480,8 +3480,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:953 lxc/operation.go:154 lxc/project.go:455
-#: lxc/project.go:460 lxc/project.go:465 lxc/project.go:470 lxc/remote.go:692
-#: lxc/remote.go:697 lxc/remote.go:702
+#: lxc/project.go:460 lxc/project.go:465 lxc/project.go:470 lxc/remote.go:710
+#: lxc/remote.go:715 lxc/remote.go:720
 msgid "NO"
 msgstr ""
 
@@ -3696,7 +3696,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:332
+#: lxc/remote.go:341
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -3763,11 +3763,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:738
+#: lxc/remote.go:756
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1070 lxc/remote.go:740
+#: lxc/image.go:1070 lxc/remote.go:758
 msgid "PUBLIC"
 msgstr ""
 
@@ -3796,7 +3796,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:182
+#: lxc/remote.go:189
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -3808,7 +3808,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:462
+#: lxc/remote.go:480
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4109,33 +4109,33 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:790
+#: lxc/remote.go:808
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:756 lxc/remote.go:781 lxc/remote.go:854 lxc/remote.go:910
-#: lxc/remote.go:950
+#: lxc/project.go:756 lxc/remote.go:799 lxc/remote.go:872 lxc/remote.go:928
+#: lxc/remote.go:968
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:301
+#: lxc/remote.go:308
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:862
+#: lxc/remote.go:880
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:785 lxc/remote.go:858 lxc/remote.go:954
+#: lxc/remote.go:803 lxc/remote.go:876 lxc/remote.go:972
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:290
+#: lxc/remote.go:297
 msgid "Remote address must not be empty"
 msgstr ""
 
@@ -4143,7 +4143,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:295
+#: lxc/remote.go:302
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4201,7 +4201,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:832 lxc/remote.go:833
+#: lxc/remote.go:850 lxc/remote.go:851
 msgid "Remove remotes"
 msgstr ""
 
@@ -4250,7 +4250,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:759 lxc/remote.go:760
+#: lxc/remote.go:777 lxc/remote.go:778
 msgid "Rename remotes"
 msgstr ""
 
@@ -4387,7 +4387,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:741
+#: lxc/remote.go:759
 msgid "STATIC"
 msgstr ""
 
@@ -4415,11 +4415,11 @@ msgstr ""
 msgid "Server authentication type (tls or candid)"
 msgstr ""
 
-#: lxc/remote.go:460
+#: lxc/remote.go:478
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:600
+#: lxc/remote.go:618
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -4600,7 +4600,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:928 lxc/remote.go:929
+#: lxc/remote.go:946 lxc/remote.go:947
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -4776,7 +4776,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:631 lxc/remote.go:632
+#: lxc/remote.go:649 lxc/remote.go:650
 msgid "Show the default remote"
 msgstr ""
 
@@ -4964,7 +4964,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:888 lxc/remote.go:889
+#: lxc/remote.go:906 lxc/remote.go:907
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5302,7 +5302,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:180 lxc/remote.go:737
+#: lxc/cluster.go:180 lxc/remote.go:755
 msgid "URL"
 msgstr ""
 
@@ -5330,7 +5330,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:213 lxc/remote.go:247
+#: lxc/remote.go:220 lxc/remote.go:254
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -5610,8 +5610,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:955 lxc/operation.go:156 lxc/project.go:457
-#: lxc/project.go:462 lxc/project.go:467 lxc/project.go:472 lxc/remote.go:694
-#: lxc/remote.go:699 lxc/remote.go:704
+#: lxc/project.go:462 lxc/project.go:467 lxc/project.go:472 lxc/remote.go:712
+#: lxc/remote.go:717 lxc/remote.go:722
 msgid "YES"
 msgstr ""
 
@@ -6176,7 +6176,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:477 lxc/remote.go:727
+#: lxc/project.go:477 lxc/remote.go:745
 msgid "current"
 msgstr ""
 
@@ -6467,7 +6467,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:459
+#: lxc/remote.go:477
 msgid "n"
 msgstr ""
 
@@ -6479,7 +6479,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:452
+#: lxc/remote.go:470
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6516,7 +6516,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:461
+#: lxc/remote.go:479
 msgid "y"
 msgstr ""
 

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-01 10:44+0100\n"
+"POT-Creation-Date: 2024-10-18 13:21+0000\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Indonesian <https://hosted.weblate.org/projects/linux-"
@@ -380,15 +380,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:830 lxc/remote.go:887
+#: lxc/remote.go:848 lxc/remote.go:905
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:927
+#: lxc/remote.go:945
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:757
+#: lxc/remote.go:775
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -421,7 +421,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:739
+#: lxc/remote.go:757
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -528,7 +528,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:564
+#: lxc/remote.go:582
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -560,7 +560,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:188
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -631,7 +631,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:550
+#: lxc/remote.go:568
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -804,7 +804,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:866
+#: lxc/remote.go:884
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -870,13 +870,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:218
+#: lxc/remote.go:225
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:451
+#: lxc/remote.go:469
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -890,7 +890,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:604
+#: lxc/remote.go:622
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1129,12 +1129,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:486
+#: lxc/remote.go:504
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:470
+#: lxc/remote.go:231 lxc/remote.go:488
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1163,7 +1163,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:481
+#: lxc/remote.go:499
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1455,8 +1455,8 @@ msgstr ""
 #: lxc/project.go:221 lxc/project.go:348 lxc/project.go:409 lxc/project.go:510
 #: lxc/project.go:567 lxc/project.go:646 lxc/project.go:677 lxc/project.go:730
 #: lxc/project.go:789 lxc/publish.go:33 lxc/query.go:34 lxc/remote.go:34
-#: lxc/remote.go:90 lxc/remote.go:632 lxc/remote.go:670 lxc/remote.go:760
-#: lxc/remote.go:833 lxc/remote.go:889 lxc/remote.go:929 lxc/rename.go:21
+#: lxc/remote.go:90 lxc/remote.go:650 lxc/remote.go:688 lxc/remote.go:778
+#: lxc/remote.go:851 lxc/remote.go:907 lxc/remote.go:947 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:92
 #: lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:340 lxc/storage.go:410
 #: lxc/storage.go:582 lxc/storage.go:661 lxc/storage.go:757 lxc/storage.go:843
@@ -1971,11 +1971,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:190
+#: lxc/remote.go:197
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:241
+#: lxc/remote.go:248
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -1985,7 +1985,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:231
+#: lxc/remote.go:238
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -1995,12 +1995,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:256
+#: lxc/remote.go:263
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:263
+#: lxc/remote.go:270
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2025,7 +2025,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:236
+#: lxc/remote.go:243
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2103,7 +2103,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:411
-#: lxc/project.go:791 lxc/remote.go:674 lxc/storage.go:584
+#: lxc/project.go:791 lxc/remote.go:692 lxc/storage.go:584
 #: lxc/storage_volume.go:1418 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -2140,7 +2140,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:742
+#: lxc/remote.go:760
 msgid "GLOBAL"
 msgstr ""
 
@@ -2156,7 +2156,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:397
+#: lxc/remote.go:159 lxc/remote.go:406
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2507,7 +2507,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:349
+#: lxc/remote.go:358
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2588,7 +2588,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:338
+#: lxc/remote.go:347
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -2924,7 +2924,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:669 lxc/remote.go:670
+#: lxc/remote.go:687 lxc/remote.go:688
 msgid "List the available remotes"
 msgstr ""
 
@@ -3458,7 +3458,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:566
 #: lxc/network.go:976 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:487 lxc/remote.go:736 lxc/storage.go:634
+#: lxc/project.go:487 lxc/remote.go:754 lxc/storage.go:634
 #: lxc/storage_volume.go:1506
 msgid "NAME"
 msgstr ""
@@ -3480,8 +3480,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:953 lxc/operation.go:154 lxc/project.go:455
-#: lxc/project.go:460 lxc/project.go:465 lxc/project.go:470 lxc/remote.go:692
-#: lxc/remote.go:697 lxc/remote.go:702
+#: lxc/project.go:460 lxc/project.go:465 lxc/project.go:470 lxc/remote.go:710
+#: lxc/remote.go:715 lxc/remote.go:720
 msgid "NO"
 msgstr ""
 
@@ -3696,7 +3696,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:332
+#: lxc/remote.go:341
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -3763,11 +3763,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:738
+#: lxc/remote.go:756
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1070 lxc/remote.go:740
+#: lxc/image.go:1070 lxc/remote.go:758
 msgid "PUBLIC"
 msgstr ""
 
@@ -3796,7 +3796,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:182
+#: lxc/remote.go:189
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -3808,7 +3808,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:462
+#: lxc/remote.go:480
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4109,33 +4109,33 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:790
+#: lxc/remote.go:808
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:756 lxc/remote.go:781 lxc/remote.go:854 lxc/remote.go:910
-#: lxc/remote.go:950
+#: lxc/project.go:756 lxc/remote.go:799 lxc/remote.go:872 lxc/remote.go:928
+#: lxc/remote.go:968
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:301
+#: lxc/remote.go:308
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:862
+#: lxc/remote.go:880
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:785 lxc/remote.go:858 lxc/remote.go:954
+#: lxc/remote.go:803 lxc/remote.go:876 lxc/remote.go:972
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:290
+#: lxc/remote.go:297
 msgid "Remote address must not be empty"
 msgstr ""
 
@@ -4143,7 +4143,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:295
+#: lxc/remote.go:302
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4201,7 +4201,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:832 lxc/remote.go:833
+#: lxc/remote.go:850 lxc/remote.go:851
 msgid "Remove remotes"
 msgstr ""
 
@@ -4250,7 +4250,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:759 lxc/remote.go:760
+#: lxc/remote.go:777 lxc/remote.go:778
 msgid "Rename remotes"
 msgstr ""
 
@@ -4387,7 +4387,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:741
+#: lxc/remote.go:759
 msgid "STATIC"
 msgstr ""
 
@@ -4415,11 +4415,11 @@ msgstr ""
 msgid "Server authentication type (tls or candid)"
 msgstr ""
 
-#: lxc/remote.go:460
+#: lxc/remote.go:478
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:600
+#: lxc/remote.go:618
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -4600,7 +4600,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:928 lxc/remote.go:929
+#: lxc/remote.go:946 lxc/remote.go:947
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -4776,7 +4776,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:631 lxc/remote.go:632
+#: lxc/remote.go:649 lxc/remote.go:650
 msgid "Show the default remote"
 msgstr ""
 
@@ -4964,7 +4964,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:888 lxc/remote.go:889
+#: lxc/remote.go:906 lxc/remote.go:907
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5302,7 +5302,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:180 lxc/remote.go:737
+#: lxc/cluster.go:180 lxc/remote.go:755
 msgid "URL"
 msgstr ""
 
@@ -5330,7 +5330,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:213 lxc/remote.go:247
+#: lxc/remote.go:220 lxc/remote.go:254
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -5610,8 +5610,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:955 lxc/operation.go:156 lxc/project.go:457
-#: lxc/project.go:462 lxc/project.go:467 lxc/project.go:472 lxc/remote.go:694
-#: lxc/remote.go:699 lxc/remote.go:704
+#: lxc/project.go:462 lxc/project.go:467 lxc/project.go:472 lxc/remote.go:712
+#: lxc/remote.go:717 lxc/remote.go:722
 msgid "YES"
 msgstr ""
 
@@ -6176,7 +6176,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:477 lxc/remote.go:727
+#: lxc/project.go:477 lxc/remote.go:745
 msgid "current"
 msgstr ""
 
@@ -6467,7 +6467,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:459
+#: lxc/remote.go:477
 msgid "n"
 msgstr ""
 
@@ -6479,7 +6479,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:452
+#: lxc/remote.go:470
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6516,7 +6516,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:461
+#: lxc/remote.go:479
 msgid "y"
 msgstr ""
 

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-01 10:44+0100\n"
+"POT-Creation-Date: 2024-10-18 13:21+0000\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Luigi Operoso <brokenpip3@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/linux-containers/"
@@ -586,15 +586,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:830 lxc/remote.go:887
+#: lxc/remote.go:848 lxc/remote.go:905
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:927
+#: lxc/remote.go:945
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:757
+#: lxc/remote.go:775
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -628,7 +628,7 @@ msgstr "ALIAS"
 msgid "ARCHITECTURE"
 msgstr "ARCHITETTURA"
 
-#: lxc/remote.go:739
+#: lxc/remote.go:757
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:564
+#: lxc/remote.go:582
 #, fuzzy, c-format
 msgid "Admin password (or token) for %s:"
 msgstr "Password amministratore per %s: "
@@ -771,7 +771,7 @@ msgstr "Alias:"
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:188
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -844,7 +844,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:550
+#: lxc/remote.go:568
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -1018,7 +1018,7 @@ msgstr "Impossibile effettuare il pull di una directory senza --recursive"
 msgid "Can't read from stdin: %w"
 msgstr "Impossible leggere da stdin: %s"
 
-#: lxc/remote.go:866
+#: lxc/remote.go:884
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1084,13 +1084,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr "Il nome del container è: %s"
 
-#: lxc/remote.go:218
+#: lxc/remote.go:225
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:451
+#: lxc/remote.go:469
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1104,7 +1104,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr "Il nome del container è: %s"
 
-#: lxc/remote.go:604
+#: lxc/remote.go:622
 #, fuzzy
 msgid "Client certificate now trusted by server:"
 msgstr "Certificato del client salvato dal server: "
@@ -1344,12 +1344,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:486
+#: lxc/remote.go:504
 #, fuzzy, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "Certificato del client salvato dal server: "
 
-#: lxc/remote.go:224 lxc/remote.go:470
+#: lxc/remote.go:231 lxc/remote.go:488
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1378,7 +1378,7 @@ msgstr "Certificato del client salvato dal server: "
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:481
+#: lxc/remote.go:499
 #, fuzzy, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "Certificato del client salvato dal server: "
@@ -1681,8 +1681,8 @@ msgstr ""
 #: lxc/project.go:221 lxc/project.go:348 lxc/project.go:409 lxc/project.go:510
 #: lxc/project.go:567 lxc/project.go:646 lxc/project.go:677 lxc/project.go:730
 #: lxc/project.go:789 lxc/publish.go:33 lxc/query.go:34 lxc/remote.go:34
-#: lxc/remote.go:90 lxc/remote.go:632 lxc/remote.go:670 lxc/remote.go:760
-#: lxc/remote.go:833 lxc/remote.go:889 lxc/remote.go:929 lxc/rename.go:21
+#: lxc/remote.go:90 lxc/remote.go:650 lxc/remote.go:688 lxc/remote.go:778
+#: lxc/remote.go:851 lxc/remote.go:907 lxc/remote.go:947 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:92
 #: lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:340 lxc/storage.go:410
 #: lxc/storage.go:582 lxc/storage.go:661 lxc/storage.go:757 lxc/storage.go:843
@@ -2209,11 +2209,11 @@ msgstr "Accetta certificato"
 msgid "Failed to accept incoming connection: %w"
 msgstr "Accetta certificato"
 
-#: lxc/remote.go:190
+#: lxc/remote.go:197
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:241
+#: lxc/remote.go:248
 #, fuzzy, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr "Accetta certificato"
@@ -2223,7 +2223,7 @@ msgstr "Accetta certificato"
 msgid "Failed to connect to cluster member: %w"
 msgstr "Il nome del container è: %s"
 
-#: lxc/remote.go:231
+#: lxc/remote.go:238
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2233,12 +2233,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr "Accetta certificato"
 
-#: lxc/remote.go:256
+#: lxc/remote.go:263
 #, fuzzy, c-format
 msgid "Failed to create certificate: %w"
 msgstr "Accetta certificato"
 
-#: lxc/remote.go:263
+#: lxc/remote.go:270
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2263,7 +2263,7 @@ msgstr "Accetta certificato"
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:236
+#: lxc/remote.go:243
 #, fuzzy, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr "Accetta certificato"
@@ -2343,7 +2343,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:411
-#: lxc/project.go:791 lxc/remote.go:674 lxc/storage.go:584
+#: lxc/project.go:791 lxc/remote.go:692 lxc/storage.go:584
 #: lxc/storage_volume.go:1418 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -2380,7 +2380,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:742
+#: lxc/remote.go:760
 msgid "GLOBAL"
 msgstr ""
 
@@ -2396,7 +2396,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:397
+#: lxc/remote.go:159 lxc/remote.go:406
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2757,7 +2757,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:349
+#: lxc/remote.go:358
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2840,7 +2840,7 @@ msgstr "numero errato di argomenti del sottocomando"
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:338
+#: lxc/remote.go:347
 #, fuzzy, c-format
 msgid "Invalid protocol: %s"
 msgstr "Proprietà errata: %s"
@@ -3186,7 +3186,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:669 lxc/remote.go:670
+#: lxc/remote.go:687 lxc/remote.go:688
 msgid "List the available remotes"
 msgstr ""
 
@@ -3744,7 +3744,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:566
 #: lxc/network.go:976 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:487 lxc/remote.go:736 lxc/storage.go:634
+#: lxc/project.go:487 lxc/remote.go:754 lxc/storage.go:634
 #: lxc/storage_volume.go:1506
 msgid "NAME"
 msgstr ""
@@ -3766,8 +3766,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:953 lxc/operation.go:154 lxc/project.go:455
-#: lxc/project.go:460 lxc/project.go:465 lxc/project.go:470 lxc/remote.go:692
-#: lxc/remote.go:697 lxc/remote.go:702
+#: lxc/project.go:460 lxc/project.go:465 lxc/project.go:470 lxc/remote.go:710
+#: lxc/remote.go:715 lxc/remote.go:720
 msgid "NO"
 msgstr ""
 
@@ -3983,7 +3983,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:332
+#: lxc/remote.go:341
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4050,11 +4050,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:738
+#: lxc/remote.go:756
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1070 lxc/remote.go:740
+#: lxc/image.go:1070 lxc/remote.go:758
 msgid "PUBLIC"
 msgstr ""
 
@@ -4084,7 +4084,7 @@ msgstr "Creazione del container in corso"
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:182
+#: lxc/remote.go:189
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4097,7 +4097,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr "Il nome del container è: %s"
 
-#: lxc/remote.go:462
+#: lxc/remote.go:480
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4400,33 +4400,33 @@ msgstr "Creazione del container in corso"
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:790
+#: lxc/remote.go:808
 #, fuzzy, c-format
 msgid "Remote %s already exists"
 msgstr "il remote %s esiste già"
 
-#: lxc/project.go:756 lxc/remote.go:781 lxc/remote.go:854 lxc/remote.go:910
-#: lxc/remote.go:950
+#: lxc/project.go:756 lxc/remote.go:799 lxc/remote.go:872 lxc/remote.go:928
+#: lxc/remote.go:968
 #, fuzzy, c-format
 msgid "Remote %s doesn't exist"
 msgstr "il remote %s non esiste"
 
-#: lxc/remote.go:301
+#: lxc/remote.go:308
 #, fuzzy, c-format
 msgid "Remote %s exists as <%s>"
 msgstr "il remote %s esiste come %s"
 
-#: lxc/remote.go:862
+#: lxc/remote.go:880
 #, fuzzy, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr "il remote %s è statico e non può essere modificato"
 
-#: lxc/remote.go:785 lxc/remote.go:858 lxc/remote.go:954
+#: lxc/remote.go:803 lxc/remote.go:876 lxc/remote.go:972
 #, fuzzy, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr "il remote %s è statico e non può essere modificato"
 
-#: lxc/remote.go:290
+#: lxc/remote.go:297
 msgid "Remote address must not be empty"
 msgstr ""
 
@@ -4434,7 +4434,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:295
+#: lxc/remote.go:302
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4495,7 +4495,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:832 lxc/remote.go:833
+#: lxc/remote.go:850 lxc/remote.go:851
 msgid "Remove remotes"
 msgstr ""
 
@@ -4546,7 +4546,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:759 lxc/remote.go:760
+#: lxc/remote.go:777 lxc/remote.go:778
 msgid "Rename remotes"
 msgstr ""
 
@@ -4689,7 +4689,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:741
+#: lxc/remote.go:759
 msgid "STATIC"
 msgstr ""
 
@@ -4717,11 +4717,11 @@ msgstr ""
 msgid "Server authentication type (tls or candid)"
 msgstr ""
 
-#: lxc/remote.go:460
+#: lxc/remote.go:478
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:600
+#: lxc/remote.go:618
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -4905,7 +4905,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:928 lxc/remote.go:929
+#: lxc/remote.go:946 lxc/remote.go:947
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5089,7 +5089,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:631 lxc/remote.go:632
+#: lxc/remote.go:649 lxc/remote.go:650
 msgid "Show the default remote"
 msgstr ""
 
@@ -5280,7 +5280,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:888 lxc/remote.go:889
+#: lxc/remote.go:906 lxc/remote.go:907
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5623,7 +5623,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:180 lxc/remote.go:737
+#: lxc/cluster.go:180 lxc/remote.go:755
 msgid "URL"
 msgstr ""
 
@@ -5651,7 +5651,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:213 lxc/remote.go:247
+#: lxc/remote.go:220 lxc/remote.go:254
 #, fuzzy
 msgid "Unavailable remote server"
 msgstr "Aggiungi un nuovo server remoto"
@@ -5941,8 +5941,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:955 lxc/operation.go:156 lxc/project.go:457
-#: lxc/project.go:462 lxc/project.go:467 lxc/project.go:472 lxc/remote.go:694
-#: lxc/remote.go:699 lxc/remote.go:704
+#: lxc/project.go:462 lxc/project.go:467 lxc/project.go:472 lxc/remote.go:712
+#: lxc/remote.go:717 lxc/remote.go:722
 msgid "YES"
 msgstr ""
 
@@ -6638,7 +6638,7 @@ msgstr "Creazione del container in corso"
 msgid "[[<remote>:]<name>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/project.go:477 lxc/remote.go:727
+#: lxc/project.go:477 lxc/remote.go:745
 msgid "current"
 msgstr ""
 
@@ -6929,7 +6929,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:459
+#: lxc/remote.go:477
 #, fuzzy
 msgid "n"
 msgstr "no"
@@ -6942,7 +6942,7 @@ msgstr ""
 msgid "no"
 msgstr "no"
 
-#: lxc/remote.go:452
+#: lxc/remote.go:470
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6979,7 +6979,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:461
+#: lxc/remote.go:479
 msgid "y"
 msgstr ""
 

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-01 10:44+0100\n"
+"POT-Creation-Date: 2024-10-18 13:21+0000\n"
 "PO-Revision-Date: 2022-03-31 14:23+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/linux-"
@@ -579,15 +579,15 @@ msgstr "<alias> <target>"
 msgid "<old alias> <new alias>"
 msgstr "<old alias> <new alias>"
 
-#: lxc/remote.go:830 lxc/remote.go:887
+#: lxc/remote.go:848 lxc/remote.go:905
 msgid "<remote>"
 msgstr "<remote>"
 
-#: lxc/remote.go:927
+#: lxc/remote.go:945
 msgid "<remote> <URL>"
 msgstr "<remote> <URL>"
 
-#: lxc/remote.go:757
+#: lxc/remote.go:775
 msgid "<remote> <new-name>"
 msgstr "<remote> <new-name>"
 
@@ -622,7 +622,7 @@ msgstr "ALIASES"
 msgid "ARCHITECTURE"
 msgstr "ARCHITECTURE"
 
-#: lxc/remote.go:739
+#: lxc/remote.go:757
 msgid "AUTH TYPE"
 msgstr "AUTH TYPE"
 
@@ -740,7 +740,7 @@ msgstr "ACLにルールを追加します"
 msgid "Address: %s"
 msgstr "アドレス: %s"
 
-#: lxc/remote.go:564
+#: lxc/remote.go:582
 #, fuzzy, c-format
 msgid "Admin password (or token) for %s:"
 msgstr "%s の管理者パスワード:"
@@ -773,7 +773,7 @@ msgstr "エイリアス:"
 msgid "All projects"
 msgstr "利用可能なプロジェクト:"
 
-#: lxc/remote.go:181
+#: lxc/remote.go:188
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -849,7 +849,7 @@ msgstr ""
 "このコマンドはインスタンスのブートコンソールに接続できます。\n"
 "そしてそこから過去のログエントリを取り出すことができます。"
 
-#: lxc/remote.go:550
+#: lxc/remote.go:568
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr "認証タイプ '%s' はサーバではサポートされていません"
@@ -1024,7 +1024,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr "標準入力から読み込めません: %w"
 
-#: lxc/remote.go:866
+#: lxc/remote.go:884
 msgid "Can't remove the default remote"
 msgstr "デフォルトのリモートは削除できません"
 
@@ -1092,14 +1092,14 @@ msgstr "カード: %s (%s)"
 msgid "Certificate add token for %s deleted"
 msgstr "%s に対する証明書追加トークンが削除されました"
 
-#: lxc/remote.go:218
+#: lxc/remote.go:225
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 "証明書のフィンガープリントが証明書トークンとサーバの間で一致しません %q"
 
-#: lxc/remote.go:451
+#: lxc/remote.go:469
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr "証明書のフィンガープリント: %s"
@@ -1113,7 +1113,7 @@ msgstr "Chassis"
 msgid "Client %s certificate add token:"
 msgstr "クライアント %s の証明書追加トークン:"
 
-#: lxc/remote.go:604
+#: lxc/remote.go:622
 msgid "Client certificate now trusted by server:"
 msgstr "クライアント証明書がサーバに信頼されました:"
 
@@ -1360,12 +1360,12 @@ msgstr "コア %d"
 msgid "Cores:"
 msgstr "コア:"
 
-#: lxc/remote.go:486
+#: lxc/remote.go:504
 #, fuzzy, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "サーバ証明書格納用のディレクトリを作成できません"
 
-#: lxc/remote.go:224 lxc/remote.go:470
+#: lxc/remote.go:231 lxc/remote.go:488
 msgid "Could not create server cert dir"
 msgstr "サーバ証明書格納用のディレクトリを作成できません"
 
@@ -1394,7 +1394,7 @@ msgstr "秘密鍵ファイル %s をエラーで読み込めません: %v"
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr "リモート '%s' に対する新しいリモート証明書がエラーで書き込めません: %v"
 
-#: lxc/remote.go:481
+#: lxc/remote.go:499
 #, fuzzy, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "サーバ証明書格納用のディレクトリを作成できません"
@@ -1690,8 +1690,8 @@ msgstr "警告を削除します"
 #: lxc/project.go:221 lxc/project.go:348 lxc/project.go:409 lxc/project.go:510
 #: lxc/project.go:567 lxc/project.go:646 lxc/project.go:677 lxc/project.go:730
 #: lxc/project.go:789 lxc/publish.go:33 lxc/query.go:34 lxc/remote.go:34
-#: lxc/remote.go:90 lxc/remote.go:632 lxc/remote.go:670 lxc/remote.go:760
-#: lxc/remote.go:833 lxc/remote.go:889 lxc/remote.go:929 lxc/rename.go:21
+#: lxc/remote.go:90 lxc/remote.go:650 lxc/remote.go:688 lxc/remote.go:778
+#: lxc/remote.go:851 lxc/remote.go:907 lxc/remote.go:947 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:92
 #: lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:340 lxc/storage.go:410
 #: lxc/storage.go:582 lxc/storage.go:661 lxc/storage.go:757 lxc/storage.go:843
@@ -2241,11 +2241,11 @@ msgstr "sshfs の起動に失敗しました: %w"
 msgid "Failed to accept incoming connection: %w"
 msgstr "受信接続の受け入れに失敗しました: %w"
 
-#: lxc/remote.go:190
+#: lxc/remote.go:197
 msgid "Failed to add remote"
 msgstr "リモートの追加に失敗しました"
 
-#: lxc/remote.go:241
+#: lxc/remote.go:248
 #, fuzzy, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr "%q の作成に失敗しました: %w"
@@ -2255,7 +2255,7 @@ msgstr "%q の作成に失敗しました: %w"
 msgid "Failed to connect to cluster member: %w"
 msgstr "クラスタメンバへの接続に失敗しました: %w"
 
-#: lxc/remote.go:231
+#: lxc/remote.go:238
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr "%q の作成に失敗しました: %w"
@@ -2265,12 +2265,12 @@ msgstr "%q の作成に失敗しました: %w"
 msgid "Failed to create alias %s: %w"
 msgstr "エイリアス %s の作成に失敗しました: %w"
 
-#: lxc/remote.go:256
+#: lxc/remote.go:263
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr "証明書の作成に失敗しました: %w"
 
-#: lxc/remote.go:263
+#: lxc/remote.go:270
 #, c-format
 msgid "Failed to find project: %w"
 msgstr "プロジェクトが見つけられませんでした: %w"
@@ -2295,7 +2295,7 @@ msgstr "エイリアス %s の削除に失敗しました: %w"
 msgid "Failed to walk path for %s: %s"
 msgstr "パス %s にアクセスできませんでした: %s"
 
-#: lxc/remote.go:236
+#: lxc/remote.go:243
 #, fuzzy, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr "証明書の作成に失敗しました: %w"
@@ -2390,7 +2390,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:411
-#: lxc/project.go:791 lxc/remote.go:674 lxc/storage.go:584
+#: lxc/project.go:791 lxc/remote.go:692 lxc/storage.go:584
 #: lxc/storage_volume.go:1418 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr "フォーマット (csv|json|table|yaml|compact)"
@@ -2427,7 +2427,7 @@ msgstr "クロック数: %vMhz"
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr "クロック数: %vMhz (最小: %vMhz, 最大: %vMhz)"
 
-#: lxc/remote.go:742
+#: lxc/remote.go:760
 msgid "GLOBAL"
 msgstr "GLOBAL"
 
@@ -2443,7 +2443,7 @@ msgstr "GPUs:"
 msgid "Generate manpages for all commands"
 msgstr "すべてのコマンドに対する man ページを作成します"
 
-#: lxc/remote.go:159 lxc/remote.go:397
+#: lxc/remote.go:159 lxc/remote.go:406
 msgid "Generating a client certificate. This may take a minute..."
 msgstr "クライアント証明書を生成します。1分ぐらいかかります..."
 
@@ -2813,7 +2813,7 @@ msgstr "インスタンスは以下のフィンガープリントで publish さ
 msgid "Instance type"
 msgstr "インスタンスタイプ"
 
-#: lxc/remote.go:349
+#: lxc/remote.go:358
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr "不正な URL スキーム \"%s\" (\"%s\" 内)"
@@ -2902,7 +2902,7 @@ msgstr "引数の数が不正です"
 msgid "Invalid path %s"
 msgstr "不正なパス %s"
 
-#: lxc/remote.go:338
+#: lxc/remote.go:347
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr "不正なプロトコル: %s"
@@ -3364,7 +3364,7 @@ msgstr ""
 "    L - インスタンスの場所 (例: its cluster member)\n"
 "    U - 現在のディスク使用量"
 
-#: lxc/remote.go:669 lxc/remote.go:670
+#: lxc/remote.go:687 lxc/remote.go:688
 msgid "List the available remotes"
 msgstr "利用可能なリモートサーバを一覧表示します"
 
@@ -3941,7 +3941,7 @@ msgstr "インスタンス名を指定する必要があります: "
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:566
 #: lxc/network.go:976 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:487 lxc/remote.go:736 lxc/storage.go:634
+#: lxc/project.go:487 lxc/remote.go:754 lxc/storage.go:634
 #: lxc/storage_volume.go:1506
 msgid "NAME"
 msgstr "NAME"
@@ -3963,8 +3963,8 @@ msgid "NICs:"
 msgstr "NICs:"
 
 #: lxc/network.go:953 lxc/operation.go:154 lxc/project.go:455
-#: lxc/project.go:460 lxc/project.go:465 lxc/project.go:470 lxc/remote.go:692
-#: lxc/remote.go:697 lxc/remote.go:702
+#: lxc/project.go:460 lxc/project.go:465 lxc/project.go:470 lxc/remote.go:710
+#: lxc/remote.go:715 lxc/remote.go:720
 msgid "NO"
 msgstr "NO"
 
@@ -4182,7 +4182,7 @@ msgstr "\"カスタム\" のボリュームのみがエクスポートできま�
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr "\"カスタム\" のボリュームのみがスナップショットを取得できます"
 
-#: lxc/remote.go:332
+#: lxc/remote.go:341
 msgid "Only https URLs are supported for simplestreams"
 msgstr "simplestreams は https の URL のみサポートします"
 
@@ -4249,11 +4249,11 @@ msgstr "PROFILES"
 msgid "PROJECT"
 msgstr "PROJECT"
 
-#: lxc/remote.go:738
+#: lxc/remote.go:756
 msgid "PROTOCOL"
 msgstr "PROTOCOL"
 
-#: lxc/image.go:1070 lxc/remote.go:740
+#: lxc/image.go:1070 lxc/remote.go:758
 msgid "PUBLIC"
 msgstr "PUBLIC"
 
@@ -4282,7 +4282,7 @@ msgstr "インスタンスを一時停止します"
 msgid "Perform an incremental copy"
 msgstr "インクリメンタルコピーを実行します"
 
-#: lxc/remote.go:182
+#: lxc/remote.go:189
 #, fuzzy
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr "別のサーバ用設定ディレクトリ"
@@ -4295,7 +4295,7 @@ msgstr "クライアント名を入力してください: "
 msgid "Please provide cluster member name: "
 msgstr "クラスターメンバー名を入力してください: "
 
-#: lxc/remote.go:462
+#: lxc/remote.go:480
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr "'y', 'n', フィンガープリントのどれかを入力してください:"
 
@@ -4601,33 +4601,33 @@ msgstr "インスタンスの更新中: %s"
 msgid "Refreshing the image: %s"
 msgstr "イメージの更新中: %s"
 
-#: lxc/remote.go:790
+#: lxc/remote.go:808
 #, c-format
 msgid "Remote %s already exists"
 msgstr "リモート %s は既に存在します"
 
-#: lxc/project.go:756 lxc/remote.go:781 lxc/remote.go:854 lxc/remote.go:910
-#: lxc/remote.go:950
+#: lxc/project.go:756 lxc/remote.go:799 lxc/remote.go:872 lxc/remote.go:928
+#: lxc/remote.go:968
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr "リモート %s は存在しません"
 
-#: lxc/remote.go:301
+#: lxc/remote.go:308
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr "リモート %s は <%s> として存在します"
 
-#: lxc/remote.go:862
+#: lxc/remote.go:880
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr "リモート %s は global ですので削除できません"
 
-#: lxc/remote.go:785 lxc/remote.go:858 lxc/remote.go:954
+#: lxc/remote.go:803 lxc/remote.go:876 lxc/remote.go:972
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr "リモート %s は static ですので変更できません"
 
-#: lxc/remote.go:290
+#: lxc/remote.go:297
 msgid "Remote address must not be empty"
 msgstr ""
 
@@ -4635,7 +4635,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr "リモートの管理者パスワード"
 
-#: lxc/remote.go:295
+#: lxc/remote.go:302
 msgid "Remote names may not contain colons"
 msgstr "リモート名にコロンを含めることはできません"
 
@@ -4693,7 +4693,7 @@ msgstr "フォワードからポートを削除します"
 msgid "Remove profiles from instances"
 msgstr "インスタンスからプロファイルを削除します"
 
-#: lxc/remote.go:832 lxc/remote.go:833
+#: lxc/remote.go:850 lxc/remote.go:851
 msgid "Remove remotes"
 msgstr "リモートサーバを削除します"
 
@@ -4744,7 +4744,7 @@ msgstr "プロファイル名を変更します"
 msgid "Rename projects"
 msgstr "プロジェクト名を変更します"
 
-#: lxc/remote.go:759 lxc/remote.go:760
+#: lxc/remote.go:777 lxc/remote.go:778
 msgid "Rename remotes"
 msgstr "リモートサーバ名を変更します"
 
@@ -4889,7 +4889,7 @@ msgstr "SSH クライアントが切断されました %q"
 msgid "STATE"
 msgstr "STATE"
 
-#: lxc/remote.go:741
+#: lxc/remote.go:759
 msgid "STATIC"
 msgstr "STATIC"
 
@@ -4917,11 +4917,11 @@ msgstr "直接リクエスト (raw query) を LXD に送ります"
 msgid "Server authentication type (tls or candid)"
 msgstr "サーバの認証タイプ (tls もしくは candid)"
 
-#: lxc/remote.go:460
+#: lxc/remote.go:478
 msgid "Server certificate NACKed by user"
 msgstr "ユーザによりサーバ証明書が拒否されました"
 
-#: lxc/remote.go:600
+#: lxc/remote.go:618
 msgid "Server doesn't trust us after authentication"
 msgstr "認証後、サーバが我々を信用していません"
 
@@ -5151,7 +5151,7 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 
-#: lxc/remote.go:928 lxc/remote.go:929
+#: lxc/remote.go:946 lxc/remote.go:947
 msgid "Set the URL for the remote"
 msgstr "リモートの URL を設定します"
 
@@ -5334,7 +5334,7 @@ msgstr "ストレージボリュームの設定を表示する"
 msgid "Show storage volume state information"
 msgstr "ストレージボリュームの状態を表示します"
 
-#: lxc/remote.go:631 lxc/remote.go:632
+#: lxc/remote.go:649 lxc/remote.go:650
 msgid "Show the default remote"
 msgstr "デフォルトのリモートを表示します"
 
@@ -5522,7 +5522,7 @@ msgstr "Swap (ピーク)"
 msgid "Switch the current project"
 msgstr "現在のプロジェクトを切り替えます"
 
-#: lxc/remote.go:888 lxc/remote.go:889
+#: lxc/remote.go:906 lxc/remote.go:907
 msgid "Switch the default remote"
 msgstr "デフォルトのリモートを切り替えます"
 
@@ -5892,7 +5892,7 @@ msgstr "UNLIMITED"
 msgid "UPLOAD DATE"
 msgstr "UPLOAD DATE"
 
-#: lxc/cluster.go:180 lxc/remote.go:737
+#: lxc/cluster.go:180 lxc/remote.go:755
 msgid "URL"
 msgstr "URL"
 
@@ -5920,7 +5920,7 @@ msgstr "UUID: %v"
 msgid "Unable to create a temporary file: %v"
 msgstr "テンポラリファイルを作成できません: %v"
 
-#: lxc/remote.go:213 lxc/remote.go:247
+#: lxc/remote.go:220 lxc/remote.go:254
 #, fuzzy
 msgid "Unavailable remote server"
 msgstr "新たにリモートサーバを追加します"
@@ -6215,8 +6215,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr "インスタンスの稼動状態のスナップショットを取得するかどうか"
 
 #: lxc/network.go:955 lxc/operation.go:156 lxc/project.go:457
-#: lxc/project.go:462 lxc/project.go:467 lxc/project.go:472 lxc/remote.go:694
-#: lxc/remote.go:699 lxc/remote.go:704
+#: lxc/project.go:462 lxc/project.go:467 lxc/project.go:472 lxc/remote.go:712
+#: lxc/remote.go:717 lxc/remote.go:722
 msgid "YES"
 msgstr "YES"
 
@@ -6801,7 +6801,7 @@ msgstr "[<remote>] <IP|FQDN|URL|token>"
 msgid "[[<remote>:]<name>]"
 msgstr "[<remote>:] <name>"
 
-#: lxc/project.go:477 lxc/remote.go:727
+#: lxc/project.go:477 lxc/remote.go:745
 msgid "current"
 msgstr "現在値"
 
@@ -7219,7 +7219,7 @@ msgstr ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tbackup0.tar.gz を使って新しいカスタムボリュームを作成します。"
 
-#: lxc/remote.go:459
+#: lxc/remote.go:477
 msgid "n"
 msgstr "n"
 
@@ -7231,7 +7231,7 @@ msgstr "名前"
 msgid "no"
 msgstr "no"
 
-#: lxc/remote.go:452
+#: lxc/remote.go:470
 msgid "ok (y/n/[fingerprint])?"
 msgstr "ok (y/n/[fingerprint])?"
 
@@ -7270,7 +7270,7 @@ msgstr "サーバに接続できません"
 msgid "used by"
 msgstr "ストレージを使用中の"
 
-#: lxc/remote.go:461
+#: lxc/remote.go:479
 msgid "y"
 msgstr "y"
 

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-01 10:44+0100\n"
+"POT-Creation-Date: 2024-10-18 13:21+0000\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Korean <https://hosted.weblate.org/projects/linux-containers/"
@@ -380,15 +380,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:830 lxc/remote.go:887
+#: lxc/remote.go:848 lxc/remote.go:905
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:927
+#: lxc/remote.go:945
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:757
+#: lxc/remote.go:775
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -421,7 +421,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:739
+#: lxc/remote.go:757
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -528,7 +528,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:564
+#: lxc/remote.go:582
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -560,7 +560,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:188
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -631,7 +631,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:550
+#: lxc/remote.go:568
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -804,7 +804,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:866
+#: lxc/remote.go:884
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -870,13 +870,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:218
+#: lxc/remote.go:225
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:451
+#: lxc/remote.go:469
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -890,7 +890,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:604
+#: lxc/remote.go:622
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1129,12 +1129,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:486
+#: lxc/remote.go:504
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:470
+#: lxc/remote.go:231 lxc/remote.go:488
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1163,7 +1163,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:481
+#: lxc/remote.go:499
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1455,8 +1455,8 @@ msgstr ""
 #: lxc/project.go:221 lxc/project.go:348 lxc/project.go:409 lxc/project.go:510
 #: lxc/project.go:567 lxc/project.go:646 lxc/project.go:677 lxc/project.go:730
 #: lxc/project.go:789 lxc/publish.go:33 lxc/query.go:34 lxc/remote.go:34
-#: lxc/remote.go:90 lxc/remote.go:632 lxc/remote.go:670 lxc/remote.go:760
-#: lxc/remote.go:833 lxc/remote.go:889 lxc/remote.go:929 lxc/rename.go:21
+#: lxc/remote.go:90 lxc/remote.go:650 lxc/remote.go:688 lxc/remote.go:778
+#: lxc/remote.go:851 lxc/remote.go:907 lxc/remote.go:947 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:92
 #: lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:340 lxc/storage.go:410
 #: lxc/storage.go:582 lxc/storage.go:661 lxc/storage.go:757 lxc/storage.go:843
@@ -1971,11 +1971,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:190
+#: lxc/remote.go:197
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:241
+#: lxc/remote.go:248
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -1985,7 +1985,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:231
+#: lxc/remote.go:238
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -1995,12 +1995,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:256
+#: lxc/remote.go:263
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:263
+#: lxc/remote.go:270
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2025,7 +2025,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:236
+#: lxc/remote.go:243
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2103,7 +2103,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:411
-#: lxc/project.go:791 lxc/remote.go:674 lxc/storage.go:584
+#: lxc/project.go:791 lxc/remote.go:692 lxc/storage.go:584
 #: lxc/storage_volume.go:1418 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -2140,7 +2140,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:742
+#: lxc/remote.go:760
 msgid "GLOBAL"
 msgstr ""
 
@@ -2156,7 +2156,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:397
+#: lxc/remote.go:159 lxc/remote.go:406
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2507,7 +2507,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:349
+#: lxc/remote.go:358
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2588,7 +2588,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:338
+#: lxc/remote.go:347
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -2924,7 +2924,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:669 lxc/remote.go:670
+#: lxc/remote.go:687 lxc/remote.go:688
 msgid "List the available remotes"
 msgstr ""
 
@@ -3458,7 +3458,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:566
 #: lxc/network.go:976 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:487 lxc/remote.go:736 lxc/storage.go:634
+#: lxc/project.go:487 lxc/remote.go:754 lxc/storage.go:634
 #: lxc/storage_volume.go:1506
 msgid "NAME"
 msgstr ""
@@ -3480,8 +3480,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:953 lxc/operation.go:154 lxc/project.go:455
-#: lxc/project.go:460 lxc/project.go:465 lxc/project.go:470 lxc/remote.go:692
-#: lxc/remote.go:697 lxc/remote.go:702
+#: lxc/project.go:460 lxc/project.go:465 lxc/project.go:470 lxc/remote.go:710
+#: lxc/remote.go:715 lxc/remote.go:720
 msgid "NO"
 msgstr ""
 
@@ -3696,7 +3696,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:332
+#: lxc/remote.go:341
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -3763,11 +3763,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:738
+#: lxc/remote.go:756
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1070 lxc/remote.go:740
+#: lxc/image.go:1070 lxc/remote.go:758
 msgid "PUBLIC"
 msgstr ""
 
@@ -3796,7 +3796,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:182
+#: lxc/remote.go:189
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -3808,7 +3808,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:462
+#: lxc/remote.go:480
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4109,33 +4109,33 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:790
+#: lxc/remote.go:808
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:756 lxc/remote.go:781 lxc/remote.go:854 lxc/remote.go:910
-#: lxc/remote.go:950
+#: lxc/project.go:756 lxc/remote.go:799 lxc/remote.go:872 lxc/remote.go:928
+#: lxc/remote.go:968
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:301
+#: lxc/remote.go:308
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:862
+#: lxc/remote.go:880
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:785 lxc/remote.go:858 lxc/remote.go:954
+#: lxc/remote.go:803 lxc/remote.go:876 lxc/remote.go:972
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:290
+#: lxc/remote.go:297
 msgid "Remote address must not be empty"
 msgstr ""
 
@@ -4143,7 +4143,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:295
+#: lxc/remote.go:302
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4201,7 +4201,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:832 lxc/remote.go:833
+#: lxc/remote.go:850 lxc/remote.go:851
 msgid "Remove remotes"
 msgstr ""
 
@@ -4250,7 +4250,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:759 lxc/remote.go:760
+#: lxc/remote.go:777 lxc/remote.go:778
 msgid "Rename remotes"
 msgstr ""
 
@@ -4387,7 +4387,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:741
+#: lxc/remote.go:759
 msgid "STATIC"
 msgstr ""
 
@@ -4415,11 +4415,11 @@ msgstr ""
 msgid "Server authentication type (tls or candid)"
 msgstr ""
 
-#: lxc/remote.go:460
+#: lxc/remote.go:478
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:600
+#: lxc/remote.go:618
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -4600,7 +4600,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:928 lxc/remote.go:929
+#: lxc/remote.go:946 lxc/remote.go:947
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -4776,7 +4776,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:631 lxc/remote.go:632
+#: lxc/remote.go:649 lxc/remote.go:650
 msgid "Show the default remote"
 msgstr ""
 
@@ -4964,7 +4964,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:888 lxc/remote.go:889
+#: lxc/remote.go:906 lxc/remote.go:907
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5302,7 +5302,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:180 lxc/remote.go:737
+#: lxc/cluster.go:180 lxc/remote.go:755
 msgid "URL"
 msgstr ""
 
@@ -5330,7 +5330,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:213 lxc/remote.go:247
+#: lxc/remote.go:220 lxc/remote.go:254
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -5610,8 +5610,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:955 lxc/operation.go:156 lxc/project.go:457
-#: lxc/project.go:462 lxc/project.go:467 lxc/project.go:472 lxc/remote.go:694
-#: lxc/remote.go:699 lxc/remote.go:704
+#: lxc/project.go:462 lxc/project.go:467 lxc/project.go:472 lxc/remote.go:712
+#: lxc/remote.go:717 lxc/remote.go:722
 msgid "YES"
 msgstr ""
 
@@ -6176,7 +6176,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:477 lxc/remote.go:727
+#: lxc/project.go:477 lxc/remote.go:745
 msgid "current"
 msgstr ""
 
@@ -6467,7 +6467,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:459
+#: lxc/remote.go:477
 msgid "n"
 msgstr ""
 
@@ -6479,7 +6479,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:452
+#: lxc/remote.go:470
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6516,7 +6516,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:461
+#: lxc/remote.go:479
 msgid "y"
 msgstr ""
 

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-        "POT-Creation-Date: 2024-10-01 10:44+0100\n"
+        "POT-Creation-Date: 2024-10-18 13:21+0000\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -357,15 +357,15 @@ msgstr  ""
 msgid   "<old alias> <new alias>"
 msgstr  ""
 
-#: lxc/remote.go:830 lxc/remote.go:887
+#: lxc/remote.go:848 lxc/remote.go:905
 msgid   "<remote>"
 msgstr  ""
 
-#: lxc/remote.go:927
+#: lxc/remote.go:945
 msgid   "<remote> <URL>"
 msgstr  ""
 
-#: lxc/remote.go:757
+#: lxc/remote.go:775
 msgid   "<remote> <new-name>"
 msgstr  ""
 
@@ -397,7 +397,7 @@ msgstr  ""
 msgid   "ARCHITECTURE"
 msgstr  ""
 
-#: lxc/remote.go:739
+#: lxc/remote.go:757
 msgid   "AUTH TYPE"
 msgstr  ""
 
@@ -497,7 +497,7 @@ msgstr  ""
 msgid   "Address: %s"
 msgstr  ""
 
-#: lxc/remote.go:564
+#: lxc/remote.go:582
 #, c-format
 msgid   "Admin password (or token) for %s:"
 msgstr  ""
@@ -529,7 +529,7 @@ msgstr  ""
 msgid   "All projects"
 msgstr  ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:188
 msgid   "All server addresses are unavailable"
 msgstr  ""
 
@@ -599,7 +599,7 @@ msgid   "Attach to instance consoles\n"
         "as well as retrieve past log entries from it."
 msgstr  ""
 
-#: lxc/remote.go:550
+#: lxc/remote.go:568
 #, c-format
 msgid   "Authentication type '%s' not supported by server"
 msgstr  ""
@@ -771,7 +771,7 @@ msgstr  ""
 msgid   "Can't read from stdin: %w"
 msgstr  ""
 
-#: lxc/remote.go:866
+#: lxc/remote.go:884
 msgid   "Can't remove the default remote"
 msgstr  ""
 
@@ -836,12 +836,12 @@ msgstr  ""
 msgid   "Certificate add token for %s deleted"
 msgstr  ""
 
-#: lxc/remote.go:218
+#: lxc/remote.go:225
 #, c-format
 msgid   "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr  ""
 
-#: lxc/remote.go:451
+#: lxc/remote.go:469
 #, c-format
 msgid   "Certificate fingerprint: %s"
 msgstr  ""
@@ -855,7 +855,7 @@ msgstr  ""
 msgid   "Client %s certificate add token:"
 msgstr  ""
 
-#: lxc/remote.go:604
+#: lxc/remote.go:622
 msgid   "Client certificate now trusted by server:"
 msgstr  ""
 
@@ -1064,12 +1064,12 @@ msgstr  ""
 msgid   "Cores:"
 msgstr  ""
 
-#: lxc/remote.go:486
+#: lxc/remote.go:504
 #, c-format
 msgid   "Could not close server cert file %q: %w"
 msgstr  ""
 
-#: lxc/remote.go:224 lxc/remote.go:470
+#: lxc/remote.go:231 lxc/remote.go:488
 msgid   "Could not create server cert dir"
 msgstr  ""
 
@@ -1098,7 +1098,7 @@ msgstr  ""
 msgid   "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr  ""
 
-#: lxc/remote.go:481
+#: lxc/remote.go:499
 #, c-format
 msgid   "Could not write server cert file %q: %w"
 msgstr  ""
@@ -1317,7 +1317,7 @@ msgstr  ""
 msgid   "Delete warning"
 msgstr  ""
 
-#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:75 lxc/action.go:98 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159 lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:118 lxc/cluster.go:202 lxc/cluster.go:253 lxc/cluster.go:314 lxc/cluster.go:386 lxc/cluster.go:418 lxc/cluster.go:468 lxc/cluster.go:551 lxc/cluster.go:636 lxc/cluster.go:751 lxc/cluster.go:827 lxc/cluster.go:929 lxc/cluster.go:1008 lxc/cluster.go:1114 lxc/cluster.go:1135 lxc/cluster_group.go:30 lxc/cluster_group.go:84 lxc/cluster_group.go:157 lxc/cluster_group.go:214 lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456 lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631 lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106 lxc/config.go:32 lxc/config.go:95 lxc/config.go:380 lxc/config.go:513 lxc/config.go:730 lxc/config.go:854 lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208 lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450 lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668 lxc/config_device.go:741 lxc/config_metadata.go:27 lxc/config_metadata.go:55 lxc/config_metadata.go:180 lxc/config_template.go:27 lxc/config_template.go:67 lxc/config_template.go:110 lxc/config_template.go:152 lxc/config_template.go:240 lxc/config_template.go:300 lxc/config_trust.go:34 lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651 lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41 lxc/export.go:32 lxc/file.go:84 lxc/file.go:125 lxc/file.go:176 lxc/file.go:248 lxc/file.go:475 lxc/file.go:993 lxc/image.go:37 lxc/image.go:157 lxc/image.go:321 lxc/image.go:376 lxc/image.go:497 lxc/image.go:661 lxc/image.go:898 lxc/image.go:1032 lxc/image.go:1351 lxc/image.go:1438 lxc/image.go:1496 lxc/image.go:1547 lxc/image.go:1602 lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:28 lxc/info.go:33 lxc/init.go:43 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82 lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:32 lxc/network.go:131 lxc/network.go:216 lxc/network.go:289 lxc/network.go:368 lxc/network.go:418 lxc/network.go:503 lxc/network.go:588 lxc/network.go:716 lxc/network.go:785 lxc/network.go:908 lxc/network.go:1001 lxc/network.go:1072 lxc/network.go:1124 lxc/network.go:1212 lxc/network.go:1276 lxc/network_acl.go:29 lxc/network_acl.go:94 lxc/network_acl.go:165 lxc/network_acl.go:218 lxc/network_acl.go:266 lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492 lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702 lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887 lxc/network_allocations.go:51 lxc/network_forward.go:29 lxc/network_forward.go:86 lxc/network_forward.go:167 lxc/network_forward.go:231 lxc/network_forward.go:329 lxc/network_forward.go:398 lxc/network_forward.go:496 lxc/network_forward.go:526 lxc/network_forward.go:668 lxc/network_forward.go:730 lxc/network_forward.go:745 lxc/network_forward.go:810 lxc/network_peer.go:28 lxc/network_peer.go:81 lxc/network_peer.go:158 lxc/network_peer.go:215 lxc/network_peer.go:331 lxc/network_peer.go:399 lxc/network_peer.go:488 lxc/network_peer.go:518 lxc/network_peer.go:643 lxc/network_zone.go:28 lxc/network_zone.go:85 lxc/network_zone.go:156 lxc/network_zone.go:211 lxc/network_zone.go:271 lxc/network_zone.go:354 lxc/network_zone.go:434 lxc/network_zone.go:465 lxc/network_zone.go:584 lxc/network_zone.go:632 lxc/network_zone.go:689 lxc/network_zone.go:759 lxc/network_zone.go:811 lxc/network_zone.go:870 lxc/network_zone.go:952 lxc/network_zone.go:1028 lxc/network_zone.go:1058 lxc/network_zone.go:1176 lxc/network_zone.go:1225 lxc/network_zone.go:1240 lxc/network_zone.go:1286 lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:106 lxc/operation.go:193 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:250 lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424 lxc/profile.go:552 lxc/profile.go:613 lxc/profile.go:674 lxc/profile.go:750 lxc/profile.go:802 lxc/profile.go:878 lxc/profile.go:934 lxc/project.go:29 lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:348 lxc/project.go:409 lxc/project.go:510 lxc/project.go:567 lxc/project.go:646 lxc/project.go:677 lxc/project.go:730 lxc/project.go:789 lxc/publish.go:33 lxc/query.go:34 lxc/remote.go:34 lxc/remote.go:90 lxc/remote.go:632 lxc/remote.go:670 lxc/remote.go:760 lxc/remote.go:833 lxc/remote.go:889 lxc/remote.go:929 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:92 lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:340 lxc/storage.go:410 lxc/storage.go:582 lxc/storage.go:661 lxc/storage.go:757 lxc/storage.go:843 lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240 lxc/storage_volume.go:331 lxc/storage_volume.go:534 lxc/storage_volume.go:613 lxc/storage_volume.go:688 lxc/storage_volume.go:770 lxc/storage_volume.go:851 lxc/storage_volume.go:1060 lxc/storage_volume.go:1175 lxc/storage_volume.go:1318 lxc/storage_volume.go:1402 lxc/storage_volume.go:1609 lxc/storage_volume.go:1690 lxc/storage_volume.go:1805 lxc/storage_volume.go:1949 lxc/storage_volume.go:2058 lxc/storage_volume.go:2104 lxc/storage_volume.go:2201 lxc/storage_volume.go:2268 lxc/storage_volume.go:2420 lxc/version.go:22 lxc/warning.go:29 lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
+#: lxc/action.go:32 lxc/action.go:53 lxc/action.go:75 lxc/action.go:98 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159 lxc/alias.go:214 lxc/cluster.go:29 lxc/cluster.go:118 lxc/cluster.go:202 lxc/cluster.go:253 lxc/cluster.go:314 lxc/cluster.go:386 lxc/cluster.go:418 lxc/cluster.go:468 lxc/cluster.go:551 lxc/cluster.go:636 lxc/cluster.go:751 lxc/cluster.go:827 lxc/cluster.go:929 lxc/cluster.go:1008 lxc/cluster.go:1114 lxc/cluster.go:1135 lxc/cluster_group.go:30 lxc/cluster_group.go:84 lxc/cluster_group.go:157 lxc/cluster_group.go:214 lxc/cluster_group.go:266 lxc/cluster_group.go:382 lxc/cluster_group.go:456 lxc/cluster_group.go:529 lxc/cluster_group.go:577 lxc/cluster_group.go:631 lxc/cluster_role.go:23 lxc/cluster_role.go:50 lxc/cluster_role.go:106 lxc/config.go:32 lxc/config.go:95 lxc/config.go:380 lxc/config.go:513 lxc/config.go:730 lxc/config.go:854 lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:208 lxc/config_device.go:285 lxc/config_device.go:356 lxc/config_device.go:450 lxc/config_device.go:548 lxc/config_device.go:555 lxc/config_device.go:668 lxc/config_device.go:741 lxc/config_metadata.go:27 lxc/config_metadata.go:55 lxc/config_metadata.go:180 lxc/config_template.go:27 lxc/config_template.go:67 lxc/config_template.go:110 lxc/config_template.go:152 lxc/config_template.go:240 lxc/config_template.go:300 lxc/config_trust.go:34 lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651 lxc/console.go:37 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41 lxc/export.go:32 lxc/file.go:84 lxc/file.go:125 lxc/file.go:176 lxc/file.go:248 lxc/file.go:475 lxc/file.go:993 lxc/image.go:37 lxc/image.go:157 lxc/image.go:321 lxc/image.go:376 lxc/image.go:497 lxc/image.go:661 lxc/image.go:898 lxc/image.go:1032 lxc/image.go:1351 lxc/image.go:1438 lxc/image.go:1496 lxc/image.go:1547 lxc/image.go:1602 lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:28 lxc/info.go:33 lxc/init.go:43 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:82 lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:32 lxc/network.go:131 lxc/network.go:216 lxc/network.go:289 lxc/network.go:368 lxc/network.go:418 lxc/network.go:503 lxc/network.go:588 lxc/network.go:716 lxc/network.go:785 lxc/network.go:908 lxc/network.go:1001 lxc/network.go:1072 lxc/network.go:1124 lxc/network.go:1212 lxc/network.go:1276 lxc/network_acl.go:29 lxc/network_acl.go:94 lxc/network_acl.go:165 lxc/network_acl.go:218 lxc/network_acl.go:266 lxc/network_acl.go:327 lxc/network_acl.go:412 lxc/network_acl.go:492 lxc/network_acl.go:522 lxc/network_acl.go:653 lxc/network_acl.go:702 lxc/network_acl.go:751 lxc/network_acl.go:766 lxc/network_acl.go:887 lxc/network_allocations.go:51 lxc/network_forward.go:29 lxc/network_forward.go:86 lxc/network_forward.go:167 lxc/network_forward.go:231 lxc/network_forward.go:329 lxc/network_forward.go:398 lxc/network_forward.go:496 lxc/network_forward.go:526 lxc/network_forward.go:668 lxc/network_forward.go:730 lxc/network_forward.go:745 lxc/network_forward.go:810 lxc/network_peer.go:28 lxc/network_peer.go:81 lxc/network_peer.go:158 lxc/network_peer.go:215 lxc/network_peer.go:331 lxc/network_peer.go:399 lxc/network_peer.go:488 lxc/network_peer.go:518 lxc/network_peer.go:643 lxc/network_zone.go:28 lxc/network_zone.go:85 lxc/network_zone.go:156 lxc/network_zone.go:211 lxc/network_zone.go:271 lxc/network_zone.go:354 lxc/network_zone.go:434 lxc/network_zone.go:465 lxc/network_zone.go:584 lxc/network_zone.go:632 lxc/network_zone.go:689 lxc/network_zone.go:759 lxc/network_zone.go:811 lxc/network_zone.go:870 lxc/network_zone.go:952 lxc/network_zone.go:1028 lxc/network_zone.go:1058 lxc/network_zone.go:1176 lxc/network_zone.go:1225 lxc/network_zone.go:1240 lxc/network_zone.go:1286 lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:106 lxc/operation.go:193 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:250 lxc/profile.go:320 lxc/profile.go:374 lxc/profile.go:424 lxc/profile.go:552 lxc/profile.go:613 lxc/profile.go:674 lxc/profile.go:750 lxc/profile.go:802 lxc/profile.go:878 lxc/profile.go:934 lxc/project.go:29 lxc/project.go:93 lxc/project.go:158 lxc/project.go:221 lxc/project.go:348 lxc/project.go:409 lxc/project.go:510 lxc/project.go:567 lxc/project.go:646 lxc/project.go:677 lxc/project.go:730 lxc/project.go:789 lxc/publish.go:33 lxc/query.go:34 lxc/remote.go:34 lxc/remote.go:90 lxc/remote.go:650 lxc/remote.go:688 lxc/remote.go:778 lxc/remote.go:851 lxc/remote.go:907 lxc/remote.go:947 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:92 lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:340 lxc/storage.go:410 lxc/storage.go:582 lxc/storage.go:661 lxc/storage.go:757 lxc/storage.go:843 lxc/storage_volume.go:43 lxc/storage_volume.go:165 lxc/storage_volume.go:240 lxc/storage_volume.go:331 lxc/storage_volume.go:534 lxc/storage_volume.go:613 lxc/storage_volume.go:688 lxc/storage_volume.go:770 lxc/storage_volume.go:851 lxc/storage_volume.go:1060 lxc/storage_volume.go:1175 lxc/storage_volume.go:1318 lxc/storage_volume.go:1402 lxc/storage_volume.go:1609 lxc/storage_volume.go:1690 lxc/storage_volume.go:1805 lxc/storage_volume.go:1949 lxc/storage_volume.go:2058 lxc/storage_volume.go:2104 lxc/storage_volume.go:2201 lxc/storage_volume.go:2268 lxc/storage_volume.go:2420 lxc/version.go:22 lxc/warning.go:29 lxc/warning.go:71 lxc/warning.go:262 lxc/warning.go:303 lxc/warning.go:357
 msgid   "Description"
 msgstr  ""
 
@@ -1793,11 +1793,11 @@ msgstr  ""
 msgid   "Failed to accept incoming connection: %w"
 msgstr  ""
 
-#: lxc/remote.go:190
+#: lxc/remote.go:197
 msgid   "Failed to add remote"
 msgstr  ""
 
-#: lxc/remote.go:241
+#: lxc/remote.go:248
 #, c-format
 msgid   "Failed to close server cert file %q: %w"
 msgstr  ""
@@ -1807,7 +1807,7 @@ msgstr  ""
 msgid   "Failed to connect to cluster member: %w"
 msgstr  ""
 
-#: lxc/remote.go:231
+#: lxc/remote.go:238
 #, c-format
 msgid   "Failed to create %q: %w"
 msgstr  ""
@@ -1817,12 +1817,12 @@ msgstr  ""
 msgid   "Failed to create alias %s: %w"
 msgstr  ""
 
-#: lxc/remote.go:256
+#: lxc/remote.go:263
 #, c-format
 msgid   "Failed to create certificate: %w"
 msgstr  ""
 
-#: lxc/remote.go:263
+#: lxc/remote.go:270
 #, c-format
 msgid   "Failed to find project: %w"
 msgstr  ""
@@ -1847,7 +1847,7 @@ msgstr  ""
 msgid   "Failed to walk path for %s: %s"
 msgstr  ""
 
-#: lxc/remote.go:236
+#: lxc/remote.go:243
 #, c-format
 msgid   "Failed to write server cert file %q: %w"
 msgstr  ""
@@ -1912,7 +1912,7 @@ msgid   "Forcefully removing a server from the cluster should only be done as a 
         "Are you really sure you want to force removing %s? (yes/no): "
 msgstr  ""
 
-#: lxc/alias.go:112 lxc/cluster.go:120 lxc/cluster.go:828 lxc/cluster_group.go:384 lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434 lxc/image.go:1058 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:912 lxc/network.go:1003 lxc/network_acl.go:97 lxc/network_allocations.go:57 lxc/network_forward.go:89 lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:411 lxc/project.go:791 lxc/remote.go:674 lxc/storage.go:584 lxc/storage_volume.go:1418 lxc/warning.go:93
+#: lxc/alias.go:112 lxc/cluster.go:120 lxc/cluster.go:828 lxc/cluster_group.go:384 lxc/config_template.go:242 lxc/config_trust.go:352 lxc/config_trust.go:434 lxc/image.go:1058 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:912 lxc/network.go:1003 lxc/network_acl.go:97 lxc/network_allocations.go:57 lxc/network_forward.go:89 lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692 lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:411 lxc/project.go:791 lxc/remote.go:692 lxc/storage.go:584 lxc/storage_volume.go:1418 lxc/warning.go:93
 msgid   "Format (csv|json|table|yaml|compact)"
 msgstr  ""
 
@@ -1948,7 +1948,7 @@ msgstr  ""
 msgid   "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr  ""
 
-#: lxc/remote.go:742
+#: lxc/remote.go:760
 msgid   "GLOBAL"
 msgstr  ""
 
@@ -1964,7 +1964,7 @@ msgstr  ""
 msgid   "Generate manpages for all commands"
 msgstr  ""
 
-#: lxc/remote.go:159 lxc/remote.go:397
+#: lxc/remote.go:159 lxc/remote.go:406
 msgid   "Generating a client certificate. This may take a minute..."
 msgstr  ""
 
@@ -2312,7 +2312,7 @@ msgstr  ""
 msgid   "Instance type"
 msgstr  ""
 
-#: lxc/remote.go:349
+#: lxc/remote.go:358
 #, c-format
 msgid   "Invalid URL scheme \"%s\" in \"%s\""
 msgstr  ""
@@ -2392,7 +2392,7 @@ msgstr  ""
 msgid   "Invalid path %s"
 msgstr  ""
 
-#: lxc/remote.go:338
+#: lxc/remote.go:347
 #, c-format
 msgid   "Invalid protocol: %s"
 msgstr  ""
@@ -2713,7 +2713,7 @@ msgid   "List storage volumes\n"
         "    U - Current disk usage"
 msgstr  ""
 
-#: lxc/remote.go:669 lxc/remote.go:670
+#: lxc/remote.go:687 lxc/remote.go:688
 msgid   "List the available remotes"
 msgstr  ""
 
@@ -3192,7 +3192,7 @@ msgstr  ""
 msgid   "Must supply instance name for: "
 msgstr  ""
 
-#: lxc/cluster.go:179 lxc/cluster.go:911 lxc/cluster_group.go:437 lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:566 lxc/network.go:976 lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:487 lxc/remote.go:736 lxc/storage.go:634 lxc/storage_volume.go:1506
+#: lxc/cluster.go:179 lxc/cluster.go:911 lxc/cluster_group.go:437 lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:566 lxc/network.go:976 lxc/network_acl.go:147 lxc/network_peer.go:139 lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657 lxc/project.go:487 lxc/remote.go:754 lxc/storage.go:634 lxc/storage_volume.go:1506
 msgid   "NAME"
 msgstr  ""
 
@@ -3212,7 +3212,7 @@ msgstr  ""
 msgid   "NICs:"
 msgstr  ""
 
-#: lxc/network.go:953 lxc/operation.go:154 lxc/project.go:455 lxc/project.go:460 lxc/project.go:465 lxc/project.go:470 lxc/remote.go:692 lxc/remote.go:697 lxc/remote.go:702
+#: lxc/network.go:953 lxc/operation.go:154 lxc/project.go:455 lxc/project.go:460 lxc/project.go:465 lxc/project.go:470 lxc/remote.go:710 lxc/remote.go:715 lxc/remote.go:720
 msgid   "NO"
 msgstr  ""
 
@@ -3425,7 +3425,7 @@ msgstr  ""
 msgid   "Only \"custom\" volumes can be snapshotted"
 msgstr  ""
 
-#: lxc/remote.go:332
+#: lxc/remote.go:341
 msgid   "Only https URLs are supported for simplestreams"
 msgstr  ""
 
@@ -3492,11 +3492,11 @@ msgstr  ""
 msgid   "PROJECT"
 msgstr  ""
 
-#: lxc/remote.go:738
+#: lxc/remote.go:756
 msgid   "PROTOCOL"
 msgstr  ""
 
-#: lxc/image.go:1070 lxc/remote.go:740
+#: lxc/image.go:1070 lxc/remote.go:758
 msgid   "PUBLIC"
 msgstr  ""
 
@@ -3525,7 +3525,7 @@ msgstr  ""
 msgid   "Perform an incremental copy"
 msgstr  ""
 
-#: lxc/remote.go:182
+#: lxc/remote.go:189
 msgid   "Please provide an alternate server address (empty to abort):"
 msgstr  ""
 
@@ -3537,7 +3537,7 @@ msgstr  ""
 msgid   "Please provide cluster member name: "
 msgstr  ""
 
-#: lxc/remote.go:462
+#: lxc/remote.go:480
 msgid   "Please type 'y', 'n' or the fingerprint:"
 msgstr  ""
 
@@ -3816,32 +3816,32 @@ msgstr  ""
 msgid   "Refreshing the image: %s"
 msgstr  ""
 
-#: lxc/remote.go:790
+#: lxc/remote.go:808
 #, c-format
 msgid   "Remote %s already exists"
 msgstr  ""
 
-#: lxc/project.go:756 lxc/remote.go:781 lxc/remote.go:854 lxc/remote.go:910 lxc/remote.go:950
+#: lxc/project.go:756 lxc/remote.go:799 lxc/remote.go:872 lxc/remote.go:928 lxc/remote.go:968
 #, c-format
 msgid   "Remote %s doesn't exist"
 msgstr  ""
 
-#: lxc/remote.go:301
+#: lxc/remote.go:308
 #, c-format
 msgid   "Remote %s exists as <%s>"
 msgstr  ""
 
-#: lxc/remote.go:862
+#: lxc/remote.go:880
 #, c-format
 msgid   "Remote %s is global and cannot be removed"
 msgstr  ""
 
-#: lxc/remote.go:785 lxc/remote.go:858 lxc/remote.go:954
+#: lxc/remote.go:803 lxc/remote.go:876 lxc/remote.go:972
 #, c-format
 msgid   "Remote %s is static and cannot be modified"
 msgstr  ""
 
-#: lxc/remote.go:290
+#: lxc/remote.go:297
 msgid   "Remote address must not be empty"
 msgstr  ""
 
@@ -3849,7 +3849,7 @@ msgstr  ""
 msgid   "Remote admin password"
 msgstr  ""
 
-#: lxc/remote.go:295
+#: lxc/remote.go:302
 msgid   "Remote names may not contain colons"
 msgstr  ""
 
@@ -3907,7 +3907,7 @@ msgstr  ""
 msgid   "Remove profiles from instances"
 msgstr  ""
 
-#: lxc/remote.go:832 lxc/remote.go:833
+#: lxc/remote.go:850 lxc/remote.go:851
 msgid   "Remove remotes"
 msgstr  ""
 
@@ -3955,7 +3955,7 @@ msgstr  ""
 msgid   "Rename projects"
 msgstr  ""
 
-#: lxc/remote.go:759 lxc/remote.go:760
+#: lxc/remote.go:777 lxc/remote.go:778
 msgid   "Rename remotes"
 msgstr  ""
 
@@ -4089,7 +4089,7 @@ msgstr  ""
 msgid   "STATE"
 msgstr  ""
 
-#: lxc/remote.go:741
+#: lxc/remote.go:759
 msgid   "STATIC"
 msgstr  ""
 
@@ -4117,11 +4117,11 @@ msgstr  ""
 msgid   "Server authentication type (tls or candid)"
 msgstr  ""
 
-#: lxc/remote.go:460
+#: lxc/remote.go:478
 msgid   "Server certificate NACKed by user"
 msgstr  ""
 
-#: lxc/remote.go:600
+#: lxc/remote.go:618
 msgid   "Server doesn't trust us after authentication"
 msgstr  ""
 
@@ -4278,7 +4278,7 @@ msgid   "Set storage volume configuration keys\n"
         "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr  ""
 
-#: lxc/remote.go:928 lxc/remote.go:929
+#: lxc/remote.go:946 lxc/remote.go:947
 msgid   "Set the URL for the remote"
 msgstr  ""
 
@@ -4454,7 +4454,7 @@ msgstr  ""
 msgid   "Show storage volume state information"
 msgstr  ""
 
-#: lxc/remote.go:631 lxc/remote.go:632
+#: lxc/remote.go:649 lxc/remote.go:650
 msgid   "Show the default remote"
 msgstr  ""
 
@@ -4642,7 +4642,7 @@ msgstr  ""
 msgid   "Switch the current project"
 msgstr  ""
 
-#: lxc/remote.go:888 lxc/remote.go:889
+#: lxc/remote.go:906 lxc/remote.go:907
 msgid   "Switch the default remote"
 msgstr  ""
 
@@ -4964,7 +4964,7 @@ msgstr  ""
 msgid   "UPLOAD DATE"
 msgstr  ""
 
-#: lxc/cluster.go:180 lxc/remote.go:737
+#: lxc/cluster.go:180 lxc/remote.go:755
 msgid   "URL"
 msgstr  ""
 
@@ -4990,7 +4990,7 @@ msgstr  ""
 msgid   "Unable to create a temporary file: %v"
 msgstr  ""
 
-#: lxc/remote.go:213 lxc/remote.go:247
+#: lxc/remote.go:220 lxc/remote.go:254
 msgid   "Unavailable remote server"
 msgstr  ""
 
@@ -5262,7 +5262,7 @@ msgstr  ""
 msgid   "Whether or not to snapshot the instance's running state"
 msgstr  ""
 
-#: lxc/network.go:955 lxc/operation.go:156 lxc/project.go:457 lxc/project.go:462 lxc/project.go:467 lxc/project.go:472 lxc/remote.go:694 lxc/remote.go:699 lxc/remote.go:704
+#: lxc/network.go:955 lxc/operation.go:156 lxc/project.go:457 lxc/project.go:462 lxc/project.go:467 lxc/project.go:472 lxc/remote.go:712 lxc/remote.go:717 lxc/remote.go:722
 msgid   "YES"
 msgstr  ""
 
@@ -5806,7 +5806,7 @@ msgstr  ""
 msgid   "[[<remote>:]<name>]"
 msgstr  ""
 
-#: lxc/project.go:477 lxc/remote.go:727
+#: lxc/project.go:477 lxc/remote.go:745
 msgid   "current"
 msgstr  ""
 
@@ -6055,7 +6055,7 @@ msgid   "lxc storage volume import default backup0.tar.gz\n"
         "		Create a new custom volume using backup0.tar.gz as the source."
 msgstr  ""
 
-#: lxc/remote.go:459
+#: lxc/remote.go:477
 msgid   "n"
 msgstr  ""
 
@@ -6067,7 +6067,7 @@ msgstr  ""
 msgid   "no"
 msgstr  ""
 
-#: lxc/remote.go:452
+#: lxc/remote.go:470
 msgid   "ok (y/n/[fingerprint])?"
 msgstr  ""
 
@@ -6104,7 +6104,7 @@ msgstr  ""
 msgid   "used by"
 msgstr  ""
 
-#: lxc/remote.go:461
+#: lxc/remote.go:479
 msgid   "y"
 msgstr  ""
 

--- a/po/mr.po
+++ b/po/mr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-01 10:44+0100\n"
+"POT-Creation-Date: 2024-10-18 13:21+0000\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Marathi <https://hosted.weblate.org/projects/linux-containers/"
@@ -380,15 +380,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:830 lxc/remote.go:887
+#: lxc/remote.go:848 lxc/remote.go:905
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:927
+#: lxc/remote.go:945
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:757
+#: lxc/remote.go:775
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -421,7 +421,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:739
+#: lxc/remote.go:757
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -528,7 +528,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:564
+#: lxc/remote.go:582
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -560,7 +560,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:188
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -631,7 +631,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:550
+#: lxc/remote.go:568
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -804,7 +804,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:866
+#: lxc/remote.go:884
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -870,13 +870,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:218
+#: lxc/remote.go:225
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:451
+#: lxc/remote.go:469
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -890,7 +890,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:604
+#: lxc/remote.go:622
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1129,12 +1129,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:486
+#: lxc/remote.go:504
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:470
+#: lxc/remote.go:231 lxc/remote.go:488
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1163,7 +1163,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:481
+#: lxc/remote.go:499
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1455,8 +1455,8 @@ msgstr ""
 #: lxc/project.go:221 lxc/project.go:348 lxc/project.go:409 lxc/project.go:510
 #: lxc/project.go:567 lxc/project.go:646 lxc/project.go:677 lxc/project.go:730
 #: lxc/project.go:789 lxc/publish.go:33 lxc/query.go:34 lxc/remote.go:34
-#: lxc/remote.go:90 lxc/remote.go:632 lxc/remote.go:670 lxc/remote.go:760
-#: lxc/remote.go:833 lxc/remote.go:889 lxc/remote.go:929 lxc/rename.go:21
+#: lxc/remote.go:90 lxc/remote.go:650 lxc/remote.go:688 lxc/remote.go:778
+#: lxc/remote.go:851 lxc/remote.go:907 lxc/remote.go:947 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:92
 #: lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:340 lxc/storage.go:410
 #: lxc/storage.go:582 lxc/storage.go:661 lxc/storage.go:757 lxc/storage.go:843
@@ -1971,11 +1971,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:190
+#: lxc/remote.go:197
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:241
+#: lxc/remote.go:248
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -1985,7 +1985,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:231
+#: lxc/remote.go:238
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -1995,12 +1995,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:256
+#: lxc/remote.go:263
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:263
+#: lxc/remote.go:270
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2025,7 +2025,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:236
+#: lxc/remote.go:243
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2103,7 +2103,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:411
-#: lxc/project.go:791 lxc/remote.go:674 lxc/storage.go:584
+#: lxc/project.go:791 lxc/remote.go:692 lxc/storage.go:584
 #: lxc/storage_volume.go:1418 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -2140,7 +2140,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:742
+#: lxc/remote.go:760
 msgid "GLOBAL"
 msgstr ""
 
@@ -2156,7 +2156,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:397
+#: lxc/remote.go:159 lxc/remote.go:406
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2507,7 +2507,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:349
+#: lxc/remote.go:358
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2588,7 +2588,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:338
+#: lxc/remote.go:347
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -2924,7 +2924,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:669 lxc/remote.go:670
+#: lxc/remote.go:687 lxc/remote.go:688
 msgid "List the available remotes"
 msgstr ""
 
@@ -3458,7 +3458,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:566
 #: lxc/network.go:976 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:487 lxc/remote.go:736 lxc/storage.go:634
+#: lxc/project.go:487 lxc/remote.go:754 lxc/storage.go:634
 #: lxc/storage_volume.go:1506
 msgid "NAME"
 msgstr ""
@@ -3480,8 +3480,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:953 lxc/operation.go:154 lxc/project.go:455
-#: lxc/project.go:460 lxc/project.go:465 lxc/project.go:470 lxc/remote.go:692
-#: lxc/remote.go:697 lxc/remote.go:702
+#: lxc/project.go:460 lxc/project.go:465 lxc/project.go:470 lxc/remote.go:710
+#: lxc/remote.go:715 lxc/remote.go:720
 msgid "NO"
 msgstr ""
 
@@ -3696,7 +3696,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:332
+#: lxc/remote.go:341
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -3763,11 +3763,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:738
+#: lxc/remote.go:756
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1070 lxc/remote.go:740
+#: lxc/image.go:1070 lxc/remote.go:758
 msgid "PUBLIC"
 msgstr ""
 
@@ -3796,7 +3796,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:182
+#: lxc/remote.go:189
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -3808,7 +3808,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:462
+#: lxc/remote.go:480
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4109,33 +4109,33 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:790
+#: lxc/remote.go:808
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:756 lxc/remote.go:781 lxc/remote.go:854 lxc/remote.go:910
-#: lxc/remote.go:950
+#: lxc/project.go:756 lxc/remote.go:799 lxc/remote.go:872 lxc/remote.go:928
+#: lxc/remote.go:968
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:301
+#: lxc/remote.go:308
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:862
+#: lxc/remote.go:880
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:785 lxc/remote.go:858 lxc/remote.go:954
+#: lxc/remote.go:803 lxc/remote.go:876 lxc/remote.go:972
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:290
+#: lxc/remote.go:297
 msgid "Remote address must not be empty"
 msgstr ""
 
@@ -4143,7 +4143,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:295
+#: lxc/remote.go:302
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4201,7 +4201,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:832 lxc/remote.go:833
+#: lxc/remote.go:850 lxc/remote.go:851
 msgid "Remove remotes"
 msgstr ""
 
@@ -4250,7 +4250,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:759 lxc/remote.go:760
+#: lxc/remote.go:777 lxc/remote.go:778
 msgid "Rename remotes"
 msgstr ""
 
@@ -4387,7 +4387,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:741
+#: lxc/remote.go:759
 msgid "STATIC"
 msgstr ""
 
@@ -4415,11 +4415,11 @@ msgstr ""
 msgid "Server authentication type (tls or candid)"
 msgstr ""
 
-#: lxc/remote.go:460
+#: lxc/remote.go:478
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:600
+#: lxc/remote.go:618
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -4600,7 +4600,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:928 lxc/remote.go:929
+#: lxc/remote.go:946 lxc/remote.go:947
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -4776,7 +4776,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:631 lxc/remote.go:632
+#: lxc/remote.go:649 lxc/remote.go:650
 msgid "Show the default remote"
 msgstr ""
 
@@ -4964,7 +4964,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:888 lxc/remote.go:889
+#: lxc/remote.go:906 lxc/remote.go:907
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5302,7 +5302,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:180 lxc/remote.go:737
+#: lxc/cluster.go:180 lxc/remote.go:755
 msgid "URL"
 msgstr ""
 
@@ -5330,7 +5330,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:213 lxc/remote.go:247
+#: lxc/remote.go:220 lxc/remote.go:254
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -5610,8 +5610,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:955 lxc/operation.go:156 lxc/project.go:457
-#: lxc/project.go:462 lxc/project.go:467 lxc/project.go:472 lxc/remote.go:694
-#: lxc/remote.go:699 lxc/remote.go:704
+#: lxc/project.go:462 lxc/project.go:467 lxc/project.go:472 lxc/remote.go:712
+#: lxc/remote.go:717 lxc/remote.go:722
 msgid "YES"
 msgstr ""
 
@@ -6176,7 +6176,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:477 lxc/remote.go:727
+#: lxc/project.go:477 lxc/remote.go:745
 msgid "current"
 msgstr ""
 
@@ -6467,7 +6467,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:459
+#: lxc/remote.go:477
 msgid "n"
 msgstr ""
 
@@ -6479,7 +6479,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:452
+#: lxc/remote.go:470
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6516,7 +6516,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:461
+#: lxc/remote.go:479
 msgid "y"
 msgstr ""
 

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-01 10:44+0100\n"
+"POT-Creation-Date: 2024-10-18 13:21+0000\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Norwegian Bokmål <https://hosted.weblate.org/projects/linux-"
@@ -380,15 +380,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:830 lxc/remote.go:887
+#: lxc/remote.go:848 lxc/remote.go:905
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:927
+#: lxc/remote.go:945
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:757
+#: lxc/remote.go:775
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -421,7 +421,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:739
+#: lxc/remote.go:757
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -528,7 +528,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:564
+#: lxc/remote.go:582
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -560,7 +560,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:188
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -631,7 +631,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:550
+#: lxc/remote.go:568
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -804,7 +804,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:866
+#: lxc/remote.go:884
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -870,13 +870,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:218
+#: lxc/remote.go:225
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:451
+#: lxc/remote.go:469
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -890,7 +890,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:604
+#: lxc/remote.go:622
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1129,12 +1129,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:486
+#: lxc/remote.go:504
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:470
+#: lxc/remote.go:231 lxc/remote.go:488
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1163,7 +1163,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:481
+#: lxc/remote.go:499
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1455,8 +1455,8 @@ msgstr ""
 #: lxc/project.go:221 lxc/project.go:348 lxc/project.go:409 lxc/project.go:510
 #: lxc/project.go:567 lxc/project.go:646 lxc/project.go:677 lxc/project.go:730
 #: lxc/project.go:789 lxc/publish.go:33 lxc/query.go:34 lxc/remote.go:34
-#: lxc/remote.go:90 lxc/remote.go:632 lxc/remote.go:670 lxc/remote.go:760
-#: lxc/remote.go:833 lxc/remote.go:889 lxc/remote.go:929 lxc/rename.go:21
+#: lxc/remote.go:90 lxc/remote.go:650 lxc/remote.go:688 lxc/remote.go:778
+#: lxc/remote.go:851 lxc/remote.go:907 lxc/remote.go:947 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:92
 #: lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:340 lxc/storage.go:410
 #: lxc/storage.go:582 lxc/storage.go:661 lxc/storage.go:757 lxc/storage.go:843
@@ -1971,11 +1971,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:190
+#: lxc/remote.go:197
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:241
+#: lxc/remote.go:248
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -1985,7 +1985,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:231
+#: lxc/remote.go:238
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -1995,12 +1995,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:256
+#: lxc/remote.go:263
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:263
+#: lxc/remote.go:270
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2025,7 +2025,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:236
+#: lxc/remote.go:243
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2103,7 +2103,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:411
-#: lxc/project.go:791 lxc/remote.go:674 lxc/storage.go:584
+#: lxc/project.go:791 lxc/remote.go:692 lxc/storage.go:584
 #: lxc/storage_volume.go:1418 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -2140,7 +2140,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:742
+#: lxc/remote.go:760
 msgid "GLOBAL"
 msgstr ""
 
@@ -2156,7 +2156,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:397
+#: lxc/remote.go:159 lxc/remote.go:406
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2507,7 +2507,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:349
+#: lxc/remote.go:358
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2588,7 +2588,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:338
+#: lxc/remote.go:347
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -2924,7 +2924,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:669 lxc/remote.go:670
+#: lxc/remote.go:687 lxc/remote.go:688
 msgid "List the available remotes"
 msgstr ""
 
@@ -3458,7 +3458,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:566
 #: lxc/network.go:976 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:487 lxc/remote.go:736 lxc/storage.go:634
+#: lxc/project.go:487 lxc/remote.go:754 lxc/storage.go:634
 #: lxc/storage_volume.go:1506
 msgid "NAME"
 msgstr ""
@@ -3480,8 +3480,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:953 lxc/operation.go:154 lxc/project.go:455
-#: lxc/project.go:460 lxc/project.go:465 lxc/project.go:470 lxc/remote.go:692
-#: lxc/remote.go:697 lxc/remote.go:702
+#: lxc/project.go:460 lxc/project.go:465 lxc/project.go:470 lxc/remote.go:710
+#: lxc/remote.go:715 lxc/remote.go:720
 msgid "NO"
 msgstr ""
 
@@ -3696,7 +3696,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:332
+#: lxc/remote.go:341
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -3763,11 +3763,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:738
+#: lxc/remote.go:756
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1070 lxc/remote.go:740
+#: lxc/image.go:1070 lxc/remote.go:758
 msgid "PUBLIC"
 msgstr ""
 
@@ -3796,7 +3796,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:182
+#: lxc/remote.go:189
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -3808,7 +3808,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:462
+#: lxc/remote.go:480
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4109,33 +4109,33 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:790
+#: lxc/remote.go:808
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:756 lxc/remote.go:781 lxc/remote.go:854 lxc/remote.go:910
-#: lxc/remote.go:950
+#: lxc/project.go:756 lxc/remote.go:799 lxc/remote.go:872 lxc/remote.go:928
+#: lxc/remote.go:968
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:301
+#: lxc/remote.go:308
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:862
+#: lxc/remote.go:880
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:785 lxc/remote.go:858 lxc/remote.go:954
+#: lxc/remote.go:803 lxc/remote.go:876 lxc/remote.go:972
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:290
+#: lxc/remote.go:297
 msgid "Remote address must not be empty"
 msgstr ""
 
@@ -4143,7 +4143,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:295
+#: lxc/remote.go:302
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4201,7 +4201,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:832 lxc/remote.go:833
+#: lxc/remote.go:850 lxc/remote.go:851
 msgid "Remove remotes"
 msgstr ""
 
@@ -4250,7 +4250,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:759 lxc/remote.go:760
+#: lxc/remote.go:777 lxc/remote.go:778
 msgid "Rename remotes"
 msgstr ""
 
@@ -4387,7 +4387,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:741
+#: lxc/remote.go:759
 msgid "STATIC"
 msgstr ""
 
@@ -4415,11 +4415,11 @@ msgstr ""
 msgid "Server authentication type (tls or candid)"
 msgstr ""
 
-#: lxc/remote.go:460
+#: lxc/remote.go:478
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:600
+#: lxc/remote.go:618
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -4600,7 +4600,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:928 lxc/remote.go:929
+#: lxc/remote.go:946 lxc/remote.go:947
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -4776,7 +4776,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:631 lxc/remote.go:632
+#: lxc/remote.go:649 lxc/remote.go:650
 msgid "Show the default remote"
 msgstr ""
 
@@ -4964,7 +4964,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:888 lxc/remote.go:889
+#: lxc/remote.go:906 lxc/remote.go:907
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5302,7 +5302,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:180 lxc/remote.go:737
+#: lxc/cluster.go:180 lxc/remote.go:755
 msgid "URL"
 msgstr ""
 
@@ -5330,7 +5330,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:213 lxc/remote.go:247
+#: lxc/remote.go:220 lxc/remote.go:254
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -5610,8 +5610,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:955 lxc/operation.go:156 lxc/project.go:457
-#: lxc/project.go:462 lxc/project.go:467 lxc/project.go:472 lxc/remote.go:694
-#: lxc/remote.go:699 lxc/remote.go:704
+#: lxc/project.go:462 lxc/project.go:467 lxc/project.go:472 lxc/remote.go:712
+#: lxc/remote.go:717 lxc/remote.go:722
 msgid "YES"
 msgstr ""
 
@@ -6176,7 +6176,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:477 lxc/remote.go:727
+#: lxc/project.go:477 lxc/remote.go:745
 msgid "current"
 msgstr ""
 
@@ -6467,7 +6467,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:459
+#: lxc/remote.go:477
 msgid "n"
 msgstr ""
 
@@ -6479,7 +6479,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:452
+#: lxc/remote.go:470
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6516,7 +6516,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:461
+#: lxc/remote.go:479
 msgid "y"
 msgstr ""
 

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-01 10:44+0100\n"
+"POT-Creation-Date: 2024-10-18 13:21+0000\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Heimen Stoffels <vistausss@fastmail.com>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/linux-containers/"
@@ -572,15 +572,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:830 lxc/remote.go:887
+#: lxc/remote.go:848 lxc/remote.go:905
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:927
+#: lxc/remote.go:945
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:757
+#: lxc/remote.go:775
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -613,7 +613,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr "ARCHITECTUUR"
 
-#: lxc/remote.go:739
+#: lxc/remote.go:757
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -720,7 +720,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:564
+#: lxc/remote.go:582
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -752,7 +752,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:188
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -823,7 +823,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:550
+#: lxc/remote.go:568
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -996,7 +996,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:866
+#: lxc/remote.go:884
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1062,13 +1062,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:218
+#: lxc/remote.go:225
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:451
+#: lxc/remote.go:469
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1082,7 +1082,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:604
+#: lxc/remote.go:622
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1321,12 +1321,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:486
+#: lxc/remote.go:504
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:470
+#: lxc/remote.go:231 lxc/remote.go:488
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1355,7 +1355,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:481
+#: lxc/remote.go:499
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1647,8 +1647,8 @@ msgstr ""
 #: lxc/project.go:221 lxc/project.go:348 lxc/project.go:409 lxc/project.go:510
 #: lxc/project.go:567 lxc/project.go:646 lxc/project.go:677 lxc/project.go:730
 #: lxc/project.go:789 lxc/publish.go:33 lxc/query.go:34 lxc/remote.go:34
-#: lxc/remote.go:90 lxc/remote.go:632 lxc/remote.go:670 lxc/remote.go:760
-#: lxc/remote.go:833 lxc/remote.go:889 lxc/remote.go:929 lxc/rename.go:21
+#: lxc/remote.go:90 lxc/remote.go:650 lxc/remote.go:688 lxc/remote.go:778
+#: lxc/remote.go:851 lxc/remote.go:907 lxc/remote.go:947 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:92
 #: lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:340 lxc/storage.go:410
 #: lxc/storage.go:582 lxc/storage.go:661 lxc/storage.go:757 lxc/storage.go:843
@@ -2163,11 +2163,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:190
+#: lxc/remote.go:197
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:241
+#: lxc/remote.go:248
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2177,7 +2177,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:231
+#: lxc/remote.go:238
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2187,12 +2187,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:256
+#: lxc/remote.go:263
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:263
+#: lxc/remote.go:270
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2217,7 +2217,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:236
+#: lxc/remote.go:243
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2295,7 +2295,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:411
-#: lxc/project.go:791 lxc/remote.go:674 lxc/storage.go:584
+#: lxc/project.go:791 lxc/remote.go:692 lxc/storage.go:584
 #: lxc/storage_volume.go:1418 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -2332,7 +2332,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:742
+#: lxc/remote.go:760
 msgid "GLOBAL"
 msgstr ""
 
@@ -2348,7 +2348,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:397
+#: lxc/remote.go:159 lxc/remote.go:406
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2699,7 +2699,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:349
+#: lxc/remote.go:358
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2780,7 +2780,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:338
+#: lxc/remote.go:347
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3116,7 +3116,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:669 lxc/remote.go:670
+#: lxc/remote.go:687 lxc/remote.go:688
 msgid "List the available remotes"
 msgstr ""
 
@@ -3650,7 +3650,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:566
 #: lxc/network.go:976 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:487 lxc/remote.go:736 lxc/storage.go:634
+#: lxc/project.go:487 lxc/remote.go:754 lxc/storage.go:634
 #: lxc/storage_volume.go:1506
 msgid "NAME"
 msgstr ""
@@ -3672,8 +3672,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:953 lxc/operation.go:154 lxc/project.go:455
-#: lxc/project.go:460 lxc/project.go:465 lxc/project.go:470 lxc/remote.go:692
-#: lxc/remote.go:697 lxc/remote.go:702
+#: lxc/project.go:460 lxc/project.go:465 lxc/project.go:470 lxc/remote.go:710
+#: lxc/remote.go:715 lxc/remote.go:720
 msgid "NO"
 msgstr ""
 
@@ -3888,7 +3888,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:332
+#: lxc/remote.go:341
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -3955,11 +3955,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:738
+#: lxc/remote.go:756
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1070 lxc/remote.go:740
+#: lxc/image.go:1070 lxc/remote.go:758
 msgid "PUBLIC"
 msgstr ""
 
@@ -3988,7 +3988,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:182
+#: lxc/remote.go:189
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4000,7 +4000,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:462
+#: lxc/remote.go:480
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4301,33 +4301,33 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:790
+#: lxc/remote.go:808
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:756 lxc/remote.go:781 lxc/remote.go:854 lxc/remote.go:910
-#: lxc/remote.go:950
+#: lxc/project.go:756 lxc/remote.go:799 lxc/remote.go:872 lxc/remote.go:928
+#: lxc/remote.go:968
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:301
+#: lxc/remote.go:308
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:862
+#: lxc/remote.go:880
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:785 lxc/remote.go:858 lxc/remote.go:954
+#: lxc/remote.go:803 lxc/remote.go:876 lxc/remote.go:972
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:290
+#: lxc/remote.go:297
 msgid "Remote address must not be empty"
 msgstr ""
 
@@ -4335,7 +4335,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:295
+#: lxc/remote.go:302
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4393,7 +4393,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:832 lxc/remote.go:833
+#: lxc/remote.go:850 lxc/remote.go:851
 msgid "Remove remotes"
 msgstr ""
 
@@ -4442,7 +4442,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:759 lxc/remote.go:760
+#: lxc/remote.go:777 lxc/remote.go:778
 msgid "Rename remotes"
 msgstr ""
 
@@ -4579,7 +4579,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:741
+#: lxc/remote.go:759
 msgid "STATIC"
 msgstr ""
 
@@ -4607,11 +4607,11 @@ msgstr ""
 msgid "Server authentication type (tls or candid)"
 msgstr ""
 
-#: lxc/remote.go:460
+#: lxc/remote.go:478
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:600
+#: lxc/remote.go:618
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -4792,7 +4792,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:928 lxc/remote.go:929
+#: lxc/remote.go:946 lxc/remote.go:947
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -4968,7 +4968,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:631 lxc/remote.go:632
+#: lxc/remote.go:649 lxc/remote.go:650
 msgid "Show the default remote"
 msgstr ""
 
@@ -5156,7 +5156,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:888 lxc/remote.go:889
+#: lxc/remote.go:906 lxc/remote.go:907
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5494,7 +5494,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:180 lxc/remote.go:737
+#: lxc/cluster.go:180 lxc/remote.go:755
 msgid "URL"
 msgstr ""
 
@@ -5522,7 +5522,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:213 lxc/remote.go:247
+#: lxc/remote.go:220 lxc/remote.go:254
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -5802,8 +5802,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:955 lxc/operation.go:156 lxc/project.go:457
-#: lxc/project.go:462 lxc/project.go:467 lxc/project.go:472 lxc/remote.go:694
-#: lxc/remote.go:699 lxc/remote.go:704
+#: lxc/project.go:462 lxc/project.go:467 lxc/project.go:472 lxc/remote.go:712
+#: lxc/remote.go:717 lxc/remote.go:722
 msgid "YES"
 msgstr ""
 
@@ -6368,7 +6368,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:477 lxc/remote.go:727
+#: lxc/project.go:477 lxc/remote.go:745
 msgid "current"
 msgstr ""
 
@@ -6659,7 +6659,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:459
+#: lxc/remote.go:477
 msgid "n"
 msgstr ""
 
@@ -6671,7 +6671,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:452
+#: lxc/remote.go:470
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6708,7 +6708,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:461
+#: lxc/remote.go:479
 msgid "y"
 msgstr ""
 

--- a/po/pa.po
+++ b/po/pa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-01 10:44+0100\n"
+"POT-Creation-Date: 2024-10-18 13:21+0000\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Punjabi <https://hosted.weblate.org/projects/linux-containers/"
@@ -380,15 +380,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:830 lxc/remote.go:887
+#: lxc/remote.go:848 lxc/remote.go:905
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:927
+#: lxc/remote.go:945
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:757
+#: lxc/remote.go:775
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -421,7 +421,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:739
+#: lxc/remote.go:757
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -528,7 +528,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:564
+#: lxc/remote.go:582
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -560,7 +560,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:188
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -631,7 +631,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:550
+#: lxc/remote.go:568
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -804,7 +804,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:866
+#: lxc/remote.go:884
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -870,13 +870,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:218
+#: lxc/remote.go:225
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:451
+#: lxc/remote.go:469
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -890,7 +890,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:604
+#: lxc/remote.go:622
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1129,12 +1129,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:486
+#: lxc/remote.go:504
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:470
+#: lxc/remote.go:231 lxc/remote.go:488
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1163,7 +1163,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:481
+#: lxc/remote.go:499
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1455,8 +1455,8 @@ msgstr ""
 #: lxc/project.go:221 lxc/project.go:348 lxc/project.go:409 lxc/project.go:510
 #: lxc/project.go:567 lxc/project.go:646 lxc/project.go:677 lxc/project.go:730
 #: lxc/project.go:789 lxc/publish.go:33 lxc/query.go:34 lxc/remote.go:34
-#: lxc/remote.go:90 lxc/remote.go:632 lxc/remote.go:670 lxc/remote.go:760
-#: lxc/remote.go:833 lxc/remote.go:889 lxc/remote.go:929 lxc/rename.go:21
+#: lxc/remote.go:90 lxc/remote.go:650 lxc/remote.go:688 lxc/remote.go:778
+#: lxc/remote.go:851 lxc/remote.go:907 lxc/remote.go:947 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:92
 #: lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:340 lxc/storage.go:410
 #: lxc/storage.go:582 lxc/storage.go:661 lxc/storage.go:757 lxc/storage.go:843
@@ -1971,11 +1971,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:190
+#: lxc/remote.go:197
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:241
+#: lxc/remote.go:248
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -1985,7 +1985,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:231
+#: lxc/remote.go:238
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -1995,12 +1995,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:256
+#: lxc/remote.go:263
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:263
+#: lxc/remote.go:270
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2025,7 +2025,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:236
+#: lxc/remote.go:243
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2103,7 +2103,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:411
-#: lxc/project.go:791 lxc/remote.go:674 lxc/storage.go:584
+#: lxc/project.go:791 lxc/remote.go:692 lxc/storage.go:584
 #: lxc/storage_volume.go:1418 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -2140,7 +2140,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:742
+#: lxc/remote.go:760
 msgid "GLOBAL"
 msgstr ""
 
@@ -2156,7 +2156,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:397
+#: lxc/remote.go:159 lxc/remote.go:406
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2507,7 +2507,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:349
+#: lxc/remote.go:358
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2588,7 +2588,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:338
+#: lxc/remote.go:347
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -2924,7 +2924,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:669 lxc/remote.go:670
+#: lxc/remote.go:687 lxc/remote.go:688
 msgid "List the available remotes"
 msgstr ""
 
@@ -3458,7 +3458,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:566
 #: lxc/network.go:976 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:487 lxc/remote.go:736 lxc/storage.go:634
+#: lxc/project.go:487 lxc/remote.go:754 lxc/storage.go:634
 #: lxc/storage_volume.go:1506
 msgid "NAME"
 msgstr ""
@@ -3480,8 +3480,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:953 lxc/operation.go:154 lxc/project.go:455
-#: lxc/project.go:460 lxc/project.go:465 lxc/project.go:470 lxc/remote.go:692
-#: lxc/remote.go:697 lxc/remote.go:702
+#: lxc/project.go:460 lxc/project.go:465 lxc/project.go:470 lxc/remote.go:710
+#: lxc/remote.go:715 lxc/remote.go:720
 msgid "NO"
 msgstr ""
 
@@ -3696,7 +3696,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:332
+#: lxc/remote.go:341
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -3763,11 +3763,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:738
+#: lxc/remote.go:756
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1070 lxc/remote.go:740
+#: lxc/image.go:1070 lxc/remote.go:758
 msgid "PUBLIC"
 msgstr ""
 
@@ -3796,7 +3796,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:182
+#: lxc/remote.go:189
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -3808,7 +3808,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:462
+#: lxc/remote.go:480
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4109,33 +4109,33 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:790
+#: lxc/remote.go:808
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:756 lxc/remote.go:781 lxc/remote.go:854 lxc/remote.go:910
-#: lxc/remote.go:950
+#: lxc/project.go:756 lxc/remote.go:799 lxc/remote.go:872 lxc/remote.go:928
+#: lxc/remote.go:968
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:301
+#: lxc/remote.go:308
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:862
+#: lxc/remote.go:880
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:785 lxc/remote.go:858 lxc/remote.go:954
+#: lxc/remote.go:803 lxc/remote.go:876 lxc/remote.go:972
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:290
+#: lxc/remote.go:297
 msgid "Remote address must not be empty"
 msgstr ""
 
@@ -4143,7 +4143,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:295
+#: lxc/remote.go:302
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4201,7 +4201,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:832 lxc/remote.go:833
+#: lxc/remote.go:850 lxc/remote.go:851
 msgid "Remove remotes"
 msgstr ""
 
@@ -4250,7 +4250,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:759 lxc/remote.go:760
+#: lxc/remote.go:777 lxc/remote.go:778
 msgid "Rename remotes"
 msgstr ""
 
@@ -4387,7 +4387,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:741
+#: lxc/remote.go:759
 msgid "STATIC"
 msgstr ""
 
@@ -4415,11 +4415,11 @@ msgstr ""
 msgid "Server authentication type (tls or candid)"
 msgstr ""
 
-#: lxc/remote.go:460
+#: lxc/remote.go:478
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:600
+#: lxc/remote.go:618
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -4600,7 +4600,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:928 lxc/remote.go:929
+#: lxc/remote.go:946 lxc/remote.go:947
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -4776,7 +4776,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:631 lxc/remote.go:632
+#: lxc/remote.go:649 lxc/remote.go:650
 msgid "Show the default remote"
 msgstr ""
 
@@ -4964,7 +4964,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:888 lxc/remote.go:889
+#: lxc/remote.go:906 lxc/remote.go:907
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5302,7 +5302,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:180 lxc/remote.go:737
+#: lxc/cluster.go:180 lxc/remote.go:755
 msgid "URL"
 msgstr ""
 
@@ -5330,7 +5330,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:213 lxc/remote.go:247
+#: lxc/remote.go:220 lxc/remote.go:254
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -5610,8 +5610,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:955 lxc/operation.go:156 lxc/project.go:457
-#: lxc/project.go:462 lxc/project.go:467 lxc/project.go:472 lxc/remote.go:694
-#: lxc/remote.go:699 lxc/remote.go:704
+#: lxc/project.go:462 lxc/project.go:467 lxc/project.go:472 lxc/remote.go:712
+#: lxc/remote.go:717 lxc/remote.go:722
 msgid "YES"
 msgstr ""
 
@@ -6176,7 +6176,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:477 lxc/remote.go:727
+#: lxc/project.go:477 lxc/remote.go:745
 msgid "current"
 msgstr ""
 
@@ -6467,7 +6467,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:459
+#: lxc/remote.go:477
 msgid "n"
 msgstr ""
 
@@ -6479,7 +6479,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:452
+#: lxc/remote.go:470
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6516,7 +6516,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:461
+#: lxc/remote.go:479
 msgid "y"
 msgstr ""
 

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-01 10:44+0100\n"
+"POT-Creation-Date: 2024-10-18 13:21+0000\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/linux-containers/"
@@ -602,15 +602,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:830 lxc/remote.go:887
+#: lxc/remote.go:848 lxc/remote.go:905
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:927
+#: lxc/remote.go:945
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:757
+#: lxc/remote.go:775
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -643,7 +643,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:739
+#: lxc/remote.go:757
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -750,7 +750,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:564
+#: lxc/remote.go:582
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -782,7 +782,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:188
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -853,7 +853,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:550
+#: lxc/remote.go:568
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -1026,7 +1026,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:866
+#: lxc/remote.go:884
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1092,13 +1092,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:218
+#: lxc/remote.go:225
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:451
+#: lxc/remote.go:469
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1112,7 +1112,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:604
+#: lxc/remote.go:622
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1351,12 +1351,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:486
+#: lxc/remote.go:504
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:470
+#: lxc/remote.go:231 lxc/remote.go:488
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1385,7 +1385,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:481
+#: lxc/remote.go:499
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1677,8 +1677,8 @@ msgstr ""
 #: lxc/project.go:221 lxc/project.go:348 lxc/project.go:409 lxc/project.go:510
 #: lxc/project.go:567 lxc/project.go:646 lxc/project.go:677 lxc/project.go:730
 #: lxc/project.go:789 lxc/publish.go:33 lxc/query.go:34 lxc/remote.go:34
-#: lxc/remote.go:90 lxc/remote.go:632 lxc/remote.go:670 lxc/remote.go:760
-#: lxc/remote.go:833 lxc/remote.go:889 lxc/remote.go:929 lxc/rename.go:21
+#: lxc/remote.go:90 lxc/remote.go:650 lxc/remote.go:688 lxc/remote.go:778
+#: lxc/remote.go:851 lxc/remote.go:907 lxc/remote.go:947 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:92
 #: lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:340 lxc/storage.go:410
 #: lxc/storage.go:582 lxc/storage.go:661 lxc/storage.go:757 lxc/storage.go:843
@@ -2193,11 +2193,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:190
+#: lxc/remote.go:197
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:241
+#: lxc/remote.go:248
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2207,7 +2207,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:231
+#: lxc/remote.go:238
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2217,12 +2217,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:256
+#: lxc/remote.go:263
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:263
+#: lxc/remote.go:270
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2247,7 +2247,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:236
+#: lxc/remote.go:243
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2325,7 +2325,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:411
-#: lxc/project.go:791 lxc/remote.go:674 lxc/storage.go:584
+#: lxc/project.go:791 lxc/remote.go:692 lxc/storage.go:584
 #: lxc/storage_volume.go:1418 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -2362,7 +2362,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:742
+#: lxc/remote.go:760
 msgid "GLOBAL"
 msgstr ""
 
@@ -2378,7 +2378,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:397
+#: lxc/remote.go:159 lxc/remote.go:406
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2729,7 +2729,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:349
+#: lxc/remote.go:358
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2810,7 +2810,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:338
+#: lxc/remote.go:347
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3146,7 +3146,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:669 lxc/remote.go:670
+#: lxc/remote.go:687 lxc/remote.go:688
 msgid "List the available remotes"
 msgstr ""
 
@@ -3680,7 +3680,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:566
 #: lxc/network.go:976 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:487 lxc/remote.go:736 lxc/storage.go:634
+#: lxc/project.go:487 lxc/remote.go:754 lxc/storage.go:634
 #: lxc/storage_volume.go:1506
 msgid "NAME"
 msgstr ""
@@ -3702,8 +3702,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:953 lxc/operation.go:154 lxc/project.go:455
-#: lxc/project.go:460 lxc/project.go:465 lxc/project.go:470 lxc/remote.go:692
-#: lxc/remote.go:697 lxc/remote.go:702
+#: lxc/project.go:460 lxc/project.go:465 lxc/project.go:470 lxc/remote.go:710
+#: lxc/remote.go:715 lxc/remote.go:720
 msgid "NO"
 msgstr ""
 
@@ -3918,7 +3918,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:332
+#: lxc/remote.go:341
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -3985,11 +3985,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:738
+#: lxc/remote.go:756
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1070 lxc/remote.go:740
+#: lxc/image.go:1070 lxc/remote.go:758
 msgid "PUBLIC"
 msgstr ""
 
@@ -4018,7 +4018,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:182
+#: lxc/remote.go:189
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4030,7 +4030,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:462
+#: lxc/remote.go:480
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4331,33 +4331,33 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:790
+#: lxc/remote.go:808
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:756 lxc/remote.go:781 lxc/remote.go:854 lxc/remote.go:910
-#: lxc/remote.go:950
+#: lxc/project.go:756 lxc/remote.go:799 lxc/remote.go:872 lxc/remote.go:928
+#: lxc/remote.go:968
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:301
+#: lxc/remote.go:308
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:862
+#: lxc/remote.go:880
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:785 lxc/remote.go:858 lxc/remote.go:954
+#: lxc/remote.go:803 lxc/remote.go:876 lxc/remote.go:972
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:290
+#: lxc/remote.go:297
 msgid "Remote address must not be empty"
 msgstr ""
 
@@ -4365,7 +4365,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:295
+#: lxc/remote.go:302
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4423,7 +4423,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:832 lxc/remote.go:833
+#: lxc/remote.go:850 lxc/remote.go:851
 msgid "Remove remotes"
 msgstr ""
 
@@ -4472,7 +4472,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:759 lxc/remote.go:760
+#: lxc/remote.go:777 lxc/remote.go:778
 msgid "Rename remotes"
 msgstr ""
 
@@ -4609,7 +4609,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:741
+#: lxc/remote.go:759
 msgid "STATIC"
 msgstr ""
 
@@ -4637,11 +4637,11 @@ msgstr ""
 msgid "Server authentication type (tls or candid)"
 msgstr ""
 
-#: lxc/remote.go:460
+#: lxc/remote.go:478
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:600
+#: lxc/remote.go:618
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -4822,7 +4822,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:928 lxc/remote.go:929
+#: lxc/remote.go:946 lxc/remote.go:947
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -4998,7 +4998,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:631 lxc/remote.go:632
+#: lxc/remote.go:649 lxc/remote.go:650
 msgid "Show the default remote"
 msgstr ""
 
@@ -5186,7 +5186,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:888 lxc/remote.go:889
+#: lxc/remote.go:906 lxc/remote.go:907
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5524,7 +5524,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:180 lxc/remote.go:737
+#: lxc/cluster.go:180 lxc/remote.go:755
 msgid "URL"
 msgstr ""
 
@@ -5552,7 +5552,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:213 lxc/remote.go:247
+#: lxc/remote.go:220 lxc/remote.go:254
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -5832,8 +5832,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:955 lxc/operation.go:156 lxc/project.go:457
-#: lxc/project.go:462 lxc/project.go:467 lxc/project.go:472 lxc/remote.go:694
-#: lxc/remote.go:699 lxc/remote.go:704
+#: lxc/project.go:462 lxc/project.go:467 lxc/project.go:472 lxc/remote.go:712
+#: lxc/remote.go:717 lxc/remote.go:722
 msgid "YES"
 msgstr ""
 
@@ -6398,7 +6398,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:477 lxc/remote.go:727
+#: lxc/project.go:477 lxc/remote.go:745
 msgid "current"
 msgstr ""
 
@@ -6689,7 +6689,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:459
+#: lxc/remote.go:477
 msgid "n"
 msgstr ""
 
@@ -6701,7 +6701,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:452
+#: lxc/remote.go:470
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6738,7 +6738,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:461
+#: lxc/remote.go:479
 msgid "y"
 msgstr ""
 

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-01 10:44+0100\n"
+"POT-Creation-Date: 2024-10-18 13:21+0000\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Renato dos Santos <renato.santos@wplex.com.br>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -600,15 +600,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:830 lxc/remote.go:887
+#: lxc/remote.go:848 lxc/remote.go:905
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:927
+#: lxc/remote.go:945
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:757
+#: lxc/remote.go:775
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -642,7 +642,7 @@ msgstr "ALIASES"
 msgid "ARCHITECTURE"
 msgstr "ARQUITETURA"
 
-#: lxc/remote.go:739
+#: lxc/remote.go:757
 msgid "AUTH TYPE"
 msgstr "TIPO DE AUTENTICAÇÃO"
 
@@ -757,7 +757,7 @@ msgstr "Adicionar perfis aos containers"
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:564
+#: lxc/remote.go:582
 #, fuzzy, c-format
 msgid "Admin password (or token) for %s:"
 msgstr "Senha de administrador para %s: "
@@ -790,7 +790,7 @@ msgstr "Aliases:"
 msgid "All projects"
 msgstr "Criar projetos"
 
-#: lxc/remote.go:181
+#: lxc/remote.go:188
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -868,7 +868,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:550
+#: lxc/remote.go:568
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr "Tipo de autenticação '%s' não suportada pelo servidor"
@@ -1043,7 +1043,7 @@ msgstr "Não pode pegar um diretório sem --recursive"
 msgid "Can't read from stdin: %w"
 msgstr "Não é possível ler stdin: %s"
 
-#: lxc/remote.go:866
+#: lxc/remote.go:884
 msgid "Can't remove the default remote"
 msgstr "Não é possível remover o default remoto"
 
@@ -1110,13 +1110,13 @@ msgstr "Em cache: %s"
 msgid "Certificate add token for %s deleted"
 msgstr "Clustering ativado"
 
-#: lxc/remote.go:218
+#: lxc/remote.go:225
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:451
+#: lxc/remote.go:469
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr "Certificado fingerprint: %s"
@@ -1130,7 +1130,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr "Nome de membro do cluster"
 
-#: lxc/remote.go:604
+#: lxc/remote.go:622
 #, fuzzy
 msgid "Client certificate now trusted by server:"
 msgstr "Certificado do cliente armazenado no servidor: "
@@ -1381,12 +1381,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:486
+#: lxc/remote.go:504
 #, fuzzy, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "Impossível criar diretório para certificado do servidor"
 
-#: lxc/remote.go:224 lxc/remote.go:470
+#: lxc/remote.go:231 lxc/remote.go:488
 msgid "Could not create server cert dir"
 msgstr "Impossível criar diretório para certificado do servidor"
 
@@ -1415,7 +1415,7 @@ msgstr "Certificado fingerprint: %s"
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:481
+#: lxc/remote.go:499
 #, fuzzy, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "Impossível criar diretório para certificado do servidor"
@@ -1730,8 +1730,8 @@ msgstr ""
 #: lxc/project.go:221 lxc/project.go:348 lxc/project.go:409 lxc/project.go:510
 #: lxc/project.go:567 lxc/project.go:646 lxc/project.go:677 lxc/project.go:730
 #: lxc/project.go:789 lxc/publish.go:33 lxc/query.go:34 lxc/remote.go:34
-#: lxc/remote.go:90 lxc/remote.go:632 lxc/remote.go:670 lxc/remote.go:760
-#: lxc/remote.go:833 lxc/remote.go:889 lxc/remote.go:929 lxc/rename.go:21
+#: lxc/remote.go:90 lxc/remote.go:650 lxc/remote.go:688 lxc/remote.go:778
+#: lxc/remote.go:851 lxc/remote.go:907 lxc/remote.go:947 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:92
 #: lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:340 lxc/storage.go:410
 #: lxc/storage.go:582 lxc/storage.go:661 lxc/storage.go:757 lxc/storage.go:843
@@ -2266,11 +2266,11 @@ msgstr "Aceitar certificado"
 msgid "Failed to accept incoming connection: %w"
 msgstr "Aceitar certificado"
 
-#: lxc/remote.go:190
+#: lxc/remote.go:197
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:241
+#: lxc/remote.go:248
 #, fuzzy, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr "Aceitar certificado"
@@ -2280,7 +2280,7 @@ msgstr "Aceitar certificado"
 msgid "Failed to connect to cluster member: %w"
 msgstr "Nome de membro do cluster"
 
-#: lxc/remote.go:231
+#: lxc/remote.go:238
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2290,12 +2290,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr "Aceitar certificado"
 
-#: lxc/remote.go:256
+#: lxc/remote.go:263
 #, fuzzy, c-format
 msgid "Failed to create certificate: %w"
 msgstr "Aceitar certificado"
 
-#: lxc/remote.go:263
+#: lxc/remote.go:270
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2320,7 +2320,7 @@ msgstr "Aceitar certificado"
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:236
+#: lxc/remote.go:243
 #, fuzzy, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr "Aceitar certificado"
@@ -2399,7 +2399,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:411
-#: lxc/project.go:791 lxc/remote.go:674 lxc/storage.go:584
+#: lxc/project.go:791 lxc/remote.go:692 lxc/storage.go:584
 #: lxc/storage_volume.go:1418 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -2436,7 +2436,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:742
+#: lxc/remote.go:760
 msgid "GLOBAL"
 msgstr ""
 
@@ -2452,7 +2452,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:397
+#: lxc/remote.go:159 lxc/remote.go:406
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2820,7 +2820,7 @@ msgstr "Certificado fingerprint: %s"
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:349
+#: lxc/remote.go:358
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2902,7 +2902,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:338
+#: lxc/remote.go:347
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3246,7 +3246,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:669 lxc/remote.go:670
+#: lxc/remote.go:687 lxc/remote.go:688
 msgid "List the available remotes"
 msgstr ""
 
@@ -3808,7 +3808,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:566
 #: lxc/network.go:976 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:487 lxc/remote.go:736 lxc/storage.go:634
+#: lxc/project.go:487 lxc/remote.go:754 lxc/storage.go:634
 #: lxc/storage_volume.go:1506
 msgid "NAME"
 msgstr ""
@@ -3830,8 +3830,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:953 lxc/operation.go:154 lxc/project.go:455
-#: lxc/project.go:460 lxc/project.go:465 lxc/project.go:470 lxc/remote.go:692
-#: lxc/remote.go:697 lxc/remote.go:702
+#: lxc/project.go:460 lxc/project.go:465 lxc/project.go:470 lxc/remote.go:710
+#: lxc/remote.go:715 lxc/remote.go:720
 msgid "NO"
 msgstr ""
 
@@ -4046,7 +4046,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:332
+#: lxc/remote.go:341
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4113,11 +4113,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:738
+#: lxc/remote.go:756
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1070 lxc/remote.go:740
+#: lxc/image.go:1070 lxc/remote.go:758
 msgid "PUBLIC"
 msgstr ""
 
@@ -4146,7 +4146,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:182
+#: lxc/remote.go:189
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4159,7 +4159,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr "Nome de membro do cluster"
 
-#: lxc/remote.go:462
+#: lxc/remote.go:480
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4465,33 +4465,33 @@ msgstr "Editar arquivos no container"
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:790
+#: lxc/remote.go:808
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:756 lxc/remote.go:781 lxc/remote.go:854 lxc/remote.go:910
-#: lxc/remote.go:950
+#: lxc/project.go:756 lxc/remote.go:799 lxc/remote.go:872 lxc/remote.go:928
+#: lxc/remote.go:968
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:301
+#: lxc/remote.go:308
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:862
+#: lxc/remote.go:880
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:785 lxc/remote.go:858 lxc/remote.go:954
+#: lxc/remote.go:803 lxc/remote.go:876 lxc/remote.go:972
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:290
+#: lxc/remote.go:297
 msgid "Remote address must not be empty"
 msgstr ""
 
@@ -4499,7 +4499,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:295
+#: lxc/remote.go:302
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4562,7 +4562,7 @@ msgstr "Adicionar perfis aos containers"
 msgid "Remove profiles from instances"
 msgstr "Adicionar perfis aos containers"
 
-#: lxc/remote.go:832 lxc/remote.go:833
+#: lxc/remote.go:850 lxc/remote.go:851
 msgid "Remove remotes"
 msgstr ""
 
@@ -4615,7 +4615,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:759 lxc/remote.go:760
+#: lxc/remote.go:777 lxc/remote.go:778
 msgid "Rename remotes"
 msgstr ""
 
@@ -4762,7 +4762,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:741
+#: lxc/remote.go:759
 msgid "STATIC"
 msgstr ""
 
@@ -4790,11 +4790,11 @@ msgstr ""
 msgid "Server authentication type (tls or candid)"
 msgstr ""
 
-#: lxc/remote.go:460
+#: lxc/remote.go:478
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:600
+#: lxc/remote.go:618
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -4985,7 +4985,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:928 lxc/remote.go:929
+#: lxc/remote.go:946 lxc/remote.go:947
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5180,7 +5180,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: lxc/remote.go:631 lxc/remote.go:632
+#: lxc/remote.go:649 lxc/remote.go:650
 msgid "Show the default remote"
 msgstr ""
 
@@ -5370,7 +5370,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:888 lxc/remote.go:889
+#: lxc/remote.go:906 lxc/remote.go:907
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5715,7 +5715,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:180 lxc/remote.go:737
+#: lxc/cluster.go:180 lxc/remote.go:755
 msgid "URL"
 msgstr ""
 
@@ -5743,7 +5743,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:213 lxc/remote.go:247
+#: lxc/remote.go:220 lxc/remote.go:254
 #, fuzzy
 msgid "Unavailable remote server"
 msgstr "Adicionar novos servidores remoto"
@@ -6044,8 +6044,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:955 lxc/operation.go:156 lxc/project.go:457
-#: lxc/project.go:462 lxc/project.go:467 lxc/project.go:472 lxc/remote.go:694
-#: lxc/remote.go:699 lxc/remote.go:704
+#: lxc/project.go:462 lxc/project.go:467 lxc/project.go:472 lxc/remote.go:712
+#: lxc/remote.go:717 lxc/remote.go:722
 msgid "YES"
 msgstr ""
 
@@ -6667,7 +6667,7 @@ msgstr "Criar perfis"
 msgid "[[<remote>:]<name>]"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/project.go:477 lxc/remote.go:727
+#: lxc/project.go:477 lxc/remote.go:745
 msgid "current"
 msgstr ""
 
@@ -6958,7 +6958,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:459
+#: lxc/remote.go:477
 msgid "n"
 msgstr ""
 
@@ -6970,7 +6970,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:452
+#: lxc/remote.go:470
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7007,7 +7007,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:461
+#: lxc/remote.go:479
 msgid "y"
 msgstr ""
 

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-01 10:44+0100\n"
+"POT-Creation-Date: 2024-10-18 13:21+0000\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Александр Киль <shorrey@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -600,15 +600,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:830 lxc/remote.go:887
+#: lxc/remote.go:848 lxc/remote.go:905
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:927
+#: lxc/remote.go:945
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:757
+#: lxc/remote.go:775
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -646,7 +646,7 @@ msgstr "ПСЕВДОНИМ"
 msgid "ARCHITECTURE"
 msgstr "АРХИТЕКТУРА"
 
-#: lxc/remote.go:739
+#: lxc/remote.go:757
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -758,7 +758,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:564
+#: lxc/remote.go:582
 #, fuzzy, c-format
 msgid "Admin password (or token) for %s:"
 msgstr "Пароль администратора для %s: "
@@ -791,7 +791,7 @@ msgstr "Псевдонимы:"
 msgid "All projects"
 msgstr "Доступные команды:"
 
-#: lxc/remote.go:181
+#: lxc/remote.go:188
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -865,7 +865,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:550
+#: lxc/remote.go:568
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -1041,7 +1041,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr "Невозможно прочитать из стандартного ввода: %s"
 
-#: lxc/remote.go:866
+#: lxc/remote.go:884
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -1107,13 +1107,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr " Использование сети:"
 
-#: lxc/remote.go:218
+#: lxc/remote.go:225
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:451
+#: lxc/remote.go:469
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1127,7 +1127,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr "Копирование образа: %s"
 
-#: lxc/remote.go:604
+#: lxc/remote.go:622
 #, fuzzy
 msgid "Client certificate now trusted by server:"
 msgstr "Сертификат клиента хранится на сервере: "
@@ -1369,12 +1369,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:486
+#: lxc/remote.go:504
 #, fuzzy, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr "Не удалось создать каталог сертификата сервера"
 
-#: lxc/remote.go:224 lxc/remote.go:470
+#: lxc/remote.go:231 lxc/remote.go:488
 msgid "Could not create server cert dir"
 msgstr "Не удалось создать каталог сертификата сервера"
 
@@ -1403,7 +1403,7 @@ msgstr "Не удалось очистить путь %s"
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:481
+#: lxc/remote.go:499
 #, fuzzy, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr "Не удалось создать каталог сертификата сервера"
@@ -1714,8 +1714,8 @@ msgstr ""
 #: lxc/project.go:221 lxc/project.go:348 lxc/project.go:409 lxc/project.go:510
 #: lxc/project.go:567 lxc/project.go:646 lxc/project.go:677 lxc/project.go:730
 #: lxc/project.go:789 lxc/publish.go:33 lxc/query.go:34 lxc/remote.go:34
-#: lxc/remote.go:90 lxc/remote.go:632 lxc/remote.go:670 lxc/remote.go:760
-#: lxc/remote.go:833 lxc/remote.go:889 lxc/remote.go:929 lxc/rename.go:21
+#: lxc/remote.go:90 lxc/remote.go:650 lxc/remote.go:688 lxc/remote.go:778
+#: lxc/remote.go:851 lxc/remote.go:907 lxc/remote.go:947 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:92
 #: lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:340 lxc/storage.go:410
 #: lxc/storage.go:582 lxc/storage.go:661 lxc/storage.go:757 lxc/storage.go:843
@@ -2250,11 +2250,11 @@ msgstr "Принять сертификат"
 msgid "Failed to accept incoming connection: %w"
 msgstr "Принять сертификат"
 
-#: lxc/remote.go:190
+#: lxc/remote.go:197
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:241
+#: lxc/remote.go:248
 #, fuzzy, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr "Принять сертификат"
@@ -2264,7 +2264,7 @@ msgstr "Принять сертификат"
 msgid "Failed to connect to cluster member: %w"
 msgstr "Копирование образа: %s"
 
-#: lxc/remote.go:231
+#: lxc/remote.go:238
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2274,12 +2274,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr "Принять сертификат"
 
-#: lxc/remote.go:256
+#: lxc/remote.go:263
 #, fuzzy, c-format
 msgid "Failed to create certificate: %w"
 msgstr "Принять сертификат"
 
-#: lxc/remote.go:263
+#: lxc/remote.go:270
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2304,7 +2304,7 @@ msgstr "Принять сертификат"
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:236
+#: lxc/remote.go:243
 #, fuzzy, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr "Принять сертификат"
@@ -2383,7 +2383,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:411
-#: lxc/project.go:791 lxc/remote.go:674 lxc/storage.go:584
+#: lxc/project.go:791 lxc/remote.go:692 lxc/storage.go:584
 #: lxc/storage_volume.go:1418 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -2420,7 +2420,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:742
+#: lxc/remote.go:760
 msgid "GLOBAL"
 msgstr ""
 
@@ -2436,7 +2436,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:397
+#: lxc/remote.go:159 lxc/remote.go:406
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2804,7 +2804,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:349
+#: lxc/remote.go:358
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2886,7 +2886,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:338
+#: lxc/remote.go:347
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3234,7 +3234,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:669 lxc/remote.go:670
+#: lxc/remote.go:687 lxc/remote.go:688
 msgid "List the available remotes"
 msgstr ""
 
@@ -3802,7 +3802,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:566
 #: lxc/network.go:976 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:487 lxc/remote.go:736 lxc/storage.go:634
+#: lxc/project.go:487 lxc/remote.go:754 lxc/storage.go:634
 #: lxc/storage_volume.go:1506
 msgid "NAME"
 msgstr ""
@@ -3824,8 +3824,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:953 lxc/operation.go:154 lxc/project.go:455
-#: lxc/project.go:460 lxc/project.go:465 lxc/project.go:470 lxc/remote.go:692
-#: lxc/remote.go:697 lxc/remote.go:702
+#: lxc/project.go:460 lxc/project.go:465 lxc/project.go:470 lxc/remote.go:710
+#: lxc/remote.go:715 lxc/remote.go:720
 msgid "NO"
 msgstr ""
 
@@ -4044,7 +4044,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:332
+#: lxc/remote.go:341
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -4111,11 +4111,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:738
+#: lxc/remote.go:756
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1070 lxc/remote.go:740
+#: lxc/image.go:1070 lxc/remote.go:758
 msgid "PUBLIC"
 msgstr ""
 
@@ -4144,7 +4144,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:182
+#: lxc/remote.go:189
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -4157,7 +4157,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr "Копирование образа: %s"
 
-#: lxc/remote.go:462
+#: lxc/remote.go:480
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4460,33 +4460,33 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Refreshing the image: %s"
 msgstr "Копирование образа: %s"
 
-#: lxc/remote.go:790
+#: lxc/remote.go:808
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:756 lxc/remote.go:781 lxc/remote.go:854 lxc/remote.go:910
-#: lxc/remote.go:950
+#: lxc/project.go:756 lxc/remote.go:799 lxc/remote.go:872 lxc/remote.go:928
+#: lxc/remote.go:968
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:301
+#: lxc/remote.go:308
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:862
+#: lxc/remote.go:880
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:785 lxc/remote.go:858 lxc/remote.go:954
+#: lxc/remote.go:803 lxc/remote.go:876 lxc/remote.go:972
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:290
+#: lxc/remote.go:297
 msgid "Remote address must not be empty"
 msgstr ""
 
@@ -4494,7 +4494,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:295
+#: lxc/remote.go:302
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4555,7 +4555,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:832 lxc/remote.go:833
+#: lxc/remote.go:850 lxc/remote.go:851
 msgid "Remove remotes"
 msgstr ""
 
@@ -4606,7 +4606,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:759 lxc/remote.go:760
+#: lxc/remote.go:777 lxc/remote.go:778
 msgid "Rename remotes"
 msgstr ""
 
@@ -4752,7 +4752,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:741
+#: lxc/remote.go:759
 msgid "STATIC"
 msgstr ""
 
@@ -4780,11 +4780,11 @@ msgstr ""
 msgid "Server authentication type (tls or candid)"
 msgstr ""
 
-#: lxc/remote.go:460
+#: lxc/remote.go:478
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:600
+#: lxc/remote.go:618
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -4970,7 +4970,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:928 lxc/remote.go:929
+#: lxc/remote.go:946 lxc/remote.go:947
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -5161,7 +5161,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr "Копирование образа: %s"
 
-#: lxc/remote.go:631 lxc/remote.go:632
+#: lxc/remote.go:649 lxc/remote.go:650
 msgid "Show the default remote"
 msgstr ""
 
@@ -5355,7 +5355,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:888 lxc/remote.go:889
+#: lxc/remote.go:906 lxc/remote.go:907
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5695,7 +5695,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:180 lxc/remote.go:737
+#: lxc/cluster.go:180 lxc/remote.go:755
 msgid "URL"
 msgstr ""
 
@@ -5723,7 +5723,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:213 lxc/remote.go:247
+#: lxc/remote.go:220 lxc/remote.go:254
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -6018,8 +6018,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:955 lxc/operation.go:156 lxc/project.go:457
-#: lxc/project.go:462 lxc/project.go:467 lxc/project.go:472 lxc/remote.go:694
-#: lxc/remote.go:699 lxc/remote.go:704
+#: lxc/project.go:462 lxc/project.go:467 lxc/project.go:472 lxc/remote.go:712
+#: lxc/remote.go:717 lxc/remote.go:722
 msgid "YES"
 msgstr ""
 
@@ -7104,7 +7104,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/project.go:477 lxc/remote.go:727
+#: lxc/project.go:477 lxc/remote.go:745
 msgid "current"
 msgstr ""
 
@@ -7395,7 +7395,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:459
+#: lxc/remote.go:477
 msgid "n"
 msgstr ""
 
@@ -7407,7 +7407,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:452
+#: lxc/remote.go:470
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -7444,7 +7444,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:461
+#: lxc/remote.go:479
 msgid "y"
 msgstr ""
 

--- a/po/si.po
+++ b/po/si.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-01 10:44+0100\n"
+"POT-Creation-Date: 2024-10-18 13:21+0000\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Sinhala <https://hosted.weblate.org/projects/linux-containers/"
@@ -380,15 +380,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:830 lxc/remote.go:887
+#: lxc/remote.go:848 lxc/remote.go:905
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:927
+#: lxc/remote.go:945
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:757
+#: lxc/remote.go:775
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -421,7 +421,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:739
+#: lxc/remote.go:757
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -528,7 +528,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:564
+#: lxc/remote.go:582
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -560,7 +560,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:188
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -631,7 +631,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:550
+#: lxc/remote.go:568
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -804,7 +804,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:866
+#: lxc/remote.go:884
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -870,13 +870,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:218
+#: lxc/remote.go:225
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:451
+#: lxc/remote.go:469
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -890,7 +890,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:604
+#: lxc/remote.go:622
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1129,12 +1129,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:486
+#: lxc/remote.go:504
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:470
+#: lxc/remote.go:231 lxc/remote.go:488
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1163,7 +1163,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:481
+#: lxc/remote.go:499
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1455,8 +1455,8 @@ msgstr ""
 #: lxc/project.go:221 lxc/project.go:348 lxc/project.go:409 lxc/project.go:510
 #: lxc/project.go:567 lxc/project.go:646 lxc/project.go:677 lxc/project.go:730
 #: lxc/project.go:789 lxc/publish.go:33 lxc/query.go:34 lxc/remote.go:34
-#: lxc/remote.go:90 lxc/remote.go:632 lxc/remote.go:670 lxc/remote.go:760
-#: lxc/remote.go:833 lxc/remote.go:889 lxc/remote.go:929 lxc/rename.go:21
+#: lxc/remote.go:90 lxc/remote.go:650 lxc/remote.go:688 lxc/remote.go:778
+#: lxc/remote.go:851 lxc/remote.go:907 lxc/remote.go:947 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:92
 #: lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:340 lxc/storage.go:410
 #: lxc/storage.go:582 lxc/storage.go:661 lxc/storage.go:757 lxc/storage.go:843
@@ -1971,11 +1971,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:190
+#: lxc/remote.go:197
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:241
+#: lxc/remote.go:248
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -1985,7 +1985,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:231
+#: lxc/remote.go:238
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -1995,12 +1995,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:256
+#: lxc/remote.go:263
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:263
+#: lxc/remote.go:270
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2025,7 +2025,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:236
+#: lxc/remote.go:243
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2103,7 +2103,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:411
-#: lxc/project.go:791 lxc/remote.go:674 lxc/storage.go:584
+#: lxc/project.go:791 lxc/remote.go:692 lxc/storage.go:584
 #: lxc/storage_volume.go:1418 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -2140,7 +2140,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:742
+#: lxc/remote.go:760
 msgid "GLOBAL"
 msgstr ""
 
@@ -2156,7 +2156,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:397
+#: lxc/remote.go:159 lxc/remote.go:406
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2507,7 +2507,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:349
+#: lxc/remote.go:358
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2588,7 +2588,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:338
+#: lxc/remote.go:347
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -2924,7 +2924,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:669 lxc/remote.go:670
+#: lxc/remote.go:687 lxc/remote.go:688
 msgid "List the available remotes"
 msgstr ""
 
@@ -3458,7 +3458,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:566
 #: lxc/network.go:976 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:487 lxc/remote.go:736 lxc/storage.go:634
+#: lxc/project.go:487 lxc/remote.go:754 lxc/storage.go:634
 #: lxc/storage_volume.go:1506
 msgid "NAME"
 msgstr ""
@@ -3480,8 +3480,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:953 lxc/operation.go:154 lxc/project.go:455
-#: lxc/project.go:460 lxc/project.go:465 lxc/project.go:470 lxc/remote.go:692
-#: lxc/remote.go:697 lxc/remote.go:702
+#: lxc/project.go:460 lxc/project.go:465 lxc/project.go:470 lxc/remote.go:710
+#: lxc/remote.go:715 lxc/remote.go:720
 msgid "NO"
 msgstr ""
 
@@ -3696,7 +3696,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:332
+#: lxc/remote.go:341
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -3763,11 +3763,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:738
+#: lxc/remote.go:756
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1070 lxc/remote.go:740
+#: lxc/image.go:1070 lxc/remote.go:758
 msgid "PUBLIC"
 msgstr ""
 
@@ -3796,7 +3796,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:182
+#: lxc/remote.go:189
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -3808,7 +3808,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:462
+#: lxc/remote.go:480
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4109,33 +4109,33 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:790
+#: lxc/remote.go:808
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:756 lxc/remote.go:781 lxc/remote.go:854 lxc/remote.go:910
-#: lxc/remote.go:950
+#: lxc/project.go:756 lxc/remote.go:799 lxc/remote.go:872 lxc/remote.go:928
+#: lxc/remote.go:968
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:301
+#: lxc/remote.go:308
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:862
+#: lxc/remote.go:880
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:785 lxc/remote.go:858 lxc/remote.go:954
+#: lxc/remote.go:803 lxc/remote.go:876 lxc/remote.go:972
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:290
+#: lxc/remote.go:297
 msgid "Remote address must not be empty"
 msgstr ""
 
@@ -4143,7 +4143,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:295
+#: lxc/remote.go:302
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4201,7 +4201,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:832 lxc/remote.go:833
+#: lxc/remote.go:850 lxc/remote.go:851
 msgid "Remove remotes"
 msgstr ""
 
@@ -4250,7 +4250,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:759 lxc/remote.go:760
+#: lxc/remote.go:777 lxc/remote.go:778
 msgid "Rename remotes"
 msgstr ""
 
@@ -4387,7 +4387,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:741
+#: lxc/remote.go:759
 msgid "STATIC"
 msgstr ""
 
@@ -4415,11 +4415,11 @@ msgstr ""
 msgid "Server authentication type (tls or candid)"
 msgstr ""
 
-#: lxc/remote.go:460
+#: lxc/remote.go:478
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:600
+#: lxc/remote.go:618
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -4600,7 +4600,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:928 lxc/remote.go:929
+#: lxc/remote.go:946 lxc/remote.go:947
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -4776,7 +4776,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:631 lxc/remote.go:632
+#: lxc/remote.go:649 lxc/remote.go:650
 msgid "Show the default remote"
 msgstr ""
 
@@ -4964,7 +4964,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:888 lxc/remote.go:889
+#: lxc/remote.go:906 lxc/remote.go:907
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5302,7 +5302,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:180 lxc/remote.go:737
+#: lxc/cluster.go:180 lxc/remote.go:755
 msgid "URL"
 msgstr ""
 
@@ -5330,7 +5330,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:213 lxc/remote.go:247
+#: lxc/remote.go:220 lxc/remote.go:254
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -5610,8 +5610,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:955 lxc/operation.go:156 lxc/project.go:457
-#: lxc/project.go:462 lxc/project.go:467 lxc/project.go:472 lxc/remote.go:694
-#: lxc/remote.go:699 lxc/remote.go:704
+#: lxc/project.go:462 lxc/project.go:467 lxc/project.go:472 lxc/remote.go:712
+#: lxc/remote.go:717 lxc/remote.go:722
 msgid "YES"
 msgstr ""
 
@@ -6176,7 +6176,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:477 lxc/remote.go:727
+#: lxc/project.go:477 lxc/remote.go:745
 msgid "current"
 msgstr ""
 
@@ -6467,7 +6467,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:459
+#: lxc/remote.go:477
 msgid "n"
 msgstr ""
 
@@ -6479,7 +6479,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:452
+#: lxc/remote.go:470
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6516,7 +6516,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:461
+#: lxc/remote.go:479
 msgid "y"
 msgstr ""
 

--- a/po/sl.po
+++ b/po/sl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-01 10:44+0100\n"
+"POT-Creation-Date: 2024-10-18 13:21+0000\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Slovenian <https://hosted.weblate.org/projects/linux-"
@@ -381,15 +381,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:830 lxc/remote.go:887
+#: lxc/remote.go:848 lxc/remote.go:905
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:927
+#: lxc/remote.go:945
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:757
+#: lxc/remote.go:775
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -422,7 +422,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:739
+#: lxc/remote.go:757
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -529,7 +529,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:564
+#: lxc/remote.go:582
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -561,7 +561,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:188
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -632,7 +632,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:550
+#: lxc/remote.go:568
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -805,7 +805,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:866
+#: lxc/remote.go:884
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -871,13 +871,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:218
+#: lxc/remote.go:225
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:451
+#: lxc/remote.go:469
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -891,7 +891,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:604
+#: lxc/remote.go:622
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1130,12 +1130,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:486
+#: lxc/remote.go:504
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:470
+#: lxc/remote.go:231 lxc/remote.go:488
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1164,7 +1164,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:481
+#: lxc/remote.go:499
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1456,8 +1456,8 @@ msgstr ""
 #: lxc/project.go:221 lxc/project.go:348 lxc/project.go:409 lxc/project.go:510
 #: lxc/project.go:567 lxc/project.go:646 lxc/project.go:677 lxc/project.go:730
 #: lxc/project.go:789 lxc/publish.go:33 lxc/query.go:34 lxc/remote.go:34
-#: lxc/remote.go:90 lxc/remote.go:632 lxc/remote.go:670 lxc/remote.go:760
-#: lxc/remote.go:833 lxc/remote.go:889 lxc/remote.go:929 lxc/rename.go:21
+#: lxc/remote.go:90 lxc/remote.go:650 lxc/remote.go:688 lxc/remote.go:778
+#: lxc/remote.go:851 lxc/remote.go:907 lxc/remote.go:947 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:92
 #: lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:340 lxc/storage.go:410
 #: lxc/storage.go:582 lxc/storage.go:661 lxc/storage.go:757 lxc/storage.go:843
@@ -1972,11 +1972,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:190
+#: lxc/remote.go:197
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:241
+#: lxc/remote.go:248
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -1986,7 +1986,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:231
+#: lxc/remote.go:238
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -1996,12 +1996,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:256
+#: lxc/remote.go:263
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:263
+#: lxc/remote.go:270
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2026,7 +2026,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:236
+#: lxc/remote.go:243
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2104,7 +2104,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:411
-#: lxc/project.go:791 lxc/remote.go:674 lxc/storage.go:584
+#: lxc/project.go:791 lxc/remote.go:692 lxc/storage.go:584
 #: lxc/storage_volume.go:1418 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -2141,7 +2141,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:742
+#: lxc/remote.go:760
 msgid "GLOBAL"
 msgstr ""
 
@@ -2157,7 +2157,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:397
+#: lxc/remote.go:159 lxc/remote.go:406
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2508,7 +2508,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:349
+#: lxc/remote.go:358
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2589,7 +2589,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:338
+#: lxc/remote.go:347
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -2925,7 +2925,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:669 lxc/remote.go:670
+#: lxc/remote.go:687 lxc/remote.go:688
 msgid "List the available remotes"
 msgstr ""
 
@@ -3459,7 +3459,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:566
 #: lxc/network.go:976 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:487 lxc/remote.go:736 lxc/storage.go:634
+#: lxc/project.go:487 lxc/remote.go:754 lxc/storage.go:634
 #: lxc/storage_volume.go:1506
 msgid "NAME"
 msgstr ""
@@ -3481,8 +3481,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:953 lxc/operation.go:154 lxc/project.go:455
-#: lxc/project.go:460 lxc/project.go:465 lxc/project.go:470 lxc/remote.go:692
-#: lxc/remote.go:697 lxc/remote.go:702
+#: lxc/project.go:460 lxc/project.go:465 lxc/project.go:470 lxc/remote.go:710
+#: lxc/remote.go:715 lxc/remote.go:720
 msgid "NO"
 msgstr ""
 
@@ -3697,7 +3697,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:332
+#: lxc/remote.go:341
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -3764,11 +3764,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:738
+#: lxc/remote.go:756
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1070 lxc/remote.go:740
+#: lxc/image.go:1070 lxc/remote.go:758
 msgid "PUBLIC"
 msgstr ""
 
@@ -3797,7 +3797,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:182
+#: lxc/remote.go:189
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -3809,7 +3809,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:462
+#: lxc/remote.go:480
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4110,33 +4110,33 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:790
+#: lxc/remote.go:808
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:756 lxc/remote.go:781 lxc/remote.go:854 lxc/remote.go:910
-#: lxc/remote.go:950
+#: lxc/project.go:756 lxc/remote.go:799 lxc/remote.go:872 lxc/remote.go:928
+#: lxc/remote.go:968
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:301
+#: lxc/remote.go:308
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:862
+#: lxc/remote.go:880
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:785 lxc/remote.go:858 lxc/remote.go:954
+#: lxc/remote.go:803 lxc/remote.go:876 lxc/remote.go:972
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:290
+#: lxc/remote.go:297
 msgid "Remote address must not be empty"
 msgstr ""
 
@@ -4144,7 +4144,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:295
+#: lxc/remote.go:302
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4202,7 +4202,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:832 lxc/remote.go:833
+#: lxc/remote.go:850 lxc/remote.go:851
 msgid "Remove remotes"
 msgstr ""
 
@@ -4251,7 +4251,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:759 lxc/remote.go:760
+#: lxc/remote.go:777 lxc/remote.go:778
 msgid "Rename remotes"
 msgstr ""
 
@@ -4388,7 +4388,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:741
+#: lxc/remote.go:759
 msgid "STATIC"
 msgstr ""
 
@@ -4416,11 +4416,11 @@ msgstr ""
 msgid "Server authentication type (tls or candid)"
 msgstr ""
 
-#: lxc/remote.go:460
+#: lxc/remote.go:478
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:600
+#: lxc/remote.go:618
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -4601,7 +4601,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:928 lxc/remote.go:929
+#: lxc/remote.go:946 lxc/remote.go:947
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -4777,7 +4777,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:631 lxc/remote.go:632
+#: lxc/remote.go:649 lxc/remote.go:650
 msgid "Show the default remote"
 msgstr ""
 
@@ -4965,7 +4965,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:888 lxc/remote.go:889
+#: lxc/remote.go:906 lxc/remote.go:907
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5303,7 +5303,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:180 lxc/remote.go:737
+#: lxc/cluster.go:180 lxc/remote.go:755
 msgid "URL"
 msgstr ""
 
@@ -5331,7 +5331,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:213 lxc/remote.go:247
+#: lxc/remote.go:220 lxc/remote.go:254
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -5611,8 +5611,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:955 lxc/operation.go:156 lxc/project.go:457
-#: lxc/project.go:462 lxc/project.go:467 lxc/project.go:472 lxc/remote.go:694
-#: lxc/remote.go:699 lxc/remote.go:704
+#: lxc/project.go:462 lxc/project.go:467 lxc/project.go:472 lxc/remote.go:712
+#: lxc/remote.go:717 lxc/remote.go:722
 msgid "YES"
 msgstr ""
 
@@ -6177,7 +6177,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:477 lxc/remote.go:727
+#: lxc/project.go:477 lxc/remote.go:745
 msgid "current"
 msgstr ""
 
@@ -6468,7 +6468,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:459
+#: lxc/remote.go:477
 msgid "n"
 msgstr ""
 
@@ -6480,7 +6480,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:452
+#: lxc/remote.go:470
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6517,7 +6517,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:461
+#: lxc/remote.go:479
 msgid "y"
 msgstr ""
 

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-01 10:44+0100\n"
+"POT-Creation-Date: 2024-10-18 13:21+0000\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Serbian <https://hosted.weblate.org/projects/linux-containers/"
@@ -381,15 +381,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:830 lxc/remote.go:887
+#: lxc/remote.go:848 lxc/remote.go:905
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:927
+#: lxc/remote.go:945
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:757
+#: lxc/remote.go:775
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -422,7 +422,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:739
+#: lxc/remote.go:757
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -529,7 +529,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:564
+#: lxc/remote.go:582
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -561,7 +561,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:188
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -632,7 +632,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:550
+#: lxc/remote.go:568
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -805,7 +805,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:866
+#: lxc/remote.go:884
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -871,13 +871,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:218
+#: lxc/remote.go:225
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:451
+#: lxc/remote.go:469
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -891,7 +891,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:604
+#: lxc/remote.go:622
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1130,12 +1130,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:486
+#: lxc/remote.go:504
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:470
+#: lxc/remote.go:231 lxc/remote.go:488
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1164,7 +1164,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:481
+#: lxc/remote.go:499
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1456,8 +1456,8 @@ msgstr ""
 #: lxc/project.go:221 lxc/project.go:348 lxc/project.go:409 lxc/project.go:510
 #: lxc/project.go:567 lxc/project.go:646 lxc/project.go:677 lxc/project.go:730
 #: lxc/project.go:789 lxc/publish.go:33 lxc/query.go:34 lxc/remote.go:34
-#: lxc/remote.go:90 lxc/remote.go:632 lxc/remote.go:670 lxc/remote.go:760
-#: lxc/remote.go:833 lxc/remote.go:889 lxc/remote.go:929 lxc/rename.go:21
+#: lxc/remote.go:90 lxc/remote.go:650 lxc/remote.go:688 lxc/remote.go:778
+#: lxc/remote.go:851 lxc/remote.go:907 lxc/remote.go:947 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:92
 #: lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:340 lxc/storage.go:410
 #: lxc/storage.go:582 lxc/storage.go:661 lxc/storage.go:757 lxc/storage.go:843
@@ -1972,11 +1972,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:190
+#: lxc/remote.go:197
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:241
+#: lxc/remote.go:248
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -1986,7 +1986,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:231
+#: lxc/remote.go:238
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -1996,12 +1996,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:256
+#: lxc/remote.go:263
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:263
+#: lxc/remote.go:270
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2026,7 +2026,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:236
+#: lxc/remote.go:243
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2104,7 +2104,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:411
-#: lxc/project.go:791 lxc/remote.go:674 lxc/storage.go:584
+#: lxc/project.go:791 lxc/remote.go:692 lxc/storage.go:584
 #: lxc/storage_volume.go:1418 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -2141,7 +2141,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:742
+#: lxc/remote.go:760
 msgid "GLOBAL"
 msgstr ""
 
@@ -2157,7 +2157,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:397
+#: lxc/remote.go:159 lxc/remote.go:406
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2508,7 +2508,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:349
+#: lxc/remote.go:358
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2589,7 +2589,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:338
+#: lxc/remote.go:347
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -2925,7 +2925,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:669 lxc/remote.go:670
+#: lxc/remote.go:687 lxc/remote.go:688
 msgid "List the available remotes"
 msgstr ""
 
@@ -3459,7 +3459,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:566
 #: lxc/network.go:976 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:487 lxc/remote.go:736 lxc/storage.go:634
+#: lxc/project.go:487 lxc/remote.go:754 lxc/storage.go:634
 #: lxc/storage_volume.go:1506
 msgid "NAME"
 msgstr ""
@@ -3481,8 +3481,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:953 lxc/operation.go:154 lxc/project.go:455
-#: lxc/project.go:460 lxc/project.go:465 lxc/project.go:470 lxc/remote.go:692
-#: lxc/remote.go:697 lxc/remote.go:702
+#: lxc/project.go:460 lxc/project.go:465 lxc/project.go:470 lxc/remote.go:710
+#: lxc/remote.go:715 lxc/remote.go:720
 msgid "NO"
 msgstr ""
 
@@ -3697,7 +3697,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:332
+#: lxc/remote.go:341
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -3764,11 +3764,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:738
+#: lxc/remote.go:756
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1070 lxc/remote.go:740
+#: lxc/image.go:1070 lxc/remote.go:758
 msgid "PUBLIC"
 msgstr ""
 
@@ -3797,7 +3797,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:182
+#: lxc/remote.go:189
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -3809,7 +3809,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:462
+#: lxc/remote.go:480
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4110,33 +4110,33 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:790
+#: lxc/remote.go:808
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:756 lxc/remote.go:781 lxc/remote.go:854 lxc/remote.go:910
-#: lxc/remote.go:950
+#: lxc/project.go:756 lxc/remote.go:799 lxc/remote.go:872 lxc/remote.go:928
+#: lxc/remote.go:968
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:301
+#: lxc/remote.go:308
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:862
+#: lxc/remote.go:880
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:785 lxc/remote.go:858 lxc/remote.go:954
+#: lxc/remote.go:803 lxc/remote.go:876 lxc/remote.go:972
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:290
+#: lxc/remote.go:297
 msgid "Remote address must not be empty"
 msgstr ""
 
@@ -4144,7 +4144,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:295
+#: lxc/remote.go:302
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4202,7 +4202,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:832 lxc/remote.go:833
+#: lxc/remote.go:850 lxc/remote.go:851
 msgid "Remove remotes"
 msgstr ""
 
@@ -4251,7 +4251,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:759 lxc/remote.go:760
+#: lxc/remote.go:777 lxc/remote.go:778
 msgid "Rename remotes"
 msgstr ""
 
@@ -4388,7 +4388,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:741
+#: lxc/remote.go:759
 msgid "STATIC"
 msgstr ""
 
@@ -4416,11 +4416,11 @@ msgstr ""
 msgid "Server authentication type (tls or candid)"
 msgstr ""
 
-#: lxc/remote.go:460
+#: lxc/remote.go:478
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:600
+#: lxc/remote.go:618
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -4601,7 +4601,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:928 lxc/remote.go:929
+#: lxc/remote.go:946 lxc/remote.go:947
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -4777,7 +4777,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:631 lxc/remote.go:632
+#: lxc/remote.go:649 lxc/remote.go:650
 msgid "Show the default remote"
 msgstr ""
 
@@ -4965,7 +4965,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:888 lxc/remote.go:889
+#: lxc/remote.go:906 lxc/remote.go:907
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5303,7 +5303,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:180 lxc/remote.go:737
+#: lxc/cluster.go:180 lxc/remote.go:755
 msgid "URL"
 msgstr ""
 
@@ -5331,7 +5331,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:213 lxc/remote.go:247
+#: lxc/remote.go:220 lxc/remote.go:254
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -5611,8 +5611,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:955 lxc/operation.go:156 lxc/project.go:457
-#: lxc/project.go:462 lxc/project.go:467 lxc/project.go:472 lxc/remote.go:694
-#: lxc/remote.go:699 lxc/remote.go:704
+#: lxc/project.go:462 lxc/project.go:467 lxc/project.go:472 lxc/remote.go:712
+#: lxc/remote.go:717 lxc/remote.go:722
 msgid "YES"
 msgstr ""
 
@@ -6177,7 +6177,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:477 lxc/remote.go:727
+#: lxc/project.go:477 lxc/remote.go:745
 msgid "current"
 msgstr ""
 
@@ -6468,7 +6468,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:459
+#: lxc/remote.go:477
 msgid "n"
 msgstr ""
 
@@ -6480,7 +6480,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:452
+#: lxc/remote.go:470
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6517,7 +6517,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:461
+#: lxc/remote.go:479
 msgid "y"
 msgstr ""
 

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-01 10:44+0100\n"
+"POT-Creation-Date: 2024-10-18 13:21+0000\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Swedish <https://hosted.weblate.org/projects/linux-containers/"
@@ -380,15 +380,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:830 lxc/remote.go:887
+#: lxc/remote.go:848 lxc/remote.go:905
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:927
+#: lxc/remote.go:945
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:757
+#: lxc/remote.go:775
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -421,7 +421,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:739
+#: lxc/remote.go:757
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -528,7 +528,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:564
+#: lxc/remote.go:582
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -560,7 +560,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:188
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -631,7 +631,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:550
+#: lxc/remote.go:568
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -804,7 +804,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:866
+#: lxc/remote.go:884
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -870,13 +870,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:218
+#: lxc/remote.go:225
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:451
+#: lxc/remote.go:469
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -890,7 +890,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:604
+#: lxc/remote.go:622
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1129,12 +1129,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:486
+#: lxc/remote.go:504
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:470
+#: lxc/remote.go:231 lxc/remote.go:488
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1163,7 +1163,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:481
+#: lxc/remote.go:499
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1455,8 +1455,8 @@ msgstr ""
 #: lxc/project.go:221 lxc/project.go:348 lxc/project.go:409 lxc/project.go:510
 #: lxc/project.go:567 lxc/project.go:646 lxc/project.go:677 lxc/project.go:730
 #: lxc/project.go:789 lxc/publish.go:33 lxc/query.go:34 lxc/remote.go:34
-#: lxc/remote.go:90 lxc/remote.go:632 lxc/remote.go:670 lxc/remote.go:760
-#: lxc/remote.go:833 lxc/remote.go:889 lxc/remote.go:929 lxc/rename.go:21
+#: lxc/remote.go:90 lxc/remote.go:650 lxc/remote.go:688 lxc/remote.go:778
+#: lxc/remote.go:851 lxc/remote.go:907 lxc/remote.go:947 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:92
 #: lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:340 lxc/storage.go:410
 #: lxc/storage.go:582 lxc/storage.go:661 lxc/storage.go:757 lxc/storage.go:843
@@ -1971,11 +1971,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:190
+#: lxc/remote.go:197
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:241
+#: lxc/remote.go:248
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -1985,7 +1985,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:231
+#: lxc/remote.go:238
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -1995,12 +1995,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:256
+#: lxc/remote.go:263
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:263
+#: lxc/remote.go:270
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2025,7 +2025,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:236
+#: lxc/remote.go:243
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2103,7 +2103,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:411
-#: lxc/project.go:791 lxc/remote.go:674 lxc/storage.go:584
+#: lxc/project.go:791 lxc/remote.go:692 lxc/storage.go:584
 #: lxc/storage_volume.go:1418 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -2140,7 +2140,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:742
+#: lxc/remote.go:760
 msgid "GLOBAL"
 msgstr ""
 
@@ -2156,7 +2156,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:397
+#: lxc/remote.go:159 lxc/remote.go:406
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2507,7 +2507,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:349
+#: lxc/remote.go:358
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2588,7 +2588,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:338
+#: lxc/remote.go:347
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -2924,7 +2924,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:669 lxc/remote.go:670
+#: lxc/remote.go:687 lxc/remote.go:688
 msgid "List the available remotes"
 msgstr ""
 
@@ -3458,7 +3458,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:566
 #: lxc/network.go:976 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:487 lxc/remote.go:736 lxc/storage.go:634
+#: lxc/project.go:487 lxc/remote.go:754 lxc/storage.go:634
 #: lxc/storage_volume.go:1506
 msgid "NAME"
 msgstr ""
@@ -3480,8 +3480,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:953 lxc/operation.go:154 lxc/project.go:455
-#: lxc/project.go:460 lxc/project.go:465 lxc/project.go:470 lxc/remote.go:692
-#: lxc/remote.go:697 lxc/remote.go:702
+#: lxc/project.go:460 lxc/project.go:465 lxc/project.go:470 lxc/remote.go:710
+#: lxc/remote.go:715 lxc/remote.go:720
 msgid "NO"
 msgstr ""
 
@@ -3696,7 +3696,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:332
+#: lxc/remote.go:341
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -3763,11 +3763,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:738
+#: lxc/remote.go:756
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1070 lxc/remote.go:740
+#: lxc/image.go:1070 lxc/remote.go:758
 msgid "PUBLIC"
 msgstr ""
 
@@ -3796,7 +3796,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:182
+#: lxc/remote.go:189
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -3808,7 +3808,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:462
+#: lxc/remote.go:480
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4109,33 +4109,33 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:790
+#: lxc/remote.go:808
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:756 lxc/remote.go:781 lxc/remote.go:854 lxc/remote.go:910
-#: lxc/remote.go:950
+#: lxc/project.go:756 lxc/remote.go:799 lxc/remote.go:872 lxc/remote.go:928
+#: lxc/remote.go:968
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:301
+#: lxc/remote.go:308
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:862
+#: lxc/remote.go:880
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:785 lxc/remote.go:858 lxc/remote.go:954
+#: lxc/remote.go:803 lxc/remote.go:876 lxc/remote.go:972
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:290
+#: lxc/remote.go:297
 msgid "Remote address must not be empty"
 msgstr ""
 
@@ -4143,7 +4143,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:295
+#: lxc/remote.go:302
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4201,7 +4201,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:832 lxc/remote.go:833
+#: lxc/remote.go:850 lxc/remote.go:851
 msgid "Remove remotes"
 msgstr ""
 
@@ -4250,7 +4250,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:759 lxc/remote.go:760
+#: lxc/remote.go:777 lxc/remote.go:778
 msgid "Rename remotes"
 msgstr ""
 
@@ -4387,7 +4387,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:741
+#: lxc/remote.go:759
 msgid "STATIC"
 msgstr ""
 
@@ -4415,11 +4415,11 @@ msgstr ""
 msgid "Server authentication type (tls or candid)"
 msgstr ""
 
-#: lxc/remote.go:460
+#: lxc/remote.go:478
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:600
+#: lxc/remote.go:618
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -4600,7 +4600,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:928 lxc/remote.go:929
+#: lxc/remote.go:946 lxc/remote.go:947
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -4776,7 +4776,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:631 lxc/remote.go:632
+#: lxc/remote.go:649 lxc/remote.go:650
 msgid "Show the default remote"
 msgstr ""
 
@@ -4964,7 +4964,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:888 lxc/remote.go:889
+#: lxc/remote.go:906 lxc/remote.go:907
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5302,7 +5302,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:180 lxc/remote.go:737
+#: lxc/cluster.go:180 lxc/remote.go:755
 msgid "URL"
 msgstr ""
 
@@ -5330,7 +5330,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:213 lxc/remote.go:247
+#: lxc/remote.go:220 lxc/remote.go:254
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -5610,8 +5610,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:955 lxc/operation.go:156 lxc/project.go:457
-#: lxc/project.go:462 lxc/project.go:467 lxc/project.go:472 lxc/remote.go:694
-#: lxc/remote.go:699 lxc/remote.go:704
+#: lxc/project.go:462 lxc/project.go:467 lxc/project.go:472 lxc/remote.go:712
+#: lxc/remote.go:717 lxc/remote.go:722
 msgid "YES"
 msgstr ""
 
@@ -6176,7 +6176,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:477 lxc/remote.go:727
+#: lxc/project.go:477 lxc/remote.go:745
 msgid "current"
 msgstr ""
 
@@ -6467,7 +6467,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:459
+#: lxc/remote.go:477
 msgid "n"
 msgstr ""
 
@@ -6479,7 +6479,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:452
+#: lxc/remote.go:470
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6516,7 +6516,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:461
+#: lxc/remote.go:479
 msgid "y"
 msgstr ""
 

--- a/po/te.po
+++ b/po/te.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-01 10:44+0100\n"
+"POT-Creation-Date: 2024-10-18 13:21+0000\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Telugu <https://hosted.weblate.org/projects/linux-containers/"
@@ -380,15 +380,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:830 lxc/remote.go:887
+#: lxc/remote.go:848 lxc/remote.go:905
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:927
+#: lxc/remote.go:945
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:757
+#: lxc/remote.go:775
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -421,7 +421,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:739
+#: lxc/remote.go:757
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -528,7 +528,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:564
+#: lxc/remote.go:582
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -560,7 +560,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:188
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -631,7 +631,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:550
+#: lxc/remote.go:568
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -804,7 +804,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:866
+#: lxc/remote.go:884
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -870,13 +870,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:218
+#: lxc/remote.go:225
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:451
+#: lxc/remote.go:469
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -890,7 +890,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:604
+#: lxc/remote.go:622
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1129,12 +1129,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:486
+#: lxc/remote.go:504
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:470
+#: lxc/remote.go:231 lxc/remote.go:488
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1163,7 +1163,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:481
+#: lxc/remote.go:499
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1455,8 +1455,8 @@ msgstr ""
 #: lxc/project.go:221 lxc/project.go:348 lxc/project.go:409 lxc/project.go:510
 #: lxc/project.go:567 lxc/project.go:646 lxc/project.go:677 lxc/project.go:730
 #: lxc/project.go:789 lxc/publish.go:33 lxc/query.go:34 lxc/remote.go:34
-#: lxc/remote.go:90 lxc/remote.go:632 lxc/remote.go:670 lxc/remote.go:760
-#: lxc/remote.go:833 lxc/remote.go:889 lxc/remote.go:929 lxc/rename.go:21
+#: lxc/remote.go:90 lxc/remote.go:650 lxc/remote.go:688 lxc/remote.go:778
+#: lxc/remote.go:851 lxc/remote.go:907 lxc/remote.go:947 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:92
 #: lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:340 lxc/storage.go:410
 #: lxc/storage.go:582 lxc/storage.go:661 lxc/storage.go:757 lxc/storage.go:843
@@ -1971,11 +1971,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:190
+#: lxc/remote.go:197
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:241
+#: lxc/remote.go:248
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -1985,7 +1985,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:231
+#: lxc/remote.go:238
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -1995,12 +1995,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:256
+#: lxc/remote.go:263
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:263
+#: lxc/remote.go:270
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2025,7 +2025,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:236
+#: lxc/remote.go:243
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2103,7 +2103,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:411
-#: lxc/project.go:791 lxc/remote.go:674 lxc/storage.go:584
+#: lxc/project.go:791 lxc/remote.go:692 lxc/storage.go:584
 #: lxc/storage_volume.go:1418 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -2140,7 +2140,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:742
+#: lxc/remote.go:760
 msgid "GLOBAL"
 msgstr ""
 
@@ -2156,7 +2156,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:397
+#: lxc/remote.go:159 lxc/remote.go:406
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2507,7 +2507,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:349
+#: lxc/remote.go:358
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2588,7 +2588,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:338
+#: lxc/remote.go:347
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -2924,7 +2924,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:669 lxc/remote.go:670
+#: lxc/remote.go:687 lxc/remote.go:688
 msgid "List the available remotes"
 msgstr ""
 
@@ -3458,7 +3458,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:566
 #: lxc/network.go:976 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:487 lxc/remote.go:736 lxc/storage.go:634
+#: lxc/project.go:487 lxc/remote.go:754 lxc/storage.go:634
 #: lxc/storage_volume.go:1506
 msgid "NAME"
 msgstr ""
@@ -3480,8 +3480,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:953 lxc/operation.go:154 lxc/project.go:455
-#: lxc/project.go:460 lxc/project.go:465 lxc/project.go:470 lxc/remote.go:692
-#: lxc/remote.go:697 lxc/remote.go:702
+#: lxc/project.go:460 lxc/project.go:465 lxc/project.go:470 lxc/remote.go:710
+#: lxc/remote.go:715 lxc/remote.go:720
 msgid "NO"
 msgstr ""
 
@@ -3696,7 +3696,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:332
+#: lxc/remote.go:341
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -3763,11 +3763,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:738
+#: lxc/remote.go:756
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1070 lxc/remote.go:740
+#: lxc/image.go:1070 lxc/remote.go:758
 msgid "PUBLIC"
 msgstr ""
 
@@ -3796,7 +3796,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:182
+#: lxc/remote.go:189
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -3808,7 +3808,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:462
+#: lxc/remote.go:480
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4109,33 +4109,33 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:790
+#: lxc/remote.go:808
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:756 lxc/remote.go:781 lxc/remote.go:854 lxc/remote.go:910
-#: lxc/remote.go:950
+#: lxc/project.go:756 lxc/remote.go:799 lxc/remote.go:872 lxc/remote.go:928
+#: lxc/remote.go:968
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:301
+#: lxc/remote.go:308
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:862
+#: lxc/remote.go:880
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:785 lxc/remote.go:858 lxc/remote.go:954
+#: lxc/remote.go:803 lxc/remote.go:876 lxc/remote.go:972
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:290
+#: lxc/remote.go:297
 msgid "Remote address must not be empty"
 msgstr ""
 
@@ -4143,7 +4143,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:295
+#: lxc/remote.go:302
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4201,7 +4201,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:832 lxc/remote.go:833
+#: lxc/remote.go:850 lxc/remote.go:851
 msgid "Remove remotes"
 msgstr ""
 
@@ -4250,7 +4250,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:759 lxc/remote.go:760
+#: lxc/remote.go:777 lxc/remote.go:778
 msgid "Rename remotes"
 msgstr ""
 
@@ -4387,7 +4387,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:741
+#: lxc/remote.go:759
 msgid "STATIC"
 msgstr ""
 
@@ -4415,11 +4415,11 @@ msgstr ""
 msgid "Server authentication type (tls or candid)"
 msgstr ""
 
-#: lxc/remote.go:460
+#: lxc/remote.go:478
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:600
+#: lxc/remote.go:618
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -4600,7 +4600,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:928 lxc/remote.go:929
+#: lxc/remote.go:946 lxc/remote.go:947
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -4776,7 +4776,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:631 lxc/remote.go:632
+#: lxc/remote.go:649 lxc/remote.go:650
 msgid "Show the default remote"
 msgstr ""
 
@@ -4964,7 +4964,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:888 lxc/remote.go:889
+#: lxc/remote.go:906 lxc/remote.go:907
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5302,7 +5302,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:180 lxc/remote.go:737
+#: lxc/cluster.go:180 lxc/remote.go:755
 msgid "URL"
 msgstr ""
 
@@ -5330,7 +5330,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:213 lxc/remote.go:247
+#: lxc/remote.go:220 lxc/remote.go:254
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -5610,8 +5610,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:955 lxc/operation.go:156 lxc/project.go:457
-#: lxc/project.go:462 lxc/project.go:467 lxc/project.go:472 lxc/remote.go:694
-#: lxc/remote.go:699 lxc/remote.go:704
+#: lxc/project.go:462 lxc/project.go:467 lxc/project.go:472 lxc/remote.go:712
+#: lxc/remote.go:717 lxc/remote.go:722
 msgid "YES"
 msgstr ""
 
@@ -6176,7 +6176,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:477 lxc/remote.go:727
+#: lxc/project.go:477 lxc/remote.go:745
 msgid "current"
 msgstr ""
 
@@ -6467,7 +6467,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:459
+#: lxc/remote.go:477
 msgid "n"
 msgstr ""
 
@@ -6479,7 +6479,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:452
+#: lxc/remote.go:470
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6516,7 +6516,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:461
+#: lxc/remote.go:479
 msgid "y"
 msgstr ""
 

--- a/po/th.po
+++ b/po/th.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-01 10:44+0100\n"
+"POT-Creation-Date: 2024-10-18 13:21+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -377,15 +377,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:830 lxc/remote.go:887
+#: lxc/remote.go:848 lxc/remote.go:905
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:927
+#: lxc/remote.go:945
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:757
+#: lxc/remote.go:775
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -418,7 +418,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:739
+#: lxc/remote.go:757
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -525,7 +525,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:564
+#: lxc/remote.go:582
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -557,7 +557,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:188
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -628,7 +628,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:550
+#: lxc/remote.go:568
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -801,7 +801,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:866
+#: lxc/remote.go:884
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -867,13 +867,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:218
+#: lxc/remote.go:225
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:451
+#: lxc/remote.go:469
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -887,7 +887,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:604
+#: lxc/remote.go:622
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1126,12 +1126,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:486
+#: lxc/remote.go:504
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:470
+#: lxc/remote.go:231 lxc/remote.go:488
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1160,7 +1160,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:481
+#: lxc/remote.go:499
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1452,8 +1452,8 @@ msgstr ""
 #: lxc/project.go:221 lxc/project.go:348 lxc/project.go:409 lxc/project.go:510
 #: lxc/project.go:567 lxc/project.go:646 lxc/project.go:677 lxc/project.go:730
 #: lxc/project.go:789 lxc/publish.go:33 lxc/query.go:34 lxc/remote.go:34
-#: lxc/remote.go:90 lxc/remote.go:632 lxc/remote.go:670 lxc/remote.go:760
-#: lxc/remote.go:833 lxc/remote.go:889 lxc/remote.go:929 lxc/rename.go:21
+#: lxc/remote.go:90 lxc/remote.go:650 lxc/remote.go:688 lxc/remote.go:778
+#: lxc/remote.go:851 lxc/remote.go:907 lxc/remote.go:947 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:92
 #: lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:340 lxc/storage.go:410
 #: lxc/storage.go:582 lxc/storage.go:661 lxc/storage.go:757 lxc/storage.go:843
@@ -1968,11 +1968,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:190
+#: lxc/remote.go:197
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:241
+#: lxc/remote.go:248
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -1982,7 +1982,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:231
+#: lxc/remote.go:238
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -1992,12 +1992,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:256
+#: lxc/remote.go:263
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:263
+#: lxc/remote.go:270
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2022,7 +2022,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:236
+#: lxc/remote.go:243
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2100,7 +2100,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:411
-#: lxc/project.go:791 lxc/remote.go:674 lxc/storage.go:584
+#: lxc/project.go:791 lxc/remote.go:692 lxc/storage.go:584
 #: lxc/storage_volume.go:1418 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -2137,7 +2137,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:742
+#: lxc/remote.go:760
 msgid "GLOBAL"
 msgstr ""
 
@@ -2153,7 +2153,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:397
+#: lxc/remote.go:159 lxc/remote.go:406
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2504,7 +2504,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:349
+#: lxc/remote.go:358
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2585,7 +2585,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:338
+#: lxc/remote.go:347
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -2921,7 +2921,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:669 lxc/remote.go:670
+#: lxc/remote.go:687 lxc/remote.go:688
 msgid "List the available remotes"
 msgstr ""
 
@@ -3455,7 +3455,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:566
 #: lxc/network.go:976 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:487 lxc/remote.go:736 lxc/storage.go:634
+#: lxc/project.go:487 lxc/remote.go:754 lxc/storage.go:634
 #: lxc/storage_volume.go:1506
 msgid "NAME"
 msgstr ""
@@ -3477,8 +3477,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:953 lxc/operation.go:154 lxc/project.go:455
-#: lxc/project.go:460 lxc/project.go:465 lxc/project.go:470 lxc/remote.go:692
-#: lxc/remote.go:697 lxc/remote.go:702
+#: lxc/project.go:460 lxc/project.go:465 lxc/project.go:470 lxc/remote.go:710
+#: lxc/remote.go:715 lxc/remote.go:720
 msgid "NO"
 msgstr ""
 
@@ -3693,7 +3693,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:332
+#: lxc/remote.go:341
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -3760,11 +3760,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:738
+#: lxc/remote.go:756
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1070 lxc/remote.go:740
+#: lxc/image.go:1070 lxc/remote.go:758
 msgid "PUBLIC"
 msgstr ""
 
@@ -3793,7 +3793,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:182
+#: lxc/remote.go:189
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -3805,7 +3805,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:462
+#: lxc/remote.go:480
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4106,33 +4106,33 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:790
+#: lxc/remote.go:808
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:756 lxc/remote.go:781 lxc/remote.go:854 lxc/remote.go:910
-#: lxc/remote.go:950
+#: lxc/project.go:756 lxc/remote.go:799 lxc/remote.go:872 lxc/remote.go:928
+#: lxc/remote.go:968
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:301
+#: lxc/remote.go:308
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:862
+#: lxc/remote.go:880
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:785 lxc/remote.go:858 lxc/remote.go:954
+#: lxc/remote.go:803 lxc/remote.go:876 lxc/remote.go:972
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:290
+#: lxc/remote.go:297
 msgid "Remote address must not be empty"
 msgstr ""
 
@@ -4140,7 +4140,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:295
+#: lxc/remote.go:302
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4198,7 +4198,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:832 lxc/remote.go:833
+#: lxc/remote.go:850 lxc/remote.go:851
 msgid "Remove remotes"
 msgstr ""
 
@@ -4247,7 +4247,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:759 lxc/remote.go:760
+#: lxc/remote.go:777 lxc/remote.go:778
 msgid "Rename remotes"
 msgstr ""
 
@@ -4384,7 +4384,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:741
+#: lxc/remote.go:759
 msgid "STATIC"
 msgstr ""
 
@@ -4412,11 +4412,11 @@ msgstr ""
 msgid "Server authentication type (tls or candid)"
 msgstr ""
 
-#: lxc/remote.go:460
+#: lxc/remote.go:478
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:600
+#: lxc/remote.go:618
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -4597,7 +4597,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:928 lxc/remote.go:929
+#: lxc/remote.go:946 lxc/remote.go:947
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -4773,7 +4773,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:631 lxc/remote.go:632
+#: lxc/remote.go:649 lxc/remote.go:650
 msgid "Show the default remote"
 msgstr ""
 
@@ -4961,7 +4961,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:888 lxc/remote.go:889
+#: lxc/remote.go:906 lxc/remote.go:907
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5299,7 +5299,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:180 lxc/remote.go:737
+#: lxc/cluster.go:180 lxc/remote.go:755
 msgid "URL"
 msgstr ""
 
@@ -5327,7 +5327,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:213 lxc/remote.go:247
+#: lxc/remote.go:220 lxc/remote.go:254
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -5607,8 +5607,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:955 lxc/operation.go:156 lxc/project.go:457
-#: lxc/project.go:462 lxc/project.go:467 lxc/project.go:472 lxc/remote.go:694
-#: lxc/remote.go:699 lxc/remote.go:704
+#: lxc/project.go:462 lxc/project.go:467 lxc/project.go:472 lxc/remote.go:712
+#: lxc/remote.go:717 lxc/remote.go:722
 msgid "YES"
 msgstr ""
 
@@ -6173,7 +6173,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:477 lxc/remote.go:727
+#: lxc/project.go:477 lxc/remote.go:745
 msgid "current"
 msgstr ""
 
@@ -6464,7 +6464,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:459
+#: lxc/remote.go:477
 msgid "n"
 msgstr ""
 
@@ -6476,7 +6476,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:452
+#: lxc/remote.go:470
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6513,7 +6513,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:461
+#: lxc/remote.go:479
 msgid "y"
 msgstr ""
 

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-01 10:44+0100\n"
+"POT-Creation-Date: 2024-10-18 13:21+0000\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Turkish <https://hosted.weblate.org/projects/linux-containers/"
@@ -380,15 +380,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:830 lxc/remote.go:887
+#: lxc/remote.go:848 lxc/remote.go:905
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:927
+#: lxc/remote.go:945
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:757
+#: lxc/remote.go:775
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -421,7 +421,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:739
+#: lxc/remote.go:757
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -528,7 +528,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:564
+#: lxc/remote.go:582
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -560,7 +560,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:188
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -631,7 +631,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:550
+#: lxc/remote.go:568
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -804,7 +804,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:866
+#: lxc/remote.go:884
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -870,13 +870,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:218
+#: lxc/remote.go:225
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:451
+#: lxc/remote.go:469
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -890,7 +890,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:604
+#: lxc/remote.go:622
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1129,12 +1129,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:486
+#: lxc/remote.go:504
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:470
+#: lxc/remote.go:231 lxc/remote.go:488
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1163,7 +1163,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:481
+#: lxc/remote.go:499
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1455,8 +1455,8 @@ msgstr ""
 #: lxc/project.go:221 lxc/project.go:348 lxc/project.go:409 lxc/project.go:510
 #: lxc/project.go:567 lxc/project.go:646 lxc/project.go:677 lxc/project.go:730
 #: lxc/project.go:789 lxc/publish.go:33 lxc/query.go:34 lxc/remote.go:34
-#: lxc/remote.go:90 lxc/remote.go:632 lxc/remote.go:670 lxc/remote.go:760
-#: lxc/remote.go:833 lxc/remote.go:889 lxc/remote.go:929 lxc/rename.go:21
+#: lxc/remote.go:90 lxc/remote.go:650 lxc/remote.go:688 lxc/remote.go:778
+#: lxc/remote.go:851 lxc/remote.go:907 lxc/remote.go:947 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:92
 #: lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:340 lxc/storage.go:410
 #: lxc/storage.go:582 lxc/storage.go:661 lxc/storage.go:757 lxc/storage.go:843
@@ -1971,11 +1971,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:190
+#: lxc/remote.go:197
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:241
+#: lxc/remote.go:248
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -1985,7 +1985,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:231
+#: lxc/remote.go:238
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -1995,12 +1995,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:256
+#: lxc/remote.go:263
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:263
+#: lxc/remote.go:270
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2025,7 +2025,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:236
+#: lxc/remote.go:243
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2103,7 +2103,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:411
-#: lxc/project.go:791 lxc/remote.go:674 lxc/storage.go:584
+#: lxc/project.go:791 lxc/remote.go:692 lxc/storage.go:584
 #: lxc/storage_volume.go:1418 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -2140,7 +2140,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:742
+#: lxc/remote.go:760
 msgid "GLOBAL"
 msgstr ""
 
@@ -2156,7 +2156,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:397
+#: lxc/remote.go:159 lxc/remote.go:406
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2507,7 +2507,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:349
+#: lxc/remote.go:358
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2588,7 +2588,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:338
+#: lxc/remote.go:347
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -2924,7 +2924,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:669 lxc/remote.go:670
+#: lxc/remote.go:687 lxc/remote.go:688
 msgid "List the available remotes"
 msgstr ""
 
@@ -3458,7 +3458,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:566
 #: lxc/network.go:976 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:487 lxc/remote.go:736 lxc/storage.go:634
+#: lxc/project.go:487 lxc/remote.go:754 lxc/storage.go:634
 #: lxc/storage_volume.go:1506
 msgid "NAME"
 msgstr ""
@@ -3480,8 +3480,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:953 lxc/operation.go:154 lxc/project.go:455
-#: lxc/project.go:460 lxc/project.go:465 lxc/project.go:470 lxc/remote.go:692
-#: lxc/remote.go:697 lxc/remote.go:702
+#: lxc/project.go:460 lxc/project.go:465 lxc/project.go:470 lxc/remote.go:710
+#: lxc/remote.go:715 lxc/remote.go:720
 msgid "NO"
 msgstr ""
 
@@ -3696,7 +3696,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:332
+#: lxc/remote.go:341
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -3763,11 +3763,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:738
+#: lxc/remote.go:756
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1070 lxc/remote.go:740
+#: lxc/image.go:1070 lxc/remote.go:758
 msgid "PUBLIC"
 msgstr ""
 
@@ -3796,7 +3796,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:182
+#: lxc/remote.go:189
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -3808,7 +3808,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:462
+#: lxc/remote.go:480
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4109,33 +4109,33 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:790
+#: lxc/remote.go:808
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:756 lxc/remote.go:781 lxc/remote.go:854 lxc/remote.go:910
-#: lxc/remote.go:950
+#: lxc/project.go:756 lxc/remote.go:799 lxc/remote.go:872 lxc/remote.go:928
+#: lxc/remote.go:968
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:301
+#: lxc/remote.go:308
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:862
+#: lxc/remote.go:880
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:785 lxc/remote.go:858 lxc/remote.go:954
+#: lxc/remote.go:803 lxc/remote.go:876 lxc/remote.go:972
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:290
+#: lxc/remote.go:297
 msgid "Remote address must not be empty"
 msgstr ""
 
@@ -4143,7 +4143,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:295
+#: lxc/remote.go:302
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4201,7 +4201,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:832 lxc/remote.go:833
+#: lxc/remote.go:850 lxc/remote.go:851
 msgid "Remove remotes"
 msgstr ""
 
@@ -4250,7 +4250,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:759 lxc/remote.go:760
+#: lxc/remote.go:777 lxc/remote.go:778
 msgid "Rename remotes"
 msgstr ""
 
@@ -4387,7 +4387,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:741
+#: lxc/remote.go:759
 msgid "STATIC"
 msgstr ""
 
@@ -4415,11 +4415,11 @@ msgstr ""
 msgid "Server authentication type (tls or candid)"
 msgstr ""
 
-#: lxc/remote.go:460
+#: lxc/remote.go:478
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:600
+#: lxc/remote.go:618
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -4600,7 +4600,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:928 lxc/remote.go:929
+#: lxc/remote.go:946 lxc/remote.go:947
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -4776,7 +4776,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:631 lxc/remote.go:632
+#: lxc/remote.go:649 lxc/remote.go:650
 msgid "Show the default remote"
 msgstr ""
 
@@ -4964,7 +4964,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:888 lxc/remote.go:889
+#: lxc/remote.go:906 lxc/remote.go:907
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5302,7 +5302,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:180 lxc/remote.go:737
+#: lxc/cluster.go:180 lxc/remote.go:755
 msgid "URL"
 msgstr ""
 
@@ -5330,7 +5330,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:213 lxc/remote.go:247
+#: lxc/remote.go:220 lxc/remote.go:254
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -5610,8 +5610,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:955 lxc/operation.go:156 lxc/project.go:457
-#: lxc/project.go:462 lxc/project.go:467 lxc/project.go:472 lxc/remote.go:694
-#: lxc/remote.go:699 lxc/remote.go:704
+#: lxc/project.go:462 lxc/project.go:467 lxc/project.go:472 lxc/remote.go:712
+#: lxc/remote.go:717 lxc/remote.go:722
 msgid "YES"
 msgstr ""
 
@@ -6176,7 +6176,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:477 lxc/remote.go:727
+#: lxc/project.go:477 lxc/remote.go:745
 msgid "current"
 msgstr ""
 
@@ -6467,7 +6467,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:459
+#: lxc/remote.go:477
 msgid "n"
 msgstr ""
 
@@ -6479,7 +6479,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:452
+#: lxc/remote.go:470
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6516,7 +6516,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:461
+#: lxc/remote.go:479
 msgid "y"
 msgstr ""
 

--- a/po/tzm.po
+++ b/po/tzm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-01 10:44+0100\n"
+"POT-Creation-Date: 2024-10-18 13:21+0000\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Tamazight (Central Atlas) <https://hosted.weblate.org/"
@@ -380,15 +380,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:830 lxc/remote.go:887
+#: lxc/remote.go:848 lxc/remote.go:905
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:927
+#: lxc/remote.go:945
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:757
+#: lxc/remote.go:775
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -421,7 +421,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:739
+#: lxc/remote.go:757
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -528,7 +528,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:564
+#: lxc/remote.go:582
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -560,7 +560,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:188
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -631,7 +631,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:550
+#: lxc/remote.go:568
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -804,7 +804,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:866
+#: lxc/remote.go:884
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -870,13 +870,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:218
+#: lxc/remote.go:225
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:451
+#: lxc/remote.go:469
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -890,7 +890,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:604
+#: lxc/remote.go:622
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1129,12 +1129,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:486
+#: lxc/remote.go:504
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:470
+#: lxc/remote.go:231 lxc/remote.go:488
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1163,7 +1163,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:481
+#: lxc/remote.go:499
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1455,8 +1455,8 @@ msgstr ""
 #: lxc/project.go:221 lxc/project.go:348 lxc/project.go:409 lxc/project.go:510
 #: lxc/project.go:567 lxc/project.go:646 lxc/project.go:677 lxc/project.go:730
 #: lxc/project.go:789 lxc/publish.go:33 lxc/query.go:34 lxc/remote.go:34
-#: lxc/remote.go:90 lxc/remote.go:632 lxc/remote.go:670 lxc/remote.go:760
-#: lxc/remote.go:833 lxc/remote.go:889 lxc/remote.go:929 lxc/rename.go:21
+#: lxc/remote.go:90 lxc/remote.go:650 lxc/remote.go:688 lxc/remote.go:778
+#: lxc/remote.go:851 lxc/remote.go:907 lxc/remote.go:947 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:92
 #: lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:340 lxc/storage.go:410
 #: lxc/storage.go:582 lxc/storage.go:661 lxc/storage.go:757 lxc/storage.go:843
@@ -1971,11 +1971,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:190
+#: lxc/remote.go:197
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:241
+#: lxc/remote.go:248
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -1985,7 +1985,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:231
+#: lxc/remote.go:238
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -1995,12 +1995,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:256
+#: lxc/remote.go:263
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:263
+#: lxc/remote.go:270
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2025,7 +2025,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:236
+#: lxc/remote.go:243
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2103,7 +2103,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:411
-#: lxc/project.go:791 lxc/remote.go:674 lxc/storage.go:584
+#: lxc/project.go:791 lxc/remote.go:692 lxc/storage.go:584
 #: lxc/storage_volume.go:1418 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -2140,7 +2140,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:742
+#: lxc/remote.go:760
 msgid "GLOBAL"
 msgstr ""
 
@@ -2156,7 +2156,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:397
+#: lxc/remote.go:159 lxc/remote.go:406
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2507,7 +2507,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:349
+#: lxc/remote.go:358
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2588,7 +2588,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:338
+#: lxc/remote.go:347
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -2924,7 +2924,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:669 lxc/remote.go:670
+#: lxc/remote.go:687 lxc/remote.go:688
 msgid "List the available remotes"
 msgstr ""
 
@@ -3458,7 +3458,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:566
 #: lxc/network.go:976 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:487 lxc/remote.go:736 lxc/storage.go:634
+#: lxc/project.go:487 lxc/remote.go:754 lxc/storage.go:634
 #: lxc/storage_volume.go:1506
 msgid "NAME"
 msgstr ""
@@ -3480,8 +3480,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:953 lxc/operation.go:154 lxc/project.go:455
-#: lxc/project.go:460 lxc/project.go:465 lxc/project.go:470 lxc/remote.go:692
-#: lxc/remote.go:697 lxc/remote.go:702
+#: lxc/project.go:460 lxc/project.go:465 lxc/project.go:470 lxc/remote.go:710
+#: lxc/remote.go:715 lxc/remote.go:720
 msgid "NO"
 msgstr ""
 
@@ -3696,7 +3696,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:332
+#: lxc/remote.go:341
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -3763,11 +3763,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:738
+#: lxc/remote.go:756
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1070 lxc/remote.go:740
+#: lxc/image.go:1070 lxc/remote.go:758
 msgid "PUBLIC"
 msgstr ""
 
@@ -3796,7 +3796,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:182
+#: lxc/remote.go:189
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -3808,7 +3808,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:462
+#: lxc/remote.go:480
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4109,33 +4109,33 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:790
+#: lxc/remote.go:808
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:756 lxc/remote.go:781 lxc/remote.go:854 lxc/remote.go:910
-#: lxc/remote.go:950
+#: lxc/project.go:756 lxc/remote.go:799 lxc/remote.go:872 lxc/remote.go:928
+#: lxc/remote.go:968
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:301
+#: lxc/remote.go:308
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:862
+#: lxc/remote.go:880
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:785 lxc/remote.go:858 lxc/remote.go:954
+#: lxc/remote.go:803 lxc/remote.go:876 lxc/remote.go:972
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:290
+#: lxc/remote.go:297
 msgid "Remote address must not be empty"
 msgstr ""
 
@@ -4143,7 +4143,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:295
+#: lxc/remote.go:302
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4201,7 +4201,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:832 lxc/remote.go:833
+#: lxc/remote.go:850 lxc/remote.go:851
 msgid "Remove remotes"
 msgstr ""
 
@@ -4250,7 +4250,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:759 lxc/remote.go:760
+#: lxc/remote.go:777 lxc/remote.go:778
 msgid "Rename remotes"
 msgstr ""
 
@@ -4387,7 +4387,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:741
+#: lxc/remote.go:759
 msgid "STATIC"
 msgstr ""
 
@@ -4415,11 +4415,11 @@ msgstr ""
 msgid "Server authentication type (tls or candid)"
 msgstr ""
 
-#: lxc/remote.go:460
+#: lxc/remote.go:478
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:600
+#: lxc/remote.go:618
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -4600,7 +4600,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:928 lxc/remote.go:929
+#: lxc/remote.go:946 lxc/remote.go:947
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -4776,7 +4776,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:631 lxc/remote.go:632
+#: lxc/remote.go:649 lxc/remote.go:650
 msgid "Show the default remote"
 msgstr ""
 
@@ -4964,7 +4964,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:888 lxc/remote.go:889
+#: lxc/remote.go:906 lxc/remote.go:907
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5302,7 +5302,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:180 lxc/remote.go:737
+#: lxc/cluster.go:180 lxc/remote.go:755
 msgid "URL"
 msgstr ""
 
@@ -5330,7 +5330,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:213 lxc/remote.go:247
+#: lxc/remote.go:220 lxc/remote.go:254
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -5610,8 +5610,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:955 lxc/operation.go:156 lxc/project.go:457
-#: lxc/project.go:462 lxc/project.go:467 lxc/project.go:472 lxc/remote.go:694
-#: lxc/remote.go:699 lxc/remote.go:704
+#: lxc/project.go:462 lxc/project.go:467 lxc/project.go:472 lxc/remote.go:712
+#: lxc/remote.go:717 lxc/remote.go:722
 msgid "YES"
 msgstr ""
 
@@ -6176,7 +6176,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:477 lxc/remote.go:727
+#: lxc/project.go:477 lxc/remote.go:745
 msgid "current"
 msgstr ""
 
@@ -6467,7 +6467,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:459
+#: lxc/remote.go:477
 msgid "n"
 msgstr ""
 
@@ -6479,7 +6479,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:452
+#: lxc/remote.go:470
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6516,7 +6516,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:461
+#: lxc/remote.go:479
 msgid "y"
 msgstr ""
 

--- a/po/ug.po
+++ b/po/ug.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-01 10:44+0100\n"
+"POT-Creation-Date: 2024-10-18 13:21+0000\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Uyghur <https://hosted.weblate.org/projects/linux-containers/"
@@ -380,15 +380,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:830 lxc/remote.go:887
+#: lxc/remote.go:848 lxc/remote.go:905
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:927
+#: lxc/remote.go:945
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:757
+#: lxc/remote.go:775
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -421,7 +421,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:739
+#: lxc/remote.go:757
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -528,7 +528,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:564
+#: lxc/remote.go:582
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -560,7 +560,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:188
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -631,7 +631,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:550
+#: lxc/remote.go:568
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -804,7 +804,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:866
+#: lxc/remote.go:884
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -870,13 +870,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:218
+#: lxc/remote.go:225
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:451
+#: lxc/remote.go:469
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -890,7 +890,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:604
+#: lxc/remote.go:622
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1129,12 +1129,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:486
+#: lxc/remote.go:504
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:470
+#: lxc/remote.go:231 lxc/remote.go:488
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1163,7 +1163,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:481
+#: lxc/remote.go:499
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1455,8 +1455,8 @@ msgstr ""
 #: lxc/project.go:221 lxc/project.go:348 lxc/project.go:409 lxc/project.go:510
 #: lxc/project.go:567 lxc/project.go:646 lxc/project.go:677 lxc/project.go:730
 #: lxc/project.go:789 lxc/publish.go:33 lxc/query.go:34 lxc/remote.go:34
-#: lxc/remote.go:90 lxc/remote.go:632 lxc/remote.go:670 lxc/remote.go:760
-#: lxc/remote.go:833 lxc/remote.go:889 lxc/remote.go:929 lxc/rename.go:21
+#: lxc/remote.go:90 lxc/remote.go:650 lxc/remote.go:688 lxc/remote.go:778
+#: lxc/remote.go:851 lxc/remote.go:907 lxc/remote.go:947 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:92
 #: lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:340 lxc/storage.go:410
 #: lxc/storage.go:582 lxc/storage.go:661 lxc/storage.go:757 lxc/storage.go:843
@@ -1971,11 +1971,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:190
+#: lxc/remote.go:197
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:241
+#: lxc/remote.go:248
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -1985,7 +1985,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:231
+#: lxc/remote.go:238
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -1995,12 +1995,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:256
+#: lxc/remote.go:263
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:263
+#: lxc/remote.go:270
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2025,7 +2025,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:236
+#: lxc/remote.go:243
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2103,7 +2103,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:411
-#: lxc/project.go:791 lxc/remote.go:674 lxc/storage.go:584
+#: lxc/project.go:791 lxc/remote.go:692 lxc/storage.go:584
 #: lxc/storage_volume.go:1418 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -2140,7 +2140,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:742
+#: lxc/remote.go:760
 msgid "GLOBAL"
 msgstr ""
 
@@ -2156,7 +2156,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:397
+#: lxc/remote.go:159 lxc/remote.go:406
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2507,7 +2507,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:349
+#: lxc/remote.go:358
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2588,7 +2588,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:338
+#: lxc/remote.go:347
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -2924,7 +2924,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:669 lxc/remote.go:670
+#: lxc/remote.go:687 lxc/remote.go:688
 msgid "List the available remotes"
 msgstr ""
 
@@ -3458,7 +3458,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:566
 #: lxc/network.go:976 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:487 lxc/remote.go:736 lxc/storage.go:634
+#: lxc/project.go:487 lxc/remote.go:754 lxc/storage.go:634
 #: lxc/storage_volume.go:1506
 msgid "NAME"
 msgstr ""
@@ -3480,8 +3480,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:953 lxc/operation.go:154 lxc/project.go:455
-#: lxc/project.go:460 lxc/project.go:465 lxc/project.go:470 lxc/remote.go:692
-#: lxc/remote.go:697 lxc/remote.go:702
+#: lxc/project.go:460 lxc/project.go:465 lxc/project.go:470 lxc/remote.go:710
+#: lxc/remote.go:715 lxc/remote.go:720
 msgid "NO"
 msgstr ""
 
@@ -3696,7 +3696,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:332
+#: lxc/remote.go:341
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -3763,11 +3763,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:738
+#: lxc/remote.go:756
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1070 lxc/remote.go:740
+#: lxc/image.go:1070 lxc/remote.go:758
 msgid "PUBLIC"
 msgstr ""
 
@@ -3796,7 +3796,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:182
+#: lxc/remote.go:189
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -3808,7 +3808,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:462
+#: lxc/remote.go:480
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4109,33 +4109,33 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:790
+#: lxc/remote.go:808
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:756 lxc/remote.go:781 lxc/remote.go:854 lxc/remote.go:910
-#: lxc/remote.go:950
+#: lxc/project.go:756 lxc/remote.go:799 lxc/remote.go:872 lxc/remote.go:928
+#: lxc/remote.go:968
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:301
+#: lxc/remote.go:308
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:862
+#: lxc/remote.go:880
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:785 lxc/remote.go:858 lxc/remote.go:954
+#: lxc/remote.go:803 lxc/remote.go:876 lxc/remote.go:972
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:290
+#: lxc/remote.go:297
 msgid "Remote address must not be empty"
 msgstr ""
 
@@ -4143,7 +4143,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:295
+#: lxc/remote.go:302
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4201,7 +4201,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:832 lxc/remote.go:833
+#: lxc/remote.go:850 lxc/remote.go:851
 msgid "Remove remotes"
 msgstr ""
 
@@ -4250,7 +4250,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:759 lxc/remote.go:760
+#: lxc/remote.go:777 lxc/remote.go:778
 msgid "Rename remotes"
 msgstr ""
 
@@ -4387,7 +4387,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:741
+#: lxc/remote.go:759
 msgid "STATIC"
 msgstr ""
 
@@ -4415,11 +4415,11 @@ msgstr ""
 msgid "Server authentication type (tls or candid)"
 msgstr ""
 
-#: lxc/remote.go:460
+#: lxc/remote.go:478
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:600
+#: lxc/remote.go:618
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -4600,7 +4600,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:928 lxc/remote.go:929
+#: lxc/remote.go:946 lxc/remote.go:947
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -4776,7 +4776,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:631 lxc/remote.go:632
+#: lxc/remote.go:649 lxc/remote.go:650
 msgid "Show the default remote"
 msgstr ""
 
@@ -4964,7 +4964,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:888 lxc/remote.go:889
+#: lxc/remote.go:906 lxc/remote.go:907
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5302,7 +5302,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:180 lxc/remote.go:737
+#: lxc/cluster.go:180 lxc/remote.go:755
 msgid "URL"
 msgstr ""
 
@@ -5330,7 +5330,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:213 lxc/remote.go:247
+#: lxc/remote.go:220 lxc/remote.go:254
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -5610,8 +5610,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:955 lxc/operation.go:156 lxc/project.go:457
-#: lxc/project.go:462 lxc/project.go:467 lxc/project.go:472 lxc/remote.go:694
-#: lxc/remote.go:699 lxc/remote.go:704
+#: lxc/project.go:462 lxc/project.go:467 lxc/project.go:472 lxc/remote.go:712
+#: lxc/remote.go:717 lxc/remote.go:722
 msgid "YES"
 msgstr ""
 
@@ -6176,7 +6176,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:477 lxc/remote.go:727
+#: lxc/project.go:477 lxc/remote.go:745
 msgid "current"
 msgstr ""
 
@@ -6467,7 +6467,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:459
+#: lxc/remote.go:477
 msgid "n"
 msgstr ""
 
@@ -6479,7 +6479,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:452
+#: lxc/remote.go:470
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6516,7 +6516,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:461
+#: lxc/remote.go:479
 msgid "y"
 msgstr ""
 

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-01 10:44+0100\n"
+"POT-Creation-Date: 2024-10-18 13:21+0000\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Ukrainian <https://hosted.weblate.org/projects/linux-"
@@ -381,15 +381,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:830 lxc/remote.go:887
+#: lxc/remote.go:848 lxc/remote.go:905
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:927
+#: lxc/remote.go:945
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:757
+#: lxc/remote.go:775
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -422,7 +422,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:739
+#: lxc/remote.go:757
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -529,7 +529,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:564
+#: lxc/remote.go:582
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -561,7 +561,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:188
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -632,7 +632,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:550
+#: lxc/remote.go:568
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -805,7 +805,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:866
+#: lxc/remote.go:884
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -871,13 +871,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:218
+#: lxc/remote.go:225
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:451
+#: lxc/remote.go:469
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -891,7 +891,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:604
+#: lxc/remote.go:622
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1130,12 +1130,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:486
+#: lxc/remote.go:504
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:470
+#: lxc/remote.go:231 lxc/remote.go:488
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1164,7 +1164,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:481
+#: lxc/remote.go:499
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1456,8 +1456,8 @@ msgstr ""
 #: lxc/project.go:221 lxc/project.go:348 lxc/project.go:409 lxc/project.go:510
 #: lxc/project.go:567 lxc/project.go:646 lxc/project.go:677 lxc/project.go:730
 #: lxc/project.go:789 lxc/publish.go:33 lxc/query.go:34 lxc/remote.go:34
-#: lxc/remote.go:90 lxc/remote.go:632 lxc/remote.go:670 lxc/remote.go:760
-#: lxc/remote.go:833 lxc/remote.go:889 lxc/remote.go:929 lxc/rename.go:21
+#: lxc/remote.go:90 lxc/remote.go:650 lxc/remote.go:688 lxc/remote.go:778
+#: lxc/remote.go:851 lxc/remote.go:907 lxc/remote.go:947 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:92
 #: lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:340 lxc/storage.go:410
 #: lxc/storage.go:582 lxc/storage.go:661 lxc/storage.go:757 lxc/storage.go:843
@@ -1972,11 +1972,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:190
+#: lxc/remote.go:197
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:241
+#: lxc/remote.go:248
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -1986,7 +1986,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:231
+#: lxc/remote.go:238
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -1996,12 +1996,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:256
+#: lxc/remote.go:263
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:263
+#: lxc/remote.go:270
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2026,7 +2026,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:236
+#: lxc/remote.go:243
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2104,7 +2104,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:411
-#: lxc/project.go:791 lxc/remote.go:674 lxc/storage.go:584
+#: lxc/project.go:791 lxc/remote.go:692 lxc/storage.go:584
 #: lxc/storage_volume.go:1418 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -2141,7 +2141,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:742
+#: lxc/remote.go:760
 msgid "GLOBAL"
 msgstr ""
 
@@ -2157,7 +2157,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:397
+#: lxc/remote.go:159 lxc/remote.go:406
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2508,7 +2508,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:349
+#: lxc/remote.go:358
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2589,7 +2589,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:338
+#: lxc/remote.go:347
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -2925,7 +2925,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:669 lxc/remote.go:670
+#: lxc/remote.go:687 lxc/remote.go:688
 msgid "List the available remotes"
 msgstr ""
 
@@ -3459,7 +3459,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:566
 #: lxc/network.go:976 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:487 lxc/remote.go:736 lxc/storage.go:634
+#: lxc/project.go:487 lxc/remote.go:754 lxc/storage.go:634
 #: lxc/storage_volume.go:1506
 msgid "NAME"
 msgstr ""
@@ -3481,8 +3481,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:953 lxc/operation.go:154 lxc/project.go:455
-#: lxc/project.go:460 lxc/project.go:465 lxc/project.go:470 lxc/remote.go:692
-#: lxc/remote.go:697 lxc/remote.go:702
+#: lxc/project.go:460 lxc/project.go:465 lxc/project.go:470 lxc/remote.go:710
+#: lxc/remote.go:715 lxc/remote.go:720
 msgid "NO"
 msgstr ""
 
@@ -3697,7 +3697,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:332
+#: lxc/remote.go:341
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -3764,11 +3764,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:738
+#: lxc/remote.go:756
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1070 lxc/remote.go:740
+#: lxc/image.go:1070 lxc/remote.go:758
 msgid "PUBLIC"
 msgstr ""
 
@@ -3797,7 +3797,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:182
+#: lxc/remote.go:189
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -3809,7 +3809,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:462
+#: lxc/remote.go:480
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4110,33 +4110,33 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:790
+#: lxc/remote.go:808
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:756 lxc/remote.go:781 lxc/remote.go:854 lxc/remote.go:910
-#: lxc/remote.go:950
+#: lxc/project.go:756 lxc/remote.go:799 lxc/remote.go:872 lxc/remote.go:928
+#: lxc/remote.go:968
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:301
+#: lxc/remote.go:308
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:862
+#: lxc/remote.go:880
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:785 lxc/remote.go:858 lxc/remote.go:954
+#: lxc/remote.go:803 lxc/remote.go:876 lxc/remote.go:972
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:290
+#: lxc/remote.go:297
 msgid "Remote address must not be empty"
 msgstr ""
 
@@ -4144,7 +4144,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:295
+#: lxc/remote.go:302
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4202,7 +4202,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:832 lxc/remote.go:833
+#: lxc/remote.go:850 lxc/remote.go:851
 msgid "Remove remotes"
 msgstr ""
 
@@ -4251,7 +4251,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:759 lxc/remote.go:760
+#: lxc/remote.go:777 lxc/remote.go:778
 msgid "Rename remotes"
 msgstr ""
 
@@ -4388,7 +4388,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:741
+#: lxc/remote.go:759
 msgid "STATIC"
 msgstr ""
 
@@ -4416,11 +4416,11 @@ msgstr ""
 msgid "Server authentication type (tls or candid)"
 msgstr ""
 
-#: lxc/remote.go:460
+#: lxc/remote.go:478
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:600
+#: lxc/remote.go:618
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -4601,7 +4601,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:928 lxc/remote.go:929
+#: lxc/remote.go:946 lxc/remote.go:947
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -4777,7 +4777,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:631 lxc/remote.go:632
+#: lxc/remote.go:649 lxc/remote.go:650
 msgid "Show the default remote"
 msgstr ""
 
@@ -4965,7 +4965,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:888 lxc/remote.go:889
+#: lxc/remote.go:906 lxc/remote.go:907
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5303,7 +5303,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:180 lxc/remote.go:737
+#: lxc/cluster.go:180 lxc/remote.go:755
 msgid "URL"
 msgstr ""
 
@@ -5331,7 +5331,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:213 lxc/remote.go:247
+#: lxc/remote.go:220 lxc/remote.go:254
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -5611,8 +5611,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:955 lxc/operation.go:156 lxc/project.go:457
-#: lxc/project.go:462 lxc/project.go:467 lxc/project.go:472 lxc/remote.go:694
-#: lxc/remote.go:699 lxc/remote.go:704
+#: lxc/project.go:462 lxc/project.go:467 lxc/project.go:472 lxc/remote.go:712
+#: lxc/remote.go:717 lxc/remote.go:722
 msgid "YES"
 msgstr ""
 
@@ -6177,7 +6177,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:477 lxc/remote.go:727
+#: lxc/project.go:477 lxc/remote.go:745
 msgid "current"
 msgstr ""
 
@@ -6468,7 +6468,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:459
+#: lxc/remote.go:477
 msgid "n"
 msgstr ""
 
@@ -6480,7 +6480,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:452
+#: lxc/remote.go:470
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6517,7 +6517,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:461
+#: lxc/remote.go:479
 msgid "y"
 msgstr ""
 

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-01 10:44+0100\n"
+"POT-Creation-Date: 2024-10-18 13:21+0000\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: 0x0916 <w@laoqinren.net>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -501,15 +501,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:830 lxc/remote.go:887
+#: lxc/remote.go:848 lxc/remote.go:905
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:927
+#: lxc/remote.go:945
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:757
+#: lxc/remote.go:775
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -542,7 +542,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:739
+#: lxc/remote.go:757
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -649,7 +649,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:564
+#: lxc/remote.go:582
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -681,7 +681,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:188
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -752,7 +752,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:550
+#: lxc/remote.go:568
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -925,7 +925,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:866
+#: lxc/remote.go:884
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -991,13 +991,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:218
+#: lxc/remote.go:225
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:451
+#: lxc/remote.go:469
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -1011,7 +1011,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:604
+#: lxc/remote.go:622
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1250,12 +1250,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:486
+#: lxc/remote.go:504
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:470
+#: lxc/remote.go:231 lxc/remote.go:488
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1284,7 +1284,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:481
+#: lxc/remote.go:499
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1576,8 +1576,8 @@ msgstr ""
 #: lxc/project.go:221 lxc/project.go:348 lxc/project.go:409 lxc/project.go:510
 #: lxc/project.go:567 lxc/project.go:646 lxc/project.go:677 lxc/project.go:730
 #: lxc/project.go:789 lxc/publish.go:33 lxc/query.go:34 lxc/remote.go:34
-#: lxc/remote.go:90 lxc/remote.go:632 lxc/remote.go:670 lxc/remote.go:760
-#: lxc/remote.go:833 lxc/remote.go:889 lxc/remote.go:929 lxc/rename.go:21
+#: lxc/remote.go:90 lxc/remote.go:650 lxc/remote.go:688 lxc/remote.go:778
+#: lxc/remote.go:851 lxc/remote.go:907 lxc/remote.go:947 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:92
 #: lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:340 lxc/storage.go:410
 #: lxc/storage.go:582 lxc/storage.go:661 lxc/storage.go:757 lxc/storage.go:843
@@ -2092,11 +2092,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:190
+#: lxc/remote.go:197
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:241
+#: lxc/remote.go:248
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -2106,7 +2106,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:231
+#: lxc/remote.go:238
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -2116,12 +2116,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:256
+#: lxc/remote.go:263
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:263
+#: lxc/remote.go:270
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2146,7 +2146,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:236
+#: lxc/remote.go:243
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2224,7 +2224,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:411
-#: lxc/project.go:791 lxc/remote.go:674 lxc/storage.go:584
+#: lxc/project.go:791 lxc/remote.go:692 lxc/storage.go:584
 #: lxc/storage_volume.go:1418 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -2261,7 +2261,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:742
+#: lxc/remote.go:760
 msgid "GLOBAL"
 msgstr ""
 
@@ -2277,7 +2277,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:397
+#: lxc/remote.go:159 lxc/remote.go:406
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2628,7 +2628,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:349
+#: lxc/remote.go:358
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2709,7 +2709,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:338
+#: lxc/remote.go:347
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -3045,7 +3045,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:669 lxc/remote.go:670
+#: lxc/remote.go:687 lxc/remote.go:688
 msgid "List the available remotes"
 msgstr ""
 
@@ -3579,7 +3579,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:566
 #: lxc/network.go:976 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:487 lxc/remote.go:736 lxc/storage.go:634
+#: lxc/project.go:487 lxc/remote.go:754 lxc/storage.go:634
 #: lxc/storage_volume.go:1506
 msgid "NAME"
 msgstr ""
@@ -3601,8 +3601,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:953 lxc/operation.go:154 lxc/project.go:455
-#: lxc/project.go:460 lxc/project.go:465 lxc/project.go:470 lxc/remote.go:692
-#: lxc/remote.go:697 lxc/remote.go:702
+#: lxc/project.go:460 lxc/project.go:465 lxc/project.go:470 lxc/remote.go:710
+#: lxc/remote.go:715 lxc/remote.go:720
 msgid "NO"
 msgstr ""
 
@@ -3817,7 +3817,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:332
+#: lxc/remote.go:341
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -3884,11 +3884,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:738
+#: lxc/remote.go:756
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1070 lxc/remote.go:740
+#: lxc/image.go:1070 lxc/remote.go:758
 msgid "PUBLIC"
 msgstr ""
 
@@ -3917,7 +3917,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:182
+#: lxc/remote.go:189
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -3929,7 +3929,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:462
+#: lxc/remote.go:480
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4230,33 +4230,33 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:790
+#: lxc/remote.go:808
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:756 lxc/remote.go:781 lxc/remote.go:854 lxc/remote.go:910
-#: lxc/remote.go:950
+#: lxc/project.go:756 lxc/remote.go:799 lxc/remote.go:872 lxc/remote.go:928
+#: lxc/remote.go:968
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:301
+#: lxc/remote.go:308
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:862
+#: lxc/remote.go:880
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:785 lxc/remote.go:858 lxc/remote.go:954
+#: lxc/remote.go:803 lxc/remote.go:876 lxc/remote.go:972
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:290
+#: lxc/remote.go:297
 msgid "Remote address must not be empty"
 msgstr ""
 
@@ -4264,7 +4264,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:295
+#: lxc/remote.go:302
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4322,7 +4322,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:832 lxc/remote.go:833
+#: lxc/remote.go:850 lxc/remote.go:851
 msgid "Remove remotes"
 msgstr ""
 
@@ -4371,7 +4371,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:759 lxc/remote.go:760
+#: lxc/remote.go:777 lxc/remote.go:778
 msgid "Rename remotes"
 msgstr ""
 
@@ -4508,7 +4508,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:741
+#: lxc/remote.go:759
 msgid "STATIC"
 msgstr ""
 
@@ -4536,11 +4536,11 @@ msgstr ""
 msgid "Server authentication type (tls or candid)"
 msgstr ""
 
-#: lxc/remote.go:460
+#: lxc/remote.go:478
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:600
+#: lxc/remote.go:618
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -4721,7 +4721,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:928 lxc/remote.go:929
+#: lxc/remote.go:946 lxc/remote.go:947
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -4897,7 +4897,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:631 lxc/remote.go:632
+#: lxc/remote.go:649 lxc/remote.go:650
 msgid "Show the default remote"
 msgstr ""
 
@@ -5085,7 +5085,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:888 lxc/remote.go:889
+#: lxc/remote.go:906 lxc/remote.go:907
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5423,7 +5423,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:180 lxc/remote.go:737
+#: lxc/cluster.go:180 lxc/remote.go:755
 msgid "URL"
 msgstr ""
 
@@ -5451,7 +5451,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:213 lxc/remote.go:247
+#: lxc/remote.go:220 lxc/remote.go:254
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -5731,8 +5731,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:955 lxc/operation.go:156 lxc/project.go:457
-#: lxc/project.go:462 lxc/project.go:467 lxc/project.go:472 lxc/remote.go:694
-#: lxc/remote.go:699 lxc/remote.go:704
+#: lxc/project.go:462 lxc/project.go:467 lxc/project.go:472 lxc/remote.go:712
+#: lxc/remote.go:717 lxc/remote.go:722
 msgid "YES"
 msgstr ""
 
@@ -6297,7 +6297,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:477 lxc/remote.go:727
+#: lxc/project.go:477 lxc/remote.go:745
 msgid "current"
 msgstr ""
 
@@ -6588,7 +6588,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:459
+#: lxc/remote.go:477
 msgid "n"
 msgstr ""
 
@@ -6600,7 +6600,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:452
+#: lxc/remote.go:470
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6637,7 +6637,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:461
+#: lxc/remote.go:479
 msgid "y"
 msgstr ""
 

--- a/po/zh_Hant.po
+++ b/po/zh_Hant.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-01 10:44+0100\n"
+"POT-Creation-Date: 2024-10-18 13:21+0000\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Chinese (Traditional) <https://hosted.weblate.org/projects/"
@@ -380,15 +380,15 @@ msgstr ""
 msgid "<old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:830 lxc/remote.go:887
+#: lxc/remote.go:848 lxc/remote.go:905
 msgid "<remote>"
 msgstr ""
 
-#: lxc/remote.go:927
+#: lxc/remote.go:945
 msgid "<remote> <URL>"
 msgstr ""
 
-#: lxc/remote.go:757
+#: lxc/remote.go:775
 msgid "<remote> <new-name>"
 msgstr ""
 
@@ -421,7 +421,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:739
+#: lxc/remote.go:757
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -528,7 +528,7 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:564
+#: lxc/remote.go:582
 #, c-format
 msgid "Admin password (or token) for %s:"
 msgstr ""
@@ -560,7 +560,7 @@ msgstr ""
 msgid "All projects"
 msgstr ""
 
-#: lxc/remote.go:181
+#: lxc/remote.go:188
 msgid "All server addresses are unavailable"
 msgstr ""
 
@@ -631,7 +631,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:550
+#: lxc/remote.go:568
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -804,7 +804,7 @@ msgstr ""
 msgid "Can't read from stdin: %w"
 msgstr ""
 
-#: lxc/remote.go:866
+#: lxc/remote.go:884
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -870,13 +870,13 @@ msgstr ""
 msgid "Certificate add token for %s deleted"
 msgstr ""
 
-#: lxc/remote.go:218
+#: lxc/remote.go:225
 #, c-format
 msgid ""
 "Certificate fingerprint mismatch between certificate token and server %q"
 msgstr ""
 
-#: lxc/remote.go:451
+#: lxc/remote.go:469
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
@@ -890,7 +890,7 @@ msgstr ""
 msgid "Client %s certificate add token:"
 msgstr ""
 
-#: lxc/remote.go:604
+#: lxc/remote.go:622
 msgid "Client certificate now trusted by server:"
 msgstr ""
 
@@ -1129,12 +1129,12 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:486
+#: lxc/remote.go:504
 #, c-format
 msgid "Could not close server cert file %q: %w"
 msgstr ""
 
-#: lxc/remote.go:224 lxc/remote.go:470
+#: lxc/remote.go:231 lxc/remote.go:488
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -1163,7 +1163,7 @@ msgstr ""
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
 
-#: lxc/remote.go:481
+#: lxc/remote.go:499
 #, c-format
 msgid "Could not write server cert file %q: %w"
 msgstr ""
@@ -1455,8 +1455,8 @@ msgstr ""
 #: lxc/project.go:221 lxc/project.go:348 lxc/project.go:409 lxc/project.go:510
 #: lxc/project.go:567 lxc/project.go:646 lxc/project.go:677 lxc/project.go:730
 #: lxc/project.go:789 lxc/publish.go:33 lxc/query.go:34 lxc/remote.go:34
-#: lxc/remote.go:90 lxc/remote.go:632 lxc/remote.go:670 lxc/remote.go:760
-#: lxc/remote.go:833 lxc/remote.go:889 lxc/remote.go:929 lxc/rename.go:21
+#: lxc/remote.go:90 lxc/remote.go:650 lxc/remote.go:688 lxc/remote.go:778
+#: lxc/remote.go:851 lxc/remote.go:907 lxc/remote.go:947 lxc/rename.go:21
 #: lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:33 lxc/storage.go:92
 #: lxc/storage.go:166 lxc/storage.go:216 lxc/storage.go:340 lxc/storage.go:410
 #: lxc/storage.go:582 lxc/storage.go:661 lxc/storage.go:757 lxc/storage.go:843
@@ -1971,11 +1971,11 @@ msgstr ""
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
 
-#: lxc/remote.go:190
+#: lxc/remote.go:197
 msgid "Failed to add remote"
 msgstr ""
 
-#: lxc/remote.go:241
+#: lxc/remote.go:248
 #, c-format
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
@@ -1985,7 +1985,7 @@ msgstr ""
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
 
-#: lxc/remote.go:231
+#: lxc/remote.go:238
 #, c-format
 msgid "Failed to create %q: %w"
 msgstr ""
@@ -1995,12 +1995,12 @@ msgstr ""
 msgid "Failed to create alias %s: %w"
 msgstr ""
 
-#: lxc/remote.go:256
+#: lxc/remote.go:263
 #, c-format
 msgid "Failed to create certificate: %w"
 msgstr ""
 
-#: lxc/remote.go:263
+#: lxc/remote.go:270
 #, c-format
 msgid "Failed to find project: %w"
 msgstr ""
@@ -2025,7 +2025,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/remote.go:236
+#: lxc/remote.go:243
 #, c-format
 msgid "Failed to write server cert file %q: %w"
 msgstr ""
@@ -2103,7 +2103,7 @@ msgstr ""
 #: lxc/network_allocations.go:57 lxc/network_forward.go:89
 #: lxc/network_peer.go:84 lxc/network_zone.go:88 lxc/network_zone.go:692
 #: lxc/operation.go:108 lxc/profile.go:617 lxc/project.go:411
-#: lxc/project.go:791 lxc/remote.go:674 lxc/storage.go:584
+#: lxc/project.go:791 lxc/remote.go:692 lxc/storage.go:584
 #: lxc/storage_volume.go:1418 lxc/warning.go:93
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
@@ -2140,7 +2140,7 @@ msgstr ""
 msgid "Frequency: %vMhz (min: %vMhz, max: %vMhz)"
 msgstr ""
 
-#: lxc/remote.go:742
+#: lxc/remote.go:760
 msgid "GLOBAL"
 msgstr ""
 
@@ -2156,7 +2156,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:159 lxc/remote.go:397
+#: lxc/remote.go:159 lxc/remote.go:406
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -2507,7 +2507,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:349
+#: lxc/remote.go:358
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -2588,7 +2588,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:338
+#: lxc/remote.go:347
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -2924,7 +2924,7 @@ msgid ""
 "    U - Current disk usage"
 msgstr ""
 
-#: lxc/remote.go:669 lxc/remote.go:670
+#: lxc/remote.go:687 lxc/remote.go:688
 msgid "List the available remotes"
 msgstr ""
 
@@ -3458,7 +3458,7 @@ msgstr ""
 #: lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:566
 #: lxc/network.go:976 lxc/network_acl.go:147 lxc/network_peer.go:139
 #: lxc/network_zone.go:138 lxc/network_zone.go:741 lxc/profile.go:657
-#: lxc/project.go:487 lxc/remote.go:736 lxc/storage.go:634
+#: lxc/project.go:487 lxc/remote.go:754 lxc/storage.go:634
 #: lxc/storage_volume.go:1506
 msgid "NAME"
 msgstr ""
@@ -3480,8 +3480,8 @@ msgid "NICs:"
 msgstr ""
 
 #: lxc/network.go:953 lxc/operation.go:154 lxc/project.go:455
-#: lxc/project.go:460 lxc/project.go:465 lxc/project.go:470 lxc/remote.go:692
-#: lxc/remote.go:697 lxc/remote.go:702
+#: lxc/project.go:460 lxc/project.go:465 lxc/project.go:470 lxc/remote.go:710
+#: lxc/remote.go:715 lxc/remote.go:720
 msgid "NO"
 msgstr ""
 
@@ -3696,7 +3696,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:332
+#: lxc/remote.go:341
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -3763,11 +3763,11 @@ msgstr ""
 msgid "PROJECT"
 msgstr ""
 
-#: lxc/remote.go:738
+#: lxc/remote.go:756
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1070 lxc/remote.go:740
+#: lxc/image.go:1070 lxc/remote.go:758
 msgid "PUBLIC"
 msgstr ""
 
@@ -3796,7 +3796,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/remote.go:182
+#: lxc/remote.go:189
 msgid "Please provide an alternate server address (empty to abort):"
 msgstr ""
 
@@ -3808,7 +3808,7 @@ msgstr ""
 msgid "Please provide cluster member name: "
 msgstr ""
 
-#: lxc/remote.go:462
+#: lxc/remote.go:480
 msgid "Please type 'y', 'n' or the fingerprint:"
 msgstr ""
 
@@ -4109,33 +4109,33 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:790
+#: lxc/remote.go:808
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:756 lxc/remote.go:781 lxc/remote.go:854 lxc/remote.go:910
-#: lxc/remote.go:950
+#: lxc/project.go:756 lxc/remote.go:799 lxc/remote.go:872 lxc/remote.go:928
+#: lxc/remote.go:968
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:301
+#: lxc/remote.go:308
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:862
+#: lxc/remote.go:880
 #, c-format
 msgid "Remote %s is global and cannot be removed"
 msgstr ""
 
-#: lxc/remote.go:785 lxc/remote.go:858 lxc/remote.go:954
+#: lxc/remote.go:803 lxc/remote.go:876 lxc/remote.go:972
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:290
+#: lxc/remote.go:297
 msgid "Remote address must not be empty"
 msgstr ""
 
@@ -4143,7 +4143,7 @@ msgstr ""
 msgid "Remote admin password"
 msgstr ""
 
-#: lxc/remote.go:295
+#: lxc/remote.go:302
 msgid "Remote names may not contain colons"
 msgstr ""
 
@@ -4201,7 +4201,7 @@ msgstr ""
 msgid "Remove profiles from instances"
 msgstr ""
 
-#: lxc/remote.go:832 lxc/remote.go:833
+#: lxc/remote.go:850 lxc/remote.go:851
 msgid "Remove remotes"
 msgstr ""
 
@@ -4250,7 +4250,7 @@ msgstr ""
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:759 lxc/remote.go:760
+#: lxc/remote.go:777 lxc/remote.go:778
 msgid "Rename remotes"
 msgstr ""
 
@@ -4387,7 +4387,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:741
+#: lxc/remote.go:759
 msgid "STATIC"
 msgstr ""
 
@@ -4415,11 +4415,11 @@ msgstr ""
 msgid "Server authentication type (tls or candid)"
 msgstr ""
 
-#: lxc/remote.go:460
+#: lxc/remote.go:478
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:600
+#: lxc/remote.go:618
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
@@ -4600,7 +4600,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> [<type>/]<volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:928 lxc/remote.go:929
+#: lxc/remote.go:946 lxc/remote.go:947
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -4776,7 +4776,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/remote.go:631 lxc/remote.go:632
+#: lxc/remote.go:649 lxc/remote.go:650
 msgid "Show the default remote"
 msgstr ""
 
@@ -4964,7 +4964,7 @@ msgstr ""
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:888 lxc/remote.go:889
+#: lxc/remote.go:906 lxc/remote.go:907
 msgid "Switch the default remote"
 msgstr ""
 
@@ -5302,7 +5302,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:180 lxc/remote.go:737
+#: lxc/cluster.go:180 lxc/remote.go:755
 msgid "URL"
 msgstr ""
 
@@ -5330,7 +5330,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/remote.go:213 lxc/remote.go:247
+#: lxc/remote.go:220 lxc/remote.go:254
 msgid "Unavailable remote server"
 msgstr ""
 
@@ -5610,8 +5610,8 @@ msgid "Whether or not to snapshot the instance's running state"
 msgstr ""
 
 #: lxc/network.go:955 lxc/operation.go:156 lxc/project.go:457
-#: lxc/project.go:462 lxc/project.go:467 lxc/project.go:472 lxc/remote.go:694
-#: lxc/remote.go:699 lxc/remote.go:704
+#: lxc/project.go:462 lxc/project.go:467 lxc/project.go:472 lxc/remote.go:712
+#: lxc/remote.go:717 lxc/remote.go:722
 msgid "YES"
 msgstr ""
 
@@ -6176,7 +6176,7 @@ msgstr ""
 msgid "[[<remote>:]<name>]"
 msgstr ""
 
-#: lxc/project.go:477 lxc/remote.go:727
+#: lxc/project.go:477 lxc/remote.go:745
 msgid "current"
 msgstr ""
 
@@ -6467,7 +6467,7 @@ msgid ""
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/remote.go:459
+#: lxc/remote.go:477
 msgid "n"
 msgstr ""
 
@@ -6479,7 +6479,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:452
+#: lxc/remote.go:470
 msgid "ok (y/n/[fingerprint])?"
 msgstr ""
 
@@ -6516,7 +6516,7 @@ msgstr ""
 msgid "used by"
 msgstr ""
 
-#: lxc/remote.go:461
+#: lxc/remote.go:479
 msgid "y"
 msgstr ""
 


### PR DESCRIPTION
Based on https://github.com/canonical/lxd/pull/14283

The only change is that if the trust token is provided with `--password` flag, it is used to validate the remote certificate instead of blindly accepting it.

However, if `--accept-certificate` flag is used, this validation is skipped.