### PR TITLE
lxd: Use explicit cluster addr when core addr is wildcard

### DIFF
--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -536,6 +536,10 @@ func clusterPutJoin(d *Daemon, r *http.Request, req api.ClusterPut) response.Res
 			}
 
 			localHTTPSAddress = req.ServerAddress
+		} else if util.IsWildCardAddress(localHTTPSAddress) {
+			// Clustering requires an explicit address,
+			// so if core.https_address is a wildcard, we should still use the explicitly defined address.
+			localHTTPSAddress = req.ServerAddress
 		}
 
 		// Update the cluster.https_address config key.


### PR DESCRIPTION
This was noticed in MicroCloud. When removing a node from the LXD cluster, and then adding it back to the cluster, the old `core.https_address` and `cluster.https_address` are preserved.

When handling the request, LXD will attempt to use the `core.https_address` value and apply it to `cluster.https_address`, but if this value is a wildcard, we should continue with the explicit address defined under `ServerAddress` in the request body.