### PR TITLE
(Backport 5.21) Use explicit cluster addr when core addr is wildcard 

### DIFF
--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -536,6 +536,10 @@ func clusterPutJoin(d *Daemon, r *http.Request, req api.ClusterPut) response.Res
 			}
 
 			localHTTPSAddress = req.ServerAddress
+		} else if util.IsWildCardAddress(localHTTPSAddress) {
+			// Clustering requires an explicit address,
+			// so if core.https_address is a wildcard, we should still use the explicitly defined address.
+			localHTTPSAddress = req.ServerAddress
 		}
 
 		// Update the cluster.https_address config key.


### PR DESCRIPTION
Signed-off-by: Max Asnaashari <max.asnaashari@canonical.com>
(cherry picked from commit 2a3a7052ebfb716bc420c865e3a96355eb12d88b)