### PR TITLE
Show gateway leases when `features.networks` is disabled (for default project networks)

### DIFF
--- a/lxd/network/zone/zone.go
+++ b/lxd/network/zone/zone.go
@@ -459,6 +459,12 @@ func (d *zone) Content() (*strings.Builder, error) {
 
 					// Convert leases to usable PTR records.
 					for _, lease := range leases {
+						// Networks can be visible from more than one project and
+						// we don't want to consider gateway leases unless dealing with the network's project.
+						if forwardZoneProjectName != n.Project() && lease.Type == "gateway" {
+							continue
+						}
+
 						ip := net.ParseIP(lease.Address)
 
 						// Get the record.
@@ -479,6 +485,12 @@ func (d *zone) Content() (*strings.Builder, error) {
 
 				// Convert leases to usable records.
 				for _, lease := range leases {
+					// Networks can be visible from more than one project and
+					// we don't want to consider gateway leases unless dealing with the network's project.
+					if d.projectName != n.Project() && lease.Type == "gateway" {
+						continue
+					}
+
 					ip := net.ParseIP(lease.Address)
 
 					// Get the record.

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -1349,7 +1349,7 @@ func networkPut(d *Daemon, r *http.Request) response.Response {
 
 	clientType := clusterRequest.UserAgentClientType(r.Header.Get("User-Agent"))
 
-	response := doNetworkUpdate(effectiveProjectName, n, req, targetNode, clientType, r.Method, s.ServerClustered)
+	response := doNetworkUpdate(n, req, targetNode, clientType, r.Method, s.ServerClustered)
 
 	requestor := request.CreateRequestor(r)
 	s.Events.SendLifecycle(effectiveProjectName, lifecycle.NetworkUpdated.Event(n, requestor, nil))
@@ -1402,7 +1402,7 @@ func networkPatch(d *Daemon, r *http.Request) response.Response {
 
 // doNetworkUpdate loads the current local network config, merges with the requested network config, validates
 // and applies the changes. Will also notify other cluster nodes of non-node specific config if needed.
-func doNetworkUpdate(projectName string, n network.Network, req api.NetworkPut, targetNode string, clientType clusterRequest.ClientType, httpMethod string, clustered bool) response.Response {
+func doNetworkUpdate(n network.Network, req api.NetworkPut, targetNode string, clientType clusterRequest.ClientType, httpMethod string, clustered bool) response.Response {
 	if req.Config == nil {
 		req.Config = map[string]string{}
 	}

--- a/test/suites/network.sh
+++ b/test/suites/network.sh
@@ -94,6 +94,7 @@ test_network() {
   # Create new project with an instance with ipv[46] for the next tests.
   lxc project create foo -c features.networks=false -c features.images=false -c features.profiles=false
   lxc launch testimage outsider -n lxdt$$ --project foo
+  gateway_addr="$(lxc network get lxdt$$ ipv4.address | cut -d/ -f1)"
   v4_addr_foo="$(lxc network get lxdt$$ ipv4.address | cut -d/ -f1)1"
   v6_addr_foo="$(lxc network get lxdt$$ ipv6.address | cut -d/ -f1)01"
   lxc config device set outsider eth0 ipv4.address "${v4_addr_foo}" --project foo
@@ -101,8 +102,10 @@ test_network() {
 
   lxc network list-leases lxdt$$ | grep STATIC | grep -q "${v4_addr}"
   lxc network list-leases lxdt$$ | grep STATIC | grep -q "${v6_addr}"
+  lxc network list-leases lxdt$$ | grep GATEWAY | grep -q "${gateway_addr}"
   lxc network list-leases lxdt$$ --project foo | grep STATIC | grep -q "${v4_addr_foo}"
   lxc network list-leases lxdt$$ --project foo | grep STATIC | grep -q "${v6_addr_foo}"
+  lxc network list-leases lxdt$$ --project foo | grep GATEWAY | grep -q "${gateway_addr}"
 
   # Request DHCPv6 lease (if udhcpc6 is in busybox image).
   busyboxUdhcpc6=1


### PR DESCRIPTION
If project `foo` has `features.networks` disabled on a project, it does not have networks of its own and the networks from the default project are visible from that project. However, the gateway leases for networks on the default project don't show on `lxc network list-leases lxdbr0 --project foo`.
This PR proposes changing this behavior and showing those leases, being more consistent with how we handle `features.networks`.