### PR TITLE
doc: embed discourse titles as link text (stable-5.0)

### DIFF
--- a/doc/installing.md
+++ b/doc/installing.md
@@ -1,5 +1,5 @@
 ---
-discourse: ubuntu:37214, ubuntu:37327
+discourse: ubuntu:[Managing&#32;the&#32;LXD&#32;snap&#32;package](37214), ubuntu:[Building&#32;custom&#32;LXD&#32;binaries&#32;for&#32;side&#32;loading&#32;into&#32;an&#32;existing&#32;snap&#32;installation](37327)
 ---
 
 # How to install LXD

--- a/doc/reference/remote_image_servers.md
+++ b/doc/reference/remote_image_servers.md
@@ -1,5 +1,5 @@
 ---
-discourse: ubuntu:43824,16647
+discourse: ubuntu:[New&#32;LXD&#32;image&#32;server&#32;available&#32;(images.lxd.canonical.com)](43824),[Image&#32;server&#32;infrastructure](16647)
 relatedlinks: https://www.youtube.com/watch?v=pM0EgUqj2a0
 ---
 


### PR DESCRIPTION
- Cherry-picked update to doc/installing.md from #14295
- Updated doc/reference/remote_image_servers manually per different links set from main branch
- The three other Discourse links in main branch not backported per the pages do not exist in stable-5.0