### PR TITLE
lxd: Fix cluster group create when >1 node is defined in the request

### DIFF
--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -3689,13 +3689,13 @@ func clusterGroupsPost(d *Daemon, r *http.Request) response.Response {
 			Nodes:       req.Members,
 		}
 
-		groupID, err := dbCluster.CreateClusterGroup(ctx, tx.Tx(), obj)
+		_, err := dbCluster.CreateClusterGroup(ctx, tx.Tx(), obj)
 		if err != nil {
 			return err
 		}
 
 		for _, node := range obj.Nodes {
-			_, err = dbCluster.CreateNodeClusterGroup(ctx, tx.Tx(), dbCluster.NodeClusterGroup{GroupID: int(groupID), Node: node})
+			err = tx.AddNodeToClusterGroup(ctx, obj.Name, node)
 			if err != nil {
 				return err
 			}
@@ -4242,7 +4242,7 @@ func clusterGroupPatch(d *Daemon, r *http.Request) response.Response {
 		}
 
 		for _, node := range obj.Nodes {
-			_, err = dbCluster.CreateNodeClusterGroup(ctx, tx.Tx(), dbCluster.NodeClusterGroup{GroupID: int(groupID), Node: node})
+			err = tx.AddNodeToClusterGroup(ctx, obj.Name, node)
 			if err != nil {
 				return err
 			}

--- a/lxd/db/cluster/nodes_cluster_groups.go
+++ b/lxd/db/cluster/nodes_cluster_groups.go
@@ -7,14 +7,9 @@ package cluster
 //
 //go:generate mapper stmt -e node_cluster_group objects table=nodes_cluster_groups
 //go:generate mapper stmt -e node_cluster_group objects-by-GroupID table=nodes_cluster_groups
-//go:generate mapper stmt -e node_cluster_group id table=nodes_cluster_groups
-//go:generate mapper stmt -e node_cluster_group create table=nodes_cluster_groups
 //go:generate mapper stmt -e node_cluster_group delete-by-GroupID table=nodes_cluster_groups
 //
 //go:generate mapper method -e node_cluster_group GetMany
-//go:generate mapper method -e node_cluster_group Create
-//go:generate mapper method -e node_cluster_group Exists
-//go:generate mapper method -e node_cluster_group ID
 //go:generate mapper method -e node_cluster_group DeleteOne-by-GroupID
 
 // NodeClusterGroup associates a node to a cluster group.

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -3626,6 +3626,19 @@ EOF
   # Delete the cluster group "yamlgroup"
   lxc cluster group delete cluster:yamlgroup
 
+  # Try to initialize a cluster group with multiple nodes
+  lxc query cluster:/1.0/cluster/groups -X POST -d '{\"name\":\"multi-node-group\",\"description\":\"\",\"members\":[\"node1\",\"node2\",\"node3\"]}'
+
+  # Ensure cluster group created with requested members
+  [ "$(lxc query cluster:/1.0/cluster/groups/multi-node-group | jq '.members | length')" -eq 3 ]
+
+  # Remove nodes and delete cluster group
+  lxc cluster group remove cluster:node1 multi-node-group
+  lxc cluster group remove cluster:node2 multi-node-group
+  lxc cluster group remove cluster:node3 multi-node-group
+
+  lxc cluster group delete cluster:multi-node-group
+
   # With these settings:
   # - node1 will receive instances unless a different node is directly targeted (not via group)
   # - node2 will receive instances if either targeted by group or directly


### PR DESCRIPTION
This PR fixes cluster group creation when multiple nodes are present in the request. This is currently failing due to an incorrect check for existing mappings in the `nodes_cluster_groups` table. This is due to the `NodeClusterGroups` struct not properly matching the backing table. To fix this, we ensure the `NodeClusterGroups` uses the `primary` directive where necessary.

Fixes https://github.com/canonical/lxd/issues/14286.