### PR TITLE
github: update apt definition in setup-microceph

### DIFF
--- a/.github/actions/setup-microceph/action.yml
+++ b/.github/actions/setup-microceph/action.yml
@@ -87,6 +87,7 @@ runs:
       run: |
           set -eux
 
+          sudo apt-get update
           sudo apt-get install --no-install-recommends -y ceph-common
           # reclaim some space
           sudo apt-get clean


### PR DESCRIPTION
This avoids getting 404 when trying to install packages that were superseded by updates:

```
+ sudo apt-get install --no-install-recommends -y ceph-common
Reading package lists...
Building dependency tree...
Reading state information...
The following additional packages will be installed:
  libbabeltrace1 libboost-context1.83.0 libboost-filesystem1.83.0
  libboost-iostreams1.83.0 libboost-program-options1.83.0
  libboost-thread1.83.0 libcephfs2 libdaxctl1 libgoogle-perftools4t64
  libndctl6 liboath0t64 libpmem1 libpmemobj1 librados2 libradosstriper1
  librbd1 librdmacm1t64 libtcmalloc-minimal4t64 python3-ceph-argparse
  python3-ceph-common python3-cephfs python3-prettytable python3-rados
  python3-rbd python3-wcwidth
Suggested packages:
  ceph ceph-mds
The following NEW packages will be installed:
  ceph-common libbabeltrace1 libboost-context1.83.0 libboost-filesystem1.83.0
  libboost-iostreams1.83.0 libboost-program-options1.83.0
  libboost-thread1.83.0 libcephfs2 libdaxctl1 libgoogle-perftools4t64
  libndctl6 liboath0t64 libpmem1 libpmemobj1 librados2 libradosstriper1
  librbd1 librdmacm1t64 libtcmalloc-minimal4t64 python3-ceph-argparse
  python3-ceph-common python3-cephfs python3-prettytable python3-rados
  python3-rbd python3-wcwidth
0 upgraded, 26 newly installed, 0 to remove and 12 not upgraded.
Need to get 35.6 MB of archives.
After this operation, 146 MB of additional disk space will be used.
Get:1 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libboost-iostreams1.83.0 amd64 1.83.0-2.1ubuntu3 [259 kB]
Get:2 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libboost-thread1.83.0 amd64 1.83.0-2.1ubuntu3 [276 kB]
Get:3 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 librdmacm1t64 amd64 50.0-2build2 [70.7 kB]
Err:4 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 librados2 amd64 19.2.0~git20240301.4c76c50-0ubuntu6.1
  404  Not Found [IP: 52.147.219.192 80]
Get:5 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libdaxctl1 amd64 77-2ubuntu2 [21.4 kB]
Get:6 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libndctl6 amd64 77-2ubuntu2 [62.8 kB]
Get:7 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libpmem1 amd64 1.13.1-1.1ubuntu2 [84.8 kB]
Get:8 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libpmemobj1 amd64 1.13.1-1.1ubuntu2 [116 kB]
Err:9 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 librbd1 amd64 19.2.0~git20240301.4c76c50-0ubuntu6.1
  404  Not Found [IP: 52.147.219.192 80]
```