### PR TITLE
github: tune docker firewall disablement to work on 20.04

### DIFF
--- a/.github/actions/disable-docker/action.yml
+++ b/.github/actions/disable-docker/action.yml
@@ -10,4 +10,4 @@ runs:
         set -eux
         sudo apt-get autopurge -y containerd.io moby-containerd docker docker-ce podman uidmap
         sudo ip link delete docker0
-        sudo nft flush ruleset
+        sudo nft flush ruleset || sudo iptables -I DOCKER-USER -j ACCEPT


### PR DESCRIPTION
This was "cherry-picked" from https://github.com/canonical/lxd-ci/commit/66158e65ac74c6055346b41021263370caf2a76b and the end goal is to be able to use the LXD action everywhere, hence the PR.