### PR TITLE
Auth: Allow updating TLS identity certificates

### DIFF
--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -785,6 +785,13 @@ definitions:
                 example: Jane Doe
                 type: string
                 x-go-name: Name
+            tls_certificate:
+                description: |-
+                    TLSCertificate is a PEM encoded x509 certificate. This is only set if the AuthenticationMethod is AuthenticationMethodTLS.
+
+                    API extension: access_management_tls.
+                type: string
+                x-go-name: TLSCertificate
             type:
                 description: Type is the type of identity.
                 example: oidc-service-account
@@ -843,6 +850,13 @@ definitions:
                 example: Jane Doe
                 type: string
                 x-go-name: Name
+            tls_certificate:
+                description: |-
+                    TLSCertificate is a PEM encoded x509 certificate. This is only set if the AuthenticationMethod is AuthenticationMethodTLS.
+
+                    API extension: access_management_tls.
+                type: string
+                x-go-name: TLSCertificate
             type:
                 description: Type is the type of identity.
                 example: oidc-service-account
@@ -903,6 +917,13 @@ definitions:
                     type: string
                 type: array
                 x-go-name: Groups
+            tls_certificate:
+                description: |-
+                    TLSCertificate is a base64 encoded x509 certificate. This can only be set if the authentication method of the identity is AuthenticationMethodTLS.
+
+                    API extension: access_management_tls.
+                type: string
+                x-go-name: TLSCertificate
         title: IdentityPut contains the editable fields of an IdentityInfo.
         type: object
         x-go-package: github.com/canonical/lxd/shared/api

--- a/lxd/certificates.go
+++ b/lxd/certificates.go
@@ -1180,11 +1180,11 @@ func certificateDelete(d *Daemon, r *http.Request) response.Response {
 
 func certificateValidate(networkCert *shared.CertInfo, cert *x509.Certificate) error {
 	if time.Now().Before(cert.NotBefore) {
-		return fmt.Errorf("The provided certificate isn't valid yet")
+		return api.NewStatusError(http.StatusBadRequest, "The provided certificate isn't valid yet")
 	}
 
 	if time.Now().After(cert.NotAfter) {
-		return fmt.Errorf("The provided certificate is expired")
+		return api.NewStatusError(http.StatusBadRequest, "The provided certificate is expired")
 	}
 
 	if networkCert != nil && networkCert.CA() != nil {
@@ -1203,7 +1203,7 @@ func certificateValidate(networkCert *shared.CertInfo, cert *x509.Certificate) e
 
 		// Check that we're dealing with at least 2048bit (Size returns a value in bytes).
 		if pubKey.Size()*8 < 2048 {
-			return fmt.Errorf("RSA key is too weak (minimum of 2048bit)")
+			return api.NewStatusError(http.StatusBadRequest, "RSA key is too weak (minimum of 2048bit)")
 		}
 	}
 

--- a/lxd/db/cluster/identities.go
+++ b/lxd/db/cluster/identities.go
@@ -370,12 +370,23 @@ func (i *Identity) ToAPI(ctx context.Context, tx *sql.Tx, canViewGroup auth.Perm
 		}
 	}
 
+	var tlsCertificate string
+	if i.AuthMethod == api.AuthenticationMethodTLS && i.Type != api.IdentityTypeCertificateClientPending {
+		metadata, err := i.CertificateMetadata()
+		if err != nil {
+			return nil, err
+		}
+
+		tlsCertificate = metadata.Certificate
+	}
+
 	return &api.Identity{
 		AuthenticationMethod: string(i.AuthMethod),
 		Type:                 string(i.Type),
 		Identifier:           i.Identifier,
 		Name:                 i.Name,
 		Groups:               groupNames,
+		TLSCertificate:       tlsCertificate,
 	}, nil
 }
 

--- a/lxd/identities.go
+++ b/lxd/identities.go
@@ -885,12 +885,23 @@ func getIdentities(authenticationMethod string) func(d *Daemon, r *http.Request)
 
 			apiIdentities := make([]api.Identity, 0, len(identities))
 			for _, id := range identities {
+				var certificate string
+				if id.AuthMethod == api.AuthenticationMethodTLS && id.Type != api.IdentityTypeCertificateClientPending {
+					metadata, err := id.CertificateMetadata()
+					if err != nil {
+						return response.SmartError(err)
+					}
+
+					certificate = metadata.Certificate
+				}
+
 				apiIdentities = append(apiIdentities, api.Identity{
 					AuthenticationMethod: string(id.AuthMethod),
 					Type:                 string(id.Type),
 					Identifier:           id.Identifier,
 					Name:                 id.Name,
 					Groups:               groupNamesByIdentityID[id.ID],
+					TLSCertificate:       certificate,
 				})
 			}
 

--- a/shared/api/auth.go
+++ b/shared/api/auth.go
@@ -61,18 +61,25 @@ type Identity struct {
 	// Groups is the list of groups for which the identity is a member.
 	// Example: ["foo", "bar"]
 	Groups []string `json:"groups" yaml:"groups"`
+
+	// TLSCertificate is a PEM encoded x509 certificate. This is only set if the AuthenticationMethod is AuthenticationMethodTLS.
+	//
+	// API extension: access_management_tls.
+	TLSCertificate string `json:"tls_certificate" yaml:"tls_certificate"`
 }
 
 // Writable converts a Identity struct into a IdentityPut struct (filters read-only fields).
 func (i Identity) Writable() IdentityPut {
 	return IdentityPut{
-		Groups: i.Groups,
+		Groups:         i.Groups,
+		TLSCertificate: i.TLSCertificate,
 	}
 }
 
 // SetWritable sets applicable values from IdentityPut struct to Identity struct.
 func (i *Identity) SetWritable(put IdentityPut) {
 	i.Groups = put.Groups
+	i.TLSCertificate = put.TLSCertificate
 }
 
 // IdentityInfo expands an Identity to include effective group membership and effective permissions.
@@ -103,6 +110,11 @@ type IdentityPut struct {
 	// Groups is the list of groups for which the identity is a member.
 	// Example: ["foo", "bar"]
 	Groups []string `json:"groups" yaml:"groups"`
+
+	// TLSCertificate is a base64 encoded x509 certificate. This can only be set if the authentication method of the identity is AuthenticationMethodTLS.
+	//
+	// API extension: access_management_tls.
+	TLSCertificate string `json:"tls_certificate" yaml:"tls_certificate"`
 }
 
 // IdentitiesTLSPost contains required information for the creation of a TLS identity.


### PR DESCRIPTION
Implements the final part of the TLS fine-grained auth specification. This allows any user to update their own certificate, as well as allowing an administrator with `can_edit` on a given identity to update the certificate for that identity.