### PR TITLE
lxd/apparmor: Update with new lxd binary location in sbin

### DIFF
--- a/lxd/apparmor/instance_forkproxy.go
+++ b/lxd/apparmor/instance_forkproxy.go
@@ -80,6 +80,7 @@ profile "{{ .name }}" flags=(attach_disconnected,mediate_deleted) {
   # The binary itself (for nesting)
   /var/snap/lxd/common/lxd.debug      mr,
   /snap/lxd/*/bin/lxd                 mr,
+  /snap/lxd/*/sbin/lxd                mr,
 
   # Snap-specific libraries
   /snap/lxd/*/lib/**.so*              mr,

--- a/lxd/apparmor/instance_qemu.go
+++ b/lxd/apparmor/instance_qemu.go
@@ -73,6 +73,7 @@ profile "{{ .name }}" flags=(attach_disconnected,mediate_deleted) {
   # The binary itself (for nesting)
   /var/snap/lxd/common/lxd.debug            mr,
   /snap/lxd/*/bin/lxd                       mr,
+  /snap/lxd/*/sbin/lxd                      mr,
   /snap/lxd/*/bin/qemu-system-*             mrix,
   /snap/lxd/*/share/qemu/**                 kr,
 

--- a/lxd/apparmor/network_forkdns.go
+++ b/lxd/apparmor/network_forkdns.go
@@ -44,6 +44,7 @@ profile "{{ .name }}" flags=(attach_disconnected,mediate_deleted) {
   # The binary itself (for nesting)
   /var/snap/lxd/common/lxd.debug      mr,
   /snap/lxd/*/bin/lxd                 mr,
+  /snap/lxd/*/sbin/lxd                mr,
 
   # Snap-specific libraries
   /snap/lxd/*/lib/**.so*              mr,


### PR DESCRIPTION
Related to https://github.com/canonical/lxd-pkg-snap/pull/564 and https://github.com/canonical/lxd/issues/13331